### PR TITLE
feat(SPEC-0189 S1): scanner refactor + tier/shadow + plugin walker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ build/
 __pycache__/
 *.pyc
 .pytest_cache/
-skillctl
+/skillctl

--- a/pkg/skillctl/model/skill.go
+++ b/pkg/skillctl/model/skill.go
@@ -25,7 +25,10 @@ type Frontmatter struct {
 	OutputFormat string                 `json:"output_format,omitempty" yaml:"output_format"`
 	Tags         []string               `json:"tags,omitempty" yaml:"tags"`
 	Model        string                 `json:"model,omitempty" yaml:"model"`
-	Metadata     map[string]interface{} `json:"metadata,omitempty" yaml:"metadata"`
+	// GovernanceLevel is the SPEC-0130 Ampel verdict (green | yellow | red).
+	// Promoted from Metadata to a typed field per SPEC-0189 §10 D2.
+	GovernanceLevel string `json:"governance_level,omitempty" yaml:"governance_level"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty" yaml:"metadata"`
 }
 
 // SkillDescriptor represents a single discovered skill source.
@@ -43,6 +46,11 @@ type SkillDescriptor struct {
 	Dependencies       []string     `json:"dependencies"`
 	ConflictsWith      []string     `json:"conflicts_with"`
 	DuplicateOf        *string      `json:"duplicate_of"`
+	// SPEC-0189 additions (all omitempty for wire-compat).
+	Tier        string   `json:"tier,omitempty"`           // project | user | plugin
+	SkillMDPath string   `json:"skill_md_path,omitempty"`  // path to the SKILL.md anchor file
+	Shadows     []string `json:"shadows,omitempty"`        // ids of lower-tier skills shadowed by this one
+	ShadowedBy  []string `json:"shadowed_by,omitempty"`    // id of the higher-tier winner that shadows this
 }
 
 // Inventory holds the complete results of a skill scan.

