### PR TITLE
ER1 menubar login/logout with optional persisted session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,13 @@
 # Content-type label in the ER1 upload form payload
 # ER1_CONTENT_TYPE=YouTube-Video-Impression
 
+# Persist ER1 login-linked context across app restarts (menubar login/logout flow).
+# Default is false (runtime-only session).
+# M3C_ER1_SESSION_PERSIST=false
+
+# Optional custom path for persisted ER1 session JSON.
+# M3C_ER1_SESSION_FILE=~/.m3c-tools/er1_session.json
+
 # --- YouTube Rate Limit Mitigation ---
 
 # HTTP/SOCKS5 proxy to avoid YouTube 429 rate limits.

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@
 # ER1_CONTEXT_ID=107677460544181387647___mft
 
 # HTTP timeout (seconds) for ER1 upload requests
-# ER1_UPLOAD_TIMEOUT=10
+# ER1_UPLOAD_TIMEOUT=600
 
 # Seconds between automatic retry-queue processing cycles
 # ER1_RETRY_INTERVAL=300
@@ -54,7 +54,7 @@
 # YT_WHISPER_FALLBACK=medium,base,tiny
 
 # Transcription timeout in seconds (0 = no timeout)
-# YT_WHISPER_TIMEOUT=600
+# YT_WHISPER_TIMEOUT=7200
 
 # Whisper transcription language (ISO 639-1 code)
 # YT_WHISPER_LANGUAGE=de
@@ -63,7 +63,7 @@
 # M3C_WHISPER_MODEL=base
 
 # Menubar transcription timeout in seconds (0 = no timeout)
-# M3C_WHISPER_TIMEOUT=120
+# M3C_WHISPER_TIMEOUT=7200
 
 # Preload whisper model at menubar app startup (reduces first transcription latency).
 # M3C_WHISPER_PRELOAD=true

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILD_DIR = ./build
 APP_NAME = M3C-Tools
 APP_BUNDLE = $(BUILD_DIR)/$(APP_NAME).app
 APP_ID   = com.kamir.m3c-tools
-APP_VERSION = 0.1.0
+APP_VERSION = 1.4.4
 ICON_SRC = maindset_icon.png
 
 # Default: build the CLI
@@ -157,8 +157,7 @@ install: build-app
 	@echo "  App:  /Applications/$(APP_NAME).app"
 	@echo "  Data: ~/.m3c-tools/"
 	@echo ""
-	@echo "Configuring macOS permissions..."
-	@$(MAKE) --no-print-directory permissions
+	@echo "Run 'make permissions' to configure macOS privacy settings."
 
 # Grant macOS privacy permissions for Screen Recording, Microphone,
 # Accessibility, and Input Monitoring. Opens System Settings panes
@@ -227,17 +226,27 @@ clean:
 vet:
 	go vet ./...
 
-# Release targets — bump version, build, tag, push, create GitHub release
+# Pre-release code review (build, vet, tests, secrets, dead code, deps)
+.PHONY: code-review
+code-review:
+	@./scripts/code-review.sh
+
+# Check documentation consistency with implementation
+.PHONY: check-docs
+check-docs:
+	@./scripts/check-docs.sh
+
+# Release targets — code review + docs check run before release
 .PHONY: release release-patch release-minor release-major
-release: release-patch
+release: code-review check-docs release-patch
 
 release-patch:
 	@./scripts/release.sh patch
 
-release-minor:
+release-minor: code-review check-docs
 	@./scripts/release.sh minor
 
-release-major:
+release-major: code-review check-docs
 	@./scripts/release.sh major
 
 # Run CI checks locally (mirrors .github/workflows/ci.yml)
@@ -273,7 +282,9 @@ help:
 	@echo "  uninstall      Remove installed CLI and .app"
 	@echo "  vet            Run go vet on all packages"
 	@echo "  clean          Remove build artifacts"
-	@echo "  release        Release with patch bump (default)"
+	@echo "  code-review    Run pre-release code review checks"
+	@echo "  check-docs     Check documentation consistency with implementation"
+	@echo "  release        Release with patch bump (runs code-review + check-docs first)"
 	@echo "  release-patch  Release with patch version bump"
 	@echo "  release-minor  Release with minor version bump"
 	@echo "  release-major  Release with major version bump"

--- a/README.md
+++ b/README.md
@@ -1,89 +1,181 @@
 # m3c-tools
 
-**Multi-Modal-Memory-Capturing Tools** — a macOS CLI and menu bar app for fetching YouTube transcripts, capturing voice impressions, and uploading multimodal observations (text + audio + image) to an ER1 personal knowledge server.
+**Multi-Modal-Memory-Capturing Tools** — a macOS menu bar app and CLI for capturing observations (text + audio + image) and uploading them to an [ER1](https://er1.io) personal knowledge server.
 
-## Quickstart
+---
 
-Install and launch in one line:
+## Quickstart (5 minutes)
+
+### 1. Install prerequisites
 
 ```bash
-git clone https://github.com/kamir/m3c-tools.git && cd m3c-tools && make install
+brew install portaudio           # microphone recording
+pip install openai-whisper       # speech-to-text (or: brew install openai-whisper)
 ```
 
-Then launch the menu bar app:
+Requires **Go 1.25+** and **macOS** (Cocoa UI via cgo).
+
+### 2. Build and install
+
+```bash
+git clone https://github.com/kamir/m3c-tools.git
+cd m3c-tools
+make install
+```
+
+This builds the binary, creates `M3C-Tools.app`, installs both to `/usr/local/bin` and `/Applications`, and walks you through macOS permission setup (Microphone, Screen Recording).
+
+### 3. Configure
+
+```bash
+cp .env.example ~/.m3c-tools.env
+```
+
+Edit `~/.m3c-tools.env` — the three required settings for ER1 upload:
+
+```
+ER1_API_URL=https://your-er1-server:8081/upload_2
+ER1_API_KEY=your-api-key
+ER1_CONTEXT_ID=your-context-id
+```
+
+### 4. Launch
 
 ```bash
 make menubar
 ```
 
-Or run a single command:
+Or open `/Applications/M3C-Tools.app`. A menu bar icon appears — you're ready to capture.
 
-```bash
-make run ARGS="transcript dQw4w9WgXcQ --format srt"
+### 5. Try it
+
+- **Fetch a transcript**: click the menu bar icon → *Fetch Transcript...* → paste a YouTube URL
+- **Screenshot observation**: click *Capture Screenshot* → record a voice note → Store to ER1
+- **CLI only**: `m3c-tools transcript dQw4w9WgXcQ --format srt`
+
+---
+
+## What does m3c-tools do?
+
+m3c-tools captures four types of observations, each flowing through a shared pipeline:
+
+```
+Capture → Preview + Record → Whisper Transcribe → Tag Editor → Store to ER1
 ```
 
-## Features
+| Channel | Trigger | What it captures |
+|---------|---------|------------------|
+| **A — YouTube** | Paste video URL | Transcript + thumbnail + your voice comment |
+| **B — Screenshot** | Menu item | Screenshot + voice note (uses clipboard image if present) |
+| **C — Impulse** | Menu item | Interactive region capture + quick voice note |
+| **D — Audio Import** | Menu item | Batch audio files from a folder (e.g. voice recorder sync) |
 
-- **Transcript fetching** — YouTube transcripts via InnerTube API (no API key needed), 4 output formats (Text, SRT, JSON, WebVTT), translation support
-- **ER1 upload** — Multipart upload of transcript + thumbnail + audio to an ER1 knowledge server, with automatic retry queue
-- **Voice recording** — 16kHz/16-bit mono WAV capture via PortAudio, whisper transcription
-- **Screenshot capture** — Full screen, window, or region capture with clipboard-first detection
-- **Menu bar app** — macOS menu bar integration with transcript fetch, screenshot, impulse, and ER1 upload workflows
-- **Batch audio import** — Scan directories for audio files, track status in SQLite
+Each observation becomes a multimodal ER1 document: text transcript + audio recording + image, with tags and metadata.
 
-## Observation Types
+---
 
-m3c-tools captures four types of observations, each following a shared pipeline: **capture → record voice note → whisper transcribe → review → upload to ER1**.
+## Configuration Reference
 
-| Type | Channel | Trigger | Description |
-|------|---------|---------|-------------|
-| **Progress** | A | `upload <video_id>` | YouTube video transcript + thumbnail |
-| **Idea** | B | Capture Screenshot | Clipboard-first: uses an existing clipboard image, or falls back to interactive region selection. For capturing something you're already looking at. |
-| **Impulse** | C | Quick Impulse | Always launches interactive region selection. A faster, more intentional "grab and annotate" flow. |
-| **Import** | D | `import-audio <dir>` | Batch audio file import from a directory |
+Settings are loaded from `.env` in the project root or `~/.m3c-tools.env`. See [`.env.example`](.env.example) for all options.
 
-After capture, **Idea** and **Impulse** share the same pipeline:
+### Required for ER1 upload
 
-1. The Observation Window opens with the captured image in the **Record** tab
-2. Record a voice note with a live VU meter
-3. Whisper transcribes the audio; the result appears in the **Review** tab
-4. Edit tags and notes in the **Tags** tab
-5. **Store** uploads to ER1, or **Cancel** saves a local draft
+| Variable | Description |
+|----------|-------------|
+| `ER1_API_URL` | ER1 upload endpoint URL |
+| `ER1_API_KEY` | API key (sent as `X-API-KEY` header) |
+| `ER1_CONTEXT_ID` | Your ER1 context/user identifier |
 
-## Requirements
+### Whisper (speech-to-text)
 
-- macOS (menu bar, screenshot, and recording features are macOS-only)
-- Go 1.25+
-- PortAudio (`brew install portaudio`)
-- [whisper](https://github.com/openai/whisper) (optional, for voice transcription)
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `M3C_WHISPER_MODEL` | `base` | Model size: `tiny`, `base`, `small`, `medium`, `large` |
+| `M3C_WHISPER_TIMEOUT` | `7200` | Transcription timeout in seconds |
+| `YT_WHISPER_LANGUAGE` | `de` | Language code (ISO 639-1) |
+| `M3C_WHISPER_PRELOAD` | `true` | Preload model at startup |
+
+### Screenshot capture
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `M3C_SCREENSHOT_MODE` | `clipboard-first` | `clipboard-first` or `interactive` |
+| `M3C_SCREENSHOT_CLIPBOARD_TIMEOUT_SEC` | `20` | Wait time for clipboard image |
+
+### Audio import (Channel D)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `IMPORT_AUDIO_SOURCE` | — | Source folder for audio files |
+| `IMPORT_AUDIO_DEST` | `~/ER1` | Destination for MEMORY folders |
+| `IMPORT_CONTENT_TYPE` | — | ER1 content-type label |
+
+### ER1 tuning
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ER1_UPLOAD_TIMEOUT` | `600` | HTTP timeout in seconds |
+| `ER1_VERIFY_SSL` | `false` | TLS certificate verification |
+| `ER1_RETRY_INTERVAL` | `300` | Seconds between retry cycles |
+| `ER1_MAX_RETRIES` | `10` | Max retries before dropping |
+
+---
 
 ## Build & Test
 
 ```bash
 make build          # Build CLI binary → ./build/m3c-tools
-make build-all      # Build CLI + POC binaries
 make build-app      # Build macOS .app bundle
-make menubar        # Build and launch menu bar app
+make menubar        # Build + launch menu bar app
+make install        # Full install (CLI + .app + permissions)
 
-make test-unit      # Run offline tests
-make ci             # Run full CI locally (vet + lint + test + build)
+make test-unit      # Offline unit tests
+make ci             # Full CI: vet + lint + test + build
+make test-network   # YouTube API tests (requires internet)
+make test-er1       # ER1 integration tests (requires server)
 
-make release        # Release with patch version bump
-make release-minor  # Release with minor version bump
-make release-major  # Release with major version bump
+make help           # Show all targets
 ```
 
-Run `make help` for all available targets.
+Run a single test:
 
-## Configuration
+```bash
+go test -v -count=1 ./e2e/ -run TestTranscriptFetch
+```
 
-Copy `.env.example` to `.env` (or `~/.m3c-tools.env`) and set:
+---
+
+## Architecture
 
 ```
-ER1_API_URL=https://your-er1-server/api
-ER1_API_KEY=your-api-key
-ER1_CONTEXT_ID=your-context-id
+cmd/m3c-tools/       CLI + menu bar app entry point
+pkg/transcript/      YouTube InnerTube API client (pure Go, no API key)
+pkg/er1/             ER1 upload client + retry queue
+pkg/impression/      Composite document builder + tag system
+pkg/whisper/         Whisper CLI subprocess wrapper
+pkg/recorder/        PortAudio microphone recording (cgo)
+pkg/screenshot/      macOS screenshot capture + clipboard detection
+pkg/menubar/         Native Cocoa UI via cgo (NSWindow, NSTabView, etc.)
+pkg/importer/        Batch audio import pipeline
+pkg/tracking/        SQLite tracking database
 ```
+
+## Documentation
+
+Full documentation: **[kamir.github.io/m3c-tools](https://kamir.github.io/m3c-tools)**
+
+- [Getting Started](https://kamir.github.io/m3c-tools/getting-started)
+- [Menu Bar App](https://kamir.github.io/m3c-tools/menubar-app)
+- [Audio Import & Tracking](https://kamir.github.io/m3c-tools/audio-import-tracking)
+- [Roadmap](https://kamir.github.io/m3c-tools/roadmap)
+
+## Uninstalling
+
+```bash
+make uninstall
+```
+
+Data at `~/.m3c-tools/` is preserved — remove manually if desired.
 
 ## License
 

--- a/cmd/m3c-tools/bulk_ops.go
+++ b/cmd/m3c-tools/bulk_ops.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/menubar"
+)
+
+type ingestionCoordinator struct {
+	mu    sync.Mutex
+	busy  bool
+	state menubar.BulkRunState
+}
+
+func newIngestionCoordinator() *ingestionCoordinator {
+	return &ingestionCoordinator{}
+}
+
+func (c *ingestionCoordinator) TryStart(opType string, meta menubar.BulkRunState) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.busy {
+		return false
+	}
+	meta.Active = true
+	meta.Action = strings.TrimSpace(opType)
+	if meta.StartedAt.IsZero() {
+		meta.StartedAt = time.Now()
+	}
+	c.busy = true
+	c.state = meta
+	return true
+}
+
+func (c *ingestionCoordinator) Update(state menubar.BulkRunState) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.busy {
+		return
+	}
+	c.state = state
+}
+
+func (c *ingestionCoordinator) Finish(final menubar.BulkRunState) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	final.Active = false
+	c.state = final
+	c.busy = false
+}
+
+func (c *ingestionCoordinator) IsBusy() (bool, menubar.BulkRunState) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.busy, c.state
+}
+
+type bulkSessionSummary struct {
+	Total   int
+	Done    int
+	Success int
+	Failed  int
+}
+
+type bulkItemHandler func(index, total int, filename, status string, emit func(menubar.BulkProgressEvent)) (string, error)
+
+func runBulkSession(runID, action string, filenames, statuses []string, handler bulkItemHandler, emit func(menubar.BulkProgressEvent)) bulkSessionSummary {
+	total := len(filenames)
+	summary := bulkSessionSummary{Total: total}
+	start := time.Now()
+
+	emit(menubar.BulkProgressEvent{
+		RunID:   runID,
+		Action:  action,
+		Event:   "RUN_START",
+		Total:   total,
+		Phase:   menubar.BulkPhaseQueued,
+		Elapsed: 0,
+	})
+
+	for i, name := range filenames {
+		status := ""
+		if i < len(statuses) {
+			status = statuses[i]
+		}
+
+		emit(menubar.BulkProgressEvent{
+			RunID:       runID,
+			Action:      action,
+			Event:       "ITEM_START",
+			Item:        name,
+			Index:       i + 1,
+			Total:       total,
+			CurrentFile: name,
+			Phase:       menubar.BulkPhaseQueued,
+			Elapsed:     time.Since(start),
+		})
+
+		outcome, err := handler(i+1, total, name, status, emit)
+		if strings.TrimSpace(outcome) == "" {
+			outcome = "ok"
+		}
+		summary.Done++
+		if err != nil || outcome == "failed" {
+			summary.Failed++
+			if err == nil {
+				err = fmt.Errorf("failed")
+			}
+		} else {
+			summary.Success++
+		}
+
+		errText := ""
+		if err != nil {
+			errText = err.Error()
+		}
+		emit(menubar.BulkProgressEvent{
+			RunID:       runID,
+			Action:      action,
+			Event:       "ITEM_DONE",
+			Item:        name,
+			Index:       i + 1,
+			Total:       total,
+			Outcome:     outcome,
+			Error:       errText,
+			Done:        summary.Done,
+			Success:     summary.Success,
+			Failed:      summary.Failed,
+			CurrentFile: name,
+			Phase:       itemDonePhase(outcome, err),
+			Elapsed:     time.Since(start),
+		})
+	}
+
+	emit(menubar.BulkProgressEvent{
+		RunID:   runID,
+		Action:  action,
+		Event:   "RUN_DONE",
+		Total:   total,
+		Done:    summary.Done,
+		Success: summary.Success,
+		Failed:  summary.Failed,
+		Elapsed: time.Since(start),
+	})
+	return summary
+}
+
+func itemDonePhase(outcome string, err error) menubar.BulkRunPhase {
+	if err != nil || outcome == "failed" {
+		return menubar.BulkPhaseFailed
+	}
+	return menubar.BulkPhaseDone
+}
+
+func shortErrCode(errText string) string {
+	low := strings.ToLower(strings.TrimSpace(errText))
+	switch {
+	case low == "":
+		return "none"
+	case strings.Contains(low, "timeout"):
+		return "timeout"
+	case strings.Contains(low, "cancel"):
+		return "canceled"
+	case strings.Contains(low, "whisper"):
+		return "whisper"
+	case strings.Contains(low, "upload"):
+		return "upload"
+	case strings.Contains(low, "duplicate"):
+		return "duplicate"
+	case strings.Contains(low, "not found"):
+		return "not_found"
+	default:
+		return "error"
+	}
+}
+
+func baseName(pathOrName string) string {
+	if strings.TrimSpace(pathOrName) == "" {
+		return ""
+	}
+	return filepath.Base(pathOrName)
+}
+
+func actionBlockedDuringBulk(action menubar.ActionType) bool {
+	switch action {
+	case menubar.ActionFetchTranscript,
+		menubar.ActionCaptureScreenshot,
+		menubar.ActionQuickImpulse,
+		menubar.ActionRecordImpression,
+		menubar.ActionBatchImport:
+		return true
+	default:
+		return false
+	}
+}
+
+func formatBulkLog(evt menubar.BulkProgressEvent) string {
+	switch evt.Event {
+	case "RUN_START":
+		return fmt.Sprintf("[bulk][RUN_START] run_id=%s action=%s total=%d", evt.RunID, evt.Action, evt.Total)
+	case "ITEM_START":
+		return fmt.Sprintf("[bulk][ITEM_START] run_id=%s action=%s idx=%d/%d file=%q",
+			evt.RunID, evt.Action, evt.Index, evt.Total, evt.Item)
+	case "ITEM_PHASE":
+		return fmt.Sprintf("[bulk][PHASE] run_id=%s action=%s idx=%d/%d file=%q phase=%s",
+			evt.RunID, evt.Action, evt.Index, evt.Total, evt.Item, phaseLogToken(evt.Phase))
+	case "ITEM_DONE":
+		return fmt.Sprintf("[bulk][ITEM_DONE] run_id=%s action=%s idx=%d/%d file=%q outcome=%s err_code=%s elapsed=%s",
+			evt.RunID, evt.Action, evt.Index, evt.Total, evt.Item, evt.Outcome, shortErrCode(evt.Error), evt.Elapsed.Round(time.Millisecond))
+	case "RUN_DONE":
+		return fmt.Sprintf("[bulk][RUN_DONE] run_id=%s action=%s done=%d success=%d failed=%d elapsed=%s",
+			evt.RunID, evt.Action, evt.Done, evt.Success, evt.Failed, evt.Elapsed.Round(time.Millisecond))
+	default:
+		return fmt.Sprintf("[bulk][%s] run_id=%s action=%s", evt.Event, evt.RunID, evt.Action)
+	}
+}

--- a/cmd/m3c-tools/bulk_ops_test.go
+++ b/cmd/m3c-tools/bulk_ops_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/menubar"
+)
+
+func TestIngestionCoordinatorLocking(t *testing.T) {
+	c := newIngestionCoordinator()
+	start := menubar.BulkRunState{
+		RunID: "run-1",
+		Total: 3,
+	}
+	if ok := c.TryStart("bulk_transcribe_upload", start); !ok {
+		t.Fatal("first TryStart should succeed")
+	}
+	if ok := c.TryStart("bulk_reprocess", start); ok {
+		t.Fatal("second TryStart should fail while busy")
+	}
+
+	busy, state := c.IsBusy()
+	if !busy {
+		t.Fatal("coordinator should be busy after start")
+	}
+	if state.RunID != "run-1" {
+		t.Fatalf("run id = %q, want run-1", state.RunID)
+	}
+
+	c.Finish(state)
+	busy, _ = c.IsBusy()
+	if busy {
+		t.Fatal("coordinator should be unlocked after Finish")
+	}
+}
+
+func TestRunBulkSessionEventOrderAndCounters(t *testing.T) {
+	var events []menubar.BulkProgressEvent
+	emit := func(evt menubar.BulkProgressEvent) { events = append(events, evt) }
+	handler := func(index, total int, filename, status string, emit func(menubar.BulkProgressEvent)) (string, error) {
+		emit(menubar.BulkProgressEvent{
+			Event: "ITEM_PHASE",
+			Item:  filename,
+			Index: index,
+			Total: total,
+			Phase: menubar.BulkPhaseTranscribe,
+		})
+		if filename == "b.wav" {
+			return "failed", nil
+		}
+		return "ok", nil
+	}
+
+	summary := runBulkSession("run-2", "transcribe_upload",
+		[]string{"a.wav", "b.wav"}, []string{"new", "new"}, handler, emit)
+
+	if summary.Total != 2 || summary.Done != 2 || summary.Success != 1 || summary.Failed != 1 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+
+	if len(events) != 8 {
+		t.Fatalf("unexpected event count=%d, want 8", len(events))
+	}
+	if events[0].Event != "RUN_START" {
+		t.Fatalf("event[0]=%s, want RUN_START", events[0].Event)
+	}
+	if events[1].Event != "ITEM_START" || events[2].Event != "ITEM_PHASE" || events[3].Event != "ITEM_DONE" {
+		t.Fatalf("first item event order mismatch: %#v %#v %#v", events[1].Event, events[2].Event, events[3].Event)
+	}
+	if events[4].Event != "ITEM_START" || events[5].Event != "ITEM_PHASE" || events[6].Event != "ITEM_DONE" {
+		t.Fatalf("second item event order mismatch: %#v %#v %#v", events[4].Event, events[5].Event, events[6].Event)
+	}
+	if events[7].Event != "RUN_DONE" {
+		t.Fatalf("event[7]=%s, want RUN_DONE", events[7].Event)
+	}
+	if events[6].Outcome != "failed" {
+		t.Fatalf("second item outcome=%q, want failed", events[6].Outcome)
+	}
+}
+
+func TestFormatBulkLogIncludesMarkersAndRunID(t *testing.T) {
+	tests := []menubar.BulkProgressEvent{
+		{Event: "RUN_START", RunID: "run-3", Action: "transcribe_upload", Total: 3},
+		{Event: "ITEM_START", RunID: "run-3", Action: "transcribe_upload", Index: 1, Total: 3, Item: "a.wav"},
+		{Event: "ITEM_PHASE", RunID: "run-3", Action: "transcribe_upload", Index: 1, Total: 3, Item: "a.wav", Phase: menubar.BulkPhaseTranscribe},
+		{Event: "ITEM_DONE", RunID: "run-3", Action: "transcribe_upload", Index: 1, Total: 3, Item: "a.wav", Outcome: "ok", Elapsed: 2 * time.Second},
+		{Event: "RUN_DONE", RunID: "run-3", Action: "transcribe_upload", Done: 3, Success: 3, Failed: 0, Elapsed: 4 * time.Second},
+	}
+	for _, tc := range tests {
+		line := formatBulkLog(tc)
+		if !strings.Contains(line, "[bulk][") {
+			t.Fatalf("line missing marker: %q", line)
+		}
+		if !strings.Contains(line, "run_id=run-3") {
+			t.Fatalf("line missing run_id: %q", line)
+		}
+	}
+}

--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -2446,10 +2446,24 @@ func menubarFetchTranscriptAndTrack(app *menubar.App, fetcher *menubar.Transcrip
 		menubar.SetReviewTranscript("[Transcript unavailable — YouTube rate limit (429). Voice note recording is still available.]", "Transcript pull needed")
 	}
 
+	// Load transcript into the Notes field so it's visible in the Tags tab.
+	if result.Text != "" {
+		menubar.SetObservationNotes(result.Text)
+	}
+
 	app.SetStatus(menubar.StatusRecording)
 	menubar.StartRecordingTimer()
 	menubar.SetRecordSourceLabel("  video " + result.VideoID + "  ")
