### PR TITLE
feat(SPEC-0189 S2): trust cross-ref via sibling .skb

### DIFF
--- a/pkg/skillctl/model/skill.go
+++ b/pkg/skillctl/model/skill.go
@@ -47,10 +47,23 @@ type SkillDescriptor struct {
 	ConflictsWith      []string     `json:"conflicts_with"`
 	DuplicateOf        *string      `json:"duplicate_of"`
 	// SPEC-0189 additions (all omitempty for wire-compat).
-	Tier        string   `json:"tier,omitempty"`           // project | user | plugin
-	SkillMDPath string   `json:"skill_md_path,omitempty"`  // path to the SKILL.md anchor file
-	Shadows     []string `json:"shadows,omitempty"`        // ids of lower-tier skills shadowed by this one
-	ShadowedBy  []string `json:"shadowed_by,omitempty"`    // id of the higher-tier winner that shadows this
+	Tier        string             `json:"tier,omitempty"`           // project | user | plugin
+	SkillMDPath string             `json:"skill_md_path,omitempty"`  // path to the SKILL.md anchor file
+	Shadows     []string           `json:"shadows,omitempty"`        // ids of lower-tier skills shadowed by this one
+	ShadowedBy  []string           `json:"shadowed_by,omitempty"`    // id of the higher-tier winner that shadows this
+	Bundle      *BundleAttestation `json:"bundle,omitempty"`         // SPEC-0189 §6 trust cross-ref
+}
+
+// BundleAttestation is the SPEC-0189 §6 trust cross-reference block.
+// Populated by scanner.AnnotateTrust when --with-trust is requested.
+type BundleAttestation struct {
+	SKBPath                string `json:"skb_path,omitempty"`
+	BundleDigest           string `json:"bundle_digest,omitempty"`
+	Signed                 bool   `json:"signed"`
+	RegisteredInLocalTrust bool   `json:"registered_in_local_registry"`
+	TrustChain             string `json:"trust_chain"`
+	VerifierExitCode       int    `json:"verifier_exit_code,omitempty"`
+	VerifierError          string `json:"verifier_error,omitempty"`
 }
 
 // Inventory holds the complete results of a skill scan.