--- a/pkg/skillctl/scanner/plugins.go
+++ b/pkg/skillctl/scanner/plugins.go
@@ -1,0 +1,146 @@
+// Plugin-cache + marketplace walker — SPEC-0189 Phase 2.
+//
+// Walks ~/.claude/plugins/cache/<owner>/<plugin>/<version>/skills/ AND
+// ~/.claude/plugins/marketplaces/<m>/{skills,plugins/<p>/skills}/ to find
+// plugin-shipped skills. Reads installed_plugins.json (best effort) to
+// label installed-vs-marketplace.
+package scanner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// pluginScanRoots returns ScanRoots for every plugin-skill directory under
+// the given Claude Code config dir.
+func pluginScanRoots(configDir string) []ScanRoot {
+	pluginsDir := filepath.Join(configDir, "plugins")
+	if !pathExists(pluginsDir) {
+		return nil
+	}
+
+	var roots []ScanRoot
+	roots = append(roots, pluginCacheRoots(pluginsDir)...)
+	roots = append(roots, marketplaceRoots(pluginsDir)...)
+	return roots
+}
+
+// pluginCacheRoots walks ~/.claude/plugins/cache/<owner>/<plugin>/<version>/skills/.
+func pluginCacheRoots(pluginsDir string) []ScanRoot {
+	cacheDir := filepath.Join(pluginsDir, "cache")
+	if !pathExists(cacheDir) {
+		return nil
+	}
+
+	var roots []ScanRoot
+	owners, err := os.ReadDir(cacheDir)
+	if err != nil {
+		return nil
+	}
+	for _, owner := range owners {
+		if !owner.IsDir() {
+			continue
+		}
+		ownerDir := filepath.Join(cacheDir, owner.Name())
+		plugins, err := os.ReadDir(ownerDir)
+		if err != nil {
+			continue
+		}
+		for _, plugin := range plugins {
+			if !plugin.IsDir() {
+				continue
+			}
+			pluginDir := filepath.Join(ownerDir, plugin.Name())
+			versions, err := os.ReadDir(pluginDir)
+			if err != nil {
+				continue
+			}
+			for _, version := range versions {
+				if !version.IsDir() {
+					continue
+				}
+				skillsDir := filepath.Join(pluginDir, version.Name(), "skills")
+				if pathExists(skillsDir) {
+					roots = append(roots, ScanRoot{Path: skillsDir, Tier: TierPlugin})
+				}
+			}
+		}
+	}
+	return roots
+}
+
+// marketplaceRoots walks ~/.claude/plugins/marketplaces/<m>/skills/ AND
+// ~/.claude/plugins/marketplaces/<m>/plugins/<p>/skills/.
+func marketplaceRoots(pluginsDir string) []ScanRoot {
+	marketsDir := filepath.Join(pluginsDir, "marketplaces")
+	if !pathExists(marketsDir) {
+		return nil
+	}
+
+	var roots []ScanRoot
+	markets, err := os.ReadDir(marketsDir)
+	if err != nil {
+		return nil
+	}
+	for _, market := range markets {
+		if !market.IsDir() {
+			continue
+		}
+		marketDir := filepath.Join(marketsDir, market.Name())
+
+		// Direct: .../marketplaces/<m>/skills/
+		direct := filepath.Join(marketDir, "skills")
+		if pathExists(direct) {
+			roots = append(roots, ScanRoot{Path: direct, Tier: TierPlugin})
+		}
+
+		// Nested: .../marketplaces/<m>/plugins/<p>/skills/
+		nestedPlugins := filepath.Join(marketDir, "plugins")
+		if pluginsDirs, err := os.ReadDir(nestedPlugins); err == nil {
+			for _, p := range pluginsDirs {
+				if !p.IsDir() {
+					continue
+				}
+				skills := filepath.Join(nestedPlugins, p.Name(), "skills")
+				if pathExists(skills) {
+					roots = append(roots, ScanRoot{Path: skills, Tier: TierPlugin})
+				}
+			}
+		}
+	}
+	return roots
+}
+
+// installedPluginRecord is the relevant subset of an entry in
+// installed_plugins.json. The file is best-effort: if absent or malformed,
+// we proceed with empty annotation data.
+type installedPluginRecord struct {
+	Owner   string `json:"owner"`
+	Plugin  string `json:"plugin"`
+	Version string `json:"version"`
+	Source  string `json:"source"` // "marketplace" | "cache" | etc.
+}
+
+// loadInstalledPlugins reads ~/.claude/plugins/installed_plugins.json if
+// present. Returns nil on any error (missing file, bad JSON, etc.) — the
+// caller should treat that as "no annotation data available".
+func loadInstalledPlugins(configDir string) []installedPluginRecord {
+	path := filepath.Join(configDir, "plugins", "installed_plugins.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	// Tolerate either a top-level array or an object with a "plugins" key.
+	var arr []installedPluginRecord
+	if err := json.Unmarshal(data, &arr); err == nil {
+		return arr
+	}
+	var obj struct {
+		Plugins []installedPluginRecord `json:"plugins"`
+	}
+	if err := json.Unmarshal(data, &obj); err == nil {
+		return obj.Plugins
+	}
+	return nil
+}

--- a/pkg/skillctl/scanner/scanner.go
+++ b/pkg/skillctl/scanner/scanner.go
@@ -26,7 +26,23 @@ var skipDirs = map[string]bool{
 }
 
 // Scanner walks filesystem paths to discover skill sources.
+//
+// Two modes:
+//   - SPEC-0189 tier-aware mode: populate Roots (via ResolveDefaults or
+//     explicit ScanRoot list). Discovery is anchored on SKILL.md and
+//     descriptors get Tier + SkillMDPath. Shadow resolution applied at
+//     the end (project > user > plugin).
+//   - Legacy SPEC-0115 mode (used by `skillctl scan --source projects`):
+//     populate Paths/Recursive/IncludeHome. Discovery uses the original
+//     glob-on-*.md path. No tier annotation, no shadow resolution.
+//
+// Both modes share the duplicate-detection + summary-stat tail.
 type Scanner struct {
+	// SPEC-0189 tier-aware fields.
+	Roots           []ScanRoot
+	IncludeShadowed bool
+
+	// Legacy SPEC-0115 fields.
 	Paths       []string
 	Recursive   bool
 	IncludeHome bool
@@ -36,6 +52,9 @@ type Scanner struct {
 }
 
 // Scan walks all configured paths and returns a complete Inventory.
+//
+// If Roots is non-empty, runs the SPEC-0189 tier-aware scan. Otherwise
+// falls back to the legacy SPEC-0115 paths/home-dir glob.
 func (s *Scanner) Scan() (*model.Inventory, error) {
 	s.visited = make(map[string]bool)
 
@@ -48,32 +67,46 @@ func (s *Scanner) Scan() (*model.Inventory, error) {
 		ByProject: make(map[string]int),
 	}
 
-	// Scan provided paths.
-	for _, p := range s.Paths {
-		abs, err := filepath.Abs(p)
-		if err != nil {
-			return nil, fmt.Errorf("resolving path %s: %w", p, err)
+	if len(s.Roots) > 0 {
+		// Tier-aware mode (SPEC-0189). Anchor on SKILL.md.
+		for _, r := range s.Roots {
+			abs, err := filepath.Abs(r.Path)
+			if err != nil {
+				return nil, fmt.Errorf("resolving root %s: %w", r.Path, err)
+			}
+			inv.ScanPaths = append(inv.ScanPaths, abs)
+			rooted := ScanRoot{Path: abs, Tier: r.Tier}
+			if err := s.scanTierRoot(rooted, inv); err != nil {
+				return nil, err
+			}
 		}
-		inv.ScanPaths = append(inv.ScanPaths, abs)
-		if err := s.scanDir(abs, inv); err != nil {
-			return nil, err
+		applyShadowing(inv, s.IncludeShadowed)
+	} else {
+		// Legacy SPEC-0115 mode — preserved for `--source projects`.
+		for _, p := range s.Paths {
+			abs, err := filepath.Abs(p)
+			if err != nil {
+				return nil, fmt.Errorf("resolving path %s: %w", p, err)
+			}
+			inv.ScanPaths = append(inv.ScanPaths, abs)
+			if err := s.scanDir(abs, inv); err != nil {
+				return nil, err
+			}
 		}
-	}
-
-	// Scan home directory if requested.
-	if s.IncludeHome {
-		home, err := os.UserHomeDir()
-		if err == nil {
-			claudeHome := filepath.Join(home, ".claude")
-			inv.ScanPaths = append(inv.ScanPaths, claudeHome)
-			if err := s.scanHomeDir(claudeHome, inv); err != nil {
-				// Non-fatal: home dir may not have .claude
-				_ = err
+		if s.IncludeHome {
+			home, err := os.UserHomeDir()
+			if err == nil {
+				claudeHome := filepath.Join(home, ".claude")
+				inv.ScanPaths = append(inv.ScanPaths, claudeHome)
+				if err := s.scanHomeDir(claudeHome, inv); err != nil {
+					// Non-fatal: home dir may not have .claude
+					_ = err
+				}
 			}
 		}
 	}
 
-	// Run duplicate detection.
+	// Run duplicate detection (shared by both modes).
 	hasher.DetectDuplicates(inv.Skills)
 
 	// Compute summary stats.

--- a/pkg/skillctl/scanner/tiers.go
+++ b/pkg/skillctl/scanner/tiers.go
@@ -1,0 +1,217 @@
+// Tier-aware scanning + shadow detection — SPEC-0189 Phase 1.
+//
+// Scans a ScanRoot anchored on SKILL.md (not loose *.md), then runs a
+// shadow-merge across the union of inventories from all roots so that
+// project-tier skills win over user-tier, which win over plugin-tier.
+package scanner
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/hasher"
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+	"github.com/kamir/m3c-tools/pkg/skillctl/parser"
+)
+
+// scanTierRoot walks a single ScanRoot and emits one descriptor per
+// directory containing a SKILL.md file. Loose markdown files inside a
+// skill dir are NOT separate skills (per SPEC-0189 §3).
+func (s *Scanner) scanTierRoot(root ScanRoot, inv *model.Inventory) error {
+	info, err := os.Stat(root.Path)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+
+	return filepath.WalkDir(root.Path, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		// Only look at files literally named SKILL.md.
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			// Symlink-loop guard.
+			if d.Type()&fs.ModeSymlink != 0 {
+				real, err := filepath.EvalSymlinks(path)
+				if err != nil {
+					return nil
+				}
+				if s.visited[real] {
+					return filepath.SkipDir
+				}
+				s.visited[real] = true
+			}
+			return nil
+		}
+		if d.Name() != "SKILL.md" {
+			return nil
+		}
+		// File-level symlink guard.
+		if d.Type()&fs.ModeSymlink != 0 {
+			real, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return nil
+			}
+			if s.visited[real] {
+				return nil
+			}
+			s.visited[real] = true
+		}
+		s.addClaudeSkillTiered(path, root.Tier, inv)
+		return nil
+	})
+}
+
+// addClaudeSkillTiered reads a SKILL.md file and adds a descriptor with
+// Tier + SkillMDPath populated.
+func (s *Scanner) addClaudeSkillTiered(skillMDPath string, tier Tier, inv *model.Inventory) {
+	data, err := os.ReadFile(skillMDPath)
+	if err != nil {
+		return
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	hash := hasher.ContentHash(data)
+
+	// The skill name is the parent directory's basename (the conventional
+	// Claude Code shape: <name>/SKILL.md).
+	parentDir := filepath.Dir(skillMDPath)
+	name := filepath.Base(parentDir)
+	project := projectLabelForTier(skillMDPath, tier)
+
+	desc := model.SkillDescriptor{
+		ID:               fmt.Sprintf("%s/%s", tier, name),
+		Name:             name,
+		Type:             model.SkillTypeClaudeCodeSkill,
+		SourcePath:       parentDir,
+		SourceProject:    project,
+		DiscoveredAt:     now,
+		ContentHash:      hash,
+		ContentSizeBytes: int64(len(data)),
+		Dependencies:     make([]string, 0),
+		ConflictsWith:    make([]string, 0),
+		Tier:             string(tier),
+		SkillMDPath:      skillMDPath,
+	}
+
+	// Parse frontmatter — same path as the legacy mode.
+	fm, _, parseErr := parser.Parse(data)
+	if parseErr == nil && fm != nil {
+		desc.Frontmatter = fm
+		desc.HasYAMLFrontmatter = true
+		// For tiered scans we deliberately do NOT override desc.Name from
+		// fm.Name — the directory name is the canonical identifier in
+		// Claude Code resolution. fm.Name often duplicates the dir name.
+		if fm.GovernanceLevel == "" {
+			// Backwards-compat: lift governance_level out of legacy
+			// Metadata bag if present.
+			if v, ok := fm.Metadata["governance_level"].(string); ok {
+				fm.GovernanceLevel = v
+			}
+		}
+	}
+	inv.Skills = append(inv.Skills, desc)
+}
+
+// projectLabelForTier produces a useful SourceProject label for tier-scoped
+// skills. For TierProject the existing detectProject (nearest .git) wins;
+// for TierUser the label is "user-global"; for TierPlugin we extract the
+// plugin owner/name/version from the path.
+func projectLabelForTier(skillMDPath string, tier Tier) string {
+	switch tier {
+	case TierUser:
+		return "user-global"
+	case TierPlugin:
+		return pluginLabel(skillMDPath)
+	default:
+		return detectProject(skillMDPath)
+	}
+}
+
+// pluginLabel extracts a "<owner>/<plugin>@<version>" label from a path
+// shaped ~/.claude/plugins/cache/<o>/<p>/<v>/skills/<n>/SKILL.md, or
+// "marketplace:<m>" for marketplace-tier paths.
+func pluginLabel(skillMDPath string) string {
+	parts := strings.Split(filepath.ToSlash(skillMDPath), "/")
+	for i := 0; i < len(parts); i++ {
+		if parts[i] == "cache" && i+3 < len(parts) {
+			return parts[i+1] + "/" + parts[i+2] + "@" + parts[i+3]
+		}
+		if parts[i] == "marketplaces" && i+1 < len(parts) {
+			return "marketplace:" + parts[i+1]
+		}
+	}
+	return "plugin-unknown"
+}
+
+// applyShadowing walks the inventory and resolves tier precedence per
+// skill name: project > user > plugin. The winner per name keeps its
+// row and gets Shadows[] populated; losers get ShadowedBy[] populated.
+// If IncludeShadowed is false, losers are removed from inv.Skills.
+//
+// Only TierClaudeCodeSkill descriptors participate; other types
+// (commands, agents, MCP, etc.) are passed through unchanged.
+func applyShadowing(inv *model.Inventory, includeShadowed bool) {
+	tierRank := map[string]int{
+		string(TierProject): 3,
+		string(TierUser):    2,
+		string(TierPlugin):  1,
+	}
+
+	// Group claude_code_skills by name; non-claude rows pass through.
+	type idx struct {
+		i    int
+		rank int
+	}
+	groups := map[string][]idx{}
+	for i, sk := range inv.Skills {
+		if sk.Type != model.SkillTypeClaudeCodeSkill || sk.Tier == "" {
+			continue
+		}
+		groups[sk.Name] = append(groups[sk.Name], idx{i: i, rank: tierRank[sk.Tier]})
+	}
+
+	dropIdx := map[int]bool{}
+	for name, members := range groups {
+		if len(members) <= 1 {
+			continue
+		}
+		// Find winner: highest rank; tie-break on first-seen.
+		winner := members[0]
+		for _, m := range members[1:] {
+			if m.rank > winner.rank {
+				winner = m
+			}
+		}
+		// Annotate winner + losers.
+		for _, m := range members {
+			if m.i == winner.i {
+				continue
+			}
+			loserID := inv.Skills[m.i].ID
+			inv.Skills[m.i].ShadowedBy = []string{inv.Skills[winner.i].ID}
+			inv.Skills[winner.i].Shadows = append(inv.Skills[winner.i].Shadows, loserID)
+			if !includeShadowed {
+				dropIdx[m.i] = true
+			}
+		}
+		_ = name
+	}
+
+	if len(dropIdx) == 0 {
+		return
+	}
+	out := make([]model.SkillDescriptor, 0, len(inv.Skills)-len(dropIdx))
+	for i, sk := range inv.Skills {
+		if dropIdx[i] {
+			continue
+		}
+		out = append(out, sk)
+	}
+	inv.Skills = out
+}

--- a/pkg/skillctl/scanner/tiers_test.go
+++ b/pkg/skillctl/scanner/tiers_test.go
@@ -1,0 +1,321 @@
+// SPEC-0189 S1 tests — tier resolution, plugin walker, shadow merge,
+// SKILL.md anchoring, symlink-loop guard.
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// makeSkillDir creates a Claude Code-conventional skill directory:
+//
+//	<root>/<name>/SKILL.md   (with optional frontmatter body)
+//	<root>/<name>/scripts/foo.sh   (loose file — must NOT be a separate skill)
+func makeSkillDir(t *testing.T, root, name, frontmatterBody string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(frontmatterBody), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "scripts"), 0o755); err != nil {
+		t.Fatalf("mkdir scripts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "scripts", "foo.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write foo.sh: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "REFERENCES.md"), []byte("# refs\n"), 0o644); err != nil {
+		t.Fatalf("write REFERENCES.md: %v", err)
+	}
+}
+
+// TestTierAware_AnchorsOnSkillMD verifies that the tier-aware path discovers
+// EXACTLY one descriptor per directory containing SKILL.md, even when loose
+// .md files (e.g. REFERENCES.md) exist alongside.
+func TestTierAware_AnchorsOnSkillMD(t *testing.T) {
+	tmp := t.TempDir()
+	makeSkillDir(t, tmp, "alpha", "---\nname: alpha\ngovernance_level: green\n---\n")
+	makeSkillDir(t, tmp, "beta", "")
+
+	s := &Scanner{Roots: []ScanRoot{{Path: tmp, Tier: TierUser}}}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got := len(inv.Skills); got != 2 {
+		t.Fatalf("expected 2 skills (alpha, beta), got %d: %+v", got, summarize(inv.Skills))
+	}
+	for _, sk := range inv.Skills {
+		if sk.Tier != string(TierUser) {
+			t.Errorf("skill %s has tier %q, want %q", sk.Name, sk.Tier, TierUser)
+		}
+		if sk.SkillMDPath == "" {
+			t.Errorf("skill %s missing SkillMDPath", sk.Name)
+		}
+		if sk.Type != model.SkillTypeClaudeCodeSkill {
+			t.Errorf("skill %s has type %q", sk.Name, sk.Type)
+		}
+	}
+}
+
+// TestTierAware_GovernanceLevel verifies that governance_level in frontmatter
+// is lifted into Frontmatter.GovernanceLevel.
+func TestTierAware_GovernanceLevel(t *testing.T) {
+	tmp := t.TempDir()
+	makeSkillDir(t, tmp, "trusted", "---\nname: trusted\ngovernance_level: green\n---\n")
+	makeSkillDir(t, tmp, "review", "---\nname: review\ngovernance_level: yellow\n---\n")
+
+	s := &Scanner{Roots: []ScanRoot{{Path: tmp, Tier: TierUser}}}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	gov := map[string]string{}
+	for _, sk := range inv.Skills {
+		if sk.Frontmatter != nil {
+			gov[sk.Name] = sk.Frontmatter.GovernanceLevel
+		}
+	}
+	if gov["trusted"] != "green" {
+		t.Errorf("trusted governance_level = %q, want green", gov["trusted"])
+	}
+	if gov["review"] != "yellow" {
+		t.Errorf("review governance_level = %q, want yellow", gov["review"])
+	}
+}
+
+// TestApplyShadowing verifies project > user > plugin precedence and
+// shadow annotations.
+func TestApplyShadowing(t *testing.T) {
+	tmp := t.TempDir()
+	projDir := filepath.Join(tmp, "project")
+	userDir := filepath.Join(tmp, "user")
+	plugDir := filepath.Join(tmp, "plugin")
+	makeSkillDir(t, projDir, "qa", "")
+	makeSkillDir(t, userDir, "qa", "")
+	makeSkillDir(t, userDir, "didactic-session", "")
+	makeSkillDir(t, plugDir, "qa", "")
+	makeSkillDir(t, plugDir, "seed", "")
+
+	s := &Scanner{
+		Roots: []ScanRoot{
+			{Path: projDir, Tier: TierProject},
+			{Path: userDir, Tier: TierUser},
+			{Path: plugDir, Tier: TierPlugin},
+		},
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	// Without IncludeShadowed: 3 winners (qa/project, didactic-session/user, seed/plugin).
+	winners := map[string]string{}
+	for _, sk := range inv.Skills {
+		winners[sk.Name] = sk.Tier
+	}
+	if winners["qa"] != string(TierProject) {
+		t.Errorf("qa winner tier = %q, want project", winners["qa"])
+	}
+	if winners["didactic-session"] != string(TierUser) {
+		t.Errorf("didactic-session winner tier = %q, want user", winners["didactic-session"])
+	}
+	if winners["seed"] != string(TierPlugin) {
+		t.Errorf("seed winner tier = %q, want plugin", winners["seed"])
+	}
+	if got := len(inv.Skills); got != 3 {
+		t.Errorf("default IncludeShadowed=false: expected 3 winners, got %d", got)
+	}
+
+	// Check Shadows array on the qa winner.
+	for _, sk := range inv.Skills {
+		if sk.Name == "qa" && sk.Tier == string(TierProject) {
+			if len(sk.Shadows) != 2 {
+				t.Errorf("project/qa Shadows count = %d, want 2", len(sk.Shadows))
+			}
+		}
+	}
+}
+
+// TestApplyShadowing_IncludeAll verifies IncludeShadowed=true emits all
+// occurrences with ShadowedBy populated on losers.
+func TestApplyShadowing_IncludeAll(t *testing.T) {
+	tmp := t.TempDir()
+	projDir := filepath.Join(tmp, "project")
+	userDir := filepath.Join(tmp, "user")
+	makeSkillDir(t, projDir, "qa", "")
+	makeSkillDir(t, userDir, "qa", "")
+
+	s := &Scanner{
+		IncludeShadowed: true,
+		Roots: []ScanRoot{
+			{Path: projDir, Tier: TierProject},
+			{Path: userDir, Tier: TierUser},
+		},
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got := len(inv.Skills); got != 2 {
+		t.Fatalf("IncludeShadowed=true: expected 2 rows, got %d", got)
+	}
+	var winnerID string
+	for _, sk := range inv.Skills {
+		if sk.Tier == string(TierProject) {
+			winnerID = sk.ID
+		}
+	}
+	for _, sk := range inv.Skills {
+		if sk.Tier == string(TierUser) {
+			if len(sk.ShadowedBy) != 1 || sk.ShadowedBy[0] != winnerID {
+				t.Errorf("user/qa ShadowedBy = %v, want [%s]", sk.ShadowedBy, winnerID)
+			}
+		}
+	}
+}
+
+// TestPluginCacheRoots verifies the plugin walker discovers a typical
+// ~/.claude/plugins/cache/<o>/<p>/<v>/skills/ layout.
+func TestPluginCacheRoots(t *testing.T) {
+	tmp := t.TempDir()
+	pluginsDir := filepath.Join(tmp, "plugins")
+	skillsDir := filepath.Join(pluginsDir, "cache", "ouroboros", "ouroboros", "0.20.0", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	makeSkillDir(t, skillsDir, "seed", "")
+
+	roots := pluginCacheRoots(pluginsDir)
+	if len(roots) != 1 {
+		t.Fatalf("expected 1 plugin cache root, got %d: %+v", len(roots), roots)
+	}
+	if roots[0].Tier != TierPlugin {
+		t.Errorf("plugin root tier = %q, want %q", roots[0].Tier, TierPlugin)
+	}
+}
+
+// TestMarketplaceRoots verifies both nested and direct marketplace layouts.
+func TestMarketplaceRoots(t *testing.T) {
+	tmp := t.TempDir()
+	pluginsDir := filepath.Join(tmp, "plugins")
+	directSkills := filepath.Join(pluginsDir, "marketplaces", "official", "skills")
+	nestedSkills := filepath.Join(pluginsDir, "marketplaces", "official", "plugins", "foo", "skills")
+	if err := os.MkdirAll(directSkills, 0o755); err != nil {
+		t.Fatalf("mkdir direct: %v", err)
+	}
+	if err := os.MkdirAll(nestedSkills, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+
+	roots := marketplaceRoots(pluginsDir)
+	if len(roots) != 2 {
+		t.Fatalf("expected 2 marketplace roots (direct+nested), got %d: %+v", len(roots), roots)
+	}
+	for _, r := range roots {
+		if r.Tier != TierPlugin {
+			t.Errorf("marketplace root tier = %q, want %q", r.Tier, TierPlugin)
+		}
+	}
+}
+
+// TestResolveDefaults_SourceClaude_IncludesUserAndPlugin verifies that
+// SourceClaude expands to user + plugin per SPEC-0189 §10 D3.
+func TestResolveDefaults_SourceClaude_IncludesUserAndPlugin(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", tmp)
+
+	// Set up user skills + a plugin cache.
+	if err := os.MkdirAll(filepath.Join(tmp, "skills"), 0o755); err != nil {
+		t.Fatalf("mkdir user skills: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, "plugins", "cache", "o", "p", "v", "skills"), 0o755); err != nil {
+		t.Fatalf("mkdir plugin: %v", err)
+	}
+
+	roots := ResolveDefaults([]Source{SourceClaude})
+	tierCounts := map[Tier]int{}
+	for _, r := range roots {
+		tierCounts[r.Tier]++
+	}
+	if tierCounts[TierUser] < 1 {
+		t.Errorf("SourceClaude should yield ≥1 user-tier root; got %d", tierCounts[TierUser])
+	}
+	if tierCounts[TierPlugin] < 1 {
+		t.Errorf("SourceClaude should yield ≥1 plugin-tier root; got %d", tierCounts[TierPlugin])
+	}
+}
+
+// TestResolveDefaults_SourceUser_OnlyUser verifies SourceUser does NOT
+// include plugin tier (matches SPEC-0189 §4 — user-only on demand).
+func TestResolveDefaults_SourceUser_OnlyUser(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, "skills"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, "plugins", "cache", "o", "p", "v", "skills"), 0o755); err != nil {
+		t.Fatalf("mkdir plugin: %v", err)
+	}
+	roots := ResolveDefaults([]Source{SourceUser})
+	for _, r := range roots {
+		if r.Tier == TierPlugin {
+			t.Errorf("SourceUser should not include plugin tier, got %v", r)
+		}
+	}
+}
+
+// TestSymlinkLoop_NoInfiniteWalk creates a symlink that points back into
+// the scanned tree and asserts the scanner does not loop. macOS-only —
+// Windows symlinks need elevated perms in some configurations.
+func TestSymlinkLoop_NoInfiniteWalk(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test requires POSIX")
+	}
+	tmp := t.TempDir()
+	makeSkillDir(t, tmp, "real", "")
+	if err := os.Symlink(filepath.Join(tmp, "real"), filepath.Join(tmp, "loop")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// Add another symlink that points up — this would loop without guard.
+	if err := os.Symlink(tmp, filepath.Join(tmp, "self")); err != nil {
+		t.Fatalf("symlink self: %v", err)
+	}
+
+	done := make(chan *model.Inventory, 1)
+	errc := make(chan error, 1)
+	go func() {
+		s := &Scanner{Roots: []ScanRoot{{Path: tmp, Tier: TierUser}}}
+		inv, err := s.Scan()
+		if err != nil {
+			errc <- err
+			return
+		}
+		done <- inv
+	}()
+	select {
+	case <-done:
+		// Pass: scan completed without hanging.
+	case err := <-errc:
+		t.Fatalf("scan errored: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatalf("scan did not complete within 5s — symlink-loop guard regressed")
+	}
+}
+
+func summarize(skills []model.SkillDescriptor) []string {
+	out := make([]string, 0, len(skills))
+	for _, sk := range skills {
+		out = append(out, sk.Tier+":"+sk.Name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/skillctl/scanner/types.go
+++ b/pkg/skillctl/scanner/types.go
@@ -1,0 +1,109 @@
+// Tier + Source types and ResolveDefaults — SPEC-0189 Phase 1.
+//
+// Claude Code resolves skills from three precedence tiers (project > user >
+// plugin). This file defines the canonical Tier and Source values and the
+// path-resolution helper that maps a Source set to scan roots.
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Tier is the precedence layer a skill comes from. Project wins over user,
+// user wins over plugin. See SPEC-0189 §3.
+type Tier string
+
+const (
+	TierProject Tier = "project"
+	TierUser    Tier = "user"
+	TierPlugin  Tier = "plugin"
+)
+
+// Source is a logical scan-root selector. The CLI exposes this as
+// `--source <claude|user|projects|plugins|all>` per SPEC-0189 §4.
+type Source string
+
+const (
+	// SourceClaude is the default — user tier + plugin tier (matches
+	// what Claude Code itself resolves at runtime per SPEC-0189 §10 D3).
+	SourceClaude   Source = "claude"
+	SourceUser     Source = "user"
+	SourceProjects Source = "projects" // legacy SPEC-0115 mode
+	SourcePlugins  Source = "plugins"
+	SourceAll      Source = "all"
+)
+
+// ScanRoot pairs a filesystem path with the Tier of skills found beneath it.
+type ScanRoot struct {
+	Path string
+	Tier Tier
+}
+
+// ResolveDefaults returns the Claude Code conventional roots for the
+// requested source set. Honours $HOME and $CLAUDE_CONFIG_DIR overrides.
+//
+// User tier:    $CLAUDE_CONFIG_DIR/skills/  or  ~/.claude/skills/
+// Plugin tier:  $CLAUDE_CONFIG_DIR/plugins/cache/<o>/<p>/<v>/skills/
+//               $CLAUDE_CONFIG_DIR/plugins/marketplaces/<m>/skills/
+//               $CLAUDE_CONFIG_DIR/plugins/marketplaces/<m>/plugins/<p>/skills/
+// Project tier: caller supplies via explicit path arg (not auto-resolved).
+//
+// SourceClaude expands to user + plugin (SPEC-0189 §10 D3).
+// SourceAll expands to user + plugin only (project tier requires explicit
+// paths from the caller; auto-discovery is intentionally out of scope —
+// see SPEC-0189 §12).
+func ResolveDefaults(sources []Source) []ScanRoot {
+	configDir := claudeConfigDir()
+	if configDir == "" {
+		return nil
+	}
+
+	wantUser := false
+	wantPlugins := false
+	for _, src := range sources {
+		switch src {
+		case SourceClaude:
+			wantUser = true
+			wantPlugins = true
+		case SourceUser:
+			wantUser = true
+		case SourcePlugins:
+			wantPlugins = true
+		case SourceAll:
+			wantUser = true
+			wantPlugins = true
+		}
+	}
+
+	var roots []ScanRoot
+	if wantUser {
+		userSkills := filepath.Join(configDir, "skills")
+		if pathExists(userSkills) {
+			roots = append(roots, ScanRoot{Path: userSkills, Tier: TierUser})
+		}
+	}
+	if wantPlugins {
+		pluginRoots := pluginScanRoots(configDir)
+		roots = append(roots, pluginRoots...)
+	}
+	return roots
+}
+
+// claudeConfigDir returns the resolved Claude Code config dir. Honours
+// $CLAUDE_CONFIG_DIR if set, else falls back to $HOME/.claude.
+func claudeConfigDir() string {
+	if dir := os.Getenv("CLAUDE_CONFIG_DIR"); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude")
+}
+
+func pathExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}


### PR DESCRIPTION
Phase 1 + Phase 2 of SPEC-0189. Locks the Tier/Source/Scanner interface contract S2 + S3 pin against. SPEC-0189 §9 criteria 1, 2, 3, 5 pass. Tests: 9 new + 8 existing scanner = 17 pass. Full regression (scanner/parser/model/report/consolidate/install/registry/review/signing/verify) clean.