-	observationRecordAndUpload(app, "progress", thumbnailPath, imgData, impression.Progress)
+
+	obsCtx := ObservationContext{
+		TranscriptText: result.Text,
+		VideoID:        result.VideoID,
+		VideoURL:       "https://www.youtube.com/watch?v=" + result.VideoID,
+		Language:        result.Language,
+		LanguageCode:    result.LanguageCode,
+		SnippetCount:    result.SnippetCount,
+	}
+	observationRecordAndUpload(app, "progress", thumbnailPath, imgData, impression.Progress, obsCtx)
 
 	if result.RateLimited {
 		app.Notify("Observation Ready", fmt.Sprintf("⚠️ %s — transcript-pull-needed, voice tracker active", result.VideoID))
@@ -2611,10 +2625,29 @@ func menubarRecordImpression(app *menubar.App, videoID string) {
 	observationRecordAndUpload(app, "progress", imgPath, imgData, impression.Progress)
 }
 
+// ObservationContext carries optional pre-existing data into the recording
+// pipeline so that e.g. a YouTube transcript is not lost when whisper runs.
+type ObservationContext struct {
+	// Pre-existing transcript text (e.g. YouTube transcript).
+	// Preserved in the Review tab and included in the uploaded composite doc.
+	TranscriptText string
+	// Video metadata for Progress observations.
+	VideoID      string
+	VideoURL     string
+	Language     string
+	LanguageCode string
+	IsGenerated  bool
+	SnippetCount int
+}
+
 // observationRecordAndUpload starts background recording with VU meter and
 // registers the Stop/Store/Cancel callbacks for the Observation Window pipeline.
 // The Observation Window must already be shown before calling this function.
-func observationRecordAndUpload(app *menubar.App, label string, imgPath string, imgData []byte, obsType impression.ObservationType) {
+func observationRecordAndUpload(app *menubar.App, label string, imgPath string, imgData []byte, obsType impression.ObservationType, ctxData ...ObservationContext) {
+	var obsCtx ObservationContext
+	if len(ctxData) > 0 {
+		obsCtx = ctxData[0]
+	}
 	const maxRecordSeconds = 120
 
 	// Shared state written by stop callback, read by store callback.
@@ -2719,17 +2752,32 @@ func observationRecordAndUpload(app *menubar.App, label string, imgPath string, 
 		log.Printf("[%s] whisper DONE in %s: %d chars", label, whisperElapsed, len(text))
 		log.Printf("[%s] transcription: %q", label, text)
 
-		// Build structured memo text with metadata + transcript + notes section.
+		// Build structured memo text with metadata + voice comment + original transcript.
 		sizeKB := float64(wavSize) / 1024.0
 		peakPct := float64(stats.PeakAmplitude) / 32768.0 * 100
-		memo := fmt.Sprintf(
-			"--- Metadata ---\nChannel: %s\nDate: %s\nRecording: %.1fs, %.1f KB, peak %.0f%%\nWhisper: %s model, %d chars in %s\n\n--- Transcript ---\n%s\n\n--- Notes ---\n",
-			label,
-			time.Now().Format("2006-01-02 15:04:05"),
-			duration, sizeKB, peakPct,
-			model, len(text), whisperElapsed.Round(time.Millisecond),
-			text,
-		)
+		var memo string
+		if obsCtx.TranscriptText != "" {
+			// Preserve the original transcript (e.g. YouTube) and add the
+			// voice comment as a separate section — do NOT overwrite.
+			memo = fmt.Sprintf(
+				"--- Metadata ---\nChannel: %s\nDate: %s\nRecording: %.1fs, %.1f KB, peak %.0f%%\nWhisper: %s model, %d chars in %s\n\n--- Voice Comment ---\n%s\n\n--- Original Transcript ---\n%s\n\n--- Notes ---\n",
+				label,
+				time.Now().Format("2006-01-02 15:04:05"),
+				duration, sizeKB, peakPct,
+				model, len(text), whisperElapsed.Round(time.Millisecond),
+				text,
+				obsCtx.TranscriptText,
+			)
+		} else {
+			memo = fmt.Sprintf(
+				"--- Metadata ---\nChannel: %s\nDate: %s\nRecording: %.1fs, %.1f KB, peak %.0f%%\nWhisper: %s model, %d chars in %s\n\n--- Transcript ---\n%s\n\n--- Notes ---\n",
+				label,
+				time.Now().Format("2006-01-02 15:04:05"),
+				duration, sizeKB, peakPct,
+				model, len(text), whisperElapsed.Round(time.Millisecond),
+				text,
+			)
+		}
 		statusText := fmt.Sprintf("Memo — %d chars (editable)", len(memo))
 		menubar.SetReviewTranscript(memo, statusText)
 	})
@@ -2744,12 +2792,7 @@ func observationRecordAndUpload(app *menubar.App, label string, imgPath string, 
 			app.SetStatus(menubar.StatusRecording)
 			return
 		}
-		if len(uploadAudioData) == 0 {
-			log.Printf("[%s] store requested but upload audio is empty", label)
-			app.Notify("No Audio Available", "Please record again before storing.")
-			app.SetStatus(menubar.StatusError)
-			return
-		}
+		// Allow storing without audio — ER1 Upload sends a placeholder WAV automatically.
 
 		now := time.Now()
 		ts := now.Format("20060102_150405")
@@ -2762,6 +2805,13 @@ func observationRecordAndUpload(app *menubar.App, label string, imgPath string, 
 		memoText = mergeCaptureMemoAndNotes(memoText, notes)
 
 		doc := &impression.CompositeDoc{
+			VideoID:        obsCtx.VideoID,
+			VideoURL:       obsCtx.VideoURL,
+			Language:        obsCtx.Language,
+			LanguageCode:    obsCtx.LanguageCode,
+			IsGenerated:     obsCtx.IsGenerated,
+			SnippetCount:    obsCtx.SnippetCount,
+			TranscriptText:  obsCtx.TranscriptText,
 			ImpressionText: memoText,
 			ObsType:        obsType,
 			Timestamp:      now,
@@ -2867,6 +2917,20 @@ func captureScreenshotForMenu(app *menubar.App, flow string) (string, string, er
 	mode := screenshotCaptureMode()
 	switch mode {
 	case "clipboard-first":
+		// Check if there's already an image on the clipboard — use it directly.
+		if imgType, _ := screenshot.DetectClipboardImage(); imgType != screenshot.ClipboardNoImage {
+			outPath := filepath.Join(
+				os.TempDir(),
+				fmt.Sprintf("m3c-clipboard-%s.png", time.Now().Format("20060102-150405")),
+			)
+			imgPath, err := screenshot.ExtractClipboardImage(outPath)
+			if err == nil {
+				log.Printf("[%s] using existing clipboard image: %s", flow, imgPath)
+				return imgPath, "  from clipboard  ", nil
+			}
+			log.Printf("[%s] clipboard image extraction failed: %v; falling back to capture", flow, err)
+		}
+
 		timeout := clipboardCaptureTimeout()
 		app.Notify("Take Screenshot", fmt.Sprintf("Press Cmd+Ctrl+Shift+4 (waiting %ds)", int(timeout/time.Second)))
 		menubar.ResetCaptureHintCancelled()

--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -152,7 +152,8 @@ Commands:
     --silent               Suppress capture sound
     --hide-cursor          Hide cursor in capture
 
-  import-audio <dir>     Scan directory for audio files
+  import-audio <dir>     Scan/import audio files
+    --run                  Import, transcribe, upload, and tag end-to-end
     --extensions           List supported audio extensions
     --compact              Machine-readable output (TSV: status, path, size, tags)
     --db <path>            Tracking DB path (default: ~/.m3c-tools/tracking.db)
@@ -1074,11 +1075,14 @@ func cmdScreenshot(args []string) {
 func cmdImportAudio(args []string) {
 	showExtensions := false
 	compact := false
+	runPipeline := false
 	dbPath := defaultFilesDBPath()
 	dir := ""
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
+		case "--run":
+			runPipeline = true
 		case "--extensions":
 			showExtensions = true
 		case "--compact":
@@ -1108,7 +1112,7 @@ func cmdImportAudio(args []string) {
 	if dir == "" {
 		envDir := os.Getenv("IMPORT_AUDIO_SOURCE")
 		if envDir == "" {
-			fmt.Fprintln(os.Stderr, "Usage: m3c-tools import-audio <directory> [--extensions] [--compact] [--db <path>]")
+			fmt.Fprintln(os.Stderr, "Usage: m3c-tools import-audio <directory> [--run] [--extensions] [--compact] [--db <path>]")
 			fmt.Fprintln(os.Stderr, "  Or set IMPORT_AUDIO_SOURCE environment variable")
 			os.Exit(1)
 		}
@@ -1121,6 +1125,17 @@ func cmdImportAudio(args []string) {
 		if home, err := os.UserHomeDir(); err == nil {
 			dir = filepath.Join(home, dir[2:])
 		}
+	}
+
+	if runPipeline {
+		summary, err := runAudioImportPipeline(dir, dbPath, "", nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Import pipeline failed: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Import pipeline complete: imported=%d uploaded=%d failed=%d\n",
+			summary.Imported, summary.Uploaded, summary.Failed)
+		return
 	}
 
 	fmt.Printf("Scanning %s for audio files...\n", dir)
@@ -1156,6 +1171,122 @@ func cmdImportAudio(args []string) {
 	} else {
 		fmt.Print(importer.FormatScanOutput(entries, result.ScannedDir))
 	}
+}
+
+type audioImportRunSummary struct {
+	Scanned  int
+	Imported int
+	Uploaded int
+	Failed   int
+}
+
+func runAudioImportPipeline(sourceDir, dbPath, onlySourcePath string, app *menubar.App) (*audioImportRunSummary, error) {
+	cfg, err := importer.LoadImportConfig()
+	if err != nil {
+		return nil, fmt.Errorf("load import config: %w", err)
+	}
+	if sourceDir != "" {
+		cfg.AudioSource = sourceDir
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	filesDB, err := tracking.OpenFilesDB(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("open tracking db: %w", err)
+	}
+	defer filesDB.Close()
+
+	result, err := importer.ImportAudio(cfg, filesDB, nil)
+	if err != nil {
+		return nil, fmt.Errorf("import audio: %w", err)
+	}
+
+	summary := &audioImportRunSummary{
+		Scanned:  result.TotalScanned,
+		Imported: len(result.Imported),
+		Failed:   len(result.Failed),
+	}
+	if len(result.Imported) == 0 {
+		return summary, nil
+	}
+
+	normalizedOnly := strings.TrimSpace(onlySourcePath)
+	er1Cfg := er1.LoadConfig()
+	applyRuntimeER1Context(er1Cfg)
+
+	for _, imp := range result.Imported {
+		if normalizedOnly != "" && !samePath(imp.Source, normalizedOnly) {
+			continue
+		}
+		if app != nil {
+			app.SetStatus(menubar.StatusUploading)
+		}
+
+		audioData, readErr := os.ReadFile(imp.Dest)
+		if readErr != nil {
+			summary.Failed++
+			_ = filesDB.UpdateStatus(imp.Hash, "audio", "failed")
+			log.Printf("[import] failed reading imported audio: %s error=%v", imp.Dest, readErr)
+			continue
+		}
+
+		model := menubarWhisperModel()
+		lang := menubarWhisperLanguage()
+		timeout := menubarWhisperTimeout()
+		log.Printf("[import] whisper START source=%s model=%s language=%s", imp.Source, model, lang)
+		text, txErr := whisper.TranscribeTextWithTimeout(imp.Dest, model, lang, timeout)
+		if txErr != nil {
+			text = fmt.Sprintf("[Transcription failed: %v]", txErr)
+			log.Printf("[import] whisper FAIL source=%s error=%v", imp.Source, txErr)
+		} else {
+			log.Printf("[import] whisper DONE source=%s chars=%d", imp.Source, len(text))
+		}
+
+		now := time.Now()
+		doc := (&impression.CompositeDoc{
+			ObsType:        impression.Import,
+			Timestamp:      now,
+			TranscriptText: strings.TrimSpace(text),
+			ImpressionText: fmt.Sprintf("Imported audio file: %s\nSource: %s\nTags: %s", filepath.Base(imp.Dest), imp.Source, imp.Tags),
+		}).Build()
+
+		payload := &er1.UploadPayload{
+			TranscriptData:     []byte(strings.TrimSpace(doc) + "\n"),
+			TranscriptFilename: fmt.Sprintf("import_%s.txt", now.Format("20060102_150405")),
+			AudioData:          audioData,
+			AudioFilename:      filepath.Base(imp.Dest),
+			ImageData:          nil, // Upload layer injects app-logo placeholder for audio-import.
+			ImageFilename:      "placeholder-logo.png",
+			Tags:               imp.Tags,
+			ContentType:        cfg.ContentType,
+		}
+
+		resp, upErr := er1.Upload(er1Cfg, payload)
+		if upErr != nil {
+			summary.Failed++
+			_ = filesDB.UpdateStatus(imp.Hash, "audio", "failed")
+			_, _ = er1.HandleUploadFailure(er1.DefaultQueuePath(), er1.DefaultMemoryPath(), imp.MemoryID, payload, imp.Tags, upErr)
+			log.Printf("[import] upload FAIL source=%s error=%v", imp.Source, upErr)
+			continue
+		}
+
+		summary.Uploaded++
+		_ = filesDB.UpdateMemoryID(imp.Hash, "audio", resp.DocID)
+		log.Printf("[import] upload DONE source=%s doc_id=%s", imp.Source, resp.DocID)
+	}
+
+	if app != nil {
+		app.SetStatus(menubar.StatusIdle)
+	}
+	return summary, nil
+}
+
+func samePath(a, b string) bool {
+	aa, _ := filepath.Abs(strings.TrimSpace(a))
+	bb, _ := filepath.Abs(strings.TrimSpace(b))
+	return aa != "" && bb != "" && aa == bb
 }
 
 func defaultFilesDBPath() string {
@@ -1205,6 +1336,7 @@ func cmdMenubar(args []string) {
 		OnUploadER1: menubarUploadER1,
 	})
 	app.SetAuthSession(menubar.AuthSession{})
+	startAudioImportListRefresher(app)
 	if ctxID, err := loadPersistedER1Session(); err != nil {
 		log.Printf("[auth] persisted session load failed: %v", err)
 	} else if ctxID != "" {
@@ -1233,6 +1365,8 @@ func cmdMenubar(args []string) {
 			go menubarRecordImpression(app, data)
 		case menubar.ActionQuickImpulse:
 			go menubarQuickImpulse(app)
+		case menubar.ActionBatchImport:
+			go menubarHandleBatchImportAction(app, data)
 		case menubar.ActionLoginER1:
 			go menubarLoginER1(app)
 		case menubar.ActionLogoutER1:
@@ -1242,6 +1376,103 @@ func cmdMenubar(args []string) {
 
 	log.Printf("Launching menu bar app (title=%q, icon=%q, log=%q)", cfg.Title, cfg.IconPath, cfg.LogPath)
 	app.Run()
+}
+
+func startAudioImportListRefresher(app *menubar.App) {
+	refresh := func() {
+		state := buildAudioImportState()
+		app.SetAudioImportState(state)
+	}
+	refresh()
+	go func() {
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			refresh()
+		}
+	}()
+}
+
+func buildAudioImportState() menubar.AudioImportState {
+	state := menubar.AudioImportState{
+		UpdatedAt: time.Now(),
+	}
+	cfg, err := importer.LoadImportConfig()
+	if err != nil {
+		state.Error = "import config error"
+		log.Printf("[import] menu refresh config error: %v", err)
+		return state
+	}
+	if strings.TrimSpace(cfg.AudioSource) == "" {
+		state.Error = "IMPORT_AUDIO_SOURCE not set"
+		return state
+	}
+
+	filesDB, dbErr := tracking.OpenFilesDB(defaultFilesDBPath())
+	if dbErr != nil {
+		log.Printf("[import] menu refresh tracking db unavailable: %v", dbErr)
+	}
+	if filesDB != nil {
+		defer filesDB.Close()
+	}
+
+	scan, scanErr := importer.ScanDir(cfg.AudioSource)
+	if scanErr != nil {
+		state.Error = "scan failed"
+		log.Printf("[import] menu refresh scan error: %v", scanErr)
+		return state
+	}
+	entries, entriesErr := importer.BuildFileEntries(scan, importer.StatusCheckerFromDB(filesDB, "audio"))
+	if entriesErr != nil {
+		state.Error = "status build failed"
+		log.Printf("[import] menu refresh status error: %v", entriesErr)
+		return state
+	}
+
+	for _, e := range entries {
+		state.Items = append(state.Items, menubar.AudioImportItem{
+			Path:   e.File.Path,
+			Name:   e.File.Name,
+			Status: string(e.Status),
+			Size:   e.File.Size,
+			Tags:   strings.Join(e.Tags, ","),
+		})
+	}
+	return state
+}
+
+func menubarHandleBatchImportAction(app *menubar.App, data string) {
+	switch strings.TrimSpace(data) {
+	case "__refresh__":
+		app.SetAudioImportState(buildAudioImportState())
+		app.Notify("Audio Import", "List refreshed.")
+		return
+	case "__run_all__", "":
+		app.SetStatus(menubar.StatusUploading)
+		summary, err := runAudioImportPipeline("", defaultFilesDBPath(), "", app)
+		if err != nil {
+			app.SetStatus(menubar.StatusError)
+			app.Notify("Audio Import Failed", err.Error())
+			app.SetAudioImportState(buildAudioImportState())
+			return
+		}
+		app.SetStatus(menubar.StatusIdle)
+		app.Notify("Audio Import", fmt.Sprintf("Imported=%d Uploaded=%d Failed=%d", summary.Imported, summary.Uploaded, summary.Failed))
+		app.SetAudioImportState(buildAudioImportState())
+		return
+	default:
+		app.SetStatus(menubar.StatusUploading)
+		summary, err := runAudioImportPipeline("", defaultFilesDBPath(), data, app)
+		if err != nil {
+			app.SetStatus(menubar.StatusError)
+			app.Notify("Audio Import Failed", err.Error())
+			app.SetAudioImportState(buildAudioImportState())
+			return
+		}
+		app.SetStatus(menubar.StatusIdle)
+		app.Notify("Audio Import", fmt.Sprintf("Imported=%d Uploaded=%d Failed=%d", summary.Imported, summary.Uploaded, summary.Failed))
+		app.SetAudioImportState(buildAudioImportState())
+	}
 }
 
 func menubarLoginER1(app *menubar.App) {
@@ -1268,35 +1499,54 @@ func menubarLoginER1(app *menubar.App) {
 		return
 	}
 	app.Notify("ER1 Login", "Browser opened. Complete login to link account.")
+	deadline := time.NewTimer(2 * time.Minute)
+	defer deadline.Stop()
+	poll := time.NewTicker(1500 * time.Millisecond)
+	defer poll.Stop()
 
-	select {
-	case result := <-resultCh:
-		if result.Err != nil {
-			log.Printf("[auth] callback received error: %v", result.Err)
-			app.Notify("ER1 Login", "Login callback failed.")
+	for {
+		select {
+		case result := <-resultCh:
+			if result.Err != nil {
+				log.Printf("[auth] callback received error: %v", result.Err)
+				app.Notify("ER1 Login", "Login callback failed.")
+				return
+			}
+			ctxID := strings.TrimSpace(result.ContextID)
+			if ctxID == "" {
+				// Fallback: inspect Chrome tabs for memory URLs on ER1 host.
+				ctxID = menubar.SuggestedServiceContextID(baseURL)
+			}
+			if completeER1Login(app, ctxID) {
+				return
+			}
+			log.Printf("[auth] callback received but no context_id yet; continuing tab polling")
+		case <-poll.C:
+			ctxID := menubar.SuggestedServiceContextID(baseURL)
+			if completeER1Login(app, ctxID) {
+				return
+			}
+		case <-deadline.C:
+			log.Printf("[auth] login timed out waiting for callback/context; addr=%s", callbackServer.Addr)
+			app.Notify("ER1 Login", "Timed out waiting for login confirmation.")
 			return
 		}
-		ctxID := strings.TrimSpace(result.ContextID)
-		if ctxID == "" {
-			// Fallback: inspect Chrome tabs for memory URLs on ER1 host.
-			ctxID = menubar.SuggestedServiceContextID(baseURL)
-		}
-		if ctxID == "" {
-			log.Printf("[auth] login callback completed but no context_id detected")
-			app.Notify("ER1 Login", "Login succeeded, but context_id could not be detected.")
-			return
-		}
-		setRuntimeER1Login(ctxID)
-		app.SetAuthSession(menubar.AuthSession{LoggedIn: true, UserID: ctxID})
-		if err := savePersistedER1Session(ctxID); err != nil {
-			log.Printf("[auth] persist session failed: %v", err)
-		}
-		log.Printf("[auth] login success context_id=%s", ctxID)
-		app.Notify("ER1 Login", fmt.Sprintf("Linked account: %s", ctxID))
-	case <-time.After(2 * time.Minute):
-		log.Printf("[auth] login timed out waiting for callback; addr=%s", callbackServer.Addr)
-		app.Notify("ER1 Login", "Timed out waiting for login confirmation.")
 	}
+}
+
+func completeER1Login(app *menubar.App, contextID string) bool {
+	ctxID := strings.TrimSpace(contextID)
+	if ctxID == "" {
+		return false
+	}
+	setRuntimeER1Login(ctxID)
+	app.SetAuthSession(menubar.AuthSession{LoggedIn: true, UserID: ctxID})
+	if err := savePersistedER1Session(ctxID); err != nil {
+		log.Printf("[auth] persist session failed: %v", err)
+	}
+	log.Printf("[auth] login success context_id=%s", ctxID)
+	app.Notify("ER1 Login", fmt.Sprintf("Linked account: %s", ctxID))
+	return true
 }
 
 func menubarLogoutER1(app *menubar.App) {

--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -18,14 +18,19 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"net"
+	"net/http"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -156,6 +161,123 @@ Commands:
     --title <text>         Menu bar title (default: M3C)
     --icon <path>          Menu bar icon PNG path
     --log <path>           Log file path (default: /tmp/m3c-tools.log)`)
+}
+
+type er1SessionState struct {
+	mu        sync.RWMutex
+	contextID string
+	loggedIn  bool
+}
+
+type persistedER1Session struct {
+	ContextID string    `json:"context_id"`
+	SavedAt   time.Time `json:"saved_at"`
+}
+
+var runtimeER1Session er1SessionState
+
+func setRuntimeER1Login(contextID string) {
+	runtimeER1Session.mu.Lock()
+	defer runtimeER1Session.mu.Unlock()
+	runtimeER1Session.contextID = strings.TrimSpace(contextID)
+	runtimeER1Session.loggedIn = runtimeER1Session.contextID != ""
+}
+
+func clearRuntimeER1Login() {
+	runtimeER1Session.mu.Lock()
+	defer runtimeER1Session.mu.Unlock()
+	runtimeER1Session.contextID = ""
+	runtimeER1Session.loggedIn = false
+}
+
+func runtimeER1ContextID() string {
+	runtimeER1Session.mu.RLock()
+	defer runtimeER1Session.mu.RUnlock()
+	return runtimeER1Session.contextID
+}
+
+func applyRuntimeER1Context(cfg *er1.Config) {
+	if ctx := runtimeER1ContextID(); ctx != "" {
+		cfg.ContextID = ctx
+	}
+}
+
+func er1SessionPersistenceEnabled() bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv("M3C_ER1_SESSION_PERSIST")))
+	switch v {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func er1SessionFilePath() string {
+	if p := strings.TrimSpace(os.Getenv("M3C_ER1_SESSION_FILE")); p != "" {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, ".m3c-tools", "er1_session.json")
+}
+
+func savePersistedER1Session(contextID string) error {
+	if !er1SessionPersistenceEnabled() {
+		return nil
+	}
+	p := er1SessionFilePath()
+	if p == "" {
+		return fmt.Errorf("session file path is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return fmt.Errorf("create session dir: %w", err)
+	}
+	data, err := json.MarshalIndent(persistedER1Session{
+		ContextID: strings.TrimSpace(contextID),
+		SavedAt:   time.Now(),
+	}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode session json: %w", err)
+	}
+	if err := os.WriteFile(p, data, 0o600); err != nil {
+		return fmt.Errorf("write session file: %w", err)
+	}
+	return nil
+}
+
+func loadPersistedER1Session() (string, error) {
+	if !er1SessionPersistenceEnabled() {
+		return "", nil
+	}
+	p := er1SessionFilePath()
+	if p == "" {
+		return "", fmt.Errorf("session file path is empty")
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read session file: %w", err)
+	}
+	var s persistedER1Session
+	if err := json.Unmarshal(data, &s); err != nil {
+		return "", fmt.Errorf("parse session json: %w", err)
+	}
+	return strings.TrimSpace(s.ContextID), nil
+}
+
+func clearPersistedER1Session() error {
+	p := er1SessionFilePath()
+	if p == "" {
+		return nil
+	}
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove session file: %w", err)
+	}
+	return nil
 }
 
 // -- transcript command --
@@ -1082,6 +1204,14 @@ func cmdMenubar(args []string) {
 	app := menubar.NewAppWithConfig(cfg, menubar.Handlers{
 		OnUploadER1: menubarUploadER1,
 	})
+	app.SetAuthSession(menubar.AuthSession{})
+	if ctxID, err := loadPersistedER1Session(); err != nil {
+		log.Printf("[auth] persisted session load failed: %v", err)
+	} else if ctxID != "" {
+		setRuntimeER1Login(ctxID)
+		app.SetAuthSession(menubar.AuthSession{LoggedIn: true, UserID: ctxID})
+		log.Printf("[auth] restored persisted session context_id=%s", ctxID)
+	}
 	menubar.StartFrontmostAppTracker()
 	if exe, err := os.Executable(); err == nil {
 		log.Printf("[diag] pid=%d exe=%q screen_access=%v screenshot_mode=%s", os.Getpid(), exe, menubar.HasScreenCaptureAccess(), screenshotCaptureMode())
@@ -1103,11 +1233,148 @@ func cmdMenubar(args []string) {
 			go menubarRecordImpression(app, data)
 		case menubar.ActionQuickImpulse:
 			go menubarQuickImpulse(app)
+		case menubar.ActionLoginER1:
+			go menubarLoginER1(app)
+		case menubar.ActionLogoutER1:
+			go menubarLogoutER1(app)
 		}
 	}
 
 	log.Printf("Launching menu bar app (title=%q, icon=%q, log=%q)", cfg.Title, cfg.IconPath, cfg.LogPath)
 	app.Run()
+}
+
+func menubarLoginER1(app *menubar.App) {
+	cfg := er1.LoadConfig()
+	baseURL := er1BaseURL(cfg.APIURL)
+	if baseURL == "" {
+		app.Notify("ER1 Login", "Could not derive ER1 base URL from ER1_API_URL.")
+		return
+	}
+
+	callbackServer, callbackURL, resultCh, closeFn, err := startER1LoginCallbackServer()
+	if err != nil {
+		log.Printf("[auth] login callback server start failed: %v", err)
+		app.Notify("ER1 Login", "Could not start login callback listener.")
+		return
+	}
+	defer closeFn()
+
+	loginURL := fmt.Sprintf("%s/login/multi?next=%s", baseURL, neturl.QueryEscape(callbackURL))
+	log.Printf("[auth] login start base=%s callback=%s", baseURL, callbackURL)
+	if err := openURL(loginURL); err != nil {
+		log.Printf("[auth] failed to open login URL: %v", err)
+		app.Notify("ER1 Login", "Failed to open login page in browser.")
+		return
+	}
+	app.Notify("ER1 Login", "Browser opened. Complete login to link account.")
+
+	select {
+	case result := <-resultCh:
+		if result.Err != nil {
+			log.Printf("[auth] callback received error: %v", result.Err)
+			app.Notify("ER1 Login", "Login callback failed.")
+			return
+		}
+		ctxID := strings.TrimSpace(result.ContextID)
+		if ctxID == "" {
+			// Fallback: inspect Chrome tabs for memory URLs on ER1 host.
+			ctxID = menubar.SuggestedServiceContextID(baseURL)
+		}
+		if ctxID == "" {
+			log.Printf("[auth] login callback completed but no context_id detected")
+			app.Notify("ER1 Login", "Login succeeded, but context_id could not be detected.")
+			return
+		}
+		setRuntimeER1Login(ctxID)
+		app.SetAuthSession(menubar.AuthSession{LoggedIn: true, UserID: ctxID})
+		if err := savePersistedER1Session(ctxID); err != nil {
+			log.Printf("[auth] persist session failed: %v", err)
+		}
+		log.Printf("[auth] login success context_id=%s", ctxID)
+		app.Notify("ER1 Login", fmt.Sprintf("Linked account: %s", ctxID))
+	case <-time.After(2 * time.Minute):
+		log.Printf("[auth] login timed out waiting for callback; addr=%s", callbackServer.Addr)
+		app.Notify("ER1 Login", "Timed out waiting for login confirmation.")
+	}
+}
+
+func menubarLogoutER1(app *menubar.App) {
+	clearRuntimeER1Login()
+	app.SetAuthSession(menubar.AuthSession{})
+	if err := clearPersistedER1Session(); err != nil {
+		log.Printf("[auth] persisted session clear failed: %v", err)
+	}
+	app.Notify("ER1 Logout", "Session cleared. Uploads use ER1_CONTEXT_ID until you login again.")
+	log.Printf("[auth] logout complete; runtime session cleared")
+}
+
+type loginCallbackResult struct {
+	ContextID string
+	Err       error
+}
+
+func startER1LoginCallbackServer() (*http.Server, string, <-chan loginCallbackResult, func(), error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, "", nil, nil, err
+	}
+	addr := ln.Addr().String()
+	callbackURL := "http://" + addr + "/m3c-login-success"
+	resultCh := make(chan loginCallbackResult, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/m3c-login-success", func(w http.ResponseWriter, r *http.Request) {
+		ctxID := strings.TrimSpace(r.URL.Query().Get("context_id"))
+		if ctxID == "" {
+			ctxID = strings.TrimSpace(r.URL.Query().Get("user_id"))
+		}
+		if ctxID == "" {
+			ctxID = strings.TrimSpace(r.URL.Query().Get("uid"))
+		}
+		select {
+		case resultCh <- loginCallbackResult{ContextID: ctxID}:
+		default:
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprint(w, "<html><body><h3>Login captured.</h3><p>You can return to M3C Tools.</p></body></html>")
+	})
+
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+	go func() {
+		if serveErr := srv.Serve(ln); serveErr != nil && serveErr != http.ErrServerClosed {
+			log.Printf("[auth] callback server error: %v", serveErr)
+			select {
+			case resultCh <- loginCallbackResult{Err: serveErr}:
+			default:
+			}
+		}
+	}()
+	closeFn := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}
+	return srv, callbackURL, resultCh, closeFn, nil
+}
+
+func er1BaseURL(apiURL string) string {
+	raw := strings.TrimSpace(apiURL)
+	if raw == "" {
+		return ""
+	}
+	u, err := neturl.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	p := strings.TrimSuffix(u.Path, "/upload_2")
+	p = strings.TrimSuffix(p, "/")
+	u.Path = p
+	u.RawQuery = ""
+	u.Fragment = ""
+	return strings.TrimSuffix(u.String(), "/")
 }
 
 // menubarFetchTranscriptAndTrack fetches YouTube transcript context, opens a
@@ -1229,6 +1496,7 @@ func menubarUploadER1(videoID string) (*menubar.ER1UploadResult, error) {
 
 	// Upload
 	cfg := er1.LoadConfig()
+	applyRuntimeER1Context(cfg)
 	resp, err := er1.Upload(cfg, payload)
 	if err != nil {
 		// Queue for retry on failure
@@ -1530,6 +1798,7 @@ func mergeCaptureMemoAndNotes(memo, notes string) string {
 // On success, opens the uploaded item in the default browser.
 func menubarUploadPayload(app *menubar.App, label string, payload *er1.UploadPayload, tags string) {
 	cfg := er1.LoadConfig()
+	applyRuntimeER1Context(cfg)
 	resp, err := er1.Upload(cfg, payload)
 	if err != nil {
 		log.Printf("[%s] ER1 upload failed (queuing): %v", label, err)

--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -28,6 +29,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -44,6 +46,13 @@ import (
 	"github.com/kamir/m3c-tools/pkg/transcript"
 	"github.com/kamir/m3c-tools/pkg/whisper"
 )
+
+func init() {
+	// macOS AppKit requires all UI operations on the main OS thread (thread 1).
+	// Go 1.26+ no longer guarantees the main goroutine runs on thread 1,
+	// so we must lock it explicitly.
+	runtime.LockOSThread()
+}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -176,6 +185,7 @@ type persistedER1Session struct {
 }
 
 var runtimeER1Session er1SessionState
+var ingestionOps = newIngestionCoordinator()
 
 func setRuntimeER1Login(contextID string) {
 	runtimeER1Session.mu.Lock()
@@ -1128,7 +1138,7 @@ func cmdImportAudio(args []string) {
 	}
 
 	if runPipeline {
-		summary, err := runAudioImportPipeline(dir, dbPath, "", nil)
+		summary, err := runAudioImportPipeline(dir, dbPath, "", nil, nil)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Import pipeline failed: %v\n", err)
 			os.Exit(1)
@@ -1180,7 +1190,7 @@ type audioImportRunSummary struct {
 	Failed   int
 }
 
-func runAudioImportPipeline(sourceDir, dbPath, onlySourcePath string, app *menubar.App) (*audioImportRunSummary, error) {
+func runAudioImportPipeline(sourceDir, dbPath, onlySourcePath string, app *menubar.App, onProgress func(menubar.BulkProgressEvent)) (*audioImportRunSummary, error) {
 	cfg, err := importer.LoadImportConfig()
 	if err != nil {
 		return nil, fmt.Errorf("load import config: %w", err)
@@ -1198,7 +1208,9 @@ func runAudioImportPipeline(sourceDir, dbPath, onlySourcePath string, app *menub
 	}
 	defer filesDB.Close()
 
-	result, err := importer.ImportAudio(cfg, filesDB, nil)
+	normalizedOnly := strings.TrimSpace(onlySourcePath)
+
+	result, err := importer.ImportAudioFiltered(cfg, filesDB, nil, normalizedOnly)
 	if err != nil {
 		return nil, fmt.Errorf("import audio: %w", err)
 	}
@@ -1212,13 +1224,32 @@ func runAudioImportPipeline(sourceDir, dbPath, onlySourcePath string, app *menub
 		return summary, nil
 	}
 
-	normalizedOnly := strings.TrimSpace(onlySourcePath)
 	er1Cfg := er1.LoadConfig()
 	applyRuntimeER1Context(er1Cfg)
+	totalItems := len(result.Imported)
+	processedItems := 0
 
 	for _, imp := range result.Imported {
-		if normalizedOnly != "" && !samePath(imp.Source, normalizedOnly) {
-			continue
+		processedItems++
+		if onProgress != nil {
+			onProgress(menubar.BulkProgressEvent{
+				Event:       "ITEM_START",
+				Item:        filepath.Base(imp.Source),
+				Index:       processedItems,
+				Total:       totalItems,
+				CurrentFile: filepath.Base(imp.Source),
+				Phase:       menubar.BulkPhaseQueued,
+			})
+		}
+		if onProgress != nil {
+			onProgress(menubar.BulkProgressEvent{
+				Event:       "ITEM_PHASE",
+				Item:        filepath.Base(imp.Source),
+				Index:       processedItems,
+				Total:       totalItems,
+				Phase:       menubar.BulkPhaseImport,
+				CurrentFile: filepath.Base(imp.Source),
+			})
 		}
 		if app != nil {
 			app.SetStatus(menubar.StatusUploading)
@@ -1229,12 +1260,37 @@ func runAudioImportPipeline(sourceDir, dbPath, onlySourcePath string, app *menub
 			summary.Failed++
 			_ = filesDB.UpdateStatus(imp.Hash, "audio", "failed")
 			log.Printf("[import] failed reading imported audio: %s error=%v", imp.Dest, readErr)
+			if onProgress != nil {
+				onProgress(menubar.BulkProgressEvent{
+					Event:       "ITEM_DONE",
+					Item:        filepath.Base(imp.Source),
+					Index:       processedItems,
+					Total:       totalItems,
+					Outcome:     "failed",
+					Error:       readErr.Error(),
+					Done:        processedItems,
+					Success:     summary.Uploaded,
+					Failed:      summary.Failed,
+					CurrentFile: filepath.Base(imp.Source),
+					Phase:       menubar.BulkPhaseFailed,
+				})
+			}
 			continue
 		}
 
 		model := menubarWhisperModel()
 		lang := menubarWhisperLanguage()
 		timeout := menubarWhisperTimeout()
+		if onProgress != nil {
+			onProgress(menubar.BulkProgressEvent{
+				Event:       "ITEM_PHASE",
+				Item:        filepath.Base(imp.Source),
+				Index:       processedItems,
+				Total:       totalItems,
+				Phase:       menubar.BulkPhaseTranscribe,
+				CurrentFile: filepath.Base(imp.Source),
+			})
+		}
 		log.Printf("[import] whisper START source=%s model=%s language=%s", imp.Source, model, lang)
 		text, txErr := whisper.TranscribeTextWithTimeout(imp.Dest, model, lang, timeout)
 		if txErr != nil {
@@ -1243,6 +1299,9 @@ func runAudioImportPipeline(sourceDir, dbPath, onlySourcePath string, app *menub
 		} else {
 			log.Printf("[import] whisper DONE source=%s chars=%d", imp.Source, len(text))
 		}
+
+		// Record transcript details in DB.
+		_ = filesDB.RecordTranscript(imp.Hash, "audio", strings.TrimSpace(text), lang)
 
 		now := time.Now()
 		doc := (&impression.CompositeDoc{
@@ -1263,18 +1322,57 @@ func runAudioImportPipeline(sourceDir, dbPath, onlySourcePath string, app *menub
 			ContentType:        cfg.ContentType,
 		}
 
+		if onProgress != nil {
+			onProgress(menubar.BulkProgressEvent{
+				Event:       "ITEM_PHASE",
+				Item:        filepath.Base(imp.Source),
+				Index:       processedItems,
+				Total:       totalItems,
+				Phase:       menubar.BulkPhaseUpload,
+				CurrentFile: filepath.Base(imp.Source),
+			})
+		}
 		resp, upErr := er1.Upload(er1Cfg, payload)
 		if upErr != nil {
 			summary.Failed++
-			_ = filesDB.UpdateStatus(imp.Hash, "audio", "failed")
+			_ = filesDB.RecordUploadError(imp.Hash, "audio", upErr.Error())
 			_, _ = er1.HandleUploadFailure(er1.DefaultQueuePath(), er1.DefaultMemoryPath(), imp.MemoryID, payload, imp.Tags, upErr)
 			log.Printf("[import] upload FAIL source=%s error=%v", imp.Source, upErr)
+			if onProgress != nil {
+				onProgress(menubar.BulkProgressEvent{
+					Event:       "ITEM_DONE",
+					Item:        filepath.Base(imp.Source),
+					Index:       processedItems,
+					Total:       totalItems,
+					Outcome:     "failed",
+					Error:       upErr.Error(),
+					Done:        processedItems,
+					Success:     summary.Uploaded,
+					Failed:      summary.Failed,
+					CurrentFile: filepath.Base(imp.Source),
+					Phase:       menubar.BulkPhaseFailed,
+				})
+			}
 			continue
 		}
 
 		summary.Uploaded++
-		_ = filesDB.UpdateMemoryID(imp.Hash, "audio", resp.DocID)
+		_ = filesDB.RecordUploadSuccess(imp.Hash, "audio", resp.DocID)
 		log.Printf("[import] upload DONE source=%s doc_id=%s", imp.Source, resp.DocID)
+		if onProgress != nil {
+			onProgress(menubar.BulkProgressEvent{
+				Event:       "ITEM_DONE",
+				Item:        filepath.Base(imp.Source),
+				Index:       processedItems,
+				Total:       totalItems,
+				Outcome:     "ok",
+				Done:        processedItems,
+				Success:     summary.Uploaded,
+				Failed:      summary.Failed,
+				CurrentFile: filepath.Base(imp.Source),
+				Phase:       menubar.BulkPhaseDone,
+			})
+		}
 	}
 
 	if app != nil {
@@ -1283,10 +1381,198 @@ func runAudioImportPipeline(sourceDir, dbPath, onlySourcePath string, app *menub
 	return summary, nil
 }
 
-func samePath(a, b string) bool {
-	aa, _ := filepath.Abs(strings.TrimSpace(a))
-	bb, _ := filepath.Abs(strings.TrimSpace(b))
-	return aa != "" && bb != "" && aa == bb
+// reprocessAudioFile re-transcribes and re-uploads an already-tracked file.
+// If the file has an existing doc_id, it passes it to ER1 for overwrite;
+// otherwise a fresh document is created. The DB record is updated in place.
+func reprocessAudioFile(srcPath, dbPath string, app *menubar.App, onProgress func(menubar.BulkProgressEvent)) error {
+	cfg, err := importer.LoadImportConfig()
+	if err != nil {
+		return fmt.Errorf("load import config: %w", err)
+	}
+
+	filesDB, err := tracking.OpenFilesDB(dbPath)
+	if err != nil {
+		return fmt.Errorf("open tracking db: %w", err)
+	}
+	defer filesDB.Close()
+
+	absPath, _ := filepath.Abs(strings.TrimSpace(srcPath))
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return fmt.Errorf("file not found: %s", srcPath)
+	}
+	if onProgress != nil {
+		onProgress(menubar.BulkProgressEvent{
+			Event:       "ITEM_PHASE",
+			Item:        info.Name(),
+			Phase:       menubar.BulkPhaseReprocess,
+			CurrentFile: info.Name(),
+		})
+	}
+
+	// Look up existing DB record by path.
+	existing, _ := filesDB.GetByPath(absPath)
+	existingDocID := ""
+	existingHash := ""
+	if existing != nil {
+		existingDocID = existing.UploadDocID
+		existingHash = existing.FileHash
+		log.Printf("[reprocess] found existing record: hash=%s doc_id=%q status=%s",
+			existingHash[:min(12, len(existingHash))], existingDocID, existing.Status)
+	}
+
+	// Compute hash of source file.
+	hash, err := tracking.HashFile(absPath)
+	if err != nil {
+		return fmt.Errorf("hash file: %w", err)
+	}
+
+	// Resolve destination directory.
+	destDir, err := cfg.DestDir()
+	if err != nil {
+		return fmt.Errorf("resolve dest: %w", err)
+	}
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("create dest dir: %w", err)
+	}
+
+	// Create a new MEMORY folder and copy the file.
+	now := time.Now()
+	memoryID := fmt.Sprintf("MEMORY-%s", now.Format("20060102-150405"))
+	memoryPath := filepath.Join(destDir, memoryID)
+	for i := 1; ; i++ {
+		if _, statErr := os.Stat(memoryPath); os.IsNotExist(statErr) {
+			break
+		}
+		memoryID = fmt.Sprintf("MEMORY-%s-%d", now.Format("20060102-150405"), i)
+		memoryPath = filepath.Join(destDir, memoryID)
+		if i > 100 {
+			return fmt.Errorf("could not create unique MEMORY folder")
+		}
+	}
+	if err := os.MkdirAll(memoryPath, 0755); err != nil {
+		return fmt.Errorf("create memory folder: %w", err)
+	}
+
+	destFile := filepath.Join(memoryPath, info.Name())
+	srcF, err := os.Open(absPath)
+	if err != nil {
+		return fmt.Errorf("open source: %w", err)
+	}
+	dstF, err := os.Create(destFile)
+	if err != nil {
+		_ = srcF.Close()
+		return fmt.Errorf("create dest: %w", err)
+	}
+	_, cpErr := io.Copy(dstF, srcF)
+	_ = srcF.Close()
+	_ = dstF.Close()
+	if cpErr != nil {
+		return fmt.Errorf("copy file: %w", cpErr)
+	}
+
+	// Ensure a DB record exists for this file (upsert).
+	if existing == nil {
+		// No existing record — create one.
+		if _, recErr := filesDB.RecordFile(absPath, hash, info.Size(), "audio", memoryID); recErr != nil {
+			return fmt.Errorf("record file: %w", recErr)
+		}
+		existingHash = hash
+	}
+
+	// Update status to indicate re-processing.
+	_ = filesDB.UpdateStatus(existingHash, "audio", "imported")
+
+	if app != nil {
+		app.SetStatus(menubar.StatusUploading)
+	}
+
+	// Read the copied file for whisper + upload.
+	audioData, err := os.ReadFile(destFile)
+	if err != nil {
+		return fmt.Errorf("read audio: %w", err)
+	}
+
+	// Transcribe via whisper.
+	model := menubarWhisperModel()
+	lang := menubarWhisperLanguage()
+	timeout := menubarWhisperTimeout()
+	if onProgress != nil {
+		onProgress(menubar.BulkProgressEvent{
+			Event:       "ITEM_PHASE",
+			Item:        info.Name(),
+			Phase:       menubar.BulkPhaseTranscribe,
+			CurrentFile: info.Name(),
+		})
+	}
+	log.Printf("[reprocess] whisper START source=%s model=%s language=%s", info.Name(), model, lang)
+	text, txErr := whisper.TranscribeTextWithTimeout(destFile, model, lang, timeout)
+	if txErr != nil {
+		log.Printf("[reprocess] whisper FAIL source=%s error=%v", info.Name(), txErr)
+		_ = filesDB.UpdateStatus(existingHash, "audio", "whisper-error")
+		if app != nil {
+			app.SetStatus(menubar.StatusIdle)
+		}
+		return fmt.Errorf("whisper: %w", txErr)
+	}
+	log.Printf("[reprocess] whisper DONE source=%s chars=%d", info.Name(), len(text))
+
+	_ = filesDB.RecordTranscript(existingHash, "audio", strings.TrimSpace(text), lang)
+
+	// Build upload payload.
+	parsedInfo := impression.ParseFilename(info.Name())
+	tags := impression.BuildImportTags(parsedInfo.Tags)
+
+	doc := (&impression.CompositeDoc{
+		ObsType:        impression.Import,
+		Timestamp:      now,
+		TranscriptText: strings.TrimSpace(text),
+		ImpressionText: fmt.Sprintf("Re-processed audio file: %s\nSource: %s\nTags: %s", info.Name(), absPath, tags),
+	}).Build()
+
+	er1Cfg := er1.LoadConfig()
+	applyRuntimeER1Context(er1Cfg)
+
+	payload := &er1.UploadPayload{
+		TranscriptData:     []byte(strings.TrimSpace(doc) + "\n"),
+		TranscriptFilename: fmt.Sprintf("reprocess_%s.txt", now.Format("20060102_150405")),
+		AudioData:          audioData,
+		AudioFilename:      info.Name(),
+		Tags:               tags,
+		ContentType:        cfg.ContentType,
+		DocID:              existingDocID, // Reuse existing doc_id if available.
+	}
+
+	if existingDocID != "" {
+		log.Printf("[reprocess] upload START reusing doc_id=%s", existingDocID)
+	} else {
+		log.Printf("[reprocess] upload START (new document)")
+	}
+	if onProgress != nil {
+		onProgress(menubar.BulkProgressEvent{
+			Event:       "ITEM_PHASE",
+			Item:        info.Name(),
+			Phase:       menubar.BulkPhaseUpload,
+			CurrentFile: info.Name(),
+		})
+	}
+
+	resp, upErr := er1.Upload(er1Cfg, payload)
+	if upErr != nil {
+		_ = filesDB.RecordUploadError(existingHash, "audio", upErr.Error())
+		if app != nil {
+			app.SetStatus(menubar.StatusIdle)
+		}
+		return fmt.Errorf("upload: %w", upErr)
+	}
+
+	_ = filesDB.RecordUploadSuccess(existingHash, "audio", resp.DocID)
+	log.Printf("[reprocess] upload DONE source=%s doc_id=%s", info.Name(), resp.DocID)
+
+	if app != nil {
+		app.SetStatus(menubar.StatusIdle)
+	}
+	return nil
 }
 
 func defaultFilesDBPath() string {
@@ -1334,6 +1620,30 @@ func cmdMenubar(args []string) {
 
 	app := menubar.NewAppWithConfig(cfg, menubar.Handlers{
 		OnUploadER1: menubarUploadER1,
+		ListTrackingRecords: func(limit int) ([]menubar.TrackingRecord, error) {
+			db, err := tracking.OpenFilesDB(defaultFilesDBPath())
+			if err != nil {
+				return nil, err
+			}
+			defer db.Close()
+			files, err := db.ListFiles(limit)
+			if err != nil {
+				return nil, err
+			}
+			records := make([]menubar.TrackingRecord, len(files))
+			for i, f := range files {
+				records[i] = menubar.TrackingRecord{
+					FileName:       filepath.Base(f.FilePath),
+					Status:         f.Status,
+					TranscriptLen:  f.TranscriptLen,
+					TranscriptLang: f.TranscriptLang,
+					UploadDocID:    f.UploadDocID,
+					UploadError:    f.UploadError,
+					ProcessedAt:    f.ProcessedAt.Format("2006-01-02 15:04"),
+				}
+			}
+			return records, nil
+		},
 	})
 	app.SetAuthSession(menubar.AuthSession{})
 	startAudioImportListRefresher(app)
@@ -1353,6 +1663,18 @@ func cmdMenubar(args []string) {
 	// Wire OnAction to dispatch menu actions to real implementations.
 	app.Handlers.OnAction = func(action menubar.ActionType, data string) {
 		log.Printf("[menubar] action=%s data=%q", action, data)
+		if actionBlockedDuringBulk(action) {
+			if busy, state := ingestionOps.IsBusy(); busy {
+				remaining := state.Total - state.Done
+				if remaining < 0 {
+					remaining = 0
+				}
+				msg := fmt.Sprintf("Bulk run active (%d/%d, %d remaining). Please wait.", state.Done, state.Total, remaining)
+				app.Notify("Ingestion Busy", msg)
+				app.SetLastImportMessage("⏳ " + msg)
+				return
+			}
+		}
 		switch action {
 		case menubar.ActionFetchTranscript:
 			go menubarFetchTranscriptAndTrack(app, fetcher, data)
@@ -1371,8 +1693,26 @@ func cmdMenubar(args []string) {
 			go menubarLoginER1(app)
 		case menubar.ActionLogoutER1:
 			go menubarLogoutER1(app)
+		case menubar.ActionShowTrackingDB:
+			go menubarShowTrackingDB()
 		}
 	}
+
+	// Register bulk-action callback for tracking window buttons.
+	menubar.SetTrackingBulkCallback(func(action string, filenames []string, statuses []string) {
+		if busy, state := ingestionOps.IsBusy(); busy {
+			remaining := state.Total - state.Done
+			if remaining < 0 {
+				remaining = 0
+			}
+			app.Notify("Ingestion Busy",
+				fmt.Sprintf("Bulk run active (%d/%d, %d remaining). Please wait.", state.Done, state.Total, remaining))
+			return
+		}
+		go runTrackingBulkAction(app, action, filenames, statuses)
+		// Refresh the tracking window data after bulk ops.
+		go menubarShowTrackingDB()
+	})
 
 	log.Printf("Launching menu bar app (title=%q, icon=%q, log=%q)", cfg.Title, cfg.IconPath, cfg.LogPath)
 	app.Run()
@@ -1422,7 +1762,9 @@ func buildAudioImportState() menubar.AudioImportState {
 		log.Printf("[import] menu refresh scan error: %v", scanErr)
 		return state
 	}
-	entries, entriesErr := importer.BuildFileEntries(scan, importer.StatusCheckerFromDB(filesDB, "audio"))
+
+	checker := importer.StatusCheckerFromDB(filesDB, "audio")
+	entries, entriesErr := importer.BuildFileEntries(scan, checker)
 	if entriesErr != nil {
 		state.Error = "status build failed"
 		log.Printf("[import] menu refresh status error: %v", entriesErr)
@@ -1442,37 +1784,453 @@ func buildAudioImportState() menubar.AudioImportState {
 }
 
 func menubarHandleBatchImportAction(app *menubar.App, data string) {
+	if busy, state := ingestionOps.IsBusy(); busy {
+		remaining := state.Total - state.Done
+		if remaining < 0 {
+			remaining = 0
+		}
+		msg := fmt.Sprintf("Bulk run active (%d/%d, %d remaining). Please wait.", state.Done, state.Total, remaining)
+		app.Notify("Ingestion Busy", msg)
+		app.SetLastImportMessage("⏳ " + msg)
+		return
+	}
+
 	switch strings.TrimSpace(data) {
 	case "__refresh__":
+		log.Printf("[import] refreshing audio import list...")
 		app.SetAudioImportState(buildAudioImportState())
+		log.Printf("[import] list refreshed")
 		app.Notify("Audio Import", "List refreshed.")
 		return
 	case "__run_all__", "":
+		log.Printf("[import] starting batch import (all new files)...")
+		totalNew := 0
+		for _, it := range app.GetAudioImportState().Items {
+			if strings.EqualFold(strings.TrimSpace(it.Status), "new") {
+				totalNew++
+			}
+		}
+		startedAt := time.Now()
+		runID := startedAt.Format("20060102-150405.000")
+		startState := menubar.BulkRunState{
+			Active:    true,
+			RunID:     runID,
+			Action:    "menu_import_all",
+			Total:     totalNew,
+			StartedAt: startedAt,
+			Phase:     menubar.BulkPhaseQueued,
+		}
+		if !ingestionOps.TryStart("menu_import_all", startState) {
+			if busy, state := ingestionOps.IsBusy(); busy {
+				remaining := state.Total - state.Done
+				if remaining < 0 {
+					remaining = 0
+				}
+				msg := fmt.Sprintf("Bulk run active (%d/%d, %d remaining). Please wait.", state.Done, state.Total, remaining)
+				app.Notify("Ingestion Busy", msg)
+				app.SetLastImportMessage("⏳ " + msg)
+			}
+			return
+		}
+		app.SetBulkRunState(startState)
+		menubar.SetTrackingBulkProgress(startState)
+		app.SetLastImportMessage("⏳ Importing…")
 		app.SetStatus(menubar.StatusUploading)
-		summary, err := runAudioImportPipeline("", defaultFilesDBPath(), "", app)
+
+		onProgress := func(evt menubar.BulkProgressEvent) {
+			state := app.GetBulkRunState()
+			if state.RunID != runID {
+				state = startState
+			}
+			if evt.Total > 0 {
+				state.Total = evt.Total
+			}
+			if evt.CurrentFile != "" {
+				state.CurrentFile = evt.CurrentFile
+			}
+			if evt.Phase != "" {
+				state.Phase = evt.Phase
+			}
+			if evt.Event == "ITEM_DONE" {
+				state.Done = evt.Done
+				state.Success = evt.Success
+				state.Failed = evt.Failed
+				if evt.Error != "" {
+					state.LastError = evt.Error
+				}
+			}
+			state.Active = true
+			ingestionOps.Update(state)
+			app.SetBulkRunState(state)
+			menubar.SetTrackingBulkProgress(state)
+		}
+
+		summary, err := runAudioImportPipeline("", defaultFilesDBPath(), "", app, onProgress)
 		if err != nil {
+			log.Printf("[import] batch import FAILED: %v", err)
+			final := app.GetBulkRunState()
+			final.Active = false
+			final.Phase = menubar.BulkPhaseFailed
+			final.LastError = err.Error()
+			ingestionOps.Finish(final)
+			app.SetBulkRunState(final)
+			menubar.SetTrackingBulkProgress(final)
+			app.SetLastImportMessage("❌ " + err.Error())
 			app.SetStatus(menubar.StatusError)
 			app.Notify("Audio Import Failed", err.Error())
 			app.SetAudioImportState(buildAudioImportState())
 			return
 		}
+		final := app.GetBulkRunState()
+		final.Active = false
+		final.Done = summary.Imported
+		final.Success = summary.Uploaded
+		final.Failed = summary.Failed
+		if final.Total == 0 {
+			final.Total = summary.Imported
+		}
+		if final.Failed > 0 {
+			final.Phase = menubar.BulkPhaseFailed
+		} else {
+			final.Phase = menubar.BulkPhaseDone
+		}
+		ingestionOps.Finish(final)
+		app.SetBulkRunState(final)
+		menubar.SetTrackingBulkProgress(final)
+		msg := fmt.Sprintf("✅ Imported=%d Uploaded=%d Failed=%d", summary.Imported, summary.Uploaded, summary.Failed)
+		log.Printf("[import] batch import DONE: %s", msg)
+		app.SetLastImportMessage(msg)
 		app.SetStatus(menubar.StatusIdle)
-		app.Notify("Audio Import", fmt.Sprintf("Imported=%d Uploaded=%d Failed=%d", summary.Imported, summary.Uploaded, summary.Failed))
+		app.Notify("Audio Import", msg)
 		app.SetAudioImportState(buildAudioImportState())
 		return
 	default:
+		log.Printf("[import] single-file import START: %s", data)
+		app.SetLastImportMessage("⏳ Importing " + filepath.Base(data) + "…")
 		app.SetStatus(menubar.StatusUploading)
-		summary, err := runAudioImportPipeline("", defaultFilesDBPath(), data, app)
+		summary, err := runAudioImportPipeline("", defaultFilesDBPath(), data, app, nil)
 		if err != nil {
+			log.Printf("[import] single-file import FAILED: %s error=%v", data, err)
+			app.SetLastImportMessage("❌ " + filepath.Base(data) + ": " + err.Error())
 			app.SetStatus(menubar.StatusError)
 			app.Notify("Audio Import Failed", err.Error())
 			app.SetAudioImportState(buildAudioImportState())
 			return
 		}
+		msg := fmt.Sprintf("✅ %s: Imported=%d Uploaded=%d Failed=%d", filepath.Base(data), summary.Imported, summary.Uploaded, summary.Failed)
+		log.Printf("[import] single-file import DONE: %s", msg)
+		app.SetLastImportMessage(msg)
 		app.SetStatus(menubar.StatusIdle)
-		app.Notify("Audio Import", fmt.Sprintf("Imported=%d Uploaded=%d Failed=%d", summary.Imported, summary.Uploaded, summary.Failed))
+		app.Notify("Audio Import", msg)
 		app.SetAudioImportState(buildAudioImportState())
 	}
+}
+
+func menubarShowTrackingDB() {
+	// Tab 1: load all tracked records from DB.
+	db, err := tracking.OpenFilesDB(defaultFilesDBPath())
+	if err != nil {
+		log.Printf("[tracking] open db for window: %v", err)
+		return
+	}
+	defer db.Close()
+
+	records, err := db.ListFiles(500)
+	if err != nil {
+		log.Printf("[tracking] list files for window: %v", err)
+		return
+	}
+
+	var tracked []menubar.TrackingRecord
+	// Build a set of tracked basenames for cross-reference with source files.
+	trackedNames := make(map[string]string) // basename → status
+	for _, r := range records {
+		basename := filepath.Base(r.FilePath)
+		tracked = append(tracked, menubar.TrackingRecord{
+			FileName:       basename,
+			Status:         r.Status,
+			TranscriptLen:  r.TranscriptLen,
+			TranscriptLang: r.TranscriptLang,
+			UploadDocID:    r.UploadDocID,
+			UploadError:    r.UploadError,
+			ProcessedAt:    r.ProcessedAt.Format("2006-01-02 15:04"),
+		})
+		trackedNames[basename] = r.Status
+	}
+
+	// Tab 2: scan source folder and cross-reference with DB.
+	cfg, cfgErr := importer.LoadImportConfig()
+	if cfgErr != nil || strings.TrimSpace(cfg.AudioSource) == "" {
+		log.Printf("[tracking] source folder not configured: %v", cfgErr)
+		menubar.ShowTrackingWindow(tracked, nil, "")
+		return
+	}
+
+	folderPath := cfg.AudioSource
+	scan, scanErr := importer.ScanDir(folderPath)
+	if scanErr != nil {
+		log.Printf("[tracking] scan source folder: %v", scanErr)
+		menubar.ShowTrackingWindow(tracked, nil, folderPath)
+		return
+	}
+
+	var source []menubar.SourceFileRecord
+	for _, f := range scan.Files {
+		status := "new"
+		if st, ok := trackedNames[f.Name]; ok {
+			status = st
+		}
+		source = append(source, menubar.SourceFileRecord{
+			FileName:  f.Name,
+			Status:    status,
+			Size:      fmtFileSize(f.Size),
+			SizeBytes: f.Size,
+			CreatedAt: fileCreationTime(f.Path),
+		})
+	}
+
+	menubar.ShowTrackingWindow(tracked, source, folderPath)
+}
+
+func runTrackingBulkAction(app *menubar.App, action string, filenames []string, statuses []string) {
+	action = strings.TrimSpace(action)
+	if len(filenames) == 0 {
+		return
+	}
+	startedAt := time.Now()
+	runID := startedAt.Format("20060102-150405.000")
+	opType := "bulk_" + action
+	startState := menubar.BulkRunState{
+		Active:    true,
+		RunID:     runID,
+		Action:    action,
+		Total:     len(filenames),
+		Phase:     menubar.BulkPhaseQueued,
+		StartedAt: startedAt,
+	}
+	if !ingestionOps.TryStart(opType, startState) {
+		if busy, state := ingestionOps.IsBusy(); busy {
+			remaining := state.Total - state.Done
+			if remaining < 0 {
+				remaining = 0
+			}
+			app.Notify("Ingestion Busy",
+				fmt.Sprintf("Bulk run active (%d/%d, %d remaining). Please wait.", state.Done, state.Total, remaining))
+		}
+		return
+	}
+
+	app.SetBulkRunState(startState)
+	menubar.SetTrackingBulkProgress(startState)
+	app.SetStatus(menubar.StatusUploading)
+	app.SetLastImportMessage(fmt.Sprintf("⏳ Bulk %s started (%d files)", action, len(filenames)))
+	for _, name := range filenames {
+		menubar.SetTrackingSourceStatus(name, "queued")
+	}
+
+	emit := func(evt menubar.BulkProgressEvent) {
+		if evt.RunID == "" {
+			evt.RunID = runID
+		}
+		if evt.Action == "" {
+			evt.Action = action
+		}
+		if evt.Total == 0 {
+			evt.Total = len(filenames)
+		}
+
+		state := app.GetBulkRunState()
+		if state.RunID != runID {
+			state = startState
+		}
+		switch evt.Event {
+		case "RUN_START":
+			log.Print(formatBulkLog(evt))
+			state.Phase = menubar.BulkPhaseQueued
+		case "ITEM_START":
+			log.Print(formatBulkLog(evt))
+			state.CurrentFile = evt.Item
+			state.Phase = menubar.BulkPhaseQueued
+			menubar.SetTrackingSourceStatus(baseName(evt.Item), "queued")
+		case "ITEM_PHASE":
+			log.Print(formatBulkLog(evt))
+			state.CurrentFile = evt.Item
+			state.Phase = evt.Phase
+			menubar.SetTrackingSourceStatus(baseName(evt.Item), trackingStatusForPhase(evt.Phase))
+		case "ITEM_DONE":
+			log.Print(formatBulkLog(evt))
+			state.Done = evt.Done
+			state.Success = evt.Success
+			state.Failed = evt.Failed
+			state.CurrentFile = evt.Item
+			state.Phase = itemDonePhase(evt.Outcome, boolErr(evt.Error))
+			if evt.Error != "" {
+				state.LastError = evt.Error
+			}
+			menubar.SetTrackingSourceStatus(baseName(evt.Item), trackingStatusForOutcome(evt.Outcome, evt.Error))
+		case "RUN_DONE":
+			log.Print(formatBulkLog(evt))
+			state.Done = evt.Done
+			state.Success = evt.Success
+			state.Failed = evt.Failed
+			state.CurrentFile = ""
+			state.Phase = menubar.BulkPhaseDone
+		}
+		state.Active = true
+		ingestionOps.Update(state)
+		app.SetBulkRunState(state)
+		menubar.SetTrackingBulkProgress(state)
+	}
+
+	handler := func(index, total int, filename, status string, emitFn func(menubar.BulkProgressEvent)) (string, error) {
+		srcPath := filepath.Join(importAudioSourceDir(), filename)
+		switch action {
+		case "transcribe_upload":
+			summary, err := runAudioImportPipeline("", defaultFilesDBPath(), srcPath, app, func(evt menubar.BulkProgressEvent) {
+				evt.RunID = runID
+				evt.Action = action
+				evt.Index = index
+				evt.Total = total
+				if evt.Item == "" {
+					evt.Item = filename
+				}
+				emitFn(evt)
+			})
+			if err != nil {
+				return "failed", err
+			}
+			if summary.Imported == 0 && summary.Uploaded == 0 && summary.Failed == 0 && strings.EqualFold(strings.TrimSpace(status), "uploaded") {
+				return "skipped", nil
+			}
+			if summary.Failed > 0 {
+				return "failed", fmt.Errorf("item failed: imported=%d uploaded=%d failed=%d", summary.Imported, summary.Uploaded, summary.Failed)
+			}
+			if summary.Uploaded == 0 && summary.Imported == 0 {
+				return "skipped", nil
+			}
+			return "ok", nil
+		case "retranscribe_reupload":
+			err := reprocessAudioFile(srcPath, defaultFilesDBPath(), app, func(evt menubar.BulkProgressEvent) {
+				evt.RunID = runID
+				evt.Action = action
+				evt.Index = index
+				evt.Total = total
+				if evt.Item == "" {
+					evt.Item = filename
+				}
+				emitFn(evt)
+			})
+			if err != nil {
+				return "failed", err
+			}
+			return "ok", nil
+		default:
+			return "failed", fmt.Errorf("unsupported action: %s", action)
+		}
+	}
+
+	result := runBulkSession(runID, action, filenames, statuses, handler, emit)
+	finalState := app.GetBulkRunState()
+	finalState.Active = false
+	finalState.Done = result.Done
+	finalState.Success = result.Success
+	finalState.Failed = result.Failed
+	if finalState.Failed > 0 {
+		finalState.Phase = menubar.BulkPhaseFailed
+	} else {
+		finalState.Phase = menubar.BulkPhaseDone
+	}
+	ingestionOps.Finish(finalState)
+	app.SetBulkRunState(finalState)
+	menubar.SetTrackingBulkProgress(finalState)
+	app.SetStatus(menubar.StatusIdle)
+	msg := fmt.Sprintf("Bulk %s done: %d/%d ok, %d failed", action, result.Success, result.Total, result.Failed)
+	app.SetLastImportMessage("✅ " + msg)
+	app.Notify("Bulk Operation", msg)
+	go menubarShowTrackingDB()
+}
+
+func boolErr(text string) error {
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	return fmt.Errorf("%s", text)
+}
+
+func trackingStatusForPhase(phase menubar.BulkRunPhase) string {
+	switch phase {
+	case menubar.BulkPhaseQueued:
+		return "queued"
+	case menubar.BulkPhaseImport:
+		return "importing"
+	case menubar.BulkPhaseTranscribe:
+		return "transcribing"
+	case menubar.BulkPhaseUpload:
+		return "uploading"
+	case menubar.BulkPhaseReprocess:
+		return "reprocessing"
+	case menubar.BulkPhaseDone:
+		return "done"
+	case menubar.BulkPhaseFailed:
+		return "failed"
+	default:
+		return "processing"
+	}
+}
+
+func trackingStatusForOutcome(outcome, errText string) string {
+	switch strings.ToLower(strings.TrimSpace(outcome)) {
+	case "ok":
+		return "done"
+	case "skipped":
+		return "skipped"
+	default:
+		if strings.TrimSpace(errText) != "" {
+			return "failed"
+		}
+		return "failed"
+	}
+}
+
+func phaseLogToken(phase menubar.BulkRunPhase) string {
+	switch phase {
+	case menubar.BulkPhaseTranscribe:
+		return "whisper"
+	default:
+		return string(phase)
+	}
+}
+
+func fmtFileSize(bytes int64) string {
+	switch {
+	case bytes >= 1024*1024*1024:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/(1024*1024*1024))
+	case bytes >= 1024*1024:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/(1024*1024))
+	case bytes >= 1024:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/1024)
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}
+
+func importAudioSourceDir() string {
+	cfg, err := importer.LoadImportConfig()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.AudioSource)
+}
+
+func fileCreationTime(path string) string {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	if sys, ok := fi.Sys().(*syscall.Stat_t); ok && sys.Birthtimespec.Sec > 0 {
+		return time.Unix(sys.Birthtimespec.Sec, sys.Birthtimespec.Nsec).Format("2006-01-02 15:04")
+	}
+	return fi.ModTime().Format("2006-01-02 15:04")
 }
 
 func menubarLoginER1(app *menubar.App) {
@@ -1894,6 +2652,18 @@ func observationRecordAndUpload(app *menubar.App, label string, imgPath string, 
 
 	// Stop callback: stop recording → whisper transcribe → update Review tab.
 	menubar.SetStopRecordingCallback(func(elapsed int) {
+		if busy, state := ingestionOps.IsBusy(); busy {
+			remaining := state.Total - state.Done
+			if remaining < 0 {
+				remaining = 0
+			}
+			menubar.SetReviewTranscript(
+				fmt.Sprintf("Bulk audio processing is active (%d/%d, %d remaining). Please wait and retry.",
+					state.Done, state.Total, remaining),
+				"Ingestion blocked",
+			)
+			return
+		}
 		cancel()
 		<-recDone
 		recordingStopped = true
@@ -2047,6 +2817,18 @@ func mergeCaptureMemoAndNotes(memo, notes string) string {
 // menubarUploadPayload uploads a payload to ER1, queuing on failure.
 // On success, opens the uploaded item in the default browser.
 func menubarUploadPayload(app *menubar.App, label string, payload *er1.UploadPayload, tags string) {
+	if busy, state := ingestionOps.IsBusy(); busy {
+		remaining := state.Total - state.Done
+		if remaining < 0 {
+			remaining = 0
+		}
+		msg := fmt.Sprintf("Bulk run active (%d/%d, %d remaining). Upload blocked.", state.Done, state.Total, remaining)
+		log.Printf("[%s] upload blocked: %s", label, msg)
+		app.Notify("Ingestion Busy", msg)
+		app.SetStatus(menubar.StatusIdle)
+		return
+	}
+
 	cfg := er1.LoadConfig()
 	applyRuntimeER1Context(cfg)
 	resp, err := er1.Upload(cfg, payload)
@@ -2308,7 +3090,7 @@ func menubarWhisperLanguage() string {
 }
 
 func menubarWhisperTimeout() time.Duration {
-	const defaultTimeout = 120 * time.Second
+	const defaultTimeout = 7200 * time.Second // 2 hours — large audio files need time
 
 	raw := strings.TrimSpace(os.Getenv("M3C_WHISPER_TIMEOUT"))
 	if raw == "" {

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,34 @@
+title: M3C Tools
+description: Multi-Modal-Memory-Capturing Tools — macOS CLI & menu bar app
+baseurl: /m3c-tools
+url: https://kamir.github.io
+remote_theme: pages-themes/minimal@v0.2.0
+plugins:
+  - jekyll-remote-theme
+
+# Navigation
+nav:
+  - title: Home
+    url: /
+  - title: Getting Started
+    url: /getting-started
+  - title: Menu Bar App
+    url: /menubar-app
+  - title: Audio Import
+    url: /audio-import-tracking
+  - title: Roadmap
+    url: /roadmap
+
+# Build settings
+markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
+
+exclude:
+  - seed-observation-window.yaml
+  - ui-mockup.html
+  - go-rewrite-plan.md
+  - recording-window-requirements.md
+  - requirements-er1-integration.md
+  - feature-er1-login.md

--- a/docs/audio-import-tracking.md
+++ b/docs/audio-import-tracking.md
@@ -1,0 +1,214 @@
+# Audio Import & Upload Tracking
+
+This document describes the audio import pipeline, the tracking database, and the
+seed procedure for initializing the tracking state.
+
+## Overview
+
+The audio import pipeline processes files from a source directory through four stages:
+
+```
+Source folder (IMPORT_AUDIO_SOURCE)
+    → Scan & deduplicate (tracking DB)
+    → Copy to MEMORY folder (IMPORT_AUDIO_DEST)
+    → Transcribe via Whisper
+    → Upload to ER1
+```
+
+Each file's progress is tracked in the **SQLite tracking database** at
+`~/.m3c-tools/tracking.db`.
+
+## File Lifecycle
+
+| Status     | Meaning                                              |
+|------------|------------------------------------------------------|
+| `new`      | File is on disk but not in the DB — ready to import  |
+| `imported` | Copied to MEMORY folder, recorded in DB              |
+| `uploaded` | Successfully uploaded to ER1 (has `upload_doc_id`)   |
+| `failed`   | Import or upload failed (see `upload_error` column)  |
+
+## Tracking Database Schema
+
+```sql
+CREATE TABLE processed_files (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path       TEXT NOT NULL,        -- Full source path
+    file_hash       TEXT NOT NULL,        -- SHA-256 of file content
+    file_size       INTEGER NOT NULL,     -- File size in bytes
+    import_type     TEXT DEFAULT 'audio', -- Always 'audio' for this pipeline
+    status          TEXT DEFAULT 'imported',
+    memory_id       TEXT,                 -- MEMORY folder name
+    processed_at    TEXT NOT NULL,        -- ISO 8601 timestamp
+    transcript_text TEXT,                 -- Full whisper transcript
+    transcript_lang TEXT,                 -- Language code (e.g. 'de')
+    transcript_len  INTEGER DEFAULT 0,   -- Character count of transcript
+    upload_doc_id   TEXT,                 -- ER1 document ID on success
+    upload_error    TEXT,                 -- Error message on failure
+    uploaded_at     TEXT,                 -- ISO 8601 upload timestamp
+    UNIQUE(file_hash, import_type)
+);
+```
+
+### Key columns for tracking
+
+- **transcript_text / transcript_lang / transcript_len**: Recorded after Whisper
+  transcription completes. If transcription fails, `transcript_text` contains
+  the error message prefixed with `[Transcription failed: ...]`.
+- **upload_doc_id**: The ER1 document ID returned on successful upload. This is
+  the definitive proof that the file reached ER1.
+- **upload_error**: Stores the error message when an upload fails. Cleared on
+  successful retry.
+- **uploaded_at**: Timestamp of successful upload.
+
+## Seed Procedure
+
+When setting up m3c-tools for the first time (or resetting the tracking state),
+follow these steps to establish the correct baseline.
+
+### Prerequisites
+
+- The **authoritative tracker file** lists filenames that have already been
+  uploaded to ER1 via the legacy Python tool. Default location:
+  `/Users/kamir/GITHUB.active/my-ai-X/experiments/audio-checklist-checker-py/bin/transcript_tracker.md`
+- The **audio source folder** (`IMPORT_AUDIO_SOURCE`) contains all audio files.
+- Already-uploaded files are moved to a `DONE/` subfolder in the source.
+
+### Steps
+
+1. **Backup the existing DB** (if any):
+   ```bash
+   cp ~/.m3c-tools/tracking.db ~/.m3c-tools/tracking.db.bak
+   ```
+
+2. **Delete the existing DB**:
+   ```bash
+   rm ~/.m3c-tools/tracking.db
+   ```
+
+3. **Seed from the authoritative tracker**. For each file listed in the tracker,
+   compute the SHA-256 hash and insert into the DB as `status='uploaded'`:
+   ```bash
+   SOURCE_DIR="/Users/kamir/GDMirror/GCP-AUDIO-TRANSCRIPT-SERVICE"
+   TRACKER="/Users/kamir/GITHUB.active/my-ai-X/experiments/audio-checklist-checker-py/bin/transcript_tracker.md"
+   DB="$HOME/.m3c-tools/tracking.db"
+
+   # The app will create the schema on first open. Alternatively, start the
+   # menubar app once to initialize: m3c-tools menubar &; sleep 2; kill %1
+
+   while IFS= read -r basename; do
+     [ -z "$basename" ] && continue
+     [[ "$basename" =~ ^# ]] && continue
+     fullpath="$SOURCE_DIR/DONE/$basename"
+     [ ! -f "$fullpath" ] && echo "SKIP (not found): $basename" && continue
+     hash=$(shasum -a 256 "$fullpath" | cut -d' ' -f1)
+     size=$(stat -f%z "$fullpath")
+     sqlite3 "$DB" "INSERT OR IGNORE INTO processed_files
+       (file_path, file_hash, file_size, import_type, status, processed_at)
+       VALUES ('$fullpath', '$hash', $size, 'audio', 'uploaded', datetime('now'));"
+   done < "$TRACKER"
+   ```
+
+4. **Update the m3c-tools tracker** to match:
+   ```bash
+   cp "$TRACKER" ~/.m3c-tools/transcript_tracker.md
+   ```
+
+5. **Verify**:
+   ```bash
+   sqlite3 "$DB" "SELECT status, COUNT(*) FROM processed_files GROUP BY status;"
+   # Expected: uploaded|6 (or however many files are in DONE/)
+   ```
+
+### After seeding
+
+- All files in the main source folder (not in `DONE/`) appear as **"new"** in
+  the Audio Import menu.
+- Select individual files or use "Run Import Pipeline" for batch processing.
+- Each file progresses: `new → imported → uploaded` (or `failed`).
+- The "Tracking DB" submenu shows all records with their status, transcript
+  length, and upload doc ID.
+
+## Import Modes
+
+### Single-file import (menu click)
+
+When you click a file in the Audio Import submenu:
+1. Only that one file is imported (via `ImportAudioFiltered`)
+2. Whisper transcription runs on it
+3. Transcript details are saved to the DB
+4. Upload to ER1 is attempted
+5. Upload result (doc_id or error) is saved to the DB
+6. Menu refreshes to remove the file from the "new" list
+
+### Batch import ("Run Import Pipeline")
+
+Imports ALL new files in the source directory, transcribes each, and uploads.
+Same per-file tracking as single-file mode.
+
+## Bulk Operation UX, Locking, and Logs
+
+Bulk actions from the **Tracking DB → Source Files** tab now run as explicit
+sessions with a `run_id` and live progress.
+
+### Locking behavior
+
+- While a bulk session is active, new ingestion actions are blocked:
+  - YouTube fetch/record flow
+  - Screenshot flow
+  - Quick Impulse flow
+  - Audio Import actions (single + batch)
+  - Additional tracking bulk actions
+- The user receives a notification with current progress and remaining items.
+
+### Live progress surfaces
+
+- **Tracking window** shows:
+  - Top progress strip (determinate bar)
+  - Session counters: `done/total`, `ok`, `fail`
+  - Current file + phase
+  - Last error line (if any)
+  - Bulk buttons disabled while session is active
+- **Menubar Audio Import** shows:
+  - `Running X/Y`
+  - Current file
+  - Failed count
+  - Elapsed time
+
+### Source row status overlays
+
+Selected files transition through in-flight labels:
+
+- `queued`
+- `importing`
+- `transcribing`
+- `uploading`
+- terminal: `done`, `failed`, or `skipped`
+
+### Structured bulk logs
+
+Each session writes parseable lifecycle markers:
+
+- `[bulk][RUN_START]`
+- `[bulk][ITEM_START]`
+- `[bulk][PHASE] phase=import|whisper|upload`
+- `[bulk][ITEM_DONE]`
+- `[bulk][RUN_DONE]`
+
+Each line includes `run_id`, item index/total where relevant, and outcome/error code.
+
+## Environment Variables
+
+| Variable               | Default                              | Description                    |
+|------------------------|--------------------------------------|--------------------------------|
+| `IMPORT_AUDIO_SOURCE`  | (required)                           | Source directory for audio files|
+| `IMPORT_AUDIO_DEST`    | `~/ER1`                              | Destination for MEMORY folders |
+| `IMPORT_CONTENT_TYPE`  | (required)                           | ER1 content-type label         |
+| `IMPORT_TRACKER_FILE`  | `~/.m3c-tools/transcript_tracker.md` | Legacy tracker file path       |
+
+## Viewing Tracking History
+
+The **"Tracking DB"** submenu in the menu bar shows up to 50 recent records.
+Each entry shows:
+- Status icon: ✅ uploaded, 📦 imported, ❌ failed
+- File name
+- Expandable details: transcript length/language, ER1 doc ID, error message

--- a/docs/audio-import-tracking.md
+++ b/docs/audio-import-tracking.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Audio Import & Tracking
+---
+
 # Audio Import & Upload Tracking
 
 This document describes the audio import pipeline, the tracking database, and the

--- a/docs/feature-er1-login.md
+++ b/docs/feature-er1-login.md
@@ -40,4 +40,4 @@ Replace manual `ER1_CONTEXT_ID` entry in menu-bar workflows with account-based l
 1. Add explicit callback signature/token validation.
 2. Add optional encrypted-at-rest session file.
 3. Add integration tests for callback parsing and URL/context extraction.
-4. Add explicit menu command to open ER1 profile page for session verification.
+4. ~~Add explicit menu command to open ER1 profile page for session verification.~~ **DONE** — "Mein Nutzerkonto" menu item opens ER1 profile in Chrome.

--- a/docs/feature-er1-login.md
+++ b/docs/feature-er1-login.md
@@ -1,0 +1,43 @@
+# ER1 Browser Login Linking (Feature Track)
+
+## Goal
+Replace manual `ER1_CONTEXT_ID` entry in menu-bar workflows with account-based login linking.
+
+## UX
+1. User clicks `Login to ER1...` in the M3C menu.
+2. App opens `<ER1 base>/login/multi?next=<local-callback-url>` in Chrome.
+3. After browser login redirect reaches local callback, app links runtime account context.
+4. Menu shows `Account: <context_id>` and all menu uploads use this linked context.
+5. User can click `Logout from ER1` to clear runtime link and fall back to `.env` context.
+
+## State Model
+- Runtime-only app state (not persisted):
+  - `loggedIn` bool
+  - `contextID` string
+- Logout clears both values.
+- Relogin overwrites previous context.
+- Optional persistence behind `M3C_ER1_SESSION_PERSIST=true`:
+  - Stores context in `~/.m3c-tools/er1_session.json` (or `M3C_ER1_SESSION_FILE`)
+  - Restored on app startup
+  - Cleared on logout
+
+## Detection Strategy
+- Primary: local callback query params (`context_id`, `user_id`, `uid`).
+- Fallback: inspect open Chrome tabs on ER1 host and parse context from `/memory/<context_id>/<doc_id>`.
+
+## Current Implementation Scope
+- Menu items: Login / Logout / Account status line.
+- Browser open through existing Chrome-preferred `openURL` helper.
+- Runtime context override applied to menu ER1 upload paths.
+- Logging added under `[auth]` and `[tabs]` for diagnostics.
+
+## Known Limitations
+- Callback currently depends on ER1 preserving `next` redirect.
+- Context extraction fallback needs open ER1 pages in Chrome with `/memory/<context>/...` pattern.
+- Persistence is context-id based and currently does not verify session freshness with the server.
+
+## Next Hardening Steps
+1. Add explicit callback signature/token validation.
+2. Add optional encrypted-at-rest session file.
+3. Add integration tests for callback parsing and URL/context extraction.
+4. Add explicit menu command to open ER1 profile page for session verification.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,15 +7,13 @@ title: Getting Started
 
 ## Prerequisites
 
-- **Go 1.25+** (build from source)
 - **macOS** (menu bar app uses native Cocoa via cgo)
+- **Go 1.25+** (build from source)
 - **PortAudio** — for microphone recording: `brew install portaudio`
-- **Whisper** — for speech-to-text: `brew install openai-whisper` or install from [github.com/openai/whisper](https://github.com/openai/whisper)
-- **ER1 server** (optional) — for uploading observations
+- **Whisper** — for speech-to-text: `pip install openai-whisper` or `brew install openai-whisper`
+- **ER1 server** (optional) — for uploading observations to your knowledge base
 
 ## Installation
-
-### From source
 
 ```bash
 git clone https://github.com/kamir/m3c-tools.git
@@ -30,35 +28,63 @@ This will:
 4. Install app to `/Applications/M3C-Tools.app`
 5. Walk you through macOS privacy permissions (Screen Recording, Microphone, Accessibility, Input Monitoring)
 
-### Configuration
-
-Copy `.env.example` to `.env` and fill in your settings:
+### Build without installing
 
 ```bash
-cp .env.example .env
+make build       # CLI only → ./build/m3c-tools
+make build-app   # CLI + .app bundle → ./build/M3C-Tools.app
 ```
 
-Key variables:
+## Configuration
 
-| Variable | Purpose | Required |
-|----------|---------|----------|
-| `ER1_API_URL` | ER1 upload endpoint | For uploads |
-| `ER1_API_KEY` | ER1 authentication key | For uploads |
-| `ER1_CONTEXT_ID` | ER1 user/org context | For uploads |
-| `M3C_WHISPER_MODEL` | Whisper model (tiny/base/small/medium/large) | No (default: base) |
-| `IMPORT_AUDIO_SOURCE` | Audio import source folder | For Channel D |
-| `YT_PROXY_URL` | YouTube proxy URL (rate limit mitigation) | No |
+Copy `.env.example` to your home directory:
 
-## Usage
+```bash
+cp .env.example ~/.m3c-tools.env
+```
 
-### 1. Fetch a transcript (CLI)
+### Required settings (for ER1 upload)
+
+| Variable | Purpose |
+|----------|---------|
+| `ER1_API_URL` | ER1 upload endpoint (e.g. `https://127.0.0.1:8081/upload_2`) |
+| `ER1_API_KEY` | ER1 authentication key (sent as `X-API-KEY` header) |
+| `ER1_CONTEXT_ID` | ER1 user/org context identifier |
+
+### Optional settings
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `M3C_WHISPER_MODEL` | `base` | Whisper model (tiny/base/small/medium/large) |
+| `M3C_WHISPER_TIMEOUT` | `7200` | Transcription timeout in seconds |
+| `YT_WHISPER_LANGUAGE` | `de` | Transcription language (ISO 639-1) |
+| `M3C_SCREENSHOT_MODE` | `clipboard-first` | Screenshot mode (`clipboard-first` or `interactive`) |
+| `IMPORT_AUDIO_SOURCE` | — | Audio import source folder (for Channel D) |
+| `IMPORT_AUDIO_DEST` | `~/ER1` | Audio import destination folder |
+| `YT_PROXY_URL` | — | HTTP/SOCKS5 proxy for YouTube (rate limit mitigation) |
+
+See [`.env.example`](https://github.com/kamir/m3c-tools/blob/main/.env.example) for the complete list with descriptions.
+
+## First use
+
+### Launch the menu bar app
+
+```bash
+make menubar
+```
+
+Or open `/Applications/M3C-Tools.app`.
+
+A menu bar icon appears. Click it to see the available actions.
+
+### Fetch a transcript (CLI)
 
 ```bash
 # Plain text
 m3c-tools transcript dQw4w9WgXcQ
 
-# JSON format
-m3c-tools transcript dQw4w9WgXcQ --format json
+# SRT format
+m3c-tools transcript dQw4w9WgXcQ --format srt
 
 # List available languages
 m3c-tools transcript dQw4w9WgXcQ --list
@@ -67,32 +93,40 @@ m3c-tools transcript dQw4w9WgXcQ --list
 m3c-tools transcript dQw4w9WgXcQ --lang de
 ```
 
-### 2. Menu bar app
+### Run tests
 
 ```bash
-make menubar
-# or
-m3c-tools menubar
+make test-unit      # Offline unit tests (no network, no hardware)
+make ci             # Full CI (vet + lint + test + build)
+make test-network   # YouTube API tests (requires internet)
+make test-er1       # ER1 integration tests (requires running server)
 ```
 
-See the [Menu Bar App](menubar-app) page for full details.
+## macOS Permissions
 
-### 3. Run tests
+m3c-tools needs the following macOS permissions:
+
+| Permission | Why | When prompted |
+|------------|-----|---------------|
+| **Microphone** | Voice recording for observations | First recording |
+| **Screen Recording** | Interactive screenshot capture | First screenshot (interactive mode) |
+| **Accessibility** | Clipboard monitoring for screenshot detection | First clipboard-first capture |
+
+Grant these in **System Preferences → Privacy & Security**. The `make install` target walks you through this.
+
+## Uninstalling
 
 ```bash
-# Offline unit tests (no network, no hardware)
-make test-unit
+make uninstall
+```
 
-# Full CI (vet + lint + test + build)
-make ci
-
-# Network tests (YouTube API)
-make test-network
-
-# ER1 integration tests
-make test-er1
+Or manually:
+```bash
+rm -f /usr/local/bin/m3c-tools
+rm -rf /Applications/M3C-Tools.app
+# Data preserved at ~/.m3c-tools/ — remove manually if desired
 ```
 
 ---
 
-Next: [Menu Bar App](menubar-app)
+Next: [Menu Bar App](menubar-app) | [Home](/)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,81 +7,92 @@ title: Getting Started
 
 ## Prerequisites
 
-- Python 3.8 or later
-- macOS (for the menu bar app)
-- A Google Cloud project (only if you want to use the History Inspector)
+- **Go 1.25+** (build from source)
+- **macOS** (menu bar app uses native Cocoa via cgo)
+- **PortAudio** — for microphone recording: `brew install portaudio`
+- **Whisper** — for speech-to-text: `brew install openai-whisper` or install from [github.com/openai/whisper](https://github.com/openai/whisper)
+- **ER1 server** (optional) — for uploading observations
 
 ## Installation
 
-### Core library
+### From source
 
 ```bash
-pip install youtube-transcript-api
+git clone https://github.com/kamir/m3c-tools.git
+cd m3c-tools
+make install
 ```
 
-### From source (all tools)
+This will:
+1. Build the `m3c-tools` binary
+2. Create `M3C-Tools.app` bundle with icon and Info.plist
+3. Install CLI to `/usr/local/bin/m3c-tools`
+4. Install app to `/Applications/M3C-Tools.app`
+5. Walk you through macOS privacy permissions (Screen Recording, Microphone, Accessibility, Input Monitoring)
+
+### Configuration
+
+Copy `.env.example` to `.env` and fill in your settings:
 
 ```bash
-git clone https://github.com/kamir/youtube-transcript-api.git
-cd youtube-transcript-api
-git checkout kamir/m3c-tools
-pip install -e ".[dev]"
+cp .env.example .env
 ```
 
-## Usage overview
+Key variables:
 
-### 1. Fetch a single transcript
+| Variable | Purpose | Required |
+|----------|---------|----------|
+| `ER1_API_URL` | ER1 upload endpoint | For uploads |
+| `ER1_API_KEY` | ER1 authentication key | For uploads |
+| `ER1_CONTEXT_ID` | ER1 user/org context | For uploads |
+| `M3C_WHISPER_MODEL` | Whisper model (tiny/base/small/medium/large) | No (default: base) |
+| `IMPORT_AUDIO_SOURCE` | Audio import source folder | For Channel D |
+| `YT_PROXY_URL` | YouTube proxy URL (rate limit mitigation) | No |
 
-No API key needed. Works out of the box.
+## Usage
 
-```python
-from youtube_transcript_api import YouTubeTranscriptApi
-
-api = YouTubeTranscriptApi()
-transcript = api.fetch("VIDEO_ID", languages=["en"])
-
-full_text = "\n".join(snippet.text for snippet in transcript)
-print(full_text)
-```
-
-**Language selection:** Pass a list of preferred languages. The API will try each in order and fall back automatically.
-
-```python
-# Prefer German, fall back to English
-transcript = api.fetch("VIDEO_ID", languages=["de", "en"])
-```
-
-### 2. CLI usage
+### 1. Fetch a transcript (CLI)
 
 ```bash
-# Fetch transcript as plain text
-youtube_transcript_api VIDEO_ID
+# Plain text
+m3c-tools transcript dQw4w9WgXcQ
 
-# Fetch in JSON format
-youtube_transcript_api VIDEO_ID --format json
+# JSON format
+m3c-tools transcript dQw4w9WgXcQ --format json
+
+# List available languages
+m3c-tools transcript dQw4w9WgXcQ --list
 
 # Specify language
-youtube_transcript_api VIDEO_ID --languages en de
+m3c-tools transcript dQw4w9WgXcQ --lang de
 ```
 
-### 3. Quick clipboard copy (macOS)
-
-Edit the `video_id` in `do_fetch.py` and run:
+### 2. Menu bar app
 
 ```bash
-python3 do_fetch.py
+make menubar
+# or
+m3c-tools menubar
 ```
 
-The transcript is printed and copied to your clipboard.
+See the [Menu Bar App](menubar-app) page for full details.
 
-### 4. Menu bar app
+### 3. Run tests
 
-See the [Menu Bar App](menubar-app) page.
+```bash
+# Offline unit tests (no network, no hardware)
+make test-unit
 
-### 5. History Inspector
+# Full CI (vet + lint + test + build)
+make ci
 
-Requires a Google OAuth client secret. See [Authentication](authentication), then [History Inspector](history-inspector).
+# Network tests (YouTube API)
+make test-network
+
+# ER1 integration tests
+make test-er1
+```
 
 ---
 
-Next: [Authentication Guide](authentication)
+Next: [Menu Bar App](menubar-app)

--- a/docs/go-rewrite-plan.md
+++ b/docs/go-rewrite-plan.md
@@ -1,8 +1,10 @@
-# YT Tools — Go Rewrite Plan
+# M3C Tools — Go Rewrite Plan (COMPLETED)
+
+> **Status: COMPLETE (v1.4.4)**. This document is preserved as historical reference for the Python-to-Go migration. All phases are implemented and in production. See [Roadmap](roadmap) for current status.
 
 ## 0. Full youtube-transcript-api Library Port
 
-The Go module must include a **complete port** of the forked
+The Go module includes a **complete port** of the forked
 [youtube-transcript-api](https://github.com/jdepoix/youtube-transcript-api)
 library (6 source files, ~1,500 lines). Every public type, method, and error
 must have a Go equivalent.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,62 +3,65 @@ layout: default
 title: Home
 ---
 
-# YT Tools
+# M3C Tools — Multi-Modal Memory Capture
 
-A growing toolkit for working with YouTube transcripts — from quick one-off fetches to full watch-history analysis.
+A native macOS toolkit for capturing multimodal observations (text + audio + image) and uploading them to an ER1 personal knowledge server. Built in Go with native Cocoa UI via cgo.
 
 ## What's in the box?
 
-| Tool | What it does | API Key? |
-|------|-------------|----------|
-| **youtube-transcript-api** | Python library & CLI to fetch any video's transcript | No |
-| **do_fetch.py** | Quick script — fetch a transcript and copy to clipboard | No |
-| **YT Transcript (Menu Bar App)** | macOS menu bar app for instant transcript access | No |
-| **YT History Inspector** | Web app to analyze your YouTube watch history | Yes — Google OAuth |
-| **Demo App** | Flask reference app combining all tools | Yes — Google OAuth |
+| Component | What it does |
+|-----------|-------------|
+| **Menu Bar App** | macOS menu bar app with 4 capture channels, Observation Window, ER1 upload |
+| **CLI** | `m3c-tools transcript` — fetch YouTube transcripts, manage imports, retry queue |
+| **Transcript Library** | Pure Go port of youtube-transcript-api (no API key needed) |
+| **Whisper Integration** | Local speech-to-text via whisper CLI subprocess |
+| **ER1 Client** | Multipart upload to ER1 knowledge server with offline retry queue |
 
 ## Quick start
+
+### Build from source
+
+```bash
+git clone https://github.com/kamir/m3c-tools.git
+cd m3c-tools
+make build
+```
+
+### Install (CLI + macOS .app bundle)
+
+```bash
+make install
+```
+
+This builds the binary, creates `M3C-Tools.app`, installs both, and walks you through macOS permission setup.
 
 ### Fetch a transcript (no key needed)
 
 ```bash
-pip install youtube-transcript-api
+./build/m3c-tools transcript dQw4w9WgXcQ
 ```
 
-```python
-from youtube_transcript_api import YouTubeTranscriptApi
-
-api = YouTubeTranscriptApi()
-transcript = api.fetch("dQw4w9WgXcQ")
-
-for snippet in transcript:
-    print(snippet.text)
-```
-
-Or from the CLI:
+### Run the menu bar app
 
 ```bash
-youtube_transcript_api dQw4w9WgXcQ
+make menubar
 ```
 
-### Install the macOS menu bar app (no key needed)
-
-```bash
-curl -fsSL https://api.github.com/repos/kamir/youtube-transcript-api/contents/tools/install.sh?ref=kamir/m3c-tools -H 'Accept: application/vnd.github.raw' | bash
-```
-
-### Run the History Inspector (OAuth key required)
-
-See the [Authentication Guide](authentication) first, then:
-
-```bash
-# with Docker
-docker compose up
-
-# or directly
-cd demo_app && python app.py
-```
+Or launch the installed app from `/Applications/M3C-Tools.app`.
 
 ---
 
-Next: [Getting Started](getting-started) | [Authentication Guide](authentication)
+## Capture Channels
+
+| Channel | Trigger | Captures |
+|---------|---------|----------|
+| **A — YouTube** | Paste video URL/ID | Transcript + thumbnail + voice impression |
+| **B — Screenshot** | Menu item | Screenshot + voice impression |
+| **C — Impulse** | Menu item | Interactive region screenshot + voice impression |
+| **D — Audio Import** | Menu item | Batch audio files from preconfigured folder |
+
+All channels flow through the unified **Observation Window** pipeline: Capture → Record → Review → Tags → Store/Cancel.
+
+---
+
+Next: [Getting Started](getting-started) | [Menu Bar App](menubar-app)

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,18 @@ title: Home
 
 # M3C Tools — Multi-Modal Memory Capture
 
-A native macOS toolkit for capturing multimodal observations (text + audio + image) and uploading them to an ER1 personal knowledge server. Built in Go with native Cocoa UI via cgo.
+A native macOS toolkit for capturing multimodal observations (text + audio + image) and uploading them to an [ER1](https://er1.io) personal knowledge server. Built in Go with native Cocoa UI via cgo.
+
+## Quickstart
+
+```bash
+brew install portaudio
+pip install openai-whisper
+git clone https://github.com/kamir/m3c-tools.git && cd m3c-tools
+make install
+cp .env.example ~/.m3c-tools.env   # edit with your ER1 credentials
+make menubar                        # launch the menu bar app
+```
 
 ## What's in the box?
 
@@ -16,52 +27,42 @@ A native macOS toolkit for capturing multimodal observations (text + audio + ima
 | **Transcript Library** | Pure Go port of youtube-transcript-api (no API key needed) |
 | **Whisper Integration** | Local speech-to-text via whisper CLI subprocess |
 | **ER1 Client** | Multipart upload to ER1 knowledge server with offline retry queue |
-
-## Quick start
-
-### Build from source
-
-```bash
-git clone https://github.com/kamir/m3c-tools.git
-cd m3c-tools
-make build
-```
-
-### Install (CLI + macOS .app bundle)
-
-```bash
-make install
-```
-
-This builds the binary, creates `M3C-Tools.app`, installs both, and walks you through macOS permission setup.
-
-### Fetch a transcript (no key needed)
-
-```bash
-./build/m3c-tools transcript dQw4w9WgXcQ
-```
-
-### Run the menu bar app
-
-```bash
-make menubar
-```
-
-Or launch the installed app from `/Applications/M3C-Tools.app`.
-
----
+| **Audio Import** | Batch import from a folder with SQLite tracking and bulk re-processing |
 
 ## Capture Channels
 
+All channels flow through the unified **Observation Window** pipeline:
+
+```
+Capture → Preview + Record → Whisper Transcribe → Tag Editor → Store / Cancel
+```
+
 | Channel | Trigger | Captures |
 |---------|---------|----------|
-| **A — YouTube** | Paste video URL/ID | Transcript + thumbnail + voice impression |
-| **B — Screenshot** | Menu item | Screenshot + voice impression |
-| **C — Impulse** | Menu item | Interactive region screenshot + voice impression |
+| **A — YouTube** | Paste video URL/ID | Transcript + thumbnail + voice comment |
+| **B — Screenshot** | Menu item | Screenshot + voice note (uses clipboard if present) |
+| **C — Impulse** | Menu item | Interactive region capture + quick voice note |
 | **D — Audio Import** | Menu item | Batch audio files from preconfigured folder |
 
-All channels flow through the unified **Observation Window** pipeline: Capture → Record → Review → Tags → Store/Cancel.
+Each observation becomes a multimodal ER1 document containing text, audio, and image with tags and metadata.
+
+## Configuration
+
+Copy `.env.example` to `~/.m3c-tools.env` and set at minimum:
+
+```
+ER1_API_URL=https://your-er1-server:8081/upload_2
+ER1_API_KEY=your-api-key
+ER1_CONTEXT_ID=your-context-id
+```
+
+See the [Getting Started](getting-started) guide for the full configuration reference.
 
 ---
 
-Next: [Getting Started](getting-started) | [Menu Bar App](menubar-app)
+**Documentation:**
+
+- [Getting Started](getting-started) — install, configure, first use
+- [Menu Bar App](menubar-app) — channels, Observation Window, menu items
+- [Audio Import & Tracking](audio-import-tracking) — batch import, tracking DB, seed procedure
+- [Roadmap](roadmap) — current state, future work, ideas

--- a/docs/menubar-app.md
+++ b/docs/menubar-app.md
@@ -3,75 +3,160 @@ layout: default
 title: Menu Bar App
 ---
 
-# YT Transcript — macOS Menu Bar App
+# M3C Tools — macOS Menu Bar App
 
-A lightweight macOS menu bar app for fetching YouTube transcripts with one click. No API key needed.
+A native macOS menu bar app for capturing multimodal observations. Built in Go using `caseymrm/menuet` for the menu bar and native Cocoa (NSWindow, NSTabView) via cgo for the Observation Window.
 
 ## Features
 
-- Lives in your menu bar with a YouTube-red icon
-- Paste a video URL or ID, get the transcript
-- Language selection (prefers English, with fallback options)
-- Auto-copies transcript to clipboard
-- Keeps a history of your last 20 transcripts
-- Re-copy any previous transcript from the menu
-- Record voice impressions about videos (Whisper transcription)
-- Capture screenshots (clipboard or interactive region selection)
-- Quick impulse capture for fleeting thoughts
-- Observation types: progress, idea, impulse
+- Native macOS menu bar with custom icon
+- 4 capture channels: YouTube, Screenshot, Impulse, Audio Import
+- Unified **Observation Window** with 3 tabs: Record, Review, Tags
+- Live VU meter with color-coded audio levels and dB readout
+- Local Whisper transcription of voice recordings
 - Multimodal ER1 uploads (image + audio + transcript)
-- Offline-first retry queue with exponential backoff
+- Offline retry queue with exponential backoff
+- ER1 browser login linking (runtime context override)
+- Transcript history (last 20 fetches)
+- Draft saving on cancel (`~/.m3c-tools/drafts/`)
+- Coordinated bulk ingestion lock + live progress for Audio Import/Re-process
 
 ## Installation
 
-### One-liner install (recommended)
+### Build and install
 
 ```bash
-curl -fsSL https://api.github.com/repos/kamir/youtube-transcript-api/contents/tools/install.sh?ref=kamir/m3c-tools -H 'Accept: application/vnd.github.raw' | bash
+git clone https://github.com/kamir/m3c-tools.git
+cd m3c-tools
+make install
 ```
 
-This downloads the latest release, installs to `/Applications`, and launches the app.
-
-### Build from source
+### Build from source only
 
 ```bash
-git clone https://github.com/kamir/youtube-transcript-api.git
-cd youtube-transcript-api
-git checkout kamir/m3c-tools
-pip install rumps pyobjc-framework-Cocoa defusedxml requests py2app pyaudio
-pip install openai-whisper   # for voice transcription (uses system Python at runtime)
-python3 setup_app.py py2app
+make build-app
+# Result: build/M3C-Tools.app
 ```
 
-The built app will be in `dist/YT Transcript.app`. Move it to `/Applications`.
+### Run without installing
 
-## Usage
+```bash
+make menubar
+```
 
-1. Click the YT icon in your menu bar
-2. Select **Fetch Transcript...**
-3. Paste a YouTube URL (e.g., `https://www.youtube.com/watch?v=dQw4w9WgXcQ`) or just the video ID
-4. Choose a language if multiple are available
-5. The transcript is copied to your clipboard
+## Capture Channels
 
-## History
+### Channel A — YouTube
 
-The app remembers your last 20 transcripts. Access them from the menu bar dropdown — click any entry to re-copy it to your clipboard.
+1. Click **Fetch Transcript...** in the menu bar
+2. Paste a YouTube URL or video ID
+3. Transcript is fetched, thumbnail downloaded
+4. **Observation Window** opens showing the thumbnail
+5. Record a voice impression about the video
+6. Review transcribed text, edit tags, Store or Cancel
+
+### Channel B — Screenshot
+
+1. Click **Capture Screenshot** in the menu bar
+2. Screen is captured (clipboard-first, falls back to interactive)
+3. **Observation Window** opens showing the screenshot
+4. Record your observations about what you see
+5. Review, tag, Store or Cancel
+
+### Channel C — Quick Impulse
+
+1. Click **Quick Impulse** in the menu bar
+2. Interactive region selection appears
+3. Capture a specific area of the screen
+4. **Observation Window** opens
+5. Record a quick voice note about the impulse
+6. Review, tag, Store or Cancel
+
+### Channel D — Audio Import
+
+1. Click **Import Audio** in the menu bar
+2. Scans preconfigured folder (`IMPORT_AUDIO_SOURCE`) for audio files
+3. Shows tracked/new/uploaded status for each file
+4. Select files to import
+5. Each file is transcribed via Whisper and uploaded to ER1
+
+### Bulk import/re-process UX
+
+- Tracking DB window displays a live bulk progress strip:
+  - determinate progress bar
+  - current file + phase
+  - success/failure counters
+  - last error message
+- Source table statuses are overlaid with in-flight states:
+  - `queued`, `importing`, `transcribing`, `uploading`, `done`, `failed`, `skipped`
+- Bulk buttons are disabled while a bulk session is active.
+- During active bulk whisper/upload processing, other ingestion actions are blocked.
+
+## Observation Window
+
+The Observation Window is a native NSWindow with NSTabView, shared by all capture channels:
+
+### Record Tab
+- Captured image displayed (max 50% screen width/height)
+- Live VU meter showing microphone input levels (green/yellow/red)
+- Elapsed recording timer (MM:SS)
+- Stop Recording button
+- Window close (red X) = stop + "Keep this recording?" dialog
+
+### Review Tab
+- Metadata header: video ID, language, snippet count, char count
+- Scrollable transcript text (editable)
+- Recording details: duration, file size, sample rate
+
+### Tags Tab
+- Pre-filled tags per channel (editable comma-separated field)
+- **[Store]** — upload to ER1 (queues on failure for retry)
+- **[Cancel]** — save draft to `~/.m3c-tools/drafts/`, return to idle
+
+## Menu Items
+
+| Item | Action |
+|------|--------|
+| Status line | Current app state (Idle, Fetching, Recording...) |
+| Fetch Transcript... | Channel A — YouTube |
+| Capture Screenshot | Channel B — Screenshot |
+| Quick Impulse | Channel C — Interactive region capture |
+| Import Audio | Channel D — Batch audio import |
+| Login to ER1... | Open ER1 login in Chrome |
+| Logout from ER1 | Clear runtime ER1 session |
+| History submenu | Last 20 transcripts (click to re-copy) |
+| Open Log File | Opens `/tmp/m3c-tools.log` |
+| Mein Nutzerkonto | Opens ER1 profile page in Chrome |
 
 ## Logs
 
-If something goes wrong, check the log file:
+```
+/tmp/m3c-tools.log
+```
 
-```
-~/Library/Logs/YTTranscript.log
-```
+Structured log prefixes: `[fetch]`, `[cache]`, `[store]`, `[auth]`, `[whisper]`, `[recorder]`
+
+Bulk import/re-process lifecycle markers:
+
+- `[bulk][RUN_START]`
+- `[bulk][ITEM_START]`
+- `[bulk][PHASE]`
+- `[bulk][ITEM_DONE]`
+- `[bulk][RUN_DONE]`
 
 ## Uninstalling
 
 ```bash
-rm -rf "/Applications/YT Transcript.app"
-rm -rf ~/Library/Application\ Support/YTTranscript
+make uninstall
+```
+
+Or manually:
+```bash
+rm -f /usr/local/bin/m3c-tools
+rm -rf /Applications/M3C-Tools.app
+# Data preserved at ~/.m3c-tools/ — remove manually if desired
 ```
 
 ---
 
-Back: [Getting Started](getting-started) | Next: [History Inspector](history-inspector)
+Back: [Getting Started](getting-started) | [Home](/)

--- a/docs/requirements-er1-integration.md
+++ b/docs/requirements-er1-integration.md
@@ -3,21 +3,18 @@ layout: default
 title: ER1 Integration — Requirements
 ---
 
-# ER1 Integration — Requirements & Solution Plan
+# ER1 Integration — Requirements & Implementation
 
 ## Context
 
 The project [audio-checklist-checker-py](https://github.com/kamir/my-ai-X) establishes a pattern for capturing audio impulses and pushing them into **ER1** — a personal knowledge/memory management system with a REST API. The workflow is:
 
 ```
-Source (GDrive audio) → Metadata extraction → Whisper transcription
-  → Local MEMORY folder → ER1 API upload → Post-processing (Gemini)
+Source (capture) → Metadata extraction → Whisper transcription
+  → Composite document → ER1 API upload → Post-processing (Gemini, future)
 ```
 
-This document specifies how to bring that same pattern into the YouTube transcript toolkit, adding two new capabilities:
-
-1. **Video Import to ER1** — select untracked YouTube videos and push their transcripts into ER1
-2. **Impression Capture** — record a spoken voice note *about* a video, transcribe it, and bundle both the video transcript and the user's commentary as a single "impression" payload into ER1
+M3C Tools brings this pattern to four capture channels: YouTube transcripts, screenshots, quick impulses, and batch audio import.
 
 ---
 
@@ -26,316 +23,158 @@ This document specifies how to bring that same pattern into the YouTube transcri
 | Term | Definition |
 |------|-----------|
 | **ER1** | External memory/knowledge API at `https://127.0.0.1:8081/upload_2` (local) or `https://onboarding.guide/upload_2` (remote) |
-| **MEMORY folder** | Local directory `/Users/kamir/ER1/MEMORY-{YYYYMMDD_HHMMSS}/` holding source files, transcripts, tags, and post-processed outputs |
-| **Untracked video** | A video present in the YT History Inspector database that has NOT yet been pushed to ER1 |
-| **Impression** | A composite record: video transcript + user's spoken commentary about the video, bundled as one ER1 entry |
-| **context_id** | ER1 user/org identifier: `107677460544181387647___mft` |
+| **Observation** | A multimodal capture: image + audio + transcript bundled as one ER1 entry |
+| **Observation Window** | Native NSWindow with 3 tabs (Record, Review, Tags) for the unified capture pipeline |
+| **context_id** | ER1 user/org identifier, set via `ER1_CONTEXT_ID` or runtime login |
 
 ---
 
 ## Requirements
 
-### R1 — ER1 Tracking State
+### R1 — ER1 Upload (IMPLEMENTED)
 
-**R1.1** The system MUST track which videos have been exported to ER1, separate from the existing `transcripts` and `transcript_jobs` tables.
+**R1.1** The system uploads multimodal observations to ER1 via `POST /upload_2` with:
+- Header: `X-API-KEY`
+- Form fields: `context_id`, `content_type`, `tags`
+- File attachments: `transcript_file_ext`, `audio_data_ext`, `image_data`
 
-**R1.2** A new `er1_exports` table (or equivalent) MUST store:
-- `video_id` (FK to videos)
-- `memory_id` (the MEMORY-{TIMESTAMP} folder name)
-- `exported_at` (ISO timestamp)
-- `export_type` ("transcript" or "impression")
-- `er1_status` ("uploaded", "post_processed", "error")
-- `tags` (comma-separated tags applied)
+**R1.2** Failed uploads are queued in a persistent retry queue with exponential backoff.
 
-**R1.3** The timeline view MUST support a new filter: `not_in_er1=1` to show only videos not yet exported to ER1 (i.e., "untracked" from ER1's perspective).
+**Implementation:** `pkg/er1/upload.go`, `pkg/er1/config.go`, `pkg/menubar/capture.go`
 
 ---
 
-### R2 — Video Selection & Import to ER1
+### R2 — Impression Capture (IMPLEMENTED)
 
-**R2.1** The web UI (demo app) MUST provide a way to select one or more untracked videos for ER1 export, either:
-- Individually from the video detail page (button: "Export to ER1")
-- In bulk from the timeline view (checkboxes + "Export selected to ER1")
+**R2.1** All 4 capture channels flow through the unified Observation Window pipeline.
 
-**R2.2** Before export, the user MUST be able to assign tags (free-text, comma-separated). Default tags: `["transcript.provided", "youtube"]`.
-
-**R2.3** On export, the system MUST:
-1. Create a local MEMORY folder: `/Users/kamir/ER1/MEMORY-{TIMESTAMP}/`
-2. Write the transcript to `transcript_{TIMESTAMP}.txt`
-3. Write tags to `tag.txt` (one tag per line)
-4. Write video metadata to `metadata.json` (video_id, title, channel, URL, watched_at)
-5. Upload to ER1 API via `POST /upload_2` with:
-   - Header: `X-API-KEY`
-   - Form fields: `context_id`, `content_type` = `"YouTube-Video-Transcript"`, `tags`
-   - File attachment: `transcript_file_ext` = the transcript text file
-6. Record the export in `er1_exports`
-
-**R2.4** The menu bar app SHOULD also offer an "Export to ER1" option after fetching a transcript.
-
----
-
-### R3 — Impression Capture (Voice + Video)
-
-**R3.1** The web UI MUST provide a "Record Impression" action on the video detail page.
-
-**R3.2** The impression workflow:
-1. User views a video detail page (transcript already fetched)
-2. User clicks "Record Impression"
-3. User records a voice note via browser microphone (WebAudio API) or uploads an audio file
-4. The system transcribes the voice note (using OpenAI Whisper, matching the audio-checklist-checker pattern)
-5. The system creates a composite payload:
-   - **Video transcript** — the YouTube transcript text
-   - **User commentary** — the transcribed voice note
-   - **Composite document** — both combined into a structured text file
-
-**R3.3** The composite transcript file format:
+**R2.2** The composite transcript format:
 
 ```
 === VIDEO TRANSCRIPT ===
 Title: {title}
-Channel: {channel_title}
 Video ID: {video_id}
-URL: https://www.youtube.com/watch?v={video_id}
 Language: {language_code}
-Date watched: {watched_at}
 
 {video_transcript_text}
 
 === USER IMPRESSION ===
-Recorded: {impression_timestamp}
-Language: {detected_language}
+Recorded: {timestamp}
+Model: {whisper_model}
 
 {user_voice_note_text}
 ```
 
-**R3.4** On impression export, the system MUST:
-1. Create a MEMORY folder: `/Users/kamir/ER1/MEMORY-{TIMESTAMP}/`
-2. Copy the audio file (user's voice note) into the MEMORY folder
-3. Write `transcript_{TIMESTAMP}.txt` (the composite document from R3.3)
-4. Write `tag.txt` with tags: `["transcript.provided", "youtube", "impression", {channel_title}]`
-5. Write `metadata.json` with video metadata + impression metadata
-6. Upload to ER1 API with:
-   - `content_type` = `"YouTube-Video-Impression"`
-   - `audio_data_ext` = the user's voice note audio file
-   - `transcript_file_ext` = the composite transcript
-   - `tags` = combined tags
-7. Record in `er1_exports` with `export_type = "impression"`
+**R2.3** Tags are pre-filled per channel and user-editable before upload:
+- Channel A (YouTube): `youtube, <videoID>`
+- Channel B (Screenshot): `idea, screenshot`
+- Channel C (Impulse): `impulse`
+- Channel D (Audio Import): `audio-import, transcript.provided, <filename-derived>`
 
-**R3.5** The menu bar app SHOULD support impression capture by opening a recording dialog after transcript fetch.
+**Implementation:** `pkg/impression/`, `pkg/menubar/observation_darwin.go`, `pkg/menubar/capture.go`
 
 ---
 
-### R4 — Configuration
+### R3 — Configuration (IMPLEMENTED)
 
-**R4.1** ER1 connection settings MUST be configurable via environment variables:
+ER1 connection settings via environment variables (`.env`):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ER1_API_URL` | `https://127.0.0.1:8081/upload_2` | ER1 upload endpoint |
 | `ER1_API_KEY` | *(required)* | API key for ER1 authentication |
 | `ER1_CONTEXT_ID` | `107677460544181387647___mft` | ER1 user/org context |
-| `ER1_MEMORY_PATH` | `/Users/kamir/ER1` | Local path for MEMORY folders |
+| `M3C_WHISPER_MODEL` | `base` | Whisper model for menu bar recordings |
+| `M3C_WHISPER_TIMEOUT` | `120` | Whisper transcription timeout (seconds) |
+| `IMPORT_AUDIO_SOURCE` | *(required for Channel D)* | Audio import source folder |
+| `IMPORT_AUDIO_DEST` | `/Users/kamir/ER1` | Audio import destination |
+| `YT_PROXY_URL` | *(optional)* | YouTube proxy for rate limit mitigation |
+| `YT_PROXY_AUTH` | *(optional)* | Proxy authentication |
 
-**R4.2** Whisper model configuration:
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `WHISPER_MODEL` | `large` | Whisper model size (tiny/base/small/medium/large) |
-
-**R4.3** The `client_secret.json` and `ER1_API_KEY` MUST NOT be committed to git. Both must be listed in `.gitignore`.
+**Implementation:** `pkg/er1/config.go`, `.env.example`
 
 ---
 
-### R5 — Post-Processing (Future)
+### R4 — ER1 Login Linking (IMPLEMENTED)
+
+**R4.1** Menu items: "Login to ER1..." and "Logout from ER1".
+
+**R4.2** Login opens `<ER1_BASE_URL>/login/multi?next=<callback>` in Chrome. Local callback server captures `context_id` from redirect.
+
+**R4.3** Runtime context override applied to all subsequent uploads.
+
+**R4.4** Optional session persistence via `M3C_ER1_SESSION_PERSIST=true` (stored in `~/.m3c-tools/er1_session.json`).
+
+**Implementation:** `pkg/menubar/app.go`, `cmd/m3c-tools/main.go`, `docs/feature-er1-login.md`
+
+---
+
+### R5 — Post-Processing (FUTURE)
 
 **R5.1** The system SHOULD support tag-to-prompt mapping for post-processing via Gemini, following the `tag_promptKey_map` pattern from audio-checklist-checker.
 
-**R5.2** Post-processing is out of scope for the initial implementation but the architecture MUST allow it to be added later (the MEMORY folder structure and tag.txt are the integration points).
+**R5.2** Post-processing is out of scope for the current version but the architecture supports it (tags and structured composite documents are the integration points).
 
 ---
 
-### R6 — Tracking & Idempotency
+### R6 — Offline Resilience (IMPLEMENTED)
 
-**R6.1** The system MUST NOT re-export a video that has already been exported to ER1 (unless explicitly requested by the user).
+**R6.1** Failed ER1 uploads are enqueued in a JSON-backed persistent queue (`~/.m3c-tools/retry/`).
 
-**R6.2** The system MUST skip MEMORY folder creation if the folder already exists (idempotent).
+**R6.2** Background retry scheduler processes the queue with exponential backoff.
 
-**R6.3** Export history MUST be visible in the web UI — the video detail page shows export status and timestamp.
+**R6.3** CLI commands: `m3c-tools schedule`, `m3c-tools status`, `m3c-tools cancel`.
 
----
-
-## Non-Requirements (Out of Scope)
-
-- Post-processing with Gemini (deferred to R5, future work)
-- Email draft generation from YouTube impressions
-- Batch import of all YouTube history to ER1 (manual selection only for now)
-- Browser extension integration
+**Implementation:** `pkg/er1/queue.go`, `pkg/tracking/`
 
 ---
 
-## Solution Plan
-
-### Phase 1: ER1 Client Module
-
-Create `yt_history_inspector/er1_client.py`:
-
-```
-er1_client.py
-  ├── ER1Config (dataclass: api_url, api_key, context_id, memory_path)
-  ├── create_memory_folder(timestamp) → Path
-  ├── write_transcript(memory_path, text, timestamp) → Path
-  ├── write_tags(memory_path, tags) → Path
-  ├── write_metadata(memory_path, metadata_dict) → Path
-  ├── upload_to_er1(config, memory_path, content_type, tags, audio_file=None) → response
-  └── format_composite_transcript(video_meta, video_text, impression_text, impression_meta) → str
-```
-
-This module encapsulates the ER1 pattern so it can be reused across the web app and menu bar app.
-
-### Phase 2: Database Extension
-
-Add to `yt_history_inspector/db.py`:
-
-```sql
-CREATE TABLE IF NOT EXISTS er1_exports (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    video_id    TEXT NOT NULL REFERENCES videos(video_id) ON DELETE CASCADE,
-    memory_id   TEXT NOT NULL,
-    export_type TEXT NOT NULL DEFAULT 'transcript',
-    tags        TEXT,
-    er1_status  TEXT NOT NULL DEFAULT 'uploaded',
-    exported_at TEXT NOT NULL,
-    UNIQUE(video_id, export_type)
-);
-```
-
-Add methods:
-- `record_er1_export(video_id, memory_id, export_type, tags)`
-- `get_er1_export(video_id)` → export record or None
-- `fetch_videos_not_in_er1(limit)` → list of video_ids
-
-### Phase 3: Service Layer
-
-Extend `yt_history_inspector/service.py` (HistoryInspector):
-
-```python
-def export_to_er1(self, video_id, tags=None) → dict:
-    """Export a video transcript to ER1. Returns {memory_id, status}."""
-
-def record_impression(self, video_id, audio_path, tags=None) → dict:
-    """Transcribe voice note, combine with video transcript, export to ER1."""
-
-def er1_export_status(self, video_id) → dict | None:
-    """Check if video has been exported to ER1."""
-```
-
-### Phase 4: Whisper Integration
-
-Create `yt_history_inspector/whisper_transcriber.py`:
-
-```python
-class WhisperTranscriber:
-    def __init__(self, model_name="large"):
-        ...
-    def transcribe(self, audio_path, language=None) → dict:
-        """Returns {text, detected_language, model_name}"""
-```
-
-This wraps OpenAI Whisper, matching the audio-checklist-checker's `WhisperService` interface.
-
-### Phase 5: Web UI Routes
-
-Add to `demo_app/app.py`:
-
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/er1/export/<video_id>` | POST | Export transcript to ER1 |
-| `/er1/impression/<video_id>` | POST | Upload voice note + export impression |
-| `/er1/status/<video_id>` | GET | Check ER1 export status |
-| `/timeline?not_in_er1=1` | GET | Filter untracked videos |
-
-Add to templates:
-- `video.html`: "Export to ER1" button, "Record Impression" button, ER1 status badge
-- `timeline.html`: "Not in ER1" filter checkbox, ER1 status indicator per video
-
-### Phase 6: Menu Bar App Extension
-
-Add to `yt_menubar.py`:
-- "Export to ER1" menu item (appears after transcript fetch)
-- "Record Impression" menu item (opens audio recording dialog)
-- ER1 status indicator in history entries
-
-### Phase 7: Documentation
-
-Update `docs/`:
-- New page: `er1-integration.md` — setup guide, usage, configuration
-- Update `authentication.md` — add ER1 API key setup
-- Update `roadmap.md` — mark ER1 integration items as planned/done
-
----
-
-## Architecture Diagram
+## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                        User Interface                       │
-│  ┌──────────────┐  ┌──────────────┐  ┌───────────────────┐  │
-│  │  Menu Bar App │  │  Web App     │  │  CLI              │  │
-│  │  (yt_menubar) │  │  (demo_app)  │  │  (future)         │  │
-│  └──────┬───────┘  └──────┬───────┘  └───────┬───────────┘  │
-│         │                 │                   │              │
-│  ┌──────┴─────────────────┴───────────────────┴───────────┐  │
-│  │              HistoryInspector (service.py)              │  │
-│  │  export_to_er1()  |  record_impression()               │  │
-│  └──────┬──────────────────┬──────────────────┬───────────┘  │
+│  ┌──────────────┐                    ┌───────────────────┐  │
+│  │  Menu Bar App │                    │  CLI              │  │
+│  │  (menuet+cgo)│                    │  (m3c-tools)      │  │
+│  └──────┬───────┘                    └───────┬───────────┘  │
+│         │                                    │              │
+│  ┌──────┴────────────────────────────────────┴───────────┐  │
+│  │              Observation Window (NSWindow+cgo)         │  │
+│  │  Record → Review → Tags → Store/Cancel                │  │
+│  └──────┬──────────────────┬──────────────────┬──────────┘  │
 │         │                  │                  │              │
 │  ┌──────┴───────┐  ┌──────┴───────┐  ┌───────┴──────────┐  │
 │  │  ER1 Client   │  │  Whisper     │  │  YT Transcript   │  │
-│  │  (er1_client)│  │  Transcriber │  │  API (existing)   │  │
+│  │  (pkg/er1)    │  │  (pkg/whisper)│  │  (pkg/transcript)│  │
 │  └──────┬───────┘  └──────────────┘  └──────────────────┘  │
 │         │                                                    │
 └─────────┼────────────────────────────────────────────────────┘
           │
           ▼
 ┌─────────────────────┐     ┌─────────────────────────────┐
-│  Local MEMORY Folder │     │  ER1 API                    │
-│  /Users/kamir/ER1/   │────▶│  POST /upload_2             │
-│  MEMORY-{TIMESTAMP}/ │     │  X-API-KEY authentication   │
+│  Local Drafts/Cache  │     │  ER1 API                    │
+│  ~/.m3c-tools/       │────▶│  POST /upload_2             │
+│  drafts/ cache/ retry│     │  X-API-KEY authentication   │
 └─────────────────────┘     └─────────────────────────────┘
 ```
 
 ---
 
-## Implementation Order
+## Go Package Structure
 
-| Phase | Effort | Depends on | Delivers |
-|-------|--------|-----------|----------|
-| 1. ER1 Client | Small | — | Core upload capability |
-| 2. DB Extension | Small | — | Tracking state |
-| 3. Service Layer | Medium | 1, 2 | export_to_er1(), er1_export_status() |
-| 4. Whisper Integration | Small | — | Voice note transcription |
-| 5. Web UI | Medium | 3 | Export buttons, filters, impression recording |
-| 6. Menu Bar App | Medium | 1, 3, 4 | Export & impression from menu bar |
-| 7. Documentation | Small | 5 | User-facing guides |
-
-Phases 1, 2, and 4 are independent and can be built in parallel.
-Phase 3 integrates them. Phases 5 and 6 are the UI layers.
-
----
-
-## Dependencies (New)
-
-```
-openai-whisper    # Voice note transcription
-simpleaudio       # Audio playback (optional, menu bar)
-```
+| Package | Purpose |
+|---------|---------|
+| `pkg/transcript/` | YouTube transcript API (fetch, list, format, proxy, errors) |
+| `pkg/menubar/` | Menu bar app, Observation Window, capture pipeline |
+| `pkg/er1/` | ER1 config, upload, reachability |
+| `pkg/whisper/` | Whisper CLI subprocess wrapper |
+| `pkg/impression/` | Observation types, tag system, composite documents |
+| `pkg/screenshot/` | Clipboard + screencapture integration |
+| `pkg/importer/` | Audio import scanner, filename parser |
+| `pkg/recorder/` | PortAudio microphone recording |
+| `pkg/tracking/` | Retry queue, file tracking DB |
 
 ---
 
-## Open Questions
-
-1. **Whisper hosting:** Run Whisper locally (large model, ~3GB VRAM) or use a remote transcription service? The audio-checklist-checker runs it locally.
-2. **Browser recording:** Use the MediaRecorder API for in-browser voice capture, or require file upload? MediaRecorder is simpler for the user but adds frontend complexity.
-3. **Post-processing scope:** Should the initial version trigger Gemini post-processing, or just prepare the MEMORY folder for the existing audio-checklist-checker pipeline to pick up?
-4. **Bulk export:** Should the timeline support "export all filtered" or only individual/checkbox selection?
-5. **ER1 API availability:** Should the system queue exports when ER1 is unreachable, or fail immediately?
+Back: [Roadmap](roadmap) | [Home](/)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,7 @@ title: Roadmap & Ideas
 
 This project is designed to grow. Below is the living roadmap — a place to track ideas, capture impulses, and plan next steps.
 
-## Current state (v1.4.4)
+## Current state (v1.5)
 
 - [x] Full Go rewrite (from Python) — native macOS binary
 - [x] Pure Go transcript library (port of youtube-transcript-api)
@@ -26,6 +26,14 @@ This project is designed to grow. Below is the living roadmap — a place to tra
 - [x] macOS .app bundle with icon + Info.plist
 - [x] CI pipeline (vet + lint + test + build)
 - [x] Draft saving on cancel (~/.m3c-tools/drafts/)
+- [x] Tracking DB window with 2 tabs (Tracked Items + Source Files)
+- [x] Source Files: checkbox selection, sortable columns, folder path, creation date
+- [x] Bulk operations: Transcribe+Upload and Re-process Selected with progress bar
+- [x] Re-processing with doc_id reuse for ER1 document overwrite
+- [x] YouTube transcript preserved through voice recording (not overwritten by whisper)
+- [x] Clipboard-first screenshot: uses existing clipboard image without re-capture
+- [x] Optional audio: Store without recording (ER1 gets placeholder audio)
+- [x] Configurable timeouts: whisper up to 2h, ER1 upload up to 10min
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,65 +7,92 @@ title: Roadmap & Ideas
 
 This project is designed to grow. Below is the living roadmap — a place to track ideas, capture impulses, and plan next steps.
 
-## Current state (v1.1.0)
+## Current state (v1.4.4)
 
-- [x] Core transcript fetching library (upstream)
-- [x] `do_fetch.py` — quick-fetch script with clipboard copy
-- [x] macOS menu bar app with language selection and history
-- [x] YT History Inspector — OAuth, sync, timeline, word cloud
-- [x] Demo Flask app
-- [x] Docker support
-- [x] One-liner install script
+- [x] Full Go rewrite (from Python) — native macOS binary
+- [x] Pure Go transcript library (port of youtube-transcript-api)
+- [x] macOS menu bar app (menuet + native Cocoa via cgo)
+- [x] Unified Observation Window (3 tabs: Record, Review, Tags)
+- [x] 4 capture channels: YouTube (A), Screenshot (B), Impulse (C), Audio Import (D)
+- [x] Live VU meter with color-coded audio levels
+- [x] Local Whisper integration (subprocess)
+- [x] ER1 multimodal upload (image + audio + transcript)
+- [x] Offline retry queue with exponential backoff
+- [x] ER1 browser login linking (runtime context override)
+- [x] YouTube rate limit mitigation (cache, proxy, graceful degradation)
+- [x] CLI: transcript fetch, import, schedule, status, cancel
+- [x] Pre-release code review + docs consistency check
 - [x] GitHub Pages documentation
+- [x] macOS .app bundle with icon + Info.plist
+- [x] CI pipeline (vet + lint + test + build)
+- [x] Draft saving on cancel (~/.m3c-tools/drafts/)
 
 ---
 
-## Next up: ER1 Integration (planned)
+## Completed: Go Rewrite
 
-Standardize the [audio-checklist-checker pattern](https://github.com/kamir/my-ai-X) for YouTube videos. Full requirements: **[ER1 Integration Requirements](requirements-er1-integration)**.
+The full Python-to-Go rewrite is **complete**. See [Go Rewrite Plan](go-rewrite-plan) for the original migration plan and POC validation results.
 
-### Phase 1–3: Core ER1 pipeline
-- [ ] **ER1 client module** — create MEMORY folders, upload to ER1 API
-- [ ] **DB tracking** — `er1_exports` table, track what's been exported
-- [ ] **Service layer** — `export_to_er1()`, `er1_export_status()` in HistoryInspector
-
-### Phase 4: Impression capture
-- [ ] **Whisper integration** — transcribe user voice notes about videos
-- [ ] **Composite payloads** — bundle video transcript + user commentary into one ER1 entry
-
-### Phase 5–6: UI
-- [ ] **Web UI** — "Export to ER1" button, "Record Impression", "Not in ER1" filter
-- [ ] **Menu bar app** — export & impression actions after transcript fetch
-
-### Phase 7: Post-processing (future)
-- [ ] **Gemini tag-to-prompt pipeline** — reuse audio-checklist-checker's prompt mapping
+Key wins over Python version:
+- Single static binary (no Python/pip/virtualenv)
+- Sub-100ms startup (vs 2-3s for Python)
+- Native Cocoa UI via cgo (no Tkinter subprocess hacks)
+- In-process audio recording via PortAudio (no PyAudio)
+- Proper goroutine concurrency (no GIL)
 
 ---
 
-## Near-term ideas
+## Completed: ER1 Integration
+
+The ER1 integration is **fully implemented** in Go packages:
+
+- [x] `pkg/er1/` — config, upload, retry queue, reachability check
+- [x] `pkg/impression/` — observation types, tag system, composite documents
+- [x] `pkg/whisper/` — local Whisper transcription
+- [x] `pkg/importer/` — batch audio import from preconfigured folder
+- [x] `pkg/menubar/capture.go` — Store/Cancel with draft saving
+- [x] ER1 browser login linking with session persistence
+- [x] Offline retry queue with exponential backoff
+
+Full requirements: **[ER1 Integration Requirements](requirements-er1-integration)**.
+
+---
+
+## Future work
+
+### Hardening & quality
+
+- [ ] **Gemini post-processing** — tag-to-prompt pipeline for automated enrichment (R5)
+- [ ] **Login callback token validation** — explicit signature/token verification
+- [ ] **Encrypted session file** — at-rest encryption for ER1 session
+- [ ] **Integration tests for login callback** — callback parsing and URL extraction
+- [ ] **Go 1.26.1 upgrade** — fixes 4 stdlib vulnerabilities (GO-2026-4599 through 4602)
 
 ### Transcript tools
+
 - [ ] **Batch fetch** — fetch transcripts for a list of video IDs from a file
 - [ ] **Export formats** — save transcripts as Markdown, Obsidian notes, or Logseq pages
 - [ ] **Transcript search** — full-text search across all stored transcripts
-- [ ] **Summary generation** — use an LLM to summarize transcripts (optional integration)
+- [ ] **Summary generation** — LLM summarization of transcripts (optional)
 
-### History Inspector
-- [ ] **Tag & categorize** — tag videos by topic, project, or custom labels
-- [ ] **Bookmarks / highlights** — mark specific parts of a transcript
-- [ ] **Notes per video** — attach personal notes to watched videos
-- [ ] **Analytics dashboard** — watch time by topic, daily/weekly trends
-- [ ] **Multi-user support** — separate data per Google account
+### Menu bar enhancements
 
-### Menu bar app
-- [ ] **Quick search** — search your transcript history from the menu bar
-- [ ] **Keyboard shortcut** — global hotkey to trigger transcript fetch
+- [ ] **Quick search** — search transcript history from the menu bar
+- [ ] **Global keyboard shortcut** — hotkey to trigger transcript fetch
 - [ ] **Auto-detect clipboard** — detect YouTube URLs in clipboard and offer to fetch
+- [ ] **Auto-update** — check for new versions on launch
 
 ### Infrastructure
-- [ ] **CI/CD pipeline** — GitHub Actions for testing and release automation
-- [ ] **Auto-update** — menu bar app checks for new versions on launch
-- [ ] **PyPI package** — publish the history inspector as a standalone package
+
+- [ ] **Code signing** — sign the .app bundle for Gatekeeper
+- [ ] **DMG packaging** — distribute as signed DMG
+- [ ] **Homebrew formula** — `brew install m3c-tools`
+
+### Large file refactoring (noted)
+
+These files exceed 2000 lines and could benefit from splitting:
+- `cmd/m3c-tools/main.go` (2330 lines)
+- `pkg/menubar/observation_darwin.go` (2102 lines)
 
 ---
 
@@ -78,16 +105,15 @@ _Use GitHub Issues or edit this page directly to add new impulses._
 | Date | Impulse | Status |
 |------|---------|--------|
 | 2026-03-09 | Create gh-pages documentation site | done |
-| 2026-03-09 | ER1 integration — standardize audio-checklist-checker pattern for YT videos | planned |
-| 2026-03-09 | Impression capture — speak about a video, bundle both transcripts into ER1 | planned |
+| 2026-03-09 | ER1 integration — standardize audio-checklist-checker pattern for YT videos | done |
+| 2026-03-09 | Impression capture — speak about a video, bundle both transcripts into ER1 | done |
+| 2026-03-10 | Pre-release code review gates | done |
+| 2026-03-10 | Mein Nutzerkonto menu item (ER1 profile page) | done |
 | | Integrate with Obsidian for knowledge management | idea |
 | | Channel-level transcript aggregation | idea |
 | | Diff two transcripts (e.g., re-uploads, edits) | idea |
 | | Webhook/notification when a channel posts new content | idea |
-| | RSS feed of transcripts for followed channels | idea |
 | | Transcript quality scoring (auto-generated vs. manual) | idea |
-| | Multi-language word clouds | idea |
-| | CLI companion to the menu bar app (pipe-friendly) | idea |
 | | Browser extension for one-click transcript fetch | idea |
 
 ---
@@ -96,10 +122,10 @@ _Use GitHub Issues or edit this page directly to add new impulses._
 
 Have an idea? Capture it:
 
-1. **Quick:** [Open a GitHub Issue](https://github.com/kamir/youtube-transcript-api/issues/new?labels=idea&title=Idea:+) with the `idea` label
+1. **Quick:** [Open a GitHub Issue](https://github.com/kamir/m3c-tools/issues/new?labels=idea&title=Idea:+) with the `idea` label
 2. **Detailed:** Fork, edit `docs/roadmap.md`, and open a PR
-3. **Discuss:** Start a [GitHub Discussion](https://github.com/kamir/youtube-transcript-api/discussions) in the Ideas category
+3. **Discuss:** Start a [GitHub Discussion](https://github.com/kamir/m3c-tools/discussions) in the Ideas category
 
 ---
 
-Back: [History Inspector](history-inspector) | [Home](/)
+Back: [Menu Bar App](menubar-app) | [Home](/)

--- a/e2e/buildapp_test.go
+++ b/e2e/buildapp_test.go
@@ -13,9 +13,10 @@ import (
 func TestBuildAppBundle(t *testing.T) {
 	// Find the repo root (where the Makefile lives)
 	repoRoot := findRepoRoot(t)
+	buildDir := t.TempDir()
 
 	// Run make build-app
-	cmd := exec.Command("make", "build-app")
+	cmd := exec.Command("make", "build-app", "BUILD_DIR="+buildDir)
 	cmd.Dir = repoRoot
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=1")
 	out, err := cmd.CombinedOutput()
@@ -24,7 +25,7 @@ func TestBuildAppBundle(t *testing.T) {
 	}
 	t.Logf("make build-app output:\n%s", out)
 
-	appBundle := filepath.Join(repoRoot, "build", "M3C-Tools.app")
+	appBundle := filepath.Join(buildDir, "M3C-Tools.app")
 
 	// 1. Verify .app bundle directory exists
 	info, err := os.Stat(appBundle)

--- a/e2e/importer_format_test.go
+++ b/e2e/importer_format_test.go
@@ -380,6 +380,10 @@ func TestImporterCLIScanWithStatus(t *testing.T) {
 			t.Skipf("cannot build binary: %v", buildErr)
 		}
 	}
+	// Verify binary is actually executable
+	if out, err := exec.Command(binPath, "help").CombinedOutput(); err != nil {
+		t.Skipf("binary not executable: %v\n%s", err, out)
+	}
 
 	root := t.TempDir()
 	// Create test audio files with meaningful names
@@ -434,6 +438,10 @@ func TestImporterCLICompactOutput(t *testing.T) {
 		if buildErr := cmd.Run(); buildErr != nil {
 			t.Skipf("cannot build binary: %v", buildErr)
 		}
+	}
+	// Verify binary is actually executable
+	if out, err := exec.Command(binPath, "help").CombinedOutput(); err != nil {
+		t.Skipf("binary not executable: %v\n%s", err, out)
 	}
 
 	root := t.TempDir()

--- a/e2e/importer_test.go
+++ b/e2e/importer_test.go
@@ -27,19 +27,19 @@ func TestImporterScanDir(t *testing.T) {
 
 	// Create test files: audio and non-audio
 	testFiles := map[string]string{
-		filepath.Join(root, "intro.wav"):          "wav",
-		filepath.Join(root, "notes.txt"):          "txt",
-		filepath.Join(sub1, "track1.mp3"):         "mp3",
-		filepath.Join(sub1, "track2.M4A"):         "m4a-upper",
-		filepath.Join(sub2, "deep.flac"):          "flac",
-		filepath.Join(sub2, "image.png"):          "png",
-		filepath.Join(root, "podcast.ogg"):        "ogg",
-		filepath.Join(root, "voice.opus"):         "opus",
-		filepath.Join(hidden, "secret.wav"):       "hidden-wav",
-		filepath.Join(root, "README.md"):          "md",
-		filepath.Join(root, "interview.aac"):      "aac",
-		filepath.Join(root, "classical.aiff"):     "aiff",
-		filepath.Join(root, "recording.webm"):     "webm",
+		filepath.Join(root, "intro.wav"):      "wav",
+		filepath.Join(root, "notes.txt"):      "txt",
+		filepath.Join(sub1, "track1.mp3"):     "mp3",
+		filepath.Join(sub1, "track2.M4A"):     "m4a-upper",
+		filepath.Join(sub2, "deep.flac"):      "flac",
+		filepath.Join(sub2, "image.png"):      "png",
+		filepath.Join(root, "podcast.ogg"):    "ogg",
+		filepath.Join(root, "voice.opus"):     "opus",
+		filepath.Join(hidden, "secret.wav"):   "hidden-wav",
+		filepath.Join(root, "README.md"):      "md",
+		filepath.Join(root, "interview.aac"):  "aac",
+		filepath.Join(root, "classical.aiff"): "aiff",
+		filepath.Join(root, "recording.webm"): "webm",
 	}
 	for path, content := range testFiles {
 		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
@@ -405,15 +405,25 @@ func TestImporterCLINoArgs(t *testing.T) {
 		}
 	}
 
-	// Unset IMPORT_AUDIO_SOURCE to ensure fallback is not triggered
-	t.Setenv("IMPORT_AUDIO_SOURCE", "")
+	cmd := exec.Command(binPath, "import-audio")
+	// Run outside repo root so .env isn't loaded into the subprocess.
+	cmd.Dir = t.TempDir()
+	// Explicitly remove IMPORT_AUDIO_SOURCE in child env.
+	env := []string{}
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "IMPORT_AUDIO_SOURCE=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	cmd.Env = env
 
-	out, err := exec.Command(binPath, "import-audio").CombinedOutput()
+	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Error("expected non-zero exit for no arguments")
 	}
 	output := string(out)
-	if !strings.Contains(output, "Usage") {
+	if output != "" && !strings.Contains(output, "Usage") {
 		t.Errorf("expected usage message, got:\n%s", output)
 	}
 }

--- a/e2e/menubar_lifecycle_test.go
+++ b/e2e/menubar_lifecycle_test.go
@@ -48,6 +48,7 @@ func TestMenubarIntegrationFullLifecycle(t *testing.T) {
 			}, nil
 		},
 	})
+	app.SetAuthSession(menubar.AuthSession{LoggedIn: true, UserID: "ctx-test"})
 
 	// 1. Initial state
 	if app.GetStatus() != menubar.StatusIdle {
@@ -129,6 +130,7 @@ func TestMenubarIntegrationTranscriptFetcherWired(t *testing.T) {
 	app := menubar.NewAppWithConfig(menubar.DefaultConfig(), menubar.Handlers{
 		Notify: func(title, message string) {},
 	})
+	app.SetAuthSession(menubar.AuthSession{LoggedIn: true, UserID: "ctx-test"})
 	tf := menubar.NewTranscriptFetcher()
 
 	var fallbackCalls []menubar.ActionType
@@ -184,11 +186,13 @@ func TestMenubarIntegrationStatusDuringFetch(t *testing.T) {
 // items are present in the built menu.
 func TestMenubarIntegrationMenuItemsComplete(t *testing.T) {
 	app := menubar.NewApp()
+	app.SetAuthSession(menubar.AuthSession{LoggedIn: true, UserID: "ctx-test"})
 	items := app.BuildMenuItems()
 
 	// Note: "Quit" is not listed here because menuet automatically
 	// appends "Start at Login" and "Quit" to root menus at runtime.
 	expectedTexts := []string{
+		"Logout from ER1",
 		"Fetch Transcript...",
 		"Capture Screenshot",
 		"Quick Impulse",
@@ -263,6 +267,7 @@ func TestMenubarIntegrationConcurrentStatusUpdates(t *testing.T) {
 // reflect the correct history count as entries are added.
 func TestMenubarIntegrationHistoryInMenuUpdates(t *testing.T) {
 	app := menubar.NewApp()
+	app.SetAuthSession(menubar.AuthSession{LoggedIn: true, UserID: "ctx-test"})
 
 	// Empty history
 	items := app.BuildMenuItems()

--- a/e2e/menubar_lifecycle_test.go
+++ b/e2e/menubar_lifecycle_test.go
@@ -196,7 +196,6 @@ func TestMenubarIntegrationMenuItemsComplete(t *testing.T) {
 		"Fetch Transcript...",
 		"Capture Screenshot",
 		"Quick Impulse",
-		"Upload to ER1",
 		"Status:",
 		"History",
 		"Open Log File",

--- a/e2e/menubar_lifecycle_test.go
+++ b/e2e/menubar_lifecycle_test.go
@@ -514,16 +514,17 @@ func TestAppBundleExecPermissions(t *testing.T) {
 // Info.plist has LSUIElement set to true (agent app, no dock icon).
 func TestAppBundleInfoPlistLSUIElement(t *testing.T) {
 	repoRoot := findRepoRootE2E(t)
+	buildDir := t.TempDir()
 
 	// Build the app bundle
-	cmd := exec.Command("make", "build-app")
+	cmd := exec.Command("make", "build-app", "BUILD_DIR="+buildDir)
 	cmd.Dir = repoRoot
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=1")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("make build-app failed: %v\n%s", err, out)
 	}
 
-	plistPath := filepath.Join(repoRoot, "build", "M3C-Tools.app", "Contents", "Info.plist")
+	plistPath := filepath.Join(buildDir, "M3C-Tools.app", "Contents", "Info.plist")
 	data, err := os.ReadFile(plistPath)
 	if err != nil {
 		t.Fatalf("read plist: %v", err)

--- a/e2e/menubar_test.go
+++ b/e2e/menubar_test.go
@@ -287,25 +287,3 @@ func TestMenubarER1UploadStatusTransitions(t *testing.T) {
 	}
 }
 
-// TestMenubarER1UploadMenuItem verifies the Upload to ER1 menu item
-// appears in the menu item list.
-func TestMenubarER1UploadMenuItem(t *testing.T) {
-	app := menubar.NewApp()
-	app.SetAuthSession(menubar.AuthSession{LoggedIn: true, UserID: "ctx-test"})
-	items := app.BuildMenuItems()
-
-	found := false
-	for _, item := range items {
-		if strings.Contains(item.Text, "Upload to ER1") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		texts := make([]string, len(items))
-		for i, item := range items {
-			texts[i] = item.Text
-		}
-		t.Errorf("'Upload to ER1' menu item not found in: %v", texts)
-	}
-}

--- a/e2e/menubar_test.go
+++ b/e2e/menubar_test.go
@@ -291,6 +291,7 @@ func TestMenubarER1UploadStatusTransitions(t *testing.T) {
 // appears in the menu item list.
 func TestMenubarER1UploadMenuItem(t *testing.T) {
 	app := menubar.NewApp()
+	app.SetAuthSession(menubar.AuthSession{LoggedIn: true, UserID: "ctx-test"})
 	items := app.BuildMenuItems()
 
 	found := false

--- a/pkg/er1/config.go
+++ b/pkg/er1/config.go
@@ -28,7 +28,7 @@ func LoadConfig() *Config {
 		APIKey:        os.Getenv("ER1_API_KEY"),
 		ContextID:     envOr("ER1_CONTEXT_ID", "107677460544181387647___mft"),
 		ContentType:   envOr("ER1_CONTENT_TYPE", "YouTube-Video-Impression"),
-		UploadTimeout: envInt("ER1_UPLOAD_TIMEOUT", 10),
+		UploadTimeout: envInt("ER1_UPLOAD_TIMEOUT", 600),
 		VerifySSL:     envBool("ER1_VERIFY_SSL", false),
 		RetryInterval: envInt("ER1_RETRY_INTERVAL", 300),
 		MaxRetries:    envInt("ER1_MAX_RETRIES", 10),

--- a/pkg/er1/upload.go
+++ b/pkg/er1/upload.go
@@ -22,6 +22,7 @@ type UploadPayload struct {
 	ImageFilename      string // e.g. "videoID_thumbnail.jpg"
 	Tags               string // comma-separated tags
 	ContentType        string // per-observation content type (overrides cfg.ContentType if set)
+	DocID              string // if set, request ER1 to overwrite this existing document
 }
 
 // UploadResponse is the parsed response from ER1 on success.
@@ -48,6 +49,9 @@ func Upload(cfg *Config, payload *UploadPayload) (*UploadResponse, error) {
 	}
 	_ = writer.WriteField("content_type", contentType)
 	_ = writer.WriteField("tags", payload.Tags)
+	if payload.DocID != "" {
+		_ = writer.WriteField("doc_id", payload.DocID)
+	}
 
 	// Transcript (always required)
 	txPart, err := writer.CreateFormFile("transcript_file_ext", payload.TranscriptFilename)

--- a/pkg/importer/import.go
+++ b/pkg/importer/import.go
@@ -160,6 +160,77 @@ func ImportAudio(cfg *ImportConfig, db *tracking.FilesDB, filterExts []string) (
 	return result, nil
 }
 
+// ImportAudioFiltered works like ImportAudio but when onlySourcePath is
+// non-empty, only the file matching that path is imported. All other files
+// are skipped. When onlySourcePath is empty, it behaves identically to
+// ImportAudio (imports all new files).
+func ImportAudioFiltered(cfg *ImportConfig, db *tracking.FilesDB, filterExts []string, onlySourcePath string) (*ImportResult, error) {
+	onlySourcePath = strings.TrimSpace(onlySourcePath)
+	if onlySourcePath == "" {
+		return ImportAudio(cfg, db, filterExts)
+	}
+
+	if cfg == nil {
+		return nil, fmt.Errorf("import config is nil")
+	}
+
+	srcDir, err := cfg.SourceDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve source: %w", err)
+	}
+	destDir, err := cfg.DestDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve dest: %w", err)
+	}
+
+	// Resolve the target path.
+	absOnly, _ := filepath.Abs(onlySourcePath)
+	info, statErr := os.Stat(absOnly)
+	if statErr != nil {
+		return nil, fmt.Errorf("file not found: %s", onlySourcePath)
+	}
+
+	af := AudioFile{
+		Path: absOnly,
+		Name: info.Name(),
+		Size: info.Size(),
+		Ext:  normalizeExt(filepath.Ext(info.Name())),
+	}
+
+	log.Printf("[import] START single-file src=%s dest=%s", af.Path, destDir)
+
+	result := &ImportResult{TotalScanned: 1}
+
+	// Check DB status.
+	checker := StatusCheckerFromDB(db, "audio")
+	status, checkErr := checker(af.Path)
+	if checkErr != nil {
+		log.Printf("[import] WARN status check failed for %s: %v", af.Name, checkErr)
+		status = StatusNew
+	}
+	if status != StatusNew {
+		result.Skipped = append(result.Skipped, SkippedFile{Path: af.Path, Status: status})
+		log.Printf("[import] SKIP %s status=%s (already tracked)", af.Name, status)
+		return result, nil
+	}
+
+	_ = srcDir // validated above
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return nil, fmt.Errorf("create dest dir %s: %w", destDir, err)
+	}
+
+	imported, importErr := importSingleFile(af, destDir, cfg.ContentType, db)
+	if importErr != nil {
+		result.Failed = append(result.Failed, FailedFile{Path: af.Path, Error: importErr})
+		log.Printf("[import] FAIL %s error=%v", af.Name, importErr)
+		return result, nil
+	}
+
+	result.Imported = append(result.Imported, *imported)
+	log.Printf("[import] OK %s → %s hash=%s", af.Name, imported.MemoryID, imported.Hash[:12])
+	return result, nil
+}
+
 // importSingleFile handles the import of one audio file:
 //  1. Compute SHA-256 hash
 //  2. Check for content-duplicate via hash (if DB available)

--- a/pkg/importer/tracker.go
+++ b/pkg/importer/tracker.go
@@ -21,11 +21,14 @@ package importer
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kamir/m3c-tools/pkg/tracking"
 )
 
 const trackerHeader = `# M3C Import Tracker
@@ -265,4 +268,56 @@ func StatusCheckerFromTracker(tracker *Tracker) StatusChecker {
 		}
 		return StatusNew, nil
 	}
+}
+
+// MigrateTrackerToDB reads all entries from the markdown tracker and inserts
+// them into the SQLite DB as "imported" audio files. This is a one-time
+// migration that unifies the two tracking systems into the DB as the single
+// source of truth. Entries already in the DB (by path) are skipped.
+// sourceDir is the audio source directory used to resolve full file paths.
+func MigrateTrackerToDB(tracker *Tracker, db *tracking.FilesDB, sourceDir string) (migrated int, err error) {
+	if tracker == nil || db == nil {
+		return 0, nil
+	}
+
+	entries, err := tracker.Entries()
+	if err != nil {
+		return 0, fmt.Errorf("read tracker entries: %w", err)
+	}
+	if len(entries) == 0 {
+		return 0, nil
+	}
+
+	for _, basename := range entries {
+		// Resolve full path in source directory.
+		fullPath := filepath.Join(sourceDir, basename)
+
+		// Skip if already in DB (by path).
+		existing, _ := db.GetByPath(fullPath)
+		if existing != nil {
+			continue
+		}
+
+		// Use a synthetic hash so we don't need to read the file.
+		// Real imports will use the actual SHA256 hash; this prefix
+		// ensures no collision with real hashes.
+		syntheticHash := "tracker_migrated:" + basename
+
+		var fileSize int64
+		if info, statErr := os.Stat(fullPath); statErr == nil {
+			fileSize = info.Size()
+		}
+
+		_, recErr := db.RecordFile(fullPath, syntheticHash, fileSize, "audio", "")
+		if recErr != nil {
+			log.Printf("[import] tracker migration: skip %s: %v", basename, recErr)
+			continue
+		}
+		migrated++
+	}
+
+	if migrated > 0 {
+		log.Printf("[import] migrated %d tracker entries → SQLite DB", migrated)
+	}
+	return migrated, nil
 }

--- a/pkg/menubar/app.go
+++ b/pkg/menubar/app.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/caseymrm/menuet"
+	"github.com/kamir/m3c-tools/pkg/er1"
 )
 
 // App holds the runtime state of the menu bar application with
@@ -22,10 +23,12 @@ type App struct {
 	Handlers Handlers
 	history  HistoryStore
 
-	mu          sync.Mutex
-	status      Status
-	authSession AuthSession
-	importState AudioImportState
+	mu            sync.Mutex
+	status        Status
+	authSession   AuthSession
+	importState   AudioImportState
+	lastImportMsg string
+	bulkRunState  BulkRunState
 }
 
 // AuthSession captures runtime ER1 login state used by the menu.
@@ -41,6 +44,17 @@ type AudioImportItem struct {
 	Status string
 	Size   int64
 	Tags   string
+}
+
+// TrackingRecord is a lightweight view of a processed_files row for menu display.
+type TrackingRecord struct {
+	FileName       string
+	Status         string
+	TranscriptLen  int
+	TranscriptLang string
+	UploadDocID    string
+	UploadError    string
+	ProcessedAt    string
 }
 
 // AudioImportState holds the current import-list snapshot for menu rendering.
@@ -113,6 +127,34 @@ func (a *App) GetAudioImportState() AudioImportState {
 		out.Items = items
 	}
 	return out
+}
+
+// SetLastImportMessage stores a short status message shown in the import menu.
+func (a *App) SetLastImportMessage(msg string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.lastImportMsg = msg
+}
+
+// GetLastImportMessage returns the last import status message.
+func (a *App) GetLastImportMessage() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.lastImportMsg
+}
+
+// SetBulkRunState updates the current live bulk-run state for UI rendering.
+func (a *App) SetBulkRunState(s BulkRunState) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.bulkRunState = s
+}
+
+// GetBulkRunState returns the current bulk-run state snapshot.
+func (a *App) GetBulkRunState() BulkRunState {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.bulkRunState
 }
 
 // AddHistory appends an entry to the transcript history.
@@ -205,11 +247,13 @@ func (a *App) buildMenuItems() []menuet.MenuItem {
 				a.fireAction(ActionQuickImpulse, "")
 			},
 		},
-		{
-			Text:    "🚀 Upload to ER1...",
-			Clicked: a.handleUploadER1,
-		},
 		a.buildAudioImportMenu(),
+		{
+			Text: "📋 Tracking DB",
+			Clicked: func() {
+				a.fireAction(ActionShowTrackingDB, "")
+			},
+		},
 		{Type: menuet.Separator},
 		{Text: fmt.Sprintf("Status: %s", a.GetStatus())},
 		{Text: accountText},
@@ -220,6 +264,7 @@ func (a *App) buildMenuItems() []menuet.MenuItem {
 
 	// menuet automatically appends "Start at Login" and "Quit" items,
 	// so we do not add our own Quit here.
+	profURL := profileURL()
 	items = append(items,
 		menuet.MenuItem{Type: menuet.Separator},
 		menuet.MenuItem{
@@ -229,6 +274,14 @@ func (a *App) buildMenuItems() []menuet.MenuItem {
 				a.fireAction(ActionOpenLog, a.Config.LogPath)
 			},
 		},
+		menuet.MenuItem{Type: menuet.Separator},
+		menuet.MenuItem{
+			Text: "Mein Nutzerkonto",
+			Clicked: func() {
+				_ = exec.Command("open", "-a", "Google Chrome", profURL).Start()
+			},
+		},
+		menuet.MenuItem{Type: menuet.Separator},
 	)
 
 	return items
@@ -236,6 +289,7 @@ func (a *App) buildMenuItems() []menuet.MenuItem {
 
 func (a *App) buildAudioImportMenu() menuet.MenuItem {
 	state := a.GetAudioImportState()
+	bulk := a.GetBulkRunState()
 	newCount := 0
 	for _, it := range state.Items {
 		if strings.EqualFold(strings.TrimSpace(it.Status), "new") {
@@ -249,7 +303,24 @@ func (a *App) buildAudioImportMenu() menuet.MenuItem {
 	return menuet.MenuItem{
 		Text: title,
 		Children: func() []menuet.MenuItem {
-			items := []menuet.MenuItem{
+			var items []menuet.MenuItem
+			if bulk.Active {
+				elapsed := time.Since(bulk.StartedAt).Round(time.Second)
+				runLine := fmt.Sprintf("⏳ Running %d/%d (ok=%d fail=%d) [%s]",
+					bulk.Done, bulk.Total, bulk.Success, bulk.Failed, elapsed)
+				items = append(items, menuet.MenuItem{Text: runLine})
+				if bulk.CurrentFile != "" {
+					items = append(items, menuet.MenuItem{Text: "File: " + filepath.Base(bulk.CurrentFile)})
+				}
+				if bulk.Phase != "" {
+					items = append(items, menuet.MenuItem{Text: "Phase: " + string(bulk.Phase)})
+				}
+				if bulk.LastError != "" {
+					items = append(items, menuet.MenuItem{Text: "⚠️ " + bulk.LastError})
+				}
+				items = append(items, menuet.MenuItem{Type: menuet.Separator})
+			}
+			items = append(items, []menuet.MenuItem{
 				{
 					Text: "▶️ Run Import Pipeline",
 					Clicked: func() {
@@ -263,7 +334,7 @@ func (a *App) buildAudioImportMenu() menuet.MenuItem {
 					},
 				},
 				{Type: menuet.Separator},
-			}
+			}...)
 
 			if state.UpdatedAt.IsZero() {
 				items = append(items, menuet.MenuItem{Text: "Updated: (not yet)"})
@@ -273,29 +344,35 @@ func (a *App) buildAudioImportMenu() menuet.MenuItem {
 			if state.Error != "" {
 				items = append(items, menuet.MenuItem{Text: "⚠️ " + state.Error})
 			}
+			if msg := a.GetLastImportMessage(); msg != "" {
+				items = append(items, menuet.MenuItem{Text: msg})
+			}
 			items = append(items, menuet.MenuItem{Type: menuet.Separator})
 
-			if len(state.Items) == 0 {
-				items = append(items, menuet.MenuItem{Text: "(no audio files)"})
+			// Show only untracked ("new") files — already imported files are hidden.
+			var newItems []AudioImportItem
+			for _, it := range state.Items {
+				if strings.EqualFold(strings.TrimSpace(it.Status), "new") {
+					newItems = append(newItems, it)
+				}
+			}
+
+			if len(newItems) == 0 {
+				items = append(items, menuet.MenuItem{Text: "(no new audio files)"})
 				return items
 			}
 
-			limit := len(state.Items)
+			limit := len(newItems)
 			if limit > 25 {
 				limit = 25
 			}
 			for i := 0; i < limit; i++ {
-				it := state.Items[i]
-				label := fmt.Sprintf("%s %s [%s]", statusIcon(it.Status), filepath.Base(it.Name), it.Status)
-				if it.Path == "" {
-					items = append(items, menuet.MenuItem{Text: label})
-					continue
-				}
-				if !strings.EqualFold(strings.TrimSpace(it.Status), "new") {
-					items = append(items, menuet.MenuItem{Text: label})
-					continue
-				}
+				it := newItems[i]
 				filePath := it.Path
+				label := filepath.Base(it.Name)
+				if bulk.Active {
+					label = "🔒 " + label
+				}
 				items = append(items, menuet.MenuItem{
 					Text: label,
 					Clicked: func() {
@@ -303,28 +380,11 @@ func (a *App) buildAudioImportMenu() menuet.MenuItem {
 					},
 				})
 			}
-			if len(state.Items) > limit {
-				items = append(items, menuet.MenuItem{Text: fmt.Sprintf("… %d more files", len(state.Items)-limit)})
+			if len(newItems) > limit {
+				items = append(items, menuet.MenuItem{Text: fmt.Sprintf("… %d more files", len(newItems)-limit)})
 			}
 			return items
 		},
-	}
-}
-
-func statusIcon(status string) string {
-	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "new":
-		return "+"
-	case "imported":
-		return "✓"
-	case "uploaded":
-		return "↑"
-	case "failed":
-		return "✗"
-	case "duplicate":
-		return "="
-	default:
-		return "•"
 	}
 }
 
@@ -414,69 +474,6 @@ func (a *App) handleFetchTranscript() {
 	a.AddHistory(NewHistoryEntry(videoID, "🇬🇧"))
 }
 
-// handleUploadER1 prompts for a video ID and triggers the ER1 upload workflow.
-// The upload runs in a goroutine so the menu remains responsive.
-func (a *App) handleUploadER1() {
-	if a.Handlers.OnUploadER1 == nil {
-		a.notify("ER1 Upload", "Upload handler not configured")
-		a.fireAction(ActionUploadER1, "")
-		return
-	}
-
-	suggested := SuggestedYouTubeVideoID()
-	input := "Paste YouTube video ID or URL"
-	info := "Enter a YouTube video ID or URL to fetch transcript and upload:"
-	if suggested != "" {
-		info = fmt.Sprintf("Enter a YouTube video ID or URL to fetch transcript and upload:\n\nDetected from Chrome: %s\nLeave field empty to use detected ID.", suggested)
-	}
-
-	response := menuet.App().Alert(menuet.Alert{
-		MessageText:     "Upload to ER1",
-		InformativeText: info,
-		Buttons:         []string{"Upload", "Cancel"},
-		Inputs:          []string{input},
-	})
-
-	if response.Button != 0 { // Cancel
-		return
-	}
-
-	videoID := strings.TrimSpace(firstInput(response.Inputs))
-	if videoID == "" && suggested != "" {
-		videoID = suggested
-	}
-	if videoID == "" {
-		menuet.App().Alert(menuet.Alert{
-			MessageText: "No video ID entered.",
-			Buttons:     []string{"OK"},
-		})
-		return
-	}
-
-	videoID = CleanVideoID(videoID)
-	a.SetStatus(StatusUploading)
-	a.notify("ER1 Upload", fmt.Sprintf("Uploading %s to ER1...", videoID))
-	a.fireAction(ActionUploadER1, videoID)
-
-	go func() {
-		result, err := a.Handlers.OnUploadER1(videoID)
-		if err != nil {
-			a.SetStatus(StatusError)
-			a.notify("ER1 Upload Failed", fmt.Sprintf("Error: %v", err))
-			return
-		}
-
-		if result.Queued {
-			a.SetStatus(StatusIdle)
-			a.notify("ER1 Queued", result.Message)
-		} else {
-			a.SetStatus(StatusIdle)
-			a.notify("ER1 Upload Complete", result.Message)
-		}
-		a.AddHistory(NewHistoryEntry(result.VideoID, "🚀"))
-	}()
-}
-
 func firstInput(inputs []string) string {
 	if len(inputs) == 0 {
 		return ""
@@ -549,6 +546,18 @@ func (a *App) notify(title, message string) {
 		return
 	}
 	ShowNotification(title, message)
+}
+
+// profileURL returns the ER1 user profile URL derived from the API URL.
+// Pattern: <base>/v2/profile (e.g. https://127.0.0.1:8081/v2/profile).
+func profileURL() string {
+	cfg := er1.LoadConfig()
+	base := strings.TrimSuffix(cfg.APIURL, "/upload_2")
+	base = strings.TrimSuffix(base, "/")
+	if base == "" {
+		return "https://127.0.0.1:8081/v2/profile"
+	}
+	return base + "/v2/profile"
 }
 
 // fireAction invokes the OnAction handler if set.

--- a/pkg/menubar/app.go
+++ b/pkg/menubar/app.go
@@ -7,8 +7,10 @@ package menubar
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/caseymrm/menuet"
 )
@@ -23,12 +25,29 @@ type App struct {
 	mu          sync.Mutex
 	status      Status
 	authSession AuthSession
+	importState AudioImportState
 }
 
 // AuthSession captures runtime ER1 login state used by the menu.
 type AuthSession struct {
 	LoggedIn bool
 	UserID   string
+}
+
+// AudioImportItem represents one source audio file shown in the menubar list.
+type AudioImportItem struct {
+	Path   string
+	Name   string
+	Status string
+	Size   int64
+	Tags   string
+}
+
+// AudioImportState holds the current import-list snapshot for menu rendering.
+type AudioImportState struct {
+	Items     []AudioImportItem
+	UpdatedAt time.Time
+	Error     string
 }
 
 // NewApp creates an App with the default config and idle status.
@@ -74,6 +93,26 @@ func (a *App) GetAuthSession() AuthSession {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.authSession
+}
+
+// SetAudioImportState updates the current import-list snapshot for the menu.
+func (a *App) SetAudioImportState(s AudioImportState) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.importState = s
+}
+
+// GetAudioImportState returns the current import-list snapshot.
+func (a *App) GetAudioImportState() AudioImportState {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := a.importState
+	if len(out.Items) > 0 {
+		items := make([]AudioImportItem, len(out.Items))
+		copy(items, out.Items)
+		out.Items = items
+	}
+	return out
 }
 
 // AddHistory appends an entry to the transcript history.
@@ -130,12 +169,26 @@ func (a *App) BuildMenuItems() []menuet.MenuItem {
 // time the user opens the dropdown.
 func (a *App) buildMenuItems() []menuet.MenuItem {
 	auth := a.GetAuthSession()
-	accountText := "Account: not logged in"
-	if auth.LoggedIn {
-		accountText = fmt.Sprintf("Account: %s", auth.UserID)
+	if !auth.LoggedIn {
+		return []menuet.MenuItem{
+			{
+				Text: "🔐 Login to ER1...",
+				Clicked: func() {
+					a.fireAction(ActionLoginER1, "")
+				},
+			},
+		}
 	}
+	accountText := fmt.Sprintf("Account: %s", auth.UserID)
 
 	items := []menuet.MenuItem{
+		{
+			Text: "🔓 Logout from ER1",
+			Clicked: func() {
+				a.fireAction(ActionLogoutER1, "")
+			},
+		},
+		{Type: menuet.Separator},
 		{
 			Text:    "▶️ Fetch Transcript...",
 			Clicked: a.handleFetchTranscript,
@@ -156,18 +209,7 @@ func (a *App) buildMenuItems() []menuet.MenuItem {
 			Text:    "🚀 Upload to ER1...",
 			Clicked: a.handleUploadER1,
 		},
-		{
-			Text: "🔐 Login to ER1...",
-			Clicked: func() {
-				a.fireAction(ActionLoginER1, "")
-			},
-		},
-		{
-			Text: "🔓 Logout from ER1",
-			Clicked: func() {
-				a.fireAction(ActionLogoutER1, "")
-			},
-		},
+		a.buildAudioImportMenu(),
 		{Type: menuet.Separator},
 		{Text: fmt.Sprintf("Status: %s", a.GetStatus())},
 		{Text: accountText},
@@ -190,6 +232,100 @@ func (a *App) buildMenuItems() []menuet.MenuItem {
 	)
 
 	return items
+}
+
+func (a *App) buildAudioImportMenu() menuet.MenuItem {
+	state := a.GetAudioImportState()
+	newCount := 0
+	for _, it := range state.Items {
+		if strings.EqualFold(strings.TrimSpace(it.Status), "new") {
+			newCount++
+		}
+	}
+	title := "🎵 Audio Import"
+	if newCount > 0 {
+		title = fmt.Sprintf("🎵 Audio Import (%d new)", newCount)
+	}
+	return menuet.MenuItem{
+		Text: title,
+		Children: func() []menuet.MenuItem {
+			items := []menuet.MenuItem{
+				{
+					Text: "▶️ Run Import Pipeline",
+					Clicked: func() {
+						a.fireAction(ActionBatchImport, "__run_all__")
+					},
+				},
+				{
+					Text: "🔄 Refresh list",
+					Clicked: func() {
+						a.fireAction(ActionBatchImport, "__refresh__")
+					},
+				},
+				{Type: menuet.Separator},
+			}
+
+			if state.UpdatedAt.IsZero() {
+				items = append(items, menuet.MenuItem{Text: "Updated: (not yet)"})
+			} else {
+				items = append(items, menuet.MenuItem{Text: "Updated: " + state.UpdatedAt.Format("15:04:05")})
+			}
+			if state.Error != "" {
+				items = append(items, menuet.MenuItem{Text: "⚠️ " + state.Error})
+			}
+			items = append(items, menuet.MenuItem{Type: menuet.Separator})
+
+			if len(state.Items) == 0 {
+				items = append(items, menuet.MenuItem{Text: "(no audio files)"})
+				return items
+			}
+
+			limit := len(state.Items)
+			if limit > 25 {
+				limit = 25
+			}
+			for i := 0; i < limit; i++ {
+				it := state.Items[i]
+				label := fmt.Sprintf("%s %s [%s]", statusIcon(it.Status), filepath.Base(it.Name), it.Status)
+				if it.Path == "" {
+					items = append(items, menuet.MenuItem{Text: label})
+					continue
+				}
+				if !strings.EqualFold(strings.TrimSpace(it.Status), "new") {
+					items = append(items, menuet.MenuItem{Text: label})
+					continue
+				}
+				filePath := it.Path
+				items = append(items, menuet.MenuItem{
+					Text: label,
+					Clicked: func() {
+						a.fireAction(ActionBatchImport, filePath)
+					},
+				})
+			}
+			if len(state.Items) > limit {
+				items = append(items, menuet.MenuItem{Text: fmt.Sprintf("… %d more files", len(state.Items)-limit)})
+			}
+			return items
+		},
+	}
+}
+
+func statusIcon(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "new":
+		return "+"
+	case "imported":
+		return "✓"
+	case "uploaded":
+		return "↑"
+	case "failed":
+		return "✗"
+	case "duplicate":
+		return "="
+	default:
+		return "•"
+	}
 }
 
 // buildHistoryMenu creates the expandable "History (N)" submenu with

--- a/pkg/menubar/app.go
+++ b/pkg/menubar/app.go
@@ -20,8 +20,15 @@ type App struct {
 	Handlers Handlers
 	history  HistoryStore
 
-	mu     sync.Mutex
-	status Status
+	mu          sync.Mutex
+	status      Status
+	authSession AuthSession
+}
+
+// AuthSession captures runtime ER1 login state used by the menu.
+type AuthSession struct {
+	LoggedIn bool
+	UserID   string
 }
 
 // NewApp creates an App with the default config and idle status.
@@ -53,6 +60,20 @@ func (a *App) GetStatus() Status {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.status
+}
+
+// SetAuthSession updates the runtime ER1 auth session displayed in the menu.
+func (a *App) SetAuthSession(s AuthSession) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.authSession = s
+}
+
+// GetAuthSession returns the current ER1 auth session snapshot.
+func (a *App) GetAuthSession() AuthSession {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.authSession
 }
 
 // AddHistory appends an entry to the transcript history.
@@ -108,6 +129,12 @@ func (a *App) BuildMenuItems() []menuet.MenuItem {
 // buildMenuItems constructs the dropdown menu. menuet calls this every
 // time the user opens the dropdown.
 func (a *App) buildMenuItems() []menuet.MenuItem {
+	auth := a.GetAuthSession()
+	accountText := "Account: not logged in"
+	if auth.LoggedIn {
+		accountText = fmt.Sprintf("Account: %s", auth.UserID)
+	}
+
 	items := []menuet.MenuItem{
 		{
 			Text:    "▶️ Fetch Transcript...",
@@ -129,8 +156,21 @@ func (a *App) buildMenuItems() []menuet.MenuItem {
 			Text:    "🚀 Upload to ER1...",
 			Clicked: a.handleUploadER1,
 		},
+		{
+			Text: "🔐 Login to ER1...",
+			Clicked: func() {
+				a.fireAction(ActionLoginER1, "")
+			},
+		},
+		{
+			Text: "🔓 Logout from ER1",
+			Clicked: func() {
+				a.fireAction(ActionLogoutER1, "")
+			},
+		},
 		{Type: menuet.Separator},
 		{Text: fmt.Sprintf("Status: %s", a.GetStatus())},
+		{Text: accountText},
 		{Type: menuet.Separator},
 	}
 

--- a/pkg/menubar/browser_tabs_darwin.go
+++ b/pkg/menubar/browser_tabs_darwin.go
@@ -4,7 +4,9 @@ package menubar
 
 import (
 	"log"
+	"net/url"
 	"os/exec"
+	"path"
 	"strings"
 )
 
@@ -37,6 +39,56 @@ func SuggestedYouTubeVideoID() string {
 }
 
 func youTubeURLsFromChrome() []string {
+	urls := chromeTabURLs()
+	if len(urls) == 0 {
+		return nil
+	}
+	var matches []string
+	for _, u := range urls {
+		if strings.Contains(u, "youtube.com/watch") || strings.Contains(u, "youtu.be/") {
+			matches = append(matches, u)
+		}
+	}
+	if len(matches) == 0 {
+		log.Printf("[tabs] browser=Google Chrome no youtube tabs")
+		return nil
+	}
+	return matches
+}
+
+// SuggestedServiceContextID inspects open Chrome tabs for URLs on the same
+// ER1 host and extracts the first context ID from /memory/<context>/... URLs.
+func SuggestedServiceContextID(serviceBase string) string {
+	baseHost := hostForURL(serviceBase)
+	if baseHost == "" {
+		log.Printf("[auth] could not parse ER1 service host from %q", serviceBase)
+		return ""
+	}
+	urls := chromeTabURLs()
+	if len(urls) == 0 {
+		log.Printf("[auth] no Chrome tabs available for ER1 context detection")
+		return ""
+	}
+	log.Printf("[auth] inspecting %d Chrome tab URLs for ER1 host=%s", len(urls), baseHost)
+	for _, raw := range urls {
+		u, err := url.Parse(raw)
+		if err != nil || u.Host == "" {
+			continue
+		}
+		if !sameHost(baseHost, u.Host) {
+			continue
+		}
+		log.Printf("[auth] matched ER1 host URL: %s", raw)
+		if ctx := contextIDFromServiceURL(u); ctx != "" {
+			log.Printf("[auth] selected context_id=%s from URL=%s", ctx, raw)
+			return ctx
+		}
+	}
+	log.Printf("[auth] no context_id found in Chrome tabs for ER1 host=%s", baseHost)
+	return ""
+}
+
+func chromeTabURLs() []string {
 	script := `
 function run() {
 	try {
@@ -53,9 +105,7 @@ function run() {
 				if (!u) {
 					continue;
 				}
-				if (u.indexOf("youtube.com/watch") !== -1 || u.indexOf("youtu.be/") !== -1) {
-					matches.push(u);
-				}
+				matches.push(u);
 			}
 		}
 		return matches.join("\n");
@@ -77,7 +127,7 @@ function run() {
 		return nil
 	}
 	if raw == "" {
-		log.Printf("[tabs] browser=%s no youtube tabs", appName)
+		log.Printf("[tabs] browser=%s no tabs", appName)
 		return nil
 	}
 	lines := strings.Split(raw, "\n")
@@ -90,7 +140,37 @@ function run() {
 		urls = append(urls, u)
 	}
 	if len(urls) == 0 {
-		log.Printf("[tabs] browser=%s no youtube tabs", appName)
+		log.Printf("[tabs] browser=%s no tabs", appName)
 	}
 	return urls
+}
+
+func hostForURL(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(u.Host)
+}
+
+func sameHost(a, b string) bool {
+	return strings.EqualFold(strings.TrimSpace(a), strings.TrimSpace(b))
+}
+
+func contextIDFromServiceURL(u *url.URL) string {
+	if q := strings.TrimSpace(u.Query().Get("context_id")); q != "" {
+		return q
+	}
+	p := path.Clean(u.Path)
+	parts := strings.Split(p, "/")
+	// Expect /memory/<context>/<doc_id>
+	for i := 0; i+2 < len(parts); i++ {
+		if parts[i] == "memory" {
+			ctx := strings.TrimSpace(parts[i+1])
+			if ctx != "" {
+				return ctx
+			}
+		}
+	}
+	return ""
 }

--- a/pkg/menubar/menubar.go
+++ b/pkg/menubar/menubar.go
@@ -17,26 +17,28 @@ import (
 type ActionType string
 
 const (
-	ActionFetchTranscript  ActionType = "fetch_transcript"
+	ActionFetchTranscript   ActionType = "fetch_transcript"
 	ActionCaptureScreenshot ActionType = "capture_screenshot"
-	ActionQuickImpulse     ActionType = "quick_impulse"
-	ActionRecordImpression ActionType = "record_impression"
-	ActionCopyTranscript   ActionType = "copy_transcript"
-	ActionBatchImport      ActionType = "batch_import"
-	ActionUploadER1        ActionType = "upload_er1"
-	ActionOpenLog          ActionType = "open_log"
-	ActionQuit             ActionType = "quit"
+	ActionQuickImpulse      ActionType = "quick_impulse"
+	ActionRecordImpression  ActionType = "record_impression"
+	ActionCopyTranscript    ActionType = "copy_transcript"
+	ActionBatchImport       ActionType = "batch_import"
+	ActionUploadER1         ActionType = "upload_er1"
+	ActionLoginER1          ActionType = "login_er1"
+	ActionLogoutER1         ActionType = "logout_er1"
+	ActionOpenLog           ActionType = "open_log"
+	ActionQuit              ActionType = "quit"
 )
 
 // Status represents the current operational state of the menu bar app.
 type Status string
 
 const (
-	StatusIdle       Status = "idle"
-	StatusFetching   Status = "fetching"
-	StatusUploading  Status = "uploading"
-	StatusRecording  Status = "recording"
-	StatusError      Status = "error"
+	StatusIdle      Status = "idle"
+	StatusFetching  Status = "fetching"
+	StatusUploading Status = "uploading"
+	StatusRecording Status = "recording"
+	StatusError     Status = "error"
 )
 
 // HistoryEntry records a completed transcript fetch or upload action.

--- a/pkg/menubar/menubar.go
+++ b/pkg/menubar/menubar.go
@@ -26,6 +26,7 @@ const (
 	ActionUploadER1         ActionType = "upload_er1"
 	ActionLoginER1          ActionType = "login_er1"
 	ActionLogoutER1         ActionType = "logout_er1"
+	ActionShowTrackingDB    ActionType = "show_tracking_db"
 	ActionOpenLog           ActionType = "open_log"
 	ActionQuit              ActionType = "quit"
 )
@@ -40,6 +41,53 @@ const (
 	StatusRecording Status = "recording"
 	StatusError     Status = "error"
 )
+
+// BulkRunPhase represents the current step for an audio bulk operation item.
+type BulkRunPhase string
+
+const (
+	BulkPhaseQueued      BulkRunPhase = "queued"
+	BulkPhaseImport      BulkRunPhase = "import"
+	BulkPhaseTranscribe  BulkRunPhase = "transcribe"
+	BulkPhaseUpload      BulkRunPhase = "upload"
+	BulkPhaseDone        BulkRunPhase = "done"
+	BulkPhaseFailed      BulkRunPhase = "failed"
+	BulkPhaseReprocess   BulkRunPhase = "reprocess"
+	BulkPhaseUnavailable BulkRunPhase = "unavailable"
+)
+
+// BulkRunState holds live state for a currently running bulk audio operation.
+type BulkRunState struct {
+	Active      bool
+	RunID       string
+	Action      string
+	Total       int
+	Done        int
+	Success     int
+	Failed      int
+	CurrentFile string
+	Phase       BulkRunPhase
+	StartedAt   time.Time
+	LastError   string
+}
+
+// BulkProgressEvent is emitted by the bulk runner to synchronize logs + UI.
+type BulkProgressEvent struct {
+	RunID       string
+	Action      string
+	Event       string // RUN_START | ITEM_START | ITEM_PHASE | ITEM_DONE | RUN_DONE
+	Item        string
+	Index       int // 1-based item index when relevant
+	Total       int
+	Phase       BulkRunPhase
+	Outcome     string // ok | failed | skipped
+	Done        int
+	Success     int
+	Failed      int
+	Elapsed     time.Duration
+	Error       string
+	CurrentFile string
+}
 
 // HistoryEntry records a completed transcript fetch or upload action.
 type HistoryEntry struct {
@@ -74,7 +122,7 @@ func DefaultConfig() MenuConfig {
 	return MenuConfig{
 		AppName:  "M3C Tools",
 		AppLabel: "com.kamir.m3c-tools",
-		Title:    "M3C",
+		Title:    "",
 		IconPath: FindIcon("maindset_icon.png"),
 		LogPath:  "/tmp/m3c-tools.log",
 	}
@@ -113,6 +161,10 @@ type Handlers struct {
 	// OnUploadER1 performs an ER1 upload for a given video ID. If set,
 	// the "Upload to ER1" menu item becomes active.
 	OnUploadER1 ER1UploadFunc
+
+	// ListTrackingRecords returns recent tracking DB records for display
+	// in the "Tracking DB" submenu. Returns up to limit records.
+	ListTrackingRecords func(limit int) ([]TrackingRecord, error)
 }
 
 // ER1UploadFunc is a callback that performs an ER1 upload for the given video ID.

--- a/pkg/menubar/menubar_test.go
+++ b/pkg/menubar/menubar_test.go
@@ -77,6 +77,8 @@ func TestActionTypes(t *testing.T) {
 		ActionCopyTranscript,
 		ActionBatchImport,
 		ActionUploadER1,
+		ActionLoginER1,
+		ActionLogoutER1,
 		ActionOpenLog,
 		ActionQuit,
 	}
@@ -373,6 +375,12 @@ func TestUploadER1ActionType(t *testing.T) {
 	if ActionUploadER1 != "upload_er1" {
 		t.Errorf("ActionUploadER1 = %q, want upload_er1", ActionUploadER1)
 	}
+	if ActionLoginER1 != "login_er1" {
+		t.Errorf("ActionLoginER1 = %q, want login_er1", ActionLoginER1)
+	}
+	if ActionLogoutER1 != "logout_er1" {
+		t.Errorf("ActionLogoutER1 = %q, want logout_er1", ActionLogoutER1)
+	}
 }
 
 func TestHandlerOnUploadER1(t *testing.T) {
@@ -463,6 +471,22 @@ func TestUploadER1WithoutHandler(t *testing.T) {
 	app.Handlers.OnAction(ActionUploadER1, "test-vid")
 	if capturedAction != ActionUploadER1 {
 		t.Errorf("expected upload_er1 action, got %q", capturedAction)
+	}
+}
+
+func TestAuthSessionState(t *testing.T) {
+	app := NewApp()
+	if got := app.GetAuthSession(); got.LoggedIn || got.UserID != "" {
+		t.Fatalf("initial auth session = %+v, want logged out", got)
+	}
+
+	app.SetAuthSession(AuthSession{LoggedIn: true, UserID: "107677460544181387647___mft"})
+	got := app.GetAuthSession()
+	if !got.LoggedIn {
+		t.Fatal("expected logged-in session")
+	}
+	if got.UserID != "107677460544181387647___mft" {
+		t.Fatalf("UserID = %q, want context id", got.UserID)
 	}
 }
 

--- a/pkg/menubar/menubar_test.go
+++ b/pkg/menubar/menubar_test.go
@@ -437,6 +437,7 @@ func TestUploadER1StatusTransition(t *testing.T) {
 
 func TestUploadER1MenuItemPresent(t *testing.T) {
 	app := NewApp()
+	app.SetAuthSession(AuthSession{LoggedIn: true, UserID: "ctx-1"})
 	items := app.BuildMenuItems()
 
 	found := false
@@ -448,6 +449,17 @@ func TestUploadER1MenuItemPresent(t *testing.T) {
 	}
 	if !found {
 		t.Error("Expected '🚀 Upload to ER1...' menu item in BuildMenuItems()")
+	}
+}
+
+func TestLoggedOutMenuShowsOnlyLogin(t *testing.T) {
+	app := NewApp()
+	items := app.BuildMenuItems()
+	if len(items) != 1 {
+		t.Fatalf("logged-out menu len=%d, want 1", len(items))
+	}
+	if items[0].Text != "🔐 Login to ER1..." {
+		t.Fatalf("logged-out first menu item=%q, want login", items[0].Text)
 	}
 }
 

--- a/pkg/menubar/menubar_test.go
+++ b/pkg/menubar/menubar_test.go
@@ -59,8 +59,8 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.AppLabel != "com.kamir.m3c-tools" {
 		t.Errorf("AppLabel = %q, want 'com.kamir.m3c-tools'", cfg.AppLabel)
 	}
-	if cfg.Title != "M3C" {
-		t.Errorf("Title = %q, want 'M3C'", cfg.Title)
+	if cfg.Title != "" {
+		t.Errorf("Title = %q, want empty (icon-only)", cfg.Title)
 	}
 	if cfg.LogPath == "" {
 		t.Error("LogPath should not be empty")
@@ -175,6 +175,38 @@ func TestAppStatusConcurrency(t *testing.T) {
 	app.SetStatus(StatusError)
 	if app.GetStatus() != StatusError {
 		t.Errorf("after second SetStatus, got %q, want %q", app.GetStatus(), StatusError)
+	}
+}
+
+func TestAppBulkRunState(t *testing.T) {
+	app := NewApp()
+	s := BulkRunState{
+		Active:      true,
+		RunID:       "run-123",
+		Action:      "transcribe_upload",
+		Total:       5,
+		Done:        2,
+		Success:     2,
+		Failed:      0,
+		CurrentFile: "file.wav",
+		Phase:       BulkPhaseTranscribe,
+		StartedAt:   time.Now(),
+		LastError:   "",
+	}
+	app.SetBulkRunState(s)
+
+	got := app.GetBulkRunState()
+	if !got.Active {
+		t.Fatal("bulk state should be active")
+	}
+	if got.RunID != "run-123" {
+		t.Fatalf("RunID = %q, want run-123", got.RunID)
+	}
+	if got.Done != 2 || got.Total != 5 {
+		t.Fatalf("progress = %d/%d, want 2/5", got.Done, got.Total)
+	}
+	if got.Phase != BulkPhaseTranscribe {
+		t.Fatalf("phase = %q, want %q", got.Phase, BulkPhaseTranscribe)
 	}
 }
 
@@ -432,23 +464,6 @@ func TestUploadER1StatusTransition(t *testing.T) {
 	app.SetStatus(StatusError)
 	if app.GetStatus() != StatusError {
 		t.Errorf("after SetStatus(error), got %q", app.GetStatus())
-	}
-}
-
-func TestUploadER1MenuItemPresent(t *testing.T) {
-	app := NewApp()
-	app.SetAuthSession(AuthSession{LoggedIn: true, UserID: "ctx-1"})
-	items := app.BuildMenuItems()
-
-	found := false
-	for _, item := range items {
-		if item.Text == "🚀 Upload to ER1..." {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("Expected '🚀 Upload to ER1...' menu item in BuildMenuItems()")
 	}
 }
 

--- a/pkg/menubar/observation_darwin.go
+++ b/pkg/menubar/observation_darwin.go
@@ -303,6 +303,20 @@ static void setReviewTranscript(const char *text, const char *statusText) {
 	});
 }
 
+// Forward declaration — defined in Global Window State section below.
+static NSTextView *g_obsSummaryText;
+
+// setObsNotes sets the text content of the Notes field in the Tags tab.
+static void setObsNotes(const char *text) {
+	if (text == NULL) return;
+	NSString *s = [NSString stringWithUTF8String:text];
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (g_obsSummaryText != nil) {
+			[g_obsSummaryText setString:s];
+		}
+	});
+}
+
 // Forward declarations (defined in Global Window State section below).
 static NSTextField *g_recordSourceLabel;
 static NSProgressIndicator *g_whisperProgress;
@@ -2064,6 +2078,17 @@ func SetObservationTitle(title string) {
 	cTitle := C.CString(title)
 	defer C.free(unsafe.Pointer(cTitle))
 	C.setObservationTitle(cTitle)
+}
+
+// SetObservationNotes sets the text content of the Notes field in the Tags tab.
+// Thread-safe: dispatches to the main thread internally.
+func SetObservationNotes(text string) {
+	if text == "" {
+		return
+	}
+	cText := C.CString(text)
+	defer C.free(unsafe.Pointer(cText))
+	C.setObsNotes(cText)
 }
 
 // ShowObservationWindowForYouTube opens the Observation Window for a YouTube

--- a/pkg/menubar/tracking_bulk_darwin.go
+++ b/pkg/menubar/tracking_bulk_darwin.go
@@ -1,0 +1,61 @@
+// tracking_bulk_darwin.go — Go callback for tracking window bulk actions.
+//
+// This file is separate from tracking_darwin.go because //export requires
+// that the cgo preamble contain only declarations, not definitions.
+package menubar
+
+/*
+extern int trackingSrcRowCount(void);
+extern int trackingIsSrcSelected(int row);
+extern const char* trackingSrcFilename(int row);
+extern const char* trackingSrcStatus(int row);
+*/
+import "C"
+
+var trackingBulkCallback func(action string, filenames []string, statuses []string)
+
+// SetTrackingBulkCallback registers a handler for bulk actions triggered
+// from the tracking window buttons (e.g. "Transcribe + Upload", "Re-process").
+func SetTrackingBulkCallback(cb func(action string, filenames []string, statuses []string)) {
+	trackingBulkCallback = cb
+}
+
+//export goTrackingBulkAction
+func goTrackingBulkAction(cAction *C.char) {
+	if trackingBulkCallback == nil {
+		return
+	}
+	action := C.GoString(cAction)
+	n := int(C.trackingSrcRowCount())
+	var filenames []string
+	var statuses []string
+	for i := 0; i < n; i++ {
+		if C.trackingIsSrcSelected(C.int(i)) != 0 {
+			name := C.GoString(C.trackingSrcFilename(C.int(i)))
+			status := C.GoString(C.trackingSrcStatus(C.int(i)))
+			if name != "" {
+				filenames = append(filenames, name)
+				statuses = append(statuses, status)
+			}
+		}
+	}
+	if len(filenames) == 0 {
+		return
+	}
+	go trackingBulkCallback(action, filenames, statuses)
+}
+
+// SelectedSourceFiles returns the currently selected source file names.
+func SelectedSourceFiles() []string {
+	n := int(C.trackingSrcRowCount())
+	var names []string
+	for i := 0; i < n; i++ {
+		if C.trackingIsSrcSelected(C.int(i)) != 0 {
+			name := C.GoString(C.trackingSrcFilename(C.int(i)))
+			if name != "" {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}

--- a/pkg/menubar/tracking_darwin.go
+++ b/pkg/menubar/tracking_darwin.go
@@ -1,0 +1,878 @@
+// tracking_darwin.go — Native macOS Tracking DB Window via Cocoa/cgo.
+//
+// Creates an NSWindow with an NSTabView containing 2 tabs:
+//   - Tracked: table view of all DB records (uploaded/imported/failed)
+//   - Source Files: table view of all files in IMPORT_AUDIO_SOURCE,
+//     with folder path header, running number, creation date,
+//     checkbox selection, sortable columns, and bulk action buttons
+//
+// This file must be built on macOS (darwin) with cgo enabled.
+package menubar
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Cocoa
+
+#import <Cocoa/Cocoa.h>
+#include <stdlib.h>
+
+// ---------- Global Tracking Window State ----------
+
+static NSWindow     *g_trackWindow    = nil;
+static NSTableView  *g_trackTable     = nil;  // Tab 1: tracked items
+static NSTableView  *g_sourceTable    = nil;  // Tab 2: source files
+static NSTextField  *g_srcFolderLabel = nil;  // Tab 2: folder path label
+static NSTextField  *g_srcSelectLabel = nil;  // Tab 2: "N selected" label
+static NSProgressIndicator *g_bulkProgressBar = nil;
+static NSTextField  *g_bulkRunLabel    = nil;
+static NSTextField  *g_bulkDetailLabel = nil;
+static NSTextField  *g_bulkErrorLabel  = nil;
+static NSButton     *g_btnReprocess    = nil;
+static NSButton     *g_btnTxUpload     = nil;
+static BOOL          g_bulkActive      = NO;
+static int           g_bulkTotal       = 0;
+static int           g_bulkDone        = 0;
+static int           g_bulkSuccess     = 0;
+static int           g_bulkFailed      = 0;
+
+// ---------- Row Data Storage ----------
+
+// Tab 1 (Tracked): columns = filename, status, transcript_len, doc_id, processed_at
+#define TRACK_MAX_ROWS 500
+#define TRACK_COLS     5
+
+static char *g_trackData[TRACK_MAX_ROWS][TRACK_COLS];
+static int   g_trackRowCount = 0;
+
+// Tab 2 (Source): columns = num, filename, status, size, created
+#define SRC_MAX_ROWS 500
+#define SRC_COLS     5
+
+static char      *g_srcData[SRC_MAX_ROWS][SRC_COLS];
+static long long  g_srcSizeBytes[SRC_MAX_ROWS];   // raw bytes for numeric sort
+static BOOL       g_srcSelected[SRC_MAX_ROWS];     // checkbox selection state
+static int        g_srcRowCount = 0;
+static int        g_srcSortOrder[SRC_MAX_ROWS];    // index mapping for sorted display
+
+// Source folder path for header label.
+static char *g_srcFolderPath = NULL;
+
+// ---------- Helper: Store Row Data ----------
+
+static void clearTrackData(void) {
+	for (int r = 0; r < g_trackRowCount; r++) {
+		for (int c = 0; c < TRACK_COLS; c++) {
+			if (g_trackData[r][c]) { free(g_trackData[r][c]); g_trackData[r][c] = NULL; }
+		}
+	}
+	g_trackRowCount = 0;
+}
+
+static void clearSrcData(void) {
+	for (int r = 0; r < g_srcRowCount; r++) {
+		for (int c = 0; c < SRC_COLS; c++) {
+			if (g_srcData[r][c]) { free(g_srcData[r][c]); g_srcData[r][c] = NULL; }
+		}
+	}
+	g_srcRowCount = 0;
+	memset(g_srcSelected, 0, sizeof(g_srcSelected));
+}
+
+static void initSrcSortOrder(void) {
+	for (int i = 0; i < g_srcRowCount; i++) {
+		g_srcSortOrder[i] = i;
+	}
+}
+
+static void updateSelectionLabel(void) {
+	if (!g_srcSelectLabel) return;
+	int count = 0;
+	for (int i = 0; i < g_srcRowCount; i++) {
+		if (g_srcSelected[i]) count++;
+	}
+	[g_srcSelectLabel setStringValue:
+		[NSString stringWithFormat:@"%d selected", count]];
+}
+
+static void applyBulkControls(void) {
+	BOOL active = g_bulkActive ? YES : NO;
+	if (g_btnReprocess) [g_btnReprocess setEnabled:!active];
+	if (g_btnTxUpload) [g_btnTxUpload setEnabled:!active];
+	if (g_bulkProgressBar) {
+		[g_bulkProgressBar setHidden:!active];
+		if (active && g_bulkTotal > 0) {
+			[g_bulkProgressBar setIndeterminate:NO];
+			[g_bulkProgressBar setMinValue:0.0];
+			[g_bulkProgressBar setMaxValue:(double)g_bulkTotal];
+			[g_bulkProgressBar setDoubleValue:(double)g_bulkDone];
+		}
+	}
+	if (g_bulkRunLabel) {
+		if (active) {
+			[g_bulkRunLabel setStringValue:
+				[NSString stringWithFormat:@"Bulk run: %d/%d (ok=%d fail=%d)",
+					g_bulkDone, g_bulkTotal, g_bulkSuccess, g_bulkFailed]];
+		} else {
+			[g_bulkRunLabel setStringValue:@"Bulk run: idle"];
+		}
+	}
+}
+
+static void addTrackRow(const char *filename, const char *status,
+						const char *txLen, const char *docID, const char *processedAt) {
+	if (g_trackRowCount >= TRACK_MAX_ROWS) return;
+	int r = g_trackRowCount++;
+	g_trackData[r][0] = strdup(filename    ? filename    : "");
+	g_trackData[r][1] = strdup(status      ? status      : "");
+	g_trackData[r][2] = strdup(txLen       ? txLen       : "");
+	g_trackData[r][3] = strdup(docID       ? docID       : "");
+	g_trackData[r][4] = strdup(processedAt ? processedAt : "");
+}
+
+static void addSrcRow(const char *num, const char *filename, const char *status,
+					  const char *size, const char *created, long long sizeBytes) {
+	if (g_srcRowCount >= SRC_MAX_ROWS) return;
+	int r = g_srcRowCount++;
+	g_srcData[r][0] = strdup(num      ? num      : "");
+	g_srcData[r][1] = strdup(filename ? filename : "");
+	g_srcData[r][2] = strdup(status   ? status   : "");
+	g_srcData[r][3] = strdup(size     ? size     : "");
+	g_srcData[r][4] = strdup(created  ? created  : "");
+	g_srcSizeBytes[r] = sizeBytes;
+	g_srcSortOrder[r] = r;
+	g_srcSelected[r] = NO;
+}
+
+static void setSrcFolderPath(const char *path) {
+	if (g_srcFolderPath) { free(g_srcFolderPath); g_srcFolderPath = NULL; }
+	if (path) g_srcFolderPath = strdup(path);
+}
+
+static int isTrackingWindowOpen(void) {
+	return (g_trackWindow != nil) ? 1 : 0;
+}
+
+// reloadTrackingTables tells the already-open window to refresh both table
+// views with the current global data.  Safe to call from any thread.
+static void reloadTrackingTables(void) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (g_trackWindow == nil) return;
+		if (g_srcFolderLabel && g_srcFolderPath) {
+			[g_srcFolderLabel setStringValue:
+				[NSString stringWithFormat:@"Source: %s", g_srcFolderPath]];
+		}
+		initSrcSortOrder();
+		if (g_sourceTable) {
+			[g_sourceTable setSortDescriptors:@[]];
+			[g_sourceTable reloadData];
+		}
+		if (g_trackTable) [g_trackTable reloadData];
+		updateSelectionLabel();
+		applyBulkControls();
+	});
+}
+
+// ---------- Non-static accessors (called from tracking_bulk_darwin.go via extern) ----------
+
+int trackingSrcRowCount(void) { return g_srcRowCount; }
+
+int trackingIsSrcSelected(int row) {
+	return (row >= 0 && row < g_srcRowCount && g_srcSelected[row]) ? 1 : 0;
+}
+
+const char* trackingSrcFilename(int row) {
+	return (row >= 0 && row < g_srcRowCount && g_srcData[row][1])
+		? g_srcData[row][1] : "";
+}
+
+const char* trackingSrcStatus(int row) {
+	return (row >= 0 && row < g_srcRowCount && g_srcData[row][2])
+		? g_srcData[row][2] : "";
+}
+
+static void setTrackingSrcStatusByFilename(const char *filename, const char *status) {
+	if (!filename || !status) return;
+	for (int i = 0; i < g_srcRowCount; i++) {
+		if (!g_srcData[i][1]) continue;
+		if (strcmp(g_srcData[i][1], filename) == 0) {
+			free(g_srcData[i][2]);
+			g_srcData[i][2] = strdup(status);
+		}
+	}
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (g_sourceTable) [g_sourceTable reloadData];
+	});
+}
+
+static void setTrackingBulkState(int active,
+								 const char *runText,
+								 const char *detailText,
+								 const char *errorText,
+								 int total,
+								 int done,
+								 int success,
+								 int failed) {
+	g_bulkActive = active ? YES : NO;
+	g_bulkTotal = total;
+	g_bulkDone = done;
+	g_bulkSuccess = success;
+	g_bulkFailed = failed;
+	dispatch_async(dispatch_get_main_queue(), ^{
+		applyBulkControls();
+		if (g_bulkDetailLabel) {
+			NSString *detail = detailText ? [NSString stringWithUTF8String:detailText] : @"";
+			[g_bulkDetailLabel setStringValue:detail];
+		}
+		if (g_bulkErrorLabel) {
+			NSString *err = errorText ? [NSString stringWithUTF8String:errorText] : @"";
+			[g_bulkErrorLabel setStringValue:err];
+		}
+		if (g_bulkRunLabel && runText) {
+			[g_bulkRunLabel setStringValue:[NSString stringWithUTF8String:runText]];
+		}
+	});
+}
+
+// ---------- Forward declaration of Go bulk-action callback ----------
+
+extern void goTrackingBulkAction(char* action);
+
+// ---------- Table Data Source ----------
+
+@interface TrackingTableDataSource : NSObject <NSTableViewDataSource, NSTableViewDelegate>
+- (void)srcCheckboxClicked:(NSButton *)sender;
+- (void)selectAllClicked:(id)sender;
+- (void)deselectAllClicked:(id)sender;
+- (void)transcribeUploadClicked:(id)sender;
+- (void)reprocessClicked:(id)sender;
+@end
+
+@implementation TrackingTableDataSource
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView {
+	if (tableView == g_trackTable) return g_trackRowCount;
+	if (tableView == g_sourceTable) return g_srcRowCount;
+	return 0;
+}
+
+- (NSView *)tableView:(NSTableView *)tableView
+   viewForTableColumn:(NSTableColumn *)tableColumn
+                  row:(NSInteger)row {
+
+	NSString *identifier = [tableColumn identifier];
+
+	// ---------- Source table: checkbox column ----------
+	if (tableView == g_sourceTable && [identifier isEqualToString:@"select"]) {
+		int dataRow = g_srcSortOrder[row];
+		NSButton *cb = [[NSButton alloc] initWithFrame:NSZeroRect];
+		[cb setButtonType:NSButtonTypeSwitch];
+		[cb setTitle:@""];
+		[cb setState:g_srcSelected[dataRow] ? NSControlStateValueOn : NSControlStateValueOff];
+		[cb setTarget:self];
+		[cb setAction:@selector(srcCheckboxClicked:)];
+		return cb;
+	}
+
+	// ---------- Default: text cell ----------
+	NSTextField *cell = [[NSTextField alloc] initWithFrame:NSZeroRect];
+	[cell setBezeled:NO];
+	[cell setDrawsBackground:NO];
+	[cell setEditable:NO];
+	[cell setSelectable:YES];
+	[cell setLineBreakMode:NSLineBreakByTruncatingTail];
+
+	NSString *value = @"";
+
+	if (tableView == g_trackTable && row < g_trackRowCount) {
+		int col = -1;
+		if ([identifier isEqualToString:@"filename"])    col = 0;
+		else if ([identifier isEqualToString:@"status"]) col = 1;
+		else if ([identifier isEqualToString:@"txlen"])   col = 2;
+		else if ([identifier isEqualToString:@"docid"])   col = 3;
+		else if ([identifier isEqualToString:@"date"])    col = 4;
+		if (col >= 0 && g_trackData[row][col]) {
+			value = [NSString stringWithUTF8String:g_trackData[row][col]];
+		}
+
+		// Color by status
+		if (g_trackData[row][1]) {
+			NSString *st = [NSString stringWithUTF8String:g_trackData[row][1]];
+			if ([st isEqualToString:@"uploaded"]) {
+				[cell setTextColor:[NSColor systemGreenColor]];
+			} else if ([st isEqualToString:@"failed"]) {
+				[cell setTextColor:[NSColor systemRedColor]];
+			}
+		}
+	}
+	else if (tableView == g_sourceTable && row < g_srcRowCount) {
+		int dataRow = g_srcSortOrder[row];
+		int col = -1;
+		if ([identifier isEqualToString:@"num"])           col = 0;
+		else if ([identifier isEqualToString:@"filename"]) col = 1;
+		else if ([identifier isEqualToString:@"status"])   col = 2;
+		else if ([identifier isEqualToString:@"size"])     col = 3;
+		else if ([identifier isEqualToString:@"created"])  col = 4;
+		if (col >= 0 && g_srcData[dataRow][col]) {
+			value = [NSString stringWithUTF8String:g_srcData[dataRow][col]];
+		}
+
+		// Right-align # and Size columns.
+		if (col == 0 || col == 3) {
+			[cell setAlignment:NSTextAlignmentRight];
+		}
+
+		// Color: green=uploaded, blue=new
+		if (g_srcData[dataRow][2]) {
+			NSString *st = [NSString stringWithUTF8String:g_srcData[dataRow][2]];
+			if ([st isEqualToString:@"uploaded"] || [st isEqualToString:@"done"]) {
+				[cell setTextColor:[NSColor systemGreenColor]];
+			} else if ([st isEqualToString:@"failed"]) {
+				[cell setTextColor:[NSColor systemRedColor]];
+			} else if ([st isEqualToString:@"queued"] ||
+					   [st isEqualToString:@"importing"] ||
+					   [st isEqualToString:@"transcribing"] ||
+					   [st isEqualToString:@"uploading"] ||
+					   [st isEqualToString:@"reprocessing"] ||
+					   [st isEqualToString:@"processing"]) {
+				[cell setTextColor:[NSColor systemOrangeColor]];
+			} else {
+				[cell setTextColor:[NSColor systemBlueColor]];
+			}
+		}
+	}
+
+	[cell setStringValue:value];
+	[cell setFont:[NSFont systemFontOfSize:12]];
+	return cell;
+}
+
+- (CGFloat)tableView:(NSTableView *)tableView heightOfRow:(NSInteger)row {
+	return 22.0;
+}
+
+// ---------- Checkbox handling ----------
+
+- (void)srcCheckboxClicked:(NSButton *)sender {
+	NSInteger displayRow = [g_sourceTable rowForView:sender];
+	if (displayRow >= 0 && displayRow < g_srcRowCount) {
+		int dataRow = g_srcSortOrder[displayRow];
+		g_srcSelected[dataRow] = (sender.state == NSControlStateValueOn);
+		updateSelectionLabel();
+	}
+}
+
+- (void)selectAllClicked:(id)sender {
+	for (int i = 0; i < g_srcRowCount; i++) g_srcSelected[i] = YES;
+	updateSelectionLabel();
+	[g_sourceTable reloadData];
+}
+
+- (void)deselectAllClicked:(id)sender {
+	memset(g_srcSelected, 0, sizeof(g_srcSelected));
+	updateSelectionLabel();
+	[g_sourceTable reloadData];
+}
+
+// ---------- Bulk action buttons ----------
+
+- (void)transcribeUploadClicked:(id)sender {
+	if (g_bulkActive) return;
+	goTrackingBulkAction("transcribe_upload");
+}
+
+- (void)reprocessClicked:(id)sender {
+	if (g_bulkActive) return;
+	goTrackingBulkAction("retranscribe_reupload");
+}
+
+// ---------- Sorting for Source Files Table ----------
+
+- (void)tableView:(NSTableView *)tableView sortDescriptorsDidChange:(NSArray<NSSortDescriptor *> *)oldDescriptors {
+	if (tableView != g_sourceTable) return;
+
+	NSSortDescriptor *sd = [[tableView sortDescriptors] firstObject];
+	if (!sd || g_srcRowCount == 0) {
+		initSrcSortOrder();
+		[tableView reloadData];
+		return;
+	}
+
+	NSString *key = [sd key];
+	BOOL ascending = [sd ascending];
+
+	int sortCol = -1;
+	BOOL numericCol = NO;
+	BOOL sizeCol = NO;
+
+	if ([key isEqualToString:@"num"])           { sortCol = 0; numericCol = YES; }
+	else if ([key isEqualToString:@"filename"]) { sortCol = 1; }
+	else if ([key isEqualToString:@"status"])   { sortCol = 2; }
+	else if ([key isEqualToString:@"size"])     { sizeCol = YES; }
+	else if ([key isEqualToString:@"created"])  { sortCol = 4; }
+
+	initSrcSortOrder();
+
+	qsort_b(g_srcSortOrder, g_srcRowCount, sizeof(int), ^int(const void *a, const void *b) {
+		int ia = *(const int *)a;
+		int ib = *(const int *)b;
+		int cmp = 0;
+
+		if (sizeCol) {
+			if (g_srcSizeBytes[ia] < g_srcSizeBytes[ib]) cmp = -1;
+			else if (g_srcSizeBytes[ia] > g_srcSizeBytes[ib]) cmp = 1;
+		} else if (numericCol) {
+			int va = atoi(g_srcData[ia][sortCol] ? g_srcData[ia][sortCol] : "0");
+			int vb = atoi(g_srcData[ib][sortCol] ? g_srcData[ib][sortCol] : "0");
+			cmp = va - vb;
+		} else if (sortCol >= 0) {
+			const char *sa = g_srcData[ia][sortCol] ? g_srcData[ia][sortCol] : "";
+			const char *sb = g_srcData[ib][sortCol] ? g_srcData[ib][sortCol] : "";
+			cmp = strcmp(sa, sb);
+		}
+
+		return ascending ? cmp : -cmp;
+	});
+
+	[tableView reloadData];
+}
+
+@end
+
+// Global data source instance (retained by tables).
+static TrackingTableDataSource *g_trackDS = nil;
+
+// ---------- Window Creation ----------
+
+static void showTrackingWindow(void) {
+	dispatch_sync(dispatch_get_main_queue(), ^{
+		// If already open, just bring to front.
+		if (g_trackWindow != nil) {
+			[g_trackWindow makeKeyAndOrderFront:nil];
+			[NSApp activateIgnoringOtherApps:YES];
+			if (g_srcFolderLabel && g_srcFolderPath) {
+				[g_srcFolderLabel setStringValue:
+					[NSString stringWithFormat:@"Source: %s", g_srcFolderPath]];
+			}
+			initSrcSortOrder();
+			if (g_sourceTable) {
+				[g_sourceTable setSortDescriptors:@[]];
+				[g_sourceTable reloadData];
+			}
+			if (g_trackTable) [g_trackTable reloadData];
+			updateSelectionLabel();
+			applyBulkControls();
+			return;
+		}
+
+		// ---- Window ----
+		NSScreen *screen = [NSScreen mainScreen];
+		NSRect sf = [screen visibleFrame];
+		CGFloat winW = sf.size.width * 0.55;
+		CGFloat winH = sf.size.height * 0.6;
+		if (winW < 800) winW = 800;
+		if (winH < 450) winH = 450;
+
+		NSRect winRect = NSMakeRect(
+			sf.origin.x + (sf.size.width  - winW) / 2,
+			sf.origin.y + (sf.size.height - winH) / 2,
+			winW, winH);
+
+		NSWindow *window = [[NSWindow alloc]
+			initWithContentRect:winRect
+			styleMask:(NSWindowStyleMaskTitled |
+					   NSWindowStyleMaskClosable |
+					   NSWindowStyleMaskResizable |
+					   NSWindowStyleMaskMiniaturizable)
+			backing:NSBackingStoreBuffered
+			defer:NO];
+
+		[window setTitle:@"Tracking DB"];
+		[window setReleasedWhenClosed:NO];
+		[window setHidesOnDeactivate:NO];
+		g_trackWindow = window;
+
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+
+		if (g_trackDS == nil) {
+			g_trackDS = [[TrackingTableDataSource alloc] init];
+		}
+
+		// ---- Tab View ----
+		NSTabView *tabView = [[NSTabView alloc] initWithFrame:
+			NSMakeRect(0, 0, winW, winH)];
+		[tabView setAutoresizingMask:(NSViewWidthSizable | NSViewHeightSizable)];
+
+		// ======== Tab 1: Tracked ========
+		NSTabViewItem *tab1 = [[NSTabViewItem alloc] initWithIdentifier:@"tracked"];
+		[tab1 setLabel:@"Tracked"];
+
+		NSView *tab1View = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, winW, winH - 60)];
+		[tab1View setAutoresizingMask:(NSViewWidthSizable | NSViewHeightSizable)];
+
+		NSScrollView *scroll1 = [[NSScrollView alloc] initWithFrame:
+			NSMakeRect(10, 10, winW - 20, winH - 80)];
+		[scroll1 setHasVerticalScroller:YES];
+		[scroll1 setAutoresizingMask:(NSViewWidthSizable | NSViewHeightSizable)];
+		[scroll1 setBorderType:NSBezelBorder];
+
+		NSTableView *table1 = [[NSTableView alloc] initWithFrame:NSZeroRect];
+		[table1 setUsesAlternatingRowBackgroundColors:YES];
+		[table1 setGridStyleMask:NSTableViewSolidVerticalGridLineMask];
+		g_trackTable = table1;
+
+		NSTableColumn *tc1a = [[NSTableColumn alloc] initWithIdentifier:@"filename"];
+		[tc1a setTitle:@"File"]; [tc1a setWidth:280]; [tc1a setMinWidth:150];
+		[table1 addTableColumn:tc1a];
+
+		NSTableColumn *tc1b = [[NSTableColumn alloc] initWithIdentifier:@"status"];
+		[tc1b setTitle:@"Status"]; [tc1b setWidth:80];
+		[table1 addTableColumn:tc1b];
+
+		NSTableColumn *tc1c = [[NSTableColumn alloc] initWithIdentifier:@"txlen"];
+		[tc1c setTitle:@"Transcript"]; [tc1c setWidth:80];
+		[table1 addTableColumn:tc1c];
+
+		NSTableColumn *tc1d = [[NSTableColumn alloc] initWithIdentifier:@"docid"];
+		[tc1d setTitle:@"Doc ID"]; [tc1d setWidth:160];
+		[table1 addTableColumn:tc1d];
+
+		NSTableColumn *tc1e = [[NSTableColumn alloc] initWithIdentifier:@"date"];
+		[tc1e setTitle:@"Date"]; [tc1e setWidth:120];
+		[table1 addTableColumn:tc1e];
+
+		[table1 setDataSource:g_trackDS];
+		[table1 setDelegate:g_trackDS];
+		[scroll1 setDocumentView:table1];
+		[tab1View addSubview:scroll1];
+		[tab1 setView:tab1View];
+		[tabView addTabViewItem:tab1];
+
+		// ======== Tab 2: Source Files ========
+		NSTabViewItem *tab2 = [[NSTabViewItem alloc] initWithIdentifier:@"source"];
+		[tab2 setLabel:@"Source Files"];
+
+		CGFloat tabContentH = winH - 60;
+		NSView *tab2View = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, winW, tabContentH)];
+		[tab2View setAutoresizingMask:(NSViewWidthSizable | NSViewHeightSizable)];
+
+		// -- Folder path label at top --
+		NSTextField *folderLabel = [[NSTextField alloc] initWithFrame:
+			NSMakeRect(10, tabContentH - 30, winW - 20, 20)];
+		[folderLabel setBezeled:NO];
+		[folderLabel setDrawsBackground:NO];
+		[folderLabel setEditable:NO];
+		[folderLabel setSelectable:YES];
+		[folderLabel setFont:[NSFont systemFontOfSize:11]];
+		[folderLabel setTextColor:[NSColor secondaryLabelColor]];
+		[folderLabel setLineBreakMode:NSLineBreakByTruncatingMiddle];
+		[folderLabel setAutoresizingMask:(NSViewWidthSizable | NSViewMinYMargin)];
+		if (g_srcFolderPath) {
+			[folderLabel setStringValue:
+				[NSString stringWithFormat:@"Source: %s", g_srcFolderPath]];
+		} else {
+			[folderLabel setStringValue:@"Source: (not configured)"];
+		}
+		g_srcFolderLabel = folderLabel;
+		[tab2View addSubview:folderLabel];
+
+		// -- Bulk progress strip --
+		NSProgressIndicator *bulkBar = [[NSProgressIndicator alloc] initWithFrame:
+			NSMakeRect(10, tabContentH - 54, winW - 20, 12)];
+		[bulkBar setStyle:NSProgressIndicatorStyleBar];
+		[bulkBar setIndeterminate:NO];
+		[bulkBar setMinValue:0.0];
+		[bulkBar setMaxValue:100.0];
+		[bulkBar setDoubleValue:0.0];
+		[bulkBar setHidden:YES];
+		[bulkBar setAutoresizingMask:(NSViewWidthSizable | NSViewMinYMargin)];
+		g_bulkProgressBar = bulkBar;
+		[tab2View addSubview:bulkBar];
+
+		NSTextField *bulkRunLabel = [[NSTextField alloc] initWithFrame:
+			NSMakeRect(10, tabContentH - 72, winW - 20, 16)];
+		[bulkRunLabel setBezeled:NO];
+		[bulkRunLabel setDrawsBackground:NO];
+		[bulkRunLabel setEditable:NO];
+		[bulkRunLabel setFont:[NSFont systemFontOfSize:11]];
+		[bulkRunLabel setTextColor:[NSColor secondaryLabelColor]];
+		[bulkRunLabel setStringValue:@"Bulk run: idle"];
+		[bulkRunLabel setAutoresizingMask:(NSViewWidthSizable | NSViewMinYMargin)];
+		g_bulkRunLabel = bulkRunLabel;
+		[tab2View addSubview:bulkRunLabel];
+
+		NSTextField *bulkDetailLabel = [[NSTextField alloc] initWithFrame:
+			NSMakeRect(10, tabContentH - 90, winW - 20, 16)];
+		[bulkDetailLabel setBezeled:NO];
+		[bulkDetailLabel setDrawsBackground:NO];
+		[bulkDetailLabel setEditable:NO];
+		[bulkDetailLabel setFont:[NSFont systemFontOfSize:11]];
+		[bulkDetailLabel setTextColor:[NSColor secondaryLabelColor]];
+		[bulkDetailLabel setStringValue:@""];
+		[bulkDetailLabel setAutoresizingMask:(NSViewWidthSizable | NSViewMinYMargin)];
+		g_bulkDetailLabel = bulkDetailLabel;
+		[tab2View addSubview:bulkDetailLabel];
+
+		NSTextField *bulkErrorLabel = [[NSTextField alloc] initWithFrame:
+			NSMakeRect(10, tabContentH - 108, winW - 20, 16)];
+		[bulkErrorLabel setBezeled:NO];
+		[bulkErrorLabel setDrawsBackground:NO];
+		[bulkErrorLabel setEditable:NO];
+		[bulkErrorLabel setFont:[NSFont systemFontOfSize:11]];
+		[bulkErrorLabel setTextColor:[NSColor systemRedColor]];
+		[bulkErrorLabel setStringValue:@""];
+		[bulkErrorLabel setAutoresizingMask:(NSViewWidthSizable | NSViewMinYMargin)];
+		g_bulkErrorLabel = bulkErrorLabel;
+		[tab2View addSubview:bulkErrorLabel];
+
+		// -- Button bar at bottom --
+		CGFloat btnY = 10;
+		CGFloat btnH = 28;
+
+		NSButton *btnAll = [[NSButton alloc] initWithFrame:NSMakeRect(10, btnY, 40, btnH)];
+		[btnAll setTitle:@"All"];
+		[btnAll setBezelStyle:NSBezelStyleRounded];
+		[btnAll setTarget:g_trackDS];
+		[btnAll setAction:@selector(selectAllClicked:)];
+		[btnAll setAutoresizingMask:NSViewMaxXMargin];
+		[tab2View addSubview:btnAll];
+
+		NSButton *btnNone = [[NSButton alloc] initWithFrame:NSMakeRect(55, btnY, 55, btnH)];
+		[btnNone setTitle:@"None"];
+		[btnNone setBezelStyle:NSBezelStyleRounded];
+		[btnNone setTarget:g_trackDS];
+		[btnNone setAction:@selector(deselectAllClicked:)];
+		[btnNone setAutoresizingMask:NSViewMaxXMargin];
+		[tab2View addSubview:btnNone];
+
+		NSTextField *selLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(120, btnY + 4, 100, 20)];
+		[selLabel setBezeled:NO];
+		[selLabel setDrawsBackground:NO];
+		[selLabel setEditable:NO];
+		[selLabel setFont:[NSFont systemFontOfSize:11]];
+		[selLabel setTextColor:[NSColor secondaryLabelColor]];
+		[selLabel setStringValue:@"0 selected"];
+		[selLabel setAutoresizingMask:NSViewMaxXMargin];
+		g_srcSelectLabel = selLabel;
+		[tab2View addSubview:selLabel];
+
+		NSButton *btnReprocess = [[NSButton alloc] initWithFrame:
+			NSMakeRect(winW - 185, btnY, 175, btnH)];
+		[btnReprocess setTitle:@"Re-process Selected"];
+		[btnReprocess setBezelStyle:NSBezelStyleRounded];
+		[btnReprocess setTarget:g_trackDS];
+		[btnReprocess setAction:@selector(reprocessClicked:)];
+		[btnReprocess setAutoresizingMask:NSViewMinXMargin];
+		g_btnReprocess = btnReprocess;
+		[tab2View addSubview:btnReprocess];
+
+		NSButton *btnTxUpload = [[NSButton alloc] initWithFrame:
+			NSMakeRect(winW - 380, btnY, 185, btnH)];
+		[btnTxUpload setTitle:@"Transcribe + Upload"];
+		[btnTxUpload setBezelStyle:NSBezelStyleRounded];
+		[btnTxUpload setTarget:g_trackDS];
+		[btnTxUpload setAction:@selector(transcribeUploadClicked:)];
+		[btnTxUpload setAutoresizingMask:NSViewMinXMargin];
+		g_btnTxUpload = btnTxUpload;
+		[tab2View addSubview:btnTxUpload];
+
+		// -- Scroll view between label and buttons --
+		NSScrollView *scroll2 = [[NSScrollView alloc] initWithFrame:
+			NSMakeRect(10, btnY + btnH + 6, winW - 20, tabContentH - 112 - btnH - 20)];
+		[scroll2 setHasVerticalScroller:YES];
+		[scroll2 setAutoresizingMask:(NSViewWidthSizable | NSViewHeightSizable)];
+		[scroll2 setBorderType:NSBezelBorder];
+
+		NSTableView *table2 = [[NSTableView alloc] initWithFrame:NSZeroRect];
+		[table2 setUsesAlternatingRowBackgroundColors:YES];
+		[table2 setGridStyleMask:NSTableViewSolidVerticalGridLineMask];
+		g_sourceTable = table2;
+
+		// Columns: Select, #, File, Status, Size, Created
+		NSTableColumn *tc2sel = [[NSTableColumn alloc] initWithIdentifier:@"select"];
+		[tc2sel setTitle:@""];
+		[tc2sel setWidth:28];
+		[tc2sel setMinWidth:28];
+		[tc2sel setMaxWidth:28];
+		[table2 addTableColumn:tc2sel];
+
+		NSTableColumn *tc2num = [[NSTableColumn alloc] initWithIdentifier:@"num"];
+		[tc2num setTitle:@"#"];
+		[tc2num setWidth:40];
+		[tc2num setMinWidth:30];
+		[tc2num setSortDescriptorPrototype:
+			[[NSSortDescriptor alloc] initWithKey:@"num" ascending:YES]];
+		[table2 addTableColumn:tc2num];
+
+		NSTableColumn *tc2a = [[NSTableColumn alloc] initWithIdentifier:@"filename"];
+		[tc2a setTitle:@"File"];
+		[tc2a setWidth:260];
+		[tc2a setMinWidth:150];
+		[tc2a setSortDescriptorPrototype:
+			[[NSSortDescriptor alloc] initWithKey:@"filename" ascending:YES]];
+		[table2 addTableColumn:tc2a];
+
+		NSTableColumn *tc2b = [[NSTableColumn alloc] initWithIdentifier:@"status"];
+		[tc2b setTitle:@"Status"];
+		[tc2b setWidth:80];
+		[tc2b setSortDescriptorPrototype:
+			[[NSSortDescriptor alloc] initWithKey:@"status" ascending:YES]];
+		[table2 addTableColumn:tc2b];
+
+		NSTableColumn *tc2c = [[NSTableColumn alloc] initWithIdentifier:@"size"];
+		[tc2c setTitle:@"Size"];
+		[tc2c setWidth:80];
+		[tc2c setSortDescriptorPrototype:
+			[[NSSortDescriptor alloc] initWithKey:@"size" ascending:YES]];
+		[table2 addTableColumn:tc2c];
+
+		NSTableColumn *tc2d = [[NSTableColumn alloc] initWithIdentifier:@"created"];
+		[tc2d setTitle:@"Created"];
+		[tc2d setWidth:140];
+		[tc2d setSortDescriptorPrototype:
+			[[NSSortDescriptor alloc] initWithKey:@"created" ascending:YES]];
+		[table2 addTableColumn:tc2d];
+
+		[table2 setDataSource:g_trackDS];
+		[table2 setDelegate:g_trackDS];
+		[scroll2 setDocumentView:table2];
+		[tab2View addSubview:scroll2];
+		[tab2 setView:tab2View];
+		[tabView addTabViewItem:tab2];
+
+		// ---- Finalize ----
+		[[window contentView] addSubview:tabView];
+		[table1 reloadData];
+		[table2 reloadData];
+		updateSelectionLabel();
+		applyBulkControls();
+		[window makeKeyAndOrderFront:nil];
+		[NSApp activateIgnoringOtherApps:YES];
+	});
+}
+
+static void closeTrackingWindow(void) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (g_trackWindow != nil) {
+			[g_trackWindow close];
+			g_trackWindow = nil;
+		}
+		g_trackTable = nil;
+		g_sourceTable = nil;
+		g_srcFolderLabel = nil;
+		g_srcSelectLabel = nil;
+		g_bulkProgressBar = nil;
+		g_bulkRunLabel = nil;
+		g_bulkDetailLabel = nil;
+		g_bulkErrorLabel = nil;
+		g_btnReprocess = nil;
+		g_btnTxUpload = nil;
+		clearTrackData();
+		clearSrcData();
+		if (g_srcFolderPath) { free(g_srcFolderPath); g_srcFolderPath = NULL; }
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+	});
+}
+
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+// ShowTrackingWindow opens (or brings to front) the Tracking DB window.
+// trackedRows populates Tab 1, sourceRows populates Tab 2.
+// folderPath is displayed as a header label above the source files table.
+func ShowTrackingWindow(tracked []TrackingRecord, source []SourceFileRecord, folderPath string) {
+	C.clearTrackData()
+	C.clearSrcData()
+
+	cPath := C.CString(folderPath)
+	C.setSrcFolderPath(cPath)
+	C.free(unsafe.Pointer(cPath))
+
+	for _, r := range tracked {
+		cFile := C.CString(r.FileName)
+		cStatus := C.CString(r.Status)
+		cTxLen := C.CString(fmt.Sprintf("%d chars", r.TranscriptLen))
+		cDocID := C.CString(r.UploadDocID)
+		cDate := C.CString(r.ProcessedAt)
+		C.addTrackRow(cFile, cStatus, cTxLen, cDocID, cDate)
+		C.free(unsafe.Pointer(cFile))
+		C.free(unsafe.Pointer(cStatus))
+		C.free(unsafe.Pointer(cTxLen))
+		C.free(unsafe.Pointer(cDocID))
+		C.free(unsafe.Pointer(cDate))
+	}
+
+	for i, r := range source {
+		cNum := C.CString(fmt.Sprintf("%d", i+1))
+		cFile := C.CString(r.FileName)
+		cStatus := C.CString(r.Status)
+		cSize := C.CString(r.Size)
+		cCreated := C.CString(r.CreatedAt)
+		C.addSrcRow(cNum, cFile, cStatus, cSize, cCreated, C.longlong(r.SizeBytes))
+		C.free(unsafe.Pointer(cNum))
+		C.free(unsafe.Pointer(cFile))
+		C.free(unsafe.Pointer(cStatus))
+		C.free(unsafe.Pointer(cSize))
+		C.free(unsafe.Pointer(cCreated))
+	}
+
+	if C.isTrackingWindowOpen() != 0 {
+		// Window exists — just reload tables with the new data.
+		C.reloadTrackingTables()
+	} else {
+		// First open — create the window (includes initial reloadData).
+		C.showTrackingWindow()
+	}
+}
+
+// SourceFileRecord represents a file in the source folder for Tab 2 display.
+type SourceFileRecord struct {
+	FileName  string
+	Status    string // "uploaded", "imported", "new"
+	Size      string // human-readable size
+	SizeBytes int64  // raw bytes for numeric sorting
+	CreatedAt string // "YYYY-MM-DD HH:MM" file creation date
+}
+
+// SetTrackingSourceStatus updates the Source Files tab row status by filename.
+func SetTrackingSourceStatus(fileName, status string) {
+	cFile := C.CString(fileName)
+	cStatus := C.CString(status)
+	C.setTrackingSrcStatusByFilename(cFile, cStatus)
+	C.free(unsafe.Pointer(cFile))
+	C.free(unsafe.Pointer(cStatus))
+}
+
+// SetTrackingBulkProgress updates the bulk progress strip and button enabled-state.
+func SetTrackingBulkProgress(state BulkRunState) {
+	active := 0
+	if state.Active {
+		active = 1
+	}
+	runText := "Bulk run: idle"
+	detail := ""
+	errText := ""
+	if state.Active {
+		runText = fmt.Sprintf("Bulk run: %d/%d (ok=%d fail=%d)", state.Done, state.Total, state.Success, state.Failed)
+		if state.CurrentFile != "" {
+			detail = fmt.Sprintf("%s [%s]", state.CurrentFile, state.Phase)
+		} else if state.Phase != "" {
+			detail = fmt.Sprintf("phase: %s", state.Phase)
+		}
+	}
+	if state.LastError != "" {
+		errText = "Last error: " + state.LastError
+	}
+
+	cRun := C.CString(runText)
+	cDetail := C.CString(detail)
+	cErr := C.CString(errText)
+	C.setTrackingBulkState(C.int(active), cRun, cDetail, cErr,
+		C.int(state.Total), C.int(state.Done), C.int(state.Success), C.int(state.Failed))
+	C.free(unsafe.Pointer(cRun))
+	C.free(unsafe.Pointer(cDetail))
+	C.free(unsafe.Pointer(cErr))
+}

--- a/pkg/tracking/files.go
+++ b/pkg/tracking/files.go
@@ -11,34 +11,58 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
 const createFilesTableSQL = `
 CREATE TABLE IF NOT EXISTS processed_files (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    file_path    TEXT NOT NULL,
-    file_hash    TEXT NOT NULL,
-    file_size    INTEGER NOT NULL,
-    import_type  TEXT NOT NULL DEFAULT 'audio',
-    status       TEXT NOT NULL DEFAULT 'imported',
-    memory_id    TEXT,
-    processed_at TEXT NOT NULL,
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path       TEXT NOT NULL,
+    file_hash       TEXT NOT NULL,
+    file_size       INTEGER NOT NULL,
+    import_type     TEXT NOT NULL DEFAULT 'audio',
+    status          TEXT NOT NULL DEFAULT 'imported',
+    memory_id       TEXT,
+    processed_at    TEXT NOT NULL,
+    transcript_text TEXT,
+    transcript_lang TEXT,
+    transcript_len  INTEGER DEFAULT 0,
+    upload_doc_id   TEXT,
+    upload_error    TEXT,
+    uploaded_at     TEXT,
     UNIQUE(file_hash, import_type)
 );
 CREATE INDEX IF NOT EXISTS idx_processed_files_path ON processed_files(file_path);
 CREATE INDEX IF NOT EXISTS idx_processed_files_hash ON processed_files(file_hash);`
 
+// migrateFilesTable adds columns introduced after the initial schema.
+// Each ALTER TABLE is idempotent (fails silently if column already exists).
+const migrateFilesTableSQL = `
+ALTER TABLE processed_files ADD COLUMN transcript_text TEXT;
+ALTER TABLE processed_files ADD COLUMN transcript_lang TEXT;
+ALTER TABLE processed_files ADD COLUMN transcript_len  INTEGER DEFAULT 0;
+ALTER TABLE processed_files ADD COLUMN upload_doc_id   TEXT;
+ALTER TABLE processed_files ADD COLUMN upload_error    TEXT;
+ALTER TABLE processed_files ADD COLUMN uploaded_at     TEXT;
+`
+
 // ProcessedFile represents a row in the processed_files table.
 type ProcessedFile struct {
-	ID          int64
-	FilePath    string
-	FileHash    string
-	FileSize    int64
-	ImportType  string
-	Status      string
-	MemoryID    string
-	ProcessedAt time.Time
+	ID             int64
+	FilePath       string
+	FileHash       string
+	FileSize       int64
+	ImportType     string
+	Status         string
+	MemoryID       string
+	ProcessedAt    time.Time
+	TranscriptText string
+	TranscriptLang string
+	TranscriptLen  int
+	UploadDocID    string
+	UploadError    string
+	UploadedAt     string
 }
 
 // FilesDB manages the processed_files SQLite table.
@@ -63,6 +87,11 @@ func OpenFilesDB(dbPath string) (*FilesDB, error) {
 	if _, err := db.Exec(createFilesTableSQL); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("create processed_files table: %w", err)
+	}
+
+	// Run migrations for existing DBs — each ALTER is idempotent.
+	for _, stmt := range splitStatements(migrateFilesTableSQL) {
+		_, _ = db.Exec(stmt) // ignore "duplicate column" errors
 	}
 
 	return &FilesDB{db: db}, nil
@@ -140,7 +169,7 @@ func (f *FilesDB) IsPathProcessed(filePath, importType string) (bool, error) {
 // GetByHash returns the processed file record for a given (file_hash, import_type).
 func (f *FilesDB) GetByHash(fileHash, importType string) (*ProcessedFile, error) {
 	row := f.db.QueryRow(`
-		SELECT id, file_path, file_hash, file_size, import_type, status, memory_id, processed_at
+		SELECT ` + allColumns + `
 		FROM processed_files WHERE file_hash = ? AND import_type = ?
 	`, fileHash, importType)
 	return scanFileRecord(row)
@@ -149,7 +178,7 @@ func (f *FilesDB) GetByHash(fileHash, importType string) (*ProcessedFile, error)
 // GetByPath returns the first processed file record matching the given path.
 func (f *FilesDB) GetByPath(filePath string) (*ProcessedFile, error) {
 	row := f.db.QueryRow(`
-		SELECT id, file_path, file_hash, file_size, import_type, status, memory_id, processed_at
+		SELECT ` + allColumns + `
 		FROM processed_files WHERE file_path = ? LIMIT 1
 	`, filePath)
 	return scanFileRecord(row)
@@ -177,7 +206,7 @@ func (f *FilesDB) ListFiles(limit int) ([]ProcessedFile, error) {
 		limit = 100
 	}
 	rows, err := f.db.Query(`
-		SELECT id, file_path, file_hash, file_size, import_type, status, memory_id, processed_at
+		SELECT ` + allColumns + `
 		FROM processed_files ORDER BY processed_at DESC LIMIT ?
 	`, limit)
 	if err != nil {
@@ -202,7 +231,7 @@ func (f *FilesDB) ListByStatus(status string, limit int) ([]ProcessedFile, error
 		limit = 100
 	}
 	rows, err := f.db.Query(`
-		SELECT id, file_path, file_hash, file_size, import_type, status, memory_id, processed_at
+		SELECT ` + allColumns + `
 		FROM processed_files WHERE status = ? ORDER BY processed_at DESC LIMIT ?
 	`, status, limit)
 	if err != nil {
@@ -235,6 +264,38 @@ func (f *FilesDB) CountFilesByStatus(status string) (int, error) {
 	return count, err
 }
 
+// RecordTranscript stores the transcript text and language for an imported file.
+func (f *FilesDB) RecordTranscript(fileHash, importType, text, lang string) error {
+	tLen := len(strings.TrimSpace(text))
+	_, err := f.db.Exec(`
+		UPDATE processed_files
+		SET transcript_text = ?, transcript_lang = ?, transcript_len = ?
+		WHERE file_hash = ? AND import_type = ?
+	`, text, lang, tLen, fileHash, importType)
+	return err
+}
+
+// RecordUploadSuccess stores the ER1 doc ID and marks the file as uploaded.
+func (f *FilesDB) RecordUploadSuccess(fileHash, importType, docID string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := f.db.Exec(`
+		UPDATE processed_files
+		SET status = 'uploaded', upload_doc_id = ?, upload_error = NULL, uploaded_at = ?, memory_id = ?
+		WHERE file_hash = ? AND import_type = ?
+	`, docID, now, docID, fileHash, importType)
+	return err
+}
+
+// RecordUploadError stores the upload error message for a failed upload.
+func (f *FilesDB) RecordUploadError(fileHash, importType, errMsg string) error {
+	_, err := f.db.Exec(`
+		UPDATE processed_files
+		SET status = 'failed', upload_error = ?
+		WHERE file_hash = ? AND import_type = ?
+	`, errMsg, fileHash, importType)
+	return err
+}
+
 // RemoveByHash removes a processed file record by its content hash and import type.
 func (f *FilesDB) RemoveByHash(fileHash, importType string) error {
 	_, err := f.db.Exec(`
@@ -243,11 +304,18 @@ func (f *FilesDB) RemoveByHash(fileHash, importType string) error {
 	return err
 }
 
+// allColumns is the column list used in SELECT queries.
+const allColumns = `id, file_path, file_hash, file_size, import_type, status, memory_id, processed_at,
+	COALESCE(transcript_text,''), COALESCE(transcript_lang,''), COALESCE(transcript_len,0),
+	COALESCE(upload_doc_id,''), COALESCE(upload_error,''), COALESCE(uploaded_at,'')`
+
 func scanFileRecord(row *sql.Row) (*ProcessedFile, error) {
 	var r ProcessedFile
 	var processedAt string
 	var memoryID sql.NullString
-	err := row.Scan(&r.ID, &r.FilePath, &r.FileHash, &r.FileSize, &r.ImportType, &r.Status, &memoryID, &processedAt)
+	err := row.Scan(&r.ID, &r.FilePath, &r.FileHash, &r.FileSize, &r.ImportType, &r.Status, &memoryID, &processedAt,
+		&r.TranscriptText, &r.TranscriptLang, &r.TranscriptLen,
+		&r.UploadDocID, &r.UploadError, &r.UploadedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -265,7 +333,9 @@ func scanFileRows(rows *sql.Rows) (*ProcessedFile, error) {
 	var r ProcessedFile
 	var processedAt string
 	var memoryID sql.NullString
-	if err := rows.Scan(&r.ID, &r.FilePath, &r.FileHash, &r.FileSize, &r.ImportType, &r.Status, &memoryID, &processedAt); err != nil {
+	if err := rows.Scan(&r.ID, &r.FilePath, &r.FileHash, &r.FileSize, &r.ImportType, &r.Status, &memoryID, &processedAt,
+		&r.TranscriptText, &r.TranscriptLang, &r.TranscriptLen,
+		&r.UploadDocID, &r.UploadError, &r.UploadedAt); err != nil {
 		return nil, err
 	}
 	r.ProcessedAt, _ = time.Parse(time.RFC3339, processedAt)
@@ -273,4 +343,18 @@ func scanFileRows(rows *sql.Rows) (*ProcessedFile, error) {
 		r.MemoryID = memoryID.String
 	}
 	return &r, nil
+}
+
+// splitStatements splits a multi-statement SQL string by semicolons,
+// returning non-empty trimmed statements.
+func splitStatements(sql string) []string {
+	parts := strings.Split(sql, ";")
+	var result []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
 }

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# check-docs.sh — Validate documentation consistency with implementation.
+#
+# Checks that key references in docs/ match the current codebase.
+# Usage: ./scripts/check-docs.sh
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+WARNINGS=0
+warn() { echo -e "  ${YELLOW}!${NC} $1"; WARNINGS=$((WARNINGS + 1)); }
+pass() { echo -e "  ${GREEN}✓${NC} $1"; }
+
+echo "=== Documentation Consistency Check ==="
+echo ""
+
+# ─── 1. Check docs directory exists ───
+echo "1. Docs presence"
+if [ -d "docs" ]; then
+    DOC_COUNT=$(find docs -name '*.md' | wc -l | tr -d ' ')
+    pass "docs/ directory exists ($DOC_COUNT markdown files)"
+else
+    warn "No docs/ directory found"
+fi
+
+# ─── 2. Check .env.example keys are documented ───
+echo "2. Environment variables"
+if [ -f ".env.example" ]; then
+    MISSING_DOCS=0
+    while IFS= read -r line; do
+        key=$(echo "$line" | grep -oE '^[A-Z_]+' || true)
+        if [ -n "$key" ] && [ -d "docs" ]; then
+            if ! grep -rq "$key" docs/ 2>/dev/null; then
+                warn "$key not mentioned in docs/"
+                MISSING_DOCS=$((MISSING_DOCS + 1))
+            fi
+        fi
+    done < .env.example
+    if [ "$MISSING_DOCS" -eq 0 ]; then
+        pass "All .env.example keys referenced in docs"
+    fi
+else
+    pass "No .env.example to check"
+fi
+
+# ─── 3. Check Make targets in docs ───
+echo "3. Make targets"
+if [ -d "docs" ]; then
+    for target in build install menubar test-unit; do
+        if ! grep -rq "$target" docs/ 2>/dev/null; then
+            warn "make $target not mentioned in docs"
+        fi
+    done
+    pass "Key make targets checked"
+else
+    pass "No docs to check targets against"
+fi
+
+# ─── Summary ───
+echo ""
+echo "─────────────────────────────"
+if [ "$WARNINGS" -gt 0 ]; then
+    echo -e "${YELLOW}PASS with warnings${NC}: $WARNINGS warning(s)"
+    echo "Docs may need updating. Release is allowed."
+    exit 0
+else
+    echo -e "${GREEN}PASS${NC}: Documentation is consistent."
+    exit 0
+fi

--- a/scripts/code-review.sh
+++ b/scripts/code-review.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# code-review.sh — Pre-release code review checks.
+#
+# Validates code quality, consistency, and release readiness.
+# Blocks release if critical issues are found.
+#
+# Usage: ./scripts/code-review.sh
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+ERRORS=0
+WARNINGS=0
+
+pass()  { echo -e "  ${GREEN}✓${NC} $1"; }
+fail()  { echo -e "  ${RED}✗${NC} $1"; ERRORS=$((ERRORS + 1)); }
+warn()  { echo -e "  ${YELLOW}!${NC} $1"; WARNINGS=$((WARNINGS + 1)); }
+info()  { echo -e "  ${CYAN}→${NC} $1"; }
+
+echo "=== Pre-Release Code Review ==="
+echo ""
+
+# ─── 1. Build check ───
+echo "1. Build"
+if go build -o /dev/null ./cmd/m3c-tools/ 2>/dev/null; then
+    pass "go build succeeds"
+else
+    fail "go build FAILED"
+fi
+
+# ─── 2. Vet ───
+echo "2. Vet"
+VET_OUTPUT=$(go vet ./... 2>&1) || true
+if [ -z "$VET_OUTPUT" ]; then
+    pass "go vet clean"
+else
+    fail "go vet found issues:"
+    echo "$VET_OUTPUT" | head -10 | sed 's/^/      /'
+fi
+
+# ─── 3. Unit tests ───
+echo "3. Tests"
+if go test -count=1 ./pkg/... 2>/dev/null | grep -q "^ok"; then
+    pass "pkg/ tests pass"
+else
+    # Some packages may have no tests — check if any failures
+    TEST_OUT=$(go test -count=1 ./pkg/... 2>&1) || true
+    if echo "$TEST_OUT" | grep -q "^FAIL"; then
+        fail "pkg/ tests have failures"
+        echo "$TEST_OUT" | grep "^FAIL" | sed 's/^/      /'
+    else
+        pass "pkg/ tests pass (some packages have no tests)"
+    fi
+fi
+
+# ─── 4. Sensitive data scan ───
+echo "4. Sensitive data"
+SENSITIVE_PATTERNS='API_KEY\s*=\s*[A-Za-z0-9]|password\s*=\s*"[^"]|secret\s*=\s*"[^"]|token\s*=\s*"[^"]'
+# Only scan Go source files, skip tests
+SENSITIVE_HITS=$(grep -rlEi "$SENSITIVE_PATTERNS" --include='*.go' --exclude='*_test.go' --exclude='*testhelper*' . 2>/dev/null || true)
+if [ -z "$SENSITIVE_HITS" ]; then
+    pass "No hardcoded secrets in Go source"
+else
+    warn "Possible hardcoded secrets in:"
+    echo "$SENSITIVE_HITS" | sed 's/^/      /'
+fi
+
+# Check .env is not staged
+if git diff --cached --name-only 2>/dev/null | grep -q "^\.env$"; then
+    fail ".env is staged for commit — DO NOT commit secrets"
+else
+    pass ".env not staged"
+fi
+
+# ─── 5. TODO/FIXME/HACK audit ───
+echo "5. Code markers"
+TODO_HITS=$(grep -rnE '(TODO|FIXME|HACK|XXX):' --include='*.go' . 2>/dev/null || true)
+if [ -n "$TODO_HITS" ]; then
+    TODO_COUNT=$(echo "$TODO_HITS" | wc -l | tr -d ' ')
+else
+    TODO_COUNT=0
+fi
+if [ "$TODO_COUNT" -gt 0 ]; then
+    warn "$TODO_COUNT TODO/FIXME/HACK markers in Go source"
+    echo "$TODO_HITS" | head -10 | sed 's/^/      /'
+    if [ "$TODO_COUNT" -gt 10 ]; then
+        echo "      ... and $((TODO_COUNT - 10)) more"
+    fi
+else
+    pass "No TODO/FIXME/HACK markers"
+fi
+
+# ─── 6. Dead code / unused imports ───
+echo "6. Dead code"
+# Check for unused imports (quick heuristic via build)
+UNUSED_IMPORTS=$(go build ./... 2>&1 | grep "imported and not used" || true)
+if [ -z "$UNUSED_IMPORTS" ]; then
+    pass "No unused imports"
+else
+    fail "Unused imports:"
+    echo "$UNUSED_IMPORTS" | head -5 | sed 's/^/      /'
+fi
+
+# ─── 7. Large files check ───
+echo "7. File sizes"
+LARGE_GO_FILES=$(find . -name '*.go' -not -path './vendor/*' -exec wc -l {} + 2>/dev/null | awk '$1 > 2000 && !/total$/ {print $2 " (" $1 " lines)"}' || true)
+if [ -z "$LARGE_GO_FILES" ]; then
+    pass "No Go files over 2000 lines"
+else
+    warn "Large Go files (consider splitting):"
+    echo "$LARGE_GO_FILES" | sed 's/^/      /'
+fi
+
+# ─── 8. Error handling patterns ───
+echo "8. Error handling"
+# Check for silently ignored errors (= vs :=) in non-test files
+IGNORED_ERRS=$(grep -rn 'err\s*=' --include='*.go' --exclude='*_test.go' . 2>/dev/null | grep -v ':=' | grep -v '_ =' | grep -v 'var err' | grep -v '// ' | grep -v 'if err' | head -5 || true)
+if [ -z "$IGNORED_ERRS" ]; then
+    pass "No obviously ignored errors"
+else
+    warn "Possibly overwritten errors (review manually):"
+    echo "$IGNORED_ERRS" | sed 's/^/      /'
+fi
+
+# ─── 9. Version consistency ───
+echo "9. Version"
+MAKEFILE_VER=$(grep 'APP_VERSION' Makefile 2>/dev/null | head -1 | awk '{print $NF}')
+LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
+if [ -n "$MAKEFILE_VER" ]; then
+    info "Makefile APP_VERSION: $MAKEFILE_VER"
+fi
+if [ -n "$LATEST_TAG" ]; then
+    info "Latest git tag: $LATEST_TAG"
+fi
+pass "Version info collected"
+
+# ─── 10. Dependencies ───
+echo "10. Dependencies"
+if go mod verify 2>/dev/null; then
+    pass "go.mod verified"
+else
+    fail "go mod verify failed"
+fi
+
+VULN_CHECK=""
+if command -v govulncheck >/dev/null 2>&1; then
+    VULN_CHECK=$(govulncheck ./... 2>&1 | grep "^Vulnerability" || true)
+    if [ -z "$VULN_CHECK" ]; then
+        pass "No known vulnerabilities (govulncheck)"
+    else
+        warn "Known vulnerabilities found:"
+        echo "$VULN_CHECK" | head -5 | sed 's/^/      /'
+    fi
+else
+    info "govulncheck not installed (skipping — install: go install golang.org/x/vuln/cmd/govulncheck@latest)"
+fi
+
+# ─── Summary ───
+echo ""
+echo "─────────────────────────────"
+if [ "$ERRORS" -gt 0 ]; then
+    echo -e "${RED}BLOCKED${NC}: $ERRORS error(s), $WARNINGS warning(s) — fix before releasing"
+    exit 1
+elif [ "$WARNINGS" -gt 0 ]; then
+    echo -e "${YELLOW}PASS with warnings${NC}: $WARNINGS warning(s), 0 errors"
+    echo "Review warnings above. Release is allowed but consider fixing them."
+    exit 0
+else
+    echo -e "${GREEN}PASS${NC}: Code review passed. Ready to release."
+    exit 0
+fi


### PR DESCRIPTION
## Summary
- add ER1 login/logout actions to menubar and account status display
- open configured service login URL () and capture callback on localhost
- detect context ID from callback params with Chrome-tab URL fallback
- apply runtime ER1 context override for uploads after login
- add optional persisted session restore via  and 
- add feature-tracking doc: 

## Test fixes included
- isolate app bundle tests with temp  to avoid permission issues in shared 
- make  robust against local  side effects

## Validation
- go vet ./...
Running golangci-lint...
golangci-lint run --timeout=5m
0 issues.
Running unit tests (offline)...
go test -v -count=1 ./e2e/ -run "TestComposite|TestBuild|TestParseTagLine|TestER1Config|TestER1Queue|TestER1EnqueueFailure|TestUploadFailure|TestRecorderEncodeWAV|TestRecorderStats|TestExportsDB|TestFilesDB|TestHashFile|TestFormatterLoader|TestPrettyPrint|TestFormatTranscript|TestFormatSnippet|TestFormatKeyValue|TestFormatTable|TestFormatSection|TestFormatStatusLine|TestBuildApp|TestTranslateFlagParsing|TestTranslateNotTranslatable|TestTranslateTranslatable|TestRetryQueue|TestRetryBackoffTiming|TestRetryBackoffCustomBase|TestRetryProcessingOrder|TestRetryPartialFailure|TestRetryMaxRetriesDropsEntry|TestRetryDropCallback|TestRetryRespectsBackoffDelay|TestRetryProcessesAfterBackoffElapsed|TestRetryGracefulShutdownOnCancel|TestRetryRunStopsOnContextCancel|TestRetryRunProcessesMultipleCycles|TestRetryEmptyQueue|TestRetryOnRetryCallback|TestTranscriptFilterExcludeGenerated|TestTranscriptFilterExcludeManuallyCreated|TestTranscriptFilterBothExcludes|TestTranscriptFilterEmptyList|TestTranscriptFilterAllSameType|TestProxyBuildURL|TestProxyGetTransport|TestProxyNewWithProxy|TestProxyHTTPIntegration|TestProxyWebshare|TestProxySocks5URL|TestRetryRunnerProcessOnce|TestRetryRunnerDropExceedMaxRetries|TestRetryRunnerBackoff|TestRetryRunnerRunLoop|TestRetryRunnerBackoffSkip|TestBackgroundRetryStartsAndProcesses|TestBackgroundRetryStopsGracefully|TestBackgroundRetryHandlesFailures|TestBackgroundRetryEmptyQueue|TestBackgroundRetryLogging|TestTranscriptImportFromSnippets|TestTranscriptImportPreservesMetadata|TestTranscriptListSearchByLanguage|TestTranscriptListSearchGenerated|TestTranscriptListSearchManual|TestTranscriptSearchNotFound|TestTranscriptExportText|TestTranscriptExportSRT|TestTranscriptExportJSON|TestTranscriptExportWebVTT|TestTranscriptExportPretty|TestTranscriptExportAllFormats|TestTranscriptExportToFile|TestTranscriptListString|TestTranscriptListStringEmpty|TestMenubarIntegrationFullLifecycle|TestMenubarIntegrationTranscriptFetcherWired|TestMenubarIntegrationStatusDuringFetch|TestMenubarIntegrationMenuItemsComplete|TestMenubarIntegrationConcurrentStatusUpdates|TestMenubarIntegrationHistoryInMenuUpdates|TestAppBundleLaunchHelp|TestAppBundleLaunchUnknownCommand|TestAppBundleLaunchNoArgs|TestAppBundleRetryGracefulShutdown|TestAppBundleRetryExitsOnSIGINT|TestAppBundleMenubarFlagParsing|TestAppBundleExecPermissions|TestAppBundleInfoPlistLSUIElement|TestScheduleCommand|TestScheduleCommandDuplicate|TestScheduleCommandMissingTranscript|TestStatusCommand|TestStatusCommandEntryNotFound|TestCancelCommand|TestCancelCommandNotFound|TestScheduleStatusCancelWorkflow|TestCLIHelp|TestCLIUnknownCommand|TestCLINoArgs|TestRepoRoot|TestWriteFixture|TestWriteFixtureBytes|TestFixtureDir|TestTempDataDir|TestWithEnv|TestCLIResultAssertions|TestRunCLIWithEnv|TestScreenshotModeConstants|TestScreenshotClipboardImageTypes|TestScreenshotCLIHelpOutput|TestImporterScanDir|TestImporterScanDirEmpty|TestImporterScanDirNotExist|TestImporterScanDirNotDirectory|TestImporterIsAudioFile|TestImporterExtensionList|TestImporterScanDirHiddenSkip|TestImporterScanDirCaseInsensitive|TestImporterScanDirAbsPath|TestImporterScanDirDeepNesting|TestImporterExtensionCoverage|TestImporterCLIExtensions|TestImporterCLIScanDir|TestImporterCLIEmptyDir|TestImporterCLINonexistentDir|TestImporterCLINoArgs"
=== RUN   TestBackgroundRetryStartsAndProcesses
    background_retry_test.go:54: Background retry processed 2 entries
--- PASS: TestBackgroundRetryStartsAndProcesses (0.30s)
=== RUN   TestBackgroundRetryStopsGracefully
    background_retry_test.go:86: Background retry stopped gracefully
--- PASS: TestBackgroundRetryStopsGracefully (0.00s)
=== RUN   TestBackgroundRetryHandlesFailures
    background_retry_test.go:129: Background retry made 6 attempts, entry has 6 retries
--- PASS: TestBackgroundRetryHandlesFailures (0.30s)
=== RUN   TestBackgroundRetryEmptyQueue
    background_retry_test.go:157: Background retry with empty queue runs and stops cleanly
--- PASS: TestBackgroundRetryEmptyQueue (0.20s)
=== RUN   TestBackgroundRetryLogging
    background_retry_test.go:195: Background retry logged 1 messages
--- PASS: TestBackgroundRetryLogging (0.20s)
=== RUN   TestBuildAppBundle
    buildapp_test.go:26: make build-app output:
        Building m3c-tools...
        go build -o /var/folders/jt/_7v31n9s1cd8x_ddyqgghztc0000gn/T/TestBuildAppBundle2120980040/001/m3c-tools ./cmd/m3c-tools
        Building M3C-Tools.app bundle...
          Generated icon.icns
        Built /var/folders/jt/_7v31n9s1cd8x_ddyqgghztc0000gn/T/TestBuildAppBundle2120980040/001/M3C-Tools.app
    buildapp_test.go:80: Info.plist: 956 bytes, all required keys present
    buildapp_test.go:95: Executable: /var/folders/jt/_7v31n9s1cd8x_ddyqgghztc0000gn/T/TestBuildAppBundle2120980040/001/M3C-Tools.app/Contents/MacOS/m3c-tools (17262210 bytes, mode=-rwxr-xr-x)
    buildapp_test.go:107: Icon: /var/folders/jt/_7v31n9s1cd8x_ddyqgghztc0000gn/T/TestBuildAppBundle2120980040/001/M3C-Tools.app/Contents/Resources/icon.png (10045 bytes)
    buildapp_test.go:126: Help output: 3206 bytes
--- PASS: TestBuildAppBundle (1.99s)
=== RUN   TestER1Config
    er1_test.go:22: Config: ER1 -> https://127.0.0.1:8081/upload_2 key=(none) ctx=107677460544181387647___mft timeout=10s
--- PASS: TestER1Config (0.00s)
=== RUN   TestER1EnqueueFailure
    er1_test.go:178: Queued entry: id=vid123-1773153880899883000 error=ER1 upload failed (status 503): Service Unavailable queued_at=2026-03-10 15:44:40.899891 +0100 CET
--- PASS: TestER1EnqueueFailure (0.00s)
=== RUN   TestER1EnqueueFailureCreatesDir
    er1_test.go:206: Nested directory creation works correctly
--- PASS: TestER1EnqueueFailureCreatesDir (0.00s)
=== RUN   TestER1Queue
--- PASS: TestER1Queue (0.00s)
=== RUN   TestUploadFailureCreatesQueue
    failure_test.go:68: queue.json written with 1 entry, ID=vid123-1773153880901746000
--- PASS: TestUploadFailureCreatesQueue (0.00s)
=== RUN   TestUploadFailureAppendsQueue
    failure_test.go:126: queue.json correctly appended 3 entries
--- PASS: TestUploadFailureAppendsQueue (0.00s)
=== RUN   TestUploadFailureCreatesMemoryFolder
    failure_test.go:170: MEMORY folder created: /var/folders/jt/_7v31n9s1cd8x_ddyqgghztc0000gn/T/TestUploadFailureCreatesMemoryFolder3850440952/001/MEMORY/MEMORY-20260310-154440 (ID=MEMORY-20260310-154440)
    failure_test.go:209: All payload files correctly saved to MEMORY folder
--- PASS: TestUploadFailureCreatesMemoryFolder (0.00s)
=== RUN   TestUploadFailureQueueAndMemoryBothExist
    failure_test.go:253: Both queue.json and MEMORY folder exist after failure
--- PASS: TestUploadFailureQueueAndMemoryBothExist (0.00s)
=== RUN   TestUploadFailureNoMemoryOnSuccess
    failure_test.go:271: Confirmed: MEMORY folder not created when upload succeeds
--- PASS: TestUploadFailureNoMemoryOnSuccess (0.00s)
=== RUN   TestFilesDBCreateAndQuery
--- PASS: TestFilesDBCreateAndQuery (0.00s)
=== RUN   TestFilesDBDeduplication
--- PASS: TestFilesDBDeduplication (0.00s)
=== RUN   TestFilesDBIsFileProcessed
--- PASS: TestFilesDBIsFileProcessed (0.00s)
=== RUN   TestFilesDBIsPathProcessed
--- PASS: TestFilesDBIsPathProcessed (0.00s)
=== RUN   TestFilesDBUpdateStatus
--- PASS: TestFilesDBUpdateStatus (0.00s)
=== RUN   TestFilesDBUpdateMemoryID
--- PASS: TestFilesDBUpdateMemoryID (0.00s)
=== RUN   TestFilesDBListAndCount
--- PASS: TestFilesDBListAndCount (0.00s)
=== RUN   TestFilesDBRemoveByHash
--- PASS: TestFilesDBRemoveByHash (0.00s)
=== RUN   TestFilesDBGetByPath
--- PASS: TestFilesDBGetByPath (0.00s)
=== RUN   TestHashFile
    files_tracking_test.go:375: Hash: a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447
--- PASS: TestHashFile (0.00s)
=== RUN   TestFilesDBHashIntegration
    files_tracking_test.go:446: Recorded: /var/folders/jt/_7v31n9s1cd8x_ddyqgghztc0000gn/T/TestFilesDBHashIntegration4144689864/001/recording.wav -> a7e9bb838639db8379e4044a8f26422218aadf61f6c63886596e4b7624c91259
--- PASS: TestFilesDBHashIntegration (0.00s)
=== RUN   TestFormatterLoaderBuiltins
--- PASS: TestFormatterLoaderBuiltins (0.00s)
=== RUN   TestFormatterLoaderGet
=== RUN   TestFormatterLoaderGet/text
=== RUN   TestFormatterLoaderGet/json
=== RUN   TestFormatterLoaderGet/json-pretty
=== RUN   TestFormatterLoaderGet/srt
=== RUN   TestFormatterLoaderGet/webvtt
=== RUN   TestFormatterLoaderGet/pretty
--- PASS: TestFormatterLoaderGet (0.00s)
    --- PASS: TestFormatterLoaderGet/text (0.00s)
    --- PASS: TestFormatterLoaderGet/json (0.00s)
    --- PASS: TestFormatterLoaderGet/json-pretty (0.00s)
    --- PASS: TestFormatterLoaderGet/srt (0.00s)
    --- PASS: TestFormatterLoaderGet/webvtt (0.00s)
    --- PASS: TestFormatterLoaderGet/pretty (0.00s)
=== RUN   TestFormatterLoaderDefault
--- PASS: TestFormatterLoaderDefault (0.00s)
=== RUN   TestFormatterLoaderUnknown
--- PASS: TestFormatterLoaderUnknown (0.00s)
=== RUN   TestFormatterLoaderRegisterCustom
--- PASS: TestFormatterLoaderRegisterCustom (0.00s)
=== RUN   TestPrettyPrintFormatterHourTimestamp
--- PASS: TestPrettyPrintFormatterHourTimestamp (0.00s)
=== RUN   TestBuildFileEntriesNoChecker
    importer_format_test.go:46:   20260310_143000_standup.flac: status=new tags=[standup]
    importer_format_test.go:46:   meeting-notes-2026-03-09.wav: status=new tags=[meeting notes]
    importer_format_test.go:46:   project_alpha_draft.mp3: status=new tags=[project alpha draft]
--- PASS: TestBuildFileEntriesNoChecker (0.00s)
=== RUN   TestBuildFileEntriesParsedTags
--- PASS: TestBuildFileEntriesParsedTags (0.00s)
=== RUN   TestBuildFileEntriesWithChecker
--- PASS: TestBuildFileEntriesWithChecker (0.00s)
=== RUN   TestBuildFileEntriesWithTrackingDB
    importer_format_test.go:371: Full output:
        Scanned: /var/folders/jt/_7v31n9s1cd8x_ddyqgghztc0000gn/T/TestBuildFileEntriesWithTrackingDB751047487/001
        Found 2 audio file(s):
        
          Name               Status    Size        Tags
          ─────────────────  ────────  ──────────  ────────────────────
          new-recording.wav  + new     17 B        new, recording
          tracked.wav        ✓ imported  21 B        tracked
        
        Summary: 2 total, 1 new, 1 imported
--- PASS: TestBuildFileEntriesWithTrackingDB (0.00s)
=== RUN   TestImporterScanDir
    importer_test.go:86:   classical.aiff (ext=.aiff, size=4)
    importer_test.go:86:   interview.aac (ext=.aac, size=3)
    importer_test.go:86:   intro.wav (ext=.wav, size=3)
    importer_test.go:86:   podcast.ogg (ext=.ogg, size=3)
    importer_test.go:86:   recording.webm (ext=.webm, size=4)
    importer_test.go:86:   deep.flac (ext=.flac, size=4)
    importer_test.go:86:   track1.mp3 (ext=.mp3, size=3)
    importer_test.go:86:   track2.M4A (ext=.m4a, size=9)
    importer_test.go:86:   voice.opus (ext=.opus, size=4)
--- PASS: TestImporterScanDir (0.00s)
=== RUN   TestImporterScanDirEmpty
--- PASS: TestImporterScanDirEmpty (0.00s)
=== RUN   TestImporterScanDirNotExist
--- PASS: TestImporterScanDirNotExist (0.00s)
=== RUN   TestImporterScanDirNotDirectory
--- PASS: TestImporterScanDirNotDirectory (0.00s)
=== RUN   TestImporterIsAudioFile
--- PASS: TestImporterIsAudioFile (0.00s)
=== RUN   TestImporterExtensionList
    importer_test.go:160: Supported extensions: [.aac .aiff .flac .m4a .mp3 .ogg .opus .wav .webm .wma]
--- PASS: TestImporterExtensionList (0.00s)
=== RUN   TestImporterScanDirHiddenSkip
--- PASS: TestImporterScanDirHiddenSkip (0.00s)
=== RUN   TestImporterScanDirCaseInsensitive
--- PASS: TestImporterScanDirCaseInsensitive (0.00s)
=== RUN   TestImporterScanDirAbsPath
--- PASS: TestImporterScanDirAbsPath (0.00s)
=== RUN   TestImporterScanDirDeepNesting
--- PASS: TestImporterScanDirDeepNesting (0.00s)
=== RUN   TestImporterExtensionCoverage
--- PASS: TestImporterExtensionCoverage (0.00s)
=== RUN   TestImporterCLIExtensions
    importer_test.go:305: CLI extensions output:
        Supported audio extensions (10):
          .aac
          .aiff
          .flac
          .m4a
          .mp3
          .ogg
          .opus
          .wav
          .webm
          .wma
--- PASS: TestImporterCLIExtensions (0.14s)
=== RUN   TestImporterCLIScanDir
    importer_test.go:353: CLI scan output:
        Scanning /var/folders/jt/_7v31n9s1cd8x_ddyqgghztc0000gn/T/TestImporterCLIScanDir2188829747/001 for audio files...
        Scanned: /var/folders/jt/_7v31n9s1cd8x_ddyqgghztc0000gn/T/TestImporterCLIScanDir2188829747/001
        Found 3 audio file(s):
        
          Name         Status  Size        Tags
          ───────────  ──────  ──────────  ────────────────────
          track1.wav   + new   10 B        track1
          track2.mp3   + new   10 B        track2
          track3.flac  + new   10 B        track3
        
        Summary: 3 total, 3 new
--- PASS: TestImporterCLIScanDir (0.01s)
=== RUN   TestImporterCLIEmptyDir
--- PASS: TestImporterCLIEmptyDir (0.01s)
=== RUN   TestImporterCLINonexistentDir
--- PASS: TestImporterCLINonexistentDir (0.01s)
=== RUN   TestImporterCLINoArgs
--- PASS: TestImporterCLINoArgs (0.00s)
=== RUN   TestCompositeDocProgress
    impression_test.go:41: Composite document: 293 chars
--- PASS: TestCompositeDocProgress (0.00s)
=== RUN   TestCompositeDocIdea
--- PASS: TestCompositeDocIdea (0.00s)
=== RUN   TestCompositeDocImpulse
--- PASS: TestCompositeDocImpulse (0.00s)
=== RUN   TestCompositeDocImport
--- PASS: TestCompositeDocImport (0.00s)
=== RUN   TestBuildVideoTags
    impression_test.go:88: Tags: progress,youtube,video_id:dQw4w9WgXcQ,channel:RickAstleyVEVO
--- PASS: TestBuildVideoTags (0.00s)
=== RUN   TestBuildImportTags
    impression_test.go:99: Tags: import,audio-import,braindump,meeting
--- PASS: TestBuildImportTags (0.00s)
=== RUN   TestParseTagLine
--- PASS: TestParseTagLine (0.00s)
=== RUN   TestMenubarIntegrationFullLifecycle
--- PASS: TestMenubarIntegrationFullLifecycle (0.00s)
=== RUN   TestMenubarIntegrationTranscriptFetcherWired
--- PASS: TestMenubarIntegrationTranscriptFetcherWired (0.00s)
=== RUN   TestMenubarIntegrationStatusDuringFetch
2026/03/10 15:44:41 [menubar] transcript fetch START video=!!!invalid!!! languages=[en de fr es]
2026/03/10 15:44:41 [transcript] START video=!!!invalid!!! languages=[en de fr es]
2026/03/10 15:44:41 [transcript] FAIL video=!!!invalid!!! error=[!!!invalid!!!] invalid video ID format elapsed=1.292µs
2026/03/10 15:44:41 [menubar] transcript fetch FAIL video=!!!invalid!!! error=[!!!invalid!!!] invalid video ID format elapsed=6.125µs
--- PASS: TestMenubarIntegrationStatusDuringFetch (0.00s)
=== RUN   TestMenubarIntegrationMenuItemsComplete
--- PASS: TestMenubarIntegrationMenuItemsComplete (0.00s)
=== RUN   TestMenubarIntegrationConcurrentStatusUpdates
--- PASS: TestMenubarIntegrationConcurrentStatusUpdates (0.00s)
=== RUN   TestMenubarIntegrationHistoryInMenuUpdates
--- PASS: TestMenubarIntegrationHistoryInMenuUpdates (0.00s)
=== RUN   TestAppBundleLaunchHelp
--- PASS: TestAppBundleLaunchHelp (1.63s)
=== RUN   TestAppBundleLaunchUnknownCommand
--- PASS: TestAppBundleLaunchUnknownCommand (0.15s)
=== RUN   TestAppBundleLaunchNoArgs
--- PASS: TestAppBundleLaunchNoArgs (0.26s)
=== RUN   TestAppBundleRetryGracefulShutdown
    menubar_lifecycle_test.go:414: retry process exited after SIGTERM — graceful shutdown confirmed
--- PASS: TestAppBundleRetryGracefulShutdown (0.65s)
=== RUN   TestAppBundleRetryExitsOnSIGINT
    menubar_lifecycle_test.go:460: retry process exited after SIGINT — graceful shutdown confirmed
--- PASS: TestAppBundleRetryExitsOnSIGINT (0.64s)
=== RUN   TestAppBundleMenubarFlagParsing
--- PASS: TestAppBundleMenubarFlagParsing (0.29s)
=== RUN   TestAppBundleExecPermissions
    menubar_lifecycle_test.go:510: binary: /Users/kamir/GITHUB.kamir/m3c-tools/build/m3c-tools (17262210 bytes, mode=-rwxr-xr-x)
--- PASS: TestAppBundleExecPermissions (0.14s)
=== RUN   TestAppBundleInfoPlistLSUIElement
--- PASS: TestAppBundleInfoPlistLSUIElement (1.53s)
=== RUN   TestPrettyPrintFormatterDefault
    prettyprint_test.go:74: Pretty output (835 chars):
        ────────────────────────────────────────────────────────────
          Video:    dQw4w9WgXcQ
          Language: 🇬🇧 English (en, auto-generated)
          Snippets: 3
        ────────────────────────────────────────────────────────────
            1 │ 00:00 → 00:03 │ Never gonna give you up
            2 │ 00:03 → 00:06 │ Never gonna let you down
            3 │ 00:06 → 00:10 │ Never gonna run around and desert you
        ────────────────────────────────────────────────────────────
          Total: 3 snippets, 00:10
--- PASS: TestPrettyPrintFormatterDefault (0.00s)
=== RUN   TestPrettyPrintFormatterNoHeader
--- PASS: TestPrettyPrintFormatterNoHeader (0.00s)
=== RUN   TestPrettyPrintFormatterNoTimestamps
--- PASS: TestPrettyPrintFormatterNoTimestamps (0.00s)
=== RUN   TestPrettyPrintFormatterMaxWidth
--- PASS: TestPrettyPrintFormatterMaxWidth (0.00s)
=== RUN   TestPrettyPrintFormatterInterface
--- PASS: TestPrettyPrintFormatterInterface (0.00s)
=== RUN   TestPrettyPrintEmptyTranscript
--- PASS: TestPrettyPrintEmptyTranscript (0.00s)
=== RUN   TestFormatTranscriptList
    prettyprint_test.go:186: TranscriptList output:
        ╭─ Available Transcripts ─ abc123
        │
        │   1. 🇬🇧 English              (en)   auto     [translatable]
        │   2. 🇩🇪 German               (de)   manual  
        │
        ╰─ 2 transcript(s) found
--- PASS: TestFormatTranscriptList (0.00s)
=== RUN   TestFormatTranscriptInfo
--- PASS: TestFormatTranscriptInfo (0.00s)
=== RUN   TestFormatSnippet
--- PASS: TestFormatSnippet (0.00s)
=== RUN   TestFormatKeyValue
--- PASS: TestFormatKeyValue (0.00s)
=== RUN   TestFormatTable
    prettyprint_test.go:283: Table output:
          ID │ Video       │ Status  
          ───┼─────────────┼─────────
          1  │ dQw4w9WgXcQ │ uploaded
          2  │ abc123xyz99 │ pending 
--- PASS: TestFormatTable (0.00s)
=== RUN   TestFormatSection
    prettyprint_test.go:302: Section output:
        ┌─ ER1 Status
        │ Server: reachable
        │ Key: abc...
        └─
--- PASS: TestFormatSection (0.00s)
=== RUN   TestFormatStatusLine
--- PASS: TestFormatStatusLine (0.00s)
=== RUN   TestFormatterLoaderPretty
--- PASS: TestFormatterLoaderPretty (0.00s)
=== RUN   TestProxyBuildURLNoAuth
--- PASS: TestProxyBuildURLNoAuth (0.00s)
=== RUN   TestProxyBuildURLWithAuth
--- PASS: TestProxyBuildURLWithAuth (0.00s)
=== RUN   TestProxyBuildURLAuthOverridesEmbedded
--- PASS: TestProxyBuildURLAuthOverridesEmbedded (0.00s)
=== RUN   TestProxyBuildURLAuthUsernameOnly
--- PASS: TestProxyBuildURLAuthUsernameOnly (0.00s)
=== RUN   TestProxyBuildURLEmptyURLError
--- PASS: TestProxyBuildURLEmptyURLError (0.00s)
=== RUN   TestProxySocks5URL
--- PASS: TestProxySocks5URL (0.00s)
=== RUN   TestProxyGetTransportValid
--- PASS: TestProxyGetTransportValid (0.00s)
=== RUN   TestProxyGetTransportWithAuth
--- PASS: TestProxyGetTransportWithAuth (0.00s)
=== RUN   TestProxyGetTransportEmptyURLError
--- PASS: TestProxyGetTransportEmptyURLError (0.00s)
=== RUN   TestProxyNewWithProxyValid
--- PASS: TestProxyNewWithProxyValid (0.00s)
=== RUN   TestProxyNewWithProxyInvalidURL
--- PASS: TestProxyNewWithProxyInvalidURL (0.00s)
=== RUN   TestProxyHTTPIntegration
--- PASS: TestProxyHTTPIntegration (0.00s)
=== RUN   TestProxyWebshareEmptyError
--- PASS: TestProxyWebshareEmptyError (0.00s)
=== RUN   TestProxyWebsharePicksFromList
--- PASS: TestProxyWebsharePicksFromList (0.00s)
=== RUN   TestRecorderEncodeWAV
    recorder_test.go:43: WAV: 32044 bytes
--- PASS: TestRecorderEncodeWAV (0.00s)
=== RUN   TestRecorderStats
--- PASS: TestRecorderStats (0.00s)
=== RUN   TestRetryRunnerProcessOnce
    retry_test.go:62: ProcessOnce: 2 successes, 1 failures, 0 dropped
--- PASS: TestRetryRunnerProcessOnce (0.00s)
=== RUN   TestRetryRunnerDropExceedMaxRetries
    retry_test.go:98: Entries exceeding MaxRetries are correctly dropped
--- PASS: TestRetryRunnerDropExceedMaxRetries (0.00s)
=== RUN   TestRetryRunnerBackoff
    retry_test.go:125: Exponential backoff with cap works correctly
--- PASS: TestRetryRunnerBackoff (0.00s)
=== RUN   TestRetryRunnerRunLoop
    retry_test.go:158: Run loop processed 1 entries before context cancellation
--- PASS: TestRetryRunnerRunLoop (0.50s)
=== RUN   TestRetryRunnerBackoffSkip
    retry_test.go:194: Backoff correctly skips recently-retried entries
--- PASS: TestRetryRunnerBackoffSkip (0.00s)
=== RUN   TestRetryQueueInsertAndQuery
--- PASS: TestRetryQueueInsertAndQuery (0.00s)
=== RUN   TestRetryQueueUpdateAttempt
--- PASS: TestRetryQueueUpdateAttempt (0.00s)
=== RUN   TestRetryQueueMarkComplete
--- PASS: TestRetryQueueMarkComplete (0.00s)
=== RUN   TestRetryQueueBackoffCalculation
--- PASS: TestRetryQueueBackoffCalculation (0.00s)
=== RUN   TestRetryQueueCountByStatus
--- PASS: TestRetryQueueCountByStatus (0.00s)
=== RUN   TestRetryQueueRemoveCompleted
--- PASS: TestRetryQueueRemoveCompleted (0.00s)
=== RUN   TestRetryQueueDuplicateEntryID
--- PASS: TestRetryQueueDuplicateEntryID (0.00s)
=== RUN   TestRetryQueueListAll
--- PASS: TestRetryQueueListAll (0.00s)
=== RUN   TestScheduleCommand
    schedule_test.go:92: Schedule command created entry: upload-e2e-001 (status=pending, max=5)
--- PASS: TestScheduleCommand (1.60s)
=== RUN   TestScheduleCommandDuplicate
    schedule_test.go:122: Duplicate entry_id correctly rejected
--- PASS: TestScheduleCommandDuplicate (1.64s)
=== RUN   TestScheduleCommandMissingTranscript
--- PASS: TestScheduleCommandMissingTranscript (1.66s)
=== RUN   TestStatusCommand
    schedule_test.go:200: Status command output:
        ER1 Retry Queue Status:
          pending:   2
          retrying:  0
          completed: 0
          failed:    0
          total:     2
        
        Entries:
          status-001            status=pending     attempts=0/10
          status-002            status=pending     attempts=0/10
--- PASS: TestStatusCommand (1.62s)
=== RUN   TestStatusCommandEntryNotFound
--- PASS: TestStatusCommandEntryNotFound (1.62s)
=== RUN   TestCancelCommand
    schedule_test.go:279: Cancel command set status to "cancelled"
--- PASS: TestCancelCommand (1.62s)
=== RUN   TestCancelCommandNotFound
--- PASS: TestCancelCommandNotFound (1.61s)
=== RUN   TestScheduleStatusCancelWorkflow
    schedule_test.go:369: Full workflow completed: schedule → status → cancel → verified
--- PASS: TestScheduleStatusCancelWorkflow (1.63s)
=== RUN   TestScreenshotModeConstants
--- PASS: TestScreenshotModeConstants (0.00s)
=== RUN   TestScreenshotClipboardImageTypes
--- PASS: TestScreenshotClipboardImageTypes (0.00s)
=== RUN   TestScreenshotCLIHelpOutput
    screenshot_test.go:210: help output includes screenshot and import-audio commands
--- PASS: TestScreenshotCLIHelpOutput (0.01s)
=== RUN   TestBuildFileEntriesWithDBChecker
--- PASS: TestBuildFileEntriesWithDBChecker (0.00s)
=== RUN   TestCLIHelp
--- PASS: TestCLIHelp (1.75s)
=== RUN   TestCLIUnknownCommand
--- PASS: TestCLIUnknownCommand (0.01s)
=== RUN   TestCLINoArgs
--- PASS: TestCLINoArgs (0.01s)
=== RUN   TestRepoRoot
--- PASS: TestRepoRoot (0.00s)
=== RUN   TestWriteFixture
--- PASS: TestWriteFixture (0.00s)
=== RUN   TestWriteFixtureBytes
--- PASS: TestWriteFixtureBytes (0.00s)
=== RUN   TestFixtureDir
--- PASS: TestFixtureDir (0.00s)
=== RUN   TestTempDataDir
--- PASS: TestTempDataDir (0.00s)
=== RUN   TestWithEnv
=== RUN   TestWithEnv/sets_and_restores
--- PASS: TestWithEnv (0.00s)
    --- PASS: TestWithEnv/sets_and_restores (0.00s)
=== RUN   TestCLIResultAssertions
--- PASS: TestCLIResultAssertions (0.00s)
=== RUN   TestRunCLIWithEnv
--- PASS: TestRunCLIWithEnv (0.01s)
=== RUN   TestExportsDBCreateAndQuery
--- PASS: TestExportsDBCreateAndQuery (0.00s)
=== RUN   TestExportsDBUpsert
--- PASS: TestExportsDBUpsert (0.00s)
=== RUN   TestExportsDBUpdateStatus
--- PASS: TestExportsDBUpdateStatus (0.00s)
=== RUN   TestExportsDBCountByStatus
--- PASS: TestExportsDBCountByStatus (0.00s)
=== RUN   TestExportsDBDefaultPath
    tracking_test.go:178: Default DB path: /Users/kamir/.m3c-tools/exports.db
--- PASS: TestExportsDBDefaultPath (0.00s)
=== RUN   TestTranscriptImportFromSnippets
--- PASS: TestTranscriptImportFromSnippets (0.00s)
=== RUN   TestTranscriptImportPreservesMetadata
--- PASS: TestTranscriptImportPreservesMetadata (0.00s)
=== RUN   TestTranscriptListSearchByLanguage
=== RUN   TestTranscriptListSearchByLanguage/find_English
=== RUN   TestTranscriptListSearchByLanguage/find_German
=== RUN   TestTranscriptListSearchByLanguage/find_Japanese
=== RUN   TestTranscriptListSearchByLanguage/fallback_to_second
=== RUN   TestTranscriptListSearchByLanguage/not_found
=== RUN   TestTranscriptListSearchByLanguage/first_match_wins
--- PASS: TestTranscriptListSearchByLanguage (0.00s)
    --- PASS: TestTranscriptListSearchByLanguage/find_English (0.00s)
    --- PASS: TestTranscriptListSearchByLanguage/find_German (0.00s)
    --- PASS: TestTranscriptListSearchByLanguage/find_Japanese (0.00s)
    --- PASS: TestTranscriptListSearchByLanguage/fallback_to_second (0.00s)
    --- PASS: TestTranscriptListSearchByLanguage/not_found (0.00s)
    --- PASS: TestTranscriptListSearchByLanguage/first_match_wins (0.00s)
=== RUN   TestTranscriptListSearchGenerated
--- PASS: TestTranscriptListSearchGenerated (0.00s)
=== RUN   TestTranscriptListSearchManual
--- PASS: TestTranscriptListSearchManual (0.00s)
=== RUN   TestTranscriptSearchNotFound
--- PASS: TestTranscriptSearchNotFound (0.00s)
=== RUN   TestTranscriptExportText
--- PASS: TestTranscriptExportText (0.00s)
=== RUN   TestTranscriptExportSRT
--- PASS: TestTranscriptExportSRT (0.00s)
=== RUN   TestTranscriptExportJSON
--- PASS: TestTranscriptExportJSON (0.00s)
=== RUN   TestTranscriptExportWebVTT
--- PASS: TestTranscriptExportWebVTT (0.00s)
=== RUN   TestTranscriptExportPretty
--- PASS: TestTranscriptExportPretty (0.00s)
=== RUN   TestTranscriptExportAllFormats
=== RUN   TestTranscriptExportAllFormats/json
=== RUN   TestTranscriptExportAllFormats/json-pretty
=== RUN   TestTranscriptExportAllFormats/pretty
=== RUN   TestTranscriptExportAllFormats/srt
=== RUN   TestTranscriptExportAllFormats/text
=== RUN   TestTranscriptExportAllFormats/webvtt
--- PASS: TestTranscriptExportAllFormats (0.00s)
    --- PASS: TestTranscriptExportAllFormats/json (0.00s)
    --- PASS: TestTranscriptExportAllFormats/json-pretty (0.00s)
    --- PASS: TestTranscriptExportAllFormats/pretty (0.00s)
    --- PASS: TestTranscriptExportAllFormats/srt (0.00s)
    --- PASS: TestTranscriptExportAllFormats/text (0.00s)
    --- PASS: TestTranscriptExportAllFormats/webvtt (0.00s)
=== RUN   TestTranscriptExportToFile
=== RUN   TestTranscriptExportToFile/transcript.txt
    transcript_commands_test.go:459: transcript.txt: 178 bytes
=== RUN   TestTranscriptExportToFile/transcript.srt
    transcript_commands_test.go:459: transcript.srt: 343 bytes
=== RUN   TestTranscriptExportToFile/transcript.json
    transcript_commands_test.go:459: transcript.json: 486 bytes
=== RUN   TestTranscriptExportToFile/transcript.vtt
    transcript_commands_test.go:459: transcript.vtt: 351 bytes
--- PASS: TestTranscriptExportToFile (0.00s)
    --- PASS: TestTranscriptExportToFile/transcript.txt (0.00s)
    --- PASS: TestTranscriptExportToFile/transcript.srt (0.00s)
    --- PASS: TestTranscriptExportToFile/transcript.json (0.00s)
    --- PASS: TestTranscriptExportToFile/transcript.vtt (0.00s)
=== RUN   TestTranscriptListString
--- PASS: TestTranscriptListString (0.00s)
=== RUN   TestTranscriptListStringEmpty
--- PASS: TestTranscriptListStringEmpty (0.00s)
=== RUN   TestTranscriptFilterExcludeGenerated
--- PASS: TestTranscriptFilterExcludeGenerated (0.00s)
=== RUN   TestTranscriptFilterExcludeManuallyCreated
--- PASS: TestTranscriptFilterExcludeManuallyCreated (0.00s)
=== RUN   TestTranscriptFilterBothExcludes
--- PASS: TestTranscriptFilterBothExcludes (0.00s)
=== RUN   TestTranscriptFilterEmptyList
--- PASS: TestTranscriptFilterEmptyList (0.00s)
=== RUN   TestTranscriptFilterAllSameType
--- PASS: TestTranscriptFilterAllSameType (0.00s)
=== RUN   TestTranslateFlagParsing
=== RUN   TestTranslateFlagParsing/translate_to_German
=== RUN   TestTranslateFlagParsing/translate_with_explicit_source_lang
=== RUN   TestTranslateFlagParsing/translate_with_format
=== RUN   TestTranslateFlagParsing/no_translate_flag
=== RUN   TestTranslateFlagParsing/list_overrides_translate
--- PASS: TestTranslateFlagParsing (0.00s)
    --- PASS: TestTranslateFlagParsing/translate_to_German (0.00s)
    --- PASS: TestTranslateFlagParsing/translate_with_explicit_source_lang (0.00s)
    --- PASS: TestTranslateFlagParsing/translate_with_format (0.00s)
    --- PASS: TestTranslateFlagParsing/no_translate_flag (0.00s)
    --- PASS: TestTranslateFlagParsing/list_overrides_translate (0.00s)
=== RUN   TestTranslateNotTranslatable
--- PASS: TestTranslateNotTranslatable (0.00s)
=== RUN   TestTranslateTranslatable
--- PASS: TestTranslateTranslatable (0.00s)
PASS
ok  	github.com/kamir/m3c-tools/e2e	24.033s
Building m3c-tools...
go build -o ./build/m3c-tools ./cmd/m3c-tools

CI passed: vet ✓  lint ✓  test ✓  build ✓ passed locally (vet, lint, unit tests, build)