--- a/pkg/skillctl/scanner/scanner.go
+++ b/pkg/skillctl/scanner/scanner.go
@@ -41,6 +41,7 @@ type Scanner struct {
 	// SPEC-0189 tier-aware fields.
 	Roots           []ScanRoot
 	IncludeShadowed bool
+	WithTrust       bool // SPEC-0189 §6: annotate each skill with sibling-.skb trust state
 
 	// Legacy SPEC-0115 fields.
 	Paths       []string
@@ -107,6 +108,11 @@ func (s *Scanner) Scan() (*model.Inventory, error) {
 	}
 
 	// Run duplicate detection (shared by both modes).
+	// SPEC-0189 §6: cross-reference each skill with sibling-.skb trust state.
+	if s.WithTrust {
+		_ = AnnotateTrust(inv)
+	}
+
 	hasher.DetectDuplicates(inv.Skills)
 
 	// Compute summary stats.

--- a/pkg/skillctl/scanner/trust.go
+++ b/pkg/skillctl/scanner/trust.go
@@ -1,0 +1,184 @@
+// Trust cross-reference for SPEC-0189 §6 (`--with-trust`).
+//
+// For each scanned skill, look for a sibling <name>-<version>.skb in the
+// same parent directory (or in ../.archive/) per Decision D1: the on-disk
+// `.skb` is the canonical signal — there is no separate per-machine
+// install ledger. Recompute the bundle digest, look for the matching
+// detached author signature, and annotate the descriptor.
+//
+// "verified" — .skb present, digest matches the digest in the sig
+// filename, and the sig file is the expected 64 raw bytes. The author
+// signature itself is not cryptographically verified here (that needs
+// a network round-trip to the registry to fetch the signer's pubkey,
+// which is the v2 of `--with-trust`); but "matches its own digest
+// envelope" is a strong local-only signal that nothing was tampered
+// after install.
+//
+// "unverified" — no sibling .skb (skill was hand-authored, not
+// installed via `skillctl install`).
+//
+// "broken" — .skb present but digest computation fails, sig file
+// missing, or sig file wrong size.
+package scanner
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// trust_chain values.
+const (
+	TrustVerified   = "verified"
+	TrustUnverified = "unverified"
+	TrustBroken     = "broken"
+)
+
+// AnnotateTrust walks every claude_code_skill in the inventory and
+// populates the SkillDescriptor.Bundle block. Errors per skill are
+// recorded on the descriptor (TrustChain="broken" + VerifierError);
+// the function itself only returns an error if the inventory pointer
+// is nil.
+//
+// Cache: results keyed by ContentHash; skills with the same SKILL.md
+// hash share an answer (cheap protection against re-scanning a
+// symlinked skill twice).
+func AnnotateTrust(inv *model.Inventory) error {
+	if inv == nil {
+		return fmt.Errorf("nil inventory")
+	}
+	cache := map[string]*model.BundleAttestation{}
+	for i := range inv.Skills {
+		sk := &inv.Skills[i]
+		if sk.Type != model.SkillTypeClaudeCodeSkill || sk.Tier == "" {
+			continue
+		}
+		if cached, ok := cache[sk.ContentHash]; ok {
+			// Clone so each descriptor has its own pointer (callers may
+			// mutate, e.g. CLI `--verbose` annotations downstream).
+			cp := *cached
+			sk.Bundle = &cp
+			continue
+		}
+		ba := annotateSkillTrust(sk)
+		sk.Bundle = ba
+		cache[sk.ContentHash] = ba
+	}
+	return nil
+}
+
+// annotateSkillTrust does the per-skill probe.
+func annotateSkillTrust(sk *model.SkillDescriptor) *model.BundleAttestation {
+	parent := filepath.Dir(sk.SourcePath) // ~/.claude/skills/<name>'s parent (skills/)
+	skbPath, found := findSiblingSKB(parent, sk.Name)
+	if !found {
+		return &model.BundleAttestation{
+			Signed:     false,
+			TrustChain: TrustUnverified,
+		}
+	}
+
+	digest, err := computeSKBDigest(skbPath)
+	if err != nil {
+		return &model.BundleAttestation{
+			SKBPath:       skbPath,
+			Signed:        false,
+			TrustChain:    TrustBroken,
+			VerifierError: fmt.Sprintf("digest compute failed: %v", err),
+		}
+	}
+
+	// Look for sibling sig file: <skbPath>.<digest>.author.sig.
+	expectedSig := fmt.Sprintf("%s.%s.author.sig", skbPath, digest)
+	sigInfo, err := os.Stat(expectedSig)
+	if err != nil {
+		return &model.BundleAttestation{
+			SKBPath:       skbPath,
+			BundleDigest:  "sha256:" + digest,
+			Signed:        false,
+			TrustChain:    TrustBroken,
+			VerifierError: fmt.Sprintf("expected sig file missing: %s", expectedSig),
+		}
+	}
+	// Sig file must be exactly 64 raw bytes (ed25519 detached).
+	if sigInfo.Size() != 64 {
+		return &model.BundleAttestation{
+			SKBPath:          skbPath,
+			BundleDigest:     "sha256:" + digest,
+			Signed:           false,
+			TrustChain:       TrustBroken,
+			VerifierExitCode: 11, // verify.ExitAuthorSigInvalid
+			VerifierError:    fmt.Sprintf("sig file size = %d, expected 64", sigInfo.Size()),
+		}
+	}
+
+	return &model.BundleAttestation{
+		SKBPath:                skbPath,
+		BundleDigest:           "sha256:" + digest,
+		Signed:                 true,
+		RegisteredInLocalTrust: false, // populated only when a registry round-trip is run
+		TrustChain:             TrustVerified,
+	}
+}
+
+// findSiblingSKB looks for `<name>-*.skb` in `parent` and `parent/../.archive/`.
+// Returns the first match. If multiple versions exist, picks the
+// lex-largest (a rough proxy for "newest" without parsing semver).
+func findSiblingSKB(parent, name string) (string, bool) {
+	candidates := []string{parent, filepath.Join(filepath.Dir(parent), ".archive")}
+	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(name) + `-.*\.skb$`)
+
+	var best string
+	for _, dir := range candidates {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			if !pattern.MatchString(e.Name()) {
+				continue
+			}
+			candidate := filepath.Join(dir, e.Name())
+			if best == "" || strings.Compare(e.Name(), filepath.Base(best)) > 0 {
+				best = candidate
+			}
+		}
+	}
+	if best == "" {
+		return "", false
+	}
+	return best, true
+}
+
+// computeSKBDigest streams the file through SHA-256 and returns the
+// lowercase hex digest (no `sha256:` prefix). 1 MiB chunks to avoid
+// pulling a large bundle into memory.
+func computeSKBDigest(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	buf := make([]byte, 1<<20)
+	if _, err := io.CopyBuffer(h, f, buf); err != nil {
+		return "", err
+	}
+	sum := h.Sum(nil)
+	const hex = "0123456789abcdef"
+	out := make([]byte, len(sum)*2)
+	for i, b := range sum {
+		out[2*i] = hex[b>>4]
+		out[2*i+1] = hex[b&0x0f]
+	}
+	return string(out), nil
+}

--- a/pkg/skillctl/scanner/trust_test.go
+++ b/pkg/skillctl/scanner/trust_test.go
@@ -1,0 +1,180 @@
+// SPEC-0189 §6 trust cross-reference tests.
+package scanner
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// makeBundleDir builds a Claude Code-conventional skill dir at <tier-root>/<name>
+// with SKILL.md frontmatter, plus optionally a sibling .skb + .author.sig.
+func makeBundleDir(t *testing.T, tierRoot, name string, withBundle, validSig bool) {
+	t.Helper()
+	skillDir := filepath.Join(tierRoot, name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: "+name+"\n---\n# "+name+"\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	if !withBundle {
+		return
+	}
+	// Make a fake .skb (just some bytes — content doesn't matter for the
+	// digest-pattern check).
+	skbContent := []byte("fake .skb content for " + name)
+	skbPath := filepath.Join(tierRoot, name+"-1.0.0.skb")
+	if err := os.WriteFile(skbPath, skbContent, 0o644); err != nil {
+		t.Fatalf("write .skb: %v", err)
+	}
+	digest := sha256.Sum256(skbContent)
+	const hex = "0123456789abcdef"
+	hexDigest := make([]byte, len(digest)*2)
+	for i, b := range digest {
+		hexDigest[2*i] = hex[b>>4]
+		hexDigest[2*i+1] = hex[b&0x0f]
+	}
+	sigPath := fmt.Sprintf("%s.%s.author.sig", skbPath, string(hexDigest))
+	sigSize := 64
+	if !validSig {
+		sigSize = 32 // wrong size triggers TrustBroken
+	}
+	if err := os.WriteFile(sigPath, make([]byte, sigSize), 0o644); err != nil {
+		t.Fatalf("write sig: %v", err)
+	}
+}
+
+// TestAnnotateTrust_Verified — sibling .skb + correct-size sig → verified.
+func TestAnnotateTrust_Verified(t *testing.T) {
+	tmp := t.TempDir()
+	makeBundleDir(t, tmp, "fetch-contract", true, true)
+
+	s := &Scanner{
+		Roots:     []ScanRoot{{Path: tmp, Tier: TierUser}},
+		WithTrust: true,
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(inv.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(inv.Skills))
+	}
+	sk := inv.Skills[0]
+	if sk.Bundle == nil {
+		t.Fatal("Bundle block missing — AnnotateTrust didn't run?")
+	}
+	if sk.Bundle.TrustChain != TrustVerified {
+		t.Errorf("trust_chain = %q, want verified; err=%q", sk.Bundle.TrustChain, sk.Bundle.VerifierError)
+	}
+	if !sk.Bundle.Signed {
+		t.Errorf("signed = false; want true for verified bundle")
+	}
+	if sk.Bundle.SKBPath == "" {
+		t.Errorf("SKBPath empty")
+	}
+	if sk.Bundle.BundleDigest == "" || sk.Bundle.BundleDigest[:7] != "sha256:" {
+		t.Errorf("BundleDigest = %q, want 'sha256:<hex>'", sk.Bundle.BundleDigest)
+	}
+}
+
+// TestAnnotateTrust_Unverified — no sibling .skb → unverified.
+func TestAnnotateTrust_Unverified(t *testing.T) {
+	tmp := t.TempDir()
+	makeBundleDir(t, tmp, "hand-authored", false, false)
+
+	s := &Scanner{
+		Roots:     []ScanRoot{{Path: tmp, Tier: TierUser}},
+		WithTrust: true,
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	sk := inv.Skills[0]
+	if sk.Bundle == nil || sk.Bundle.TrustChain != TrustUnverified {
+		t.Errorf("trust_chain = %v, want unverified", sk.Bundle)
+	}
+	if sk.Bundle.Signed {
+		t.Errorf("signed = true; want false for hand-authored skill")
+	}
+}
+
+// TestAnnotateTrust_Broken — sibling .skb but sig file wrong size → broken.
+func TestAnnotateTrust_Broken(t *testing.T) {
+	tmp := t.TempDir()
+	makeBundleDir(t, tmp, "tampered", true, false /* sig wrong size */)
+
+	s := &Scanner{
+		Roots:     []ScanRoot{{Path: tmp, Tier: TierUser}},
+		WithTrust: true,
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	sk := inv.Skills[0]
+	if sk.Bundle == nil || sk.Bundle.TrustChain != TrustBroken {
+		t.Errorf("trust_chain = %v, want broken", sk.Bundle)
+	}
+	if sk.Bundle.VerifierError == "" {
+		t.Errorf("VerifierError empty for broken bundle")
+	}
+}
+
+// TestAnnotateTrust_NoTrust — without WithTrust=true, Bundle stays nil.
+func TestAnnotateTrust_NoTrust(t *testing.T) {
+	tmp := t.TempDir()
+	makeBundleDir(t, tmp, "untouched", true, true)
+
+	s := &Scanner{
+		Roots: []ScanRoot{{Path: tmp, Tier: TierUser}},
+		// WithTrust: false (default)
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	sk := inv.Skills[0]
+	if sk.Bundle != nil {
+		t.Errorf("Bundle populated without WithTrust=true")
+	}
+}
+
+// TestAnnotateTrust_CacheByContentHash — two skills with identical
+// SKILL.md content share an answer (sanity check the cache path).
+func TestAnnotateTrust_CacheByContentHash(t *testing.T) {
+	tmp := t.TempDir()
+	makeBundleDir(t, tmp, "twin-a", false, false)
+	makeBundleDir(t, tmp, "twin-b", false, false)
+	// Twin SKILL.md content — overwrite to identical bytes.
+	bytes := []byte("same content\n")
+	_ = os.WriteFile(filepath.Join(tmp, "twin-a", "SKILL.md"), bytes, 0o644)
+	_ = os.WriteFile(filepath.Join(tmp, "twin-b", "SKILL.md"), bytes, 0o644)
+
+	s := &Scanner{
+		Roots:     []ScanRoot{{Path: tmp, Tier: TierUser}},
+		WithTrust: true,
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(inv.Skills) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(inv.Skills))
+	}
+	for _, sk := range inv.Skills {
+		if sk.Bundle == nil {
+			t.Errorf("%s missing Bundle block", sk.Name)
+		} else if sk.Bundle.TrustChain != TrustUnverified {
+			t.Errorf("%s trust_chain = %q, want unverified", sk.Name, sk.Bundle.TrustChain)
+		}
+	}
+	// Suppress unused-var warning.
+	_ = model.SkillTypeClaudeCodeSkill
+}


### PR DESCRIPTION
Phase 3 of SPEC-0189. Adds --with-trust support per Decision D1. SPEC-0189 §9 criterion 4 pass. 5 new tests; full regression clean.