### PR TITLE
feat(SPEC-0189): skillctl scan — Claude Code-native local skill inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ build/
 __pycache__/
 *.pyc
 .pytest_cache/
+skillctl

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ build/
 __pycache__/
 *.pyc
 .pytest_cache/
-skillctl
+/skillctl

--- a/cmd/skillctl/main.go
+++ b/cmd/skillctl/main.go
@@ -47,6 +47,29 @@ func main() {
 	case "verify":
 		os.Exit(runVerify(os.Args[2:], os.Stdout, os.Stderr))
 	// === END SPEC-0188 S8 ===
+	// === SPEC-0189 S0a: scanner family dispatchers (imported from
+	// feature/thinking-engine-phase1; pre-SPEC-0189 behaviour preserved). ===
+	case "scan":
+		cmdScan(os.Args[2:])
+	case "report":
+		cmdReport(os.Args[2:])
+	case "diff":
+		cmdDiff(os.Args[2:])
+	case "seal":
+		cmdSeal(os.Args[2:])
+	case "import":
+		cmdImport(os.Args[2:])
+	case "audit":
+		cmdAudit(os.Args[2:])
+	case "review":
+		cmdReview(os.Args[2:])
+	case "browse":
+		cmdBrowse(os.Args[2:])
+	case "consolidate":
+		cmdConsolidate(os.Args[2:])
+	case "sync-usage":
+		cmdSyncUsage(os.Args[2:])
+	// === END SPEC-0189 S0a ===
 	case "help", "--help", "-h":
 		printUsage(os.Stdout)
 		os.Exit(0)

--- a/cmd/skillctl/scan_table.go
+++ b/cmd/skillctl/scan_table.go
@@ -1,0 +1,150 @@
+// Tabwriter-based renderer for `skillctl scan` per SPEC-0189 §5.
+//
+// Two output formats live here:
+//   - renderScanTable — TTY-friendly aligned columns
+//   - renderScanTSV   — tab-separated for grep/awk pipelines
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// renderScanTable writes a SPEC-0189 §5 row layout to w.
+func renderScanTable(w io.Writer, inv *model.Inventory, withTrust bool) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if withTrust {
+		fmt.Fprintln(tw, "NAME\tTIER\tVERSION\tGOV\tSIGNED\tTRUSTED\tPATH")
+	} else {
+		fmt.Fprintln(tw, "NAME\tTIER\tVERSION\tGOV\tPATH")
+	}
+	rows := tabRows(inv, withTrust)
+	for _, r := range rows {
+		fmt.Fprintln(tw, r)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "\n%d skill(s) total.\n", inv.TotalCount)
+	return nil
+}
+
+// renderScanTSV writes the same data with literal tabs for pipelines.
+func renderScanTSV(w io.Writer, inv *model.Inventory, withTrust bool) error {
+	if withTrust {
+		fmt.Fprintln(w, "NAME\tTIER\tVERSION\tGOV\tSIGNED\tTRUSTED\tPATH")
+	} else {
+		fmt.Fprintln(w, "NAME\tTIER\tVERSION\tGOV\tPATH")
+	}
+	for _, r := range tabRows(inv, withTrust) {
+		fmt.Fprintln(w, r)
+	}
+	return nil
+}
+
+// tabRows turns the inventory into a sorted []string of pre-tabbed rows.
+func tabRows(inv *model.Inventory, withTrust bool) []string {
+	tierRank := map[string]int{"project": 0, "user": 1, "plugin": 2}
+
+	rows := make([]string, 0, len(inv.Skills))
+	for _, sk := range inv.Skills {
+		// Only emit claude_code_skills in the SPEC-0189 row layout. Other
+		// types (commands, agents, MCP) keep flowing through JSON output
+		// but are noisy in a tier-oriented table.
+		if sk.Type != model.SkillTypeClaudeCodeSkill {
+			continue
+		}
+		version := "-"
+		gov := "-"
+		if sk.Frontmatter != nil {
+			if sk.Frontmatter.Version != "" {
+				version = sk.Frontmatter.Version
+			}
+			if sk.Frontmatter.GovernanceLevel != "" {
+				gov = sk.Frontmatter.GovernanceLevel
+			}
+		}
+		tier := sk.Tier
+		if tier == "" {
+			tier = "-"
+		}
+		path := sk.SourcePath
+		if len(sk.Shadows) > 0 {
+			path = fmt.Sprintf("%s  (shadows: %d)", path, len(sk.Shadows))
+		}
+		var row string
+		if withTrust {
+			signed := "no"
+			trusted := "n/a"
+			if sk.Bundle != nil {
+				if sk.Bundle.Signed {
+					signed = "yes"
+				}
+				switch sk.Bundle.TrustChain {
+				case "verified":
+					trusted = "yes"
+				case "broken":
+					trusted = "BROKEN"
+				case "unverified":
+					trusted = "n/a"
+				}
+			}
+			row = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s", sk.Name, tier, version, gov, signed, trusted, path)
+		} else {
+			row = fmt.Sprintf("%s\t%s\t%s\t%s\t%s", sk.Name, tier, version, gov, path)
+		}
+		rows = append(rows, row)
+	}
+
+	// Sort: tier first, then name. Stable so reruns give identical output.
+	sort.SliceStable(rows, func(i, j int) bool {
+		ai := tierFromRow(rows[i])
+		aj := tierFromRow(rows[j])
+		if tierRank[ai] != tierRank[aj] {
+			return tierRank[ai] < tierRank[aj]
+		}
+		ni := nameFromRow(rows[i])
+		nj := nameFromRow(rows[j])
+		return ni < nj
+	})
+	return rows
+}
+
+func tierFromRow(row string) string {
+	for i, ch := range row {
+		if ch == '\t' {
+			rest := row[i+1:]
+			for j, ch2 := range rest {
+				if ch2 == '\t' {
+					return rest[:j]
+				}
+			}
+			return rest
+		}
+	}
+	return ""
+}
+
+func nameFromRow(row string) string {
+	for i, ch := range row {
+		if ch == '\t' {
+			return row[:i]
+		}
+	}
+	return row
+}
+
+// isTerminal returns true if w is a TTY. Used to default --format to
+// table on TTY and json on pipe per SPEC-0189 §4.
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/cmd/skillctl/scanner_cmds.go
+++ b/cmd/skillctl/scanner_cmds.go
@@ -29,14 +29,39 @@ import (
 )
 
 func cmdScan(args []string) {
-	var paths []string
-	recursive := false
-	includeHome := false
-	output := "json"
-	outFile := ""
+	// SPEC-0189 §4 flag set + SPEC-0115 legacy flags.
+	var (
+		paths           []string
+		sources         []string
+		recursive       = false
+		includeHome     = false
+		includeShadowed = false
+		withTrust       = false
+		verbose         = false
+		output          = ""
+		outFile         = ""
+	)
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
+		// SPEC-0189 flags.
+		case "--source":
+			if i+1 < len(args) {
+				i++
+				sources = append(sources, args[i])
+			}
+		case "--include-shadowed":
+			includeShadowed = true
+		case "--with-trust":
+			withTrust = true
+		case "--verbose":
+			verbose = true
+		case "--format":
+			if i+1 < len(args) {
+				i++
+				output = args[i]
+			}
+		// Legacy SPEC-0115 flags.
 		case "--path":
 			if i+1 < len(args) {
 				i++
@@ -57,7 +82,6 @@ func cmdScan(args []string) {
 				outFile = args[i]
 			}
 		default:
-			// Treat bare arguments as paths.
 			if args[i] != "" && args[i][0] != '-' {
 				paths = append(paths, args[i])
 			} else {
@@ -67,20 +91,48 @@ func cmdScan(args []string) {
 		}
 	}
 
-	// Default to current directory if no paths given.
-	if len(paths) == 0 {
-		cwd, err := os.Getwd()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting working directory: %v\n", err)
-			os.Exit(1)
-		}
-		paths = []string{cwd}
+	// SPEC-0189 §4: default --source claude when no flags supplied.
+	// Legacy SPEC-0115 paths (--path / cwd) is implicitly --source projects.
+	useTierAware := len(sources) > 0 && !containsString(sources, string(scanner.SourceProjects))
+	if len(sources) == 0 && len(paths) == 0 && !includeHome {
+		// True default invocation: scan Claude Code surfaces.
+		sources = []string{string(scanner.SourceClaude)}
+		useTierAware = true
 	}
 
-	sc := &scanner.Scanner{
-		Paths:       paths,
-		Recursive:   recursive,
-		IncludeHome: includeHome,
+	var sc *scanner.Scanner
+	if useTierAware {
+		// SPEC-0189 tier-aware mode.
+		var srcs []scanner.Source
+		for _, s := range sources {
+			srcs = append(srcs, scanner.Source(s))
+		}
+		roots := scanner.ResolveDefaults(srcs)
+		// Append explicit --path roots as TierProject.
+		for _, p := range paths {
+			abs, _ := filepath.Abs(p)
+			roots = append(roots, scanner.ScanRoot{Path: abs, Tier: scanner.TierProject})
+		}
+		sc = &scanner.Scanner{
+			Roots:           roots,
+			IncludeShadowed: includeShadowed,
+			WithTrust:       withTrust,
+		}
+	} else {
+		// Legacy SPEC-0115 mode.
+		if len(paths) == 0 {
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error getting working directory: %v\n", err)
+				os.Exit(1)
+			}
+			paths = []string{cwd}
+		}
+		sc = &scanner.Scanner{
+			Paths:       paths,
+			Recursive:   recursive,
+			IncludeHome: includeHome,
+		}
 	}
 
 	inv, err := sc.Scan()
@@ -89,7 +141,15 @@ func cmdScan(args []string) {
 		os.Exit(1)
 	}
 
-	// Determine output writer.
+	// Determine output format default per SPEC-0189 §4: table on TTY, json on pipe.
+	if output == "" {
+		if isTerminal(os.Stdout) {
+			output = "table"
+		} else {
+			output = "json"
+		}
+	}
+
 	w := os.Stdout
 	if outFile != "" {
 		f, err := os.Create(outFile)
@@ -109,6 +169,16 @@ func cmdScan(args []string) {
 			fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
 			os.Exit(1)
 		}
+	case "table":
+		if err := renderScanTable(w, inv, withTrust); err != nil {
+			fmt.Fprintf(os.Stderr, "Error rendering table: %v\n", err)
+			os.Exit(1)
+		}
+	case "tsv":
+		if err := renderScanTSV(w, inv, withTrust); err != nil {
+			fmt.Fprintf(os.Stderr, "Error rendering TSV: %v\n", err)
+			os.Exit(1)
+		}
 	case "html":
 		if err := report.GenerateHTML(w, inv); err != nil {
 			fmt.Fprintf(os.Stderr, "Error generating HTML: %v\n", err)
@@ -120,15 +190,27 @@ func cmdScan(args []string) {
 			os.Exit(1)
 		}
 	default:
-		fmt.Fprintf(os.Stderr, "Unknown output format: %s (use json, html, or md)\n", output)
+		fmt.Fprintf(os.Stderr, "Unknown output format: %s (use json, table, tsv, html, or md)\n", output)
 		os.Exit(1)
 	}
 
-	// Print summary to stderr when writing to file.
 	if outFile != "" {
 		fmt.Fprintf(os.Stderr, "Scanned %d skills across %d projects. Output written to %s\n",
 			inv.TotalCount, len(inv.ByProject), outFile)
 	}
+	if verbose {
+		fmt.Fprintf(os.Stderr, "Scan paths: %v\n", inv.ScanPaths)
+	}
+}
+
+// containsString returns true if s contains x.
+func containsString(s []string, x string) bool {
+	for _, v := range s {
+		if v == x {
+			return true
+		}
+	}
+	return false
 }
 
 // cmdReport generates a report from a previously saved scan JSON.

--- a/cmd/skillctl/scanner_cmds.go
+++ b/cmd/skillctl/scanner_cmds.go
@@ -1,0 +1,1188 @@
+// Code imported from feature/thinking-engine-phase1 cmd/skillctl/main.go
+// as part of SPEC-0189 S0a (scanner family baseline).
+// No behavioural changes from feature-branch HEAD.
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/internal/dbdriver"
+	"github.com/kamir/m3c-tools/pkg/skillctl/browse"
+	"github.com/kamir/m3c-tools/pkg/skillctl/consolidate"
+	"github.com/kamir/m3c-tools/pkg/skillctl/delta"
+	"github.com/kamir/m3c-tools/pkg/skillctl/hasher"
+	"github.com/kamir/m3c-tools/pkg/skillctl/importer"
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+	"github.com/kamir/m3c-tools/pkg/skillctl/report"
+	"github.com/kamir/m3c-tools/pkg/skillctl/review"
+	"github.com/kamir/m3c-tools/pkg/skillctl/scanner"
+)
+
+func cmdScan(args []string) {
+	var paths []string
+	recursive := false
+	includeHome := false
+	output := "json"
+	outFile := ""
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--path":
+			if i+1 < len(args) {
+				i++
+				paths = append(paths, args[i])
+			}
+		case "--recursive":
+			recursive = true
+		case "--include-home":
+			includeHome = true
+		case "--output":
+			if i+1 < len(args) {
+				i++
+				output = args[i]
+			}
+		case "--out":
+			if i+1 < len(args) {
+				i++
+				outFile = args[i]
+			}
+		default:
+			// Treat bare arguments as paths.
+			if args[i] != "" && args[i][0] != '-' {
+				paths = append(paths, args[i])
+			} else {
+				fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
+				os.Exit(1)
+			}
+		}
+	}
+
+	// Default to current directory if no paths given.
+	if len(paths) == 0 {
+		cwd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting working directory: %v\n", err)
+			os.Exit(1)
+		}
+		paths = []string{cwd}
+	}
+
+	sc := &scanner.Scanner{
+		Paths:       paths,
+		Recursive:   recursive,
+		IncludeHome: includeHome,
+	}
+
+	inv, err := sc.Scan()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Scan error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Determine output writer.
+	w := os.Stdout
+	if outFile != "" {
+		f, err := os.Create(outFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating output file: %v\n", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		w = f
+	}
+
+	switch output {
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(inv); err != nil {
+			fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
+			os.Exit(1)
+		}
+	case "html":
+		if err := report.GenerateHTML(w, inv); err != nil {
+			fmt.Fprintf(os.Stderr, "Error generating HTML: %v\n", err)
+			os.Exit(1)
+		}
+	case "md":
+		if err := report.GenerateMarkdown(w, inv); err != nil {
+			fmt.Fprintf(os.Stderr, "Error generating Markdown: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown output format: %s (use json, html, or md)\n", output)
+		os.Exit(1)
+	}
+
+	// Print summary to stderr when writing to file.
+	if outFile != "" {
+		fmt.Fprintf(os.Stderr, "Scanned %d skills across %d projects. Output written to %s\n",
+			inv.TotalCount, len(inv.ByProject), outFile)
+	}
+}
+
+// cmdReport generates a report from a previously saved scan JSON.
+func cmdReport(args []string) {
+	format := "html"
+	input := ""
+	outFile := ""
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--format":
+			if i+1 < len(args) {
+				i++
+				format = args[i]
+			}
+		case "--input":
+			if i+1 < len(args) {
+				i++
+				input = args[i]
+			}
+		case "--out":
+			if i+1 < len(args) {
+				i++
+				outFile = args[i]
+			}
+		default:
+			// Treat bare argument as input file.
+			if args[i] != "" && args[i][0] != '-' {
+				input = args[i]
+			} else {
+				fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
+				os.Exit(1)
+			}
+		}
+	}
+
+	if input == "" {
+		fmt.Fprintln(os.Stderr, "Error: --input <scan.json> is required")
+		fmt.Fprintln(os.Stderr, "Usage: skillctl report [--format html|md] --input <scan.json> [--out <file>]")
+		os.Exit(1)
+	}
+
+	// Read scan JSON.
+	data, err := os.ReadFile(input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading input: %v\n", err)
+		os.Exit(1)
+	}
+
+	var inv model.Inventory
+	if err := json.Unmarshal(data, &inv); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing JSON: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Determine output writer.
+	w := os.Stdout
+	if outFile != "" {
+		f, err := os.Create(outFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating output file: %v\n", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		w = f
+	}
+
+	switch format {
+	case "html":
+		if err := report.GenerateHTML(w, &inv); err != nil {
+			fmt.Fprintf(os.Stderr, "Error generating HTML: %v\n", err)
+			os.Exit(1)
+		}
+	case "md":
+		if err := report.GenerateMarkdown(w, &inv); err != nil {
+			fmt.Fprintf(os.Stderr, "Error generating Markdown: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown format: %s (use html or md)\n", format)
+		os.Exit(1)
+	}
+
+	if outFile != "" {
+		fmt.Fprintf(os.Stderr, "Report written to %s\n", outFile)
+	}
+}
+
+// cmdReview starts a local web server for reviewing skill delta reports.
+func cmdReview(args []string) {
+	input := ""
+	port := "9115"
+	noBrowser := false
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--input":
+			if i+1 < len(args) {
+				i++
+				input = args[i]
+			}
+		case "--port":
+			if i+1 < len(args) {
+				i++
+				port = args[i]
+			}
+		case "--no-browser":
+			noBrowser = true
+		default:
+			// Treat bare argument as input file.
+			if args[i] != "" && args[i][0] != '-' {
+				input = args[i]
+			} else {
+				fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
+				os.Exit(1)
+			}
+		}
+	}
+
+	if input == "" {
+		fmt.Fprintln(os.Stderr, "Error: --input <delta.json> is required")
+		fmt.Fprintln(os.Stderr, "Usage: skillctl review [--input <delta.json>] [--port 9115] [--no-browser]")
+		os.Exit(1)
+	}
+
+	addr := ":" + port
+	srv := review.NewServer(addr, input)
+	srv.NoBrowser = noBrowser
+
+	fmt.Fprintf(os.Stderr, "Starting review UI for %s on port %s\n", input, port)
+	if err := srv.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "Server error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// cmdBrowse launches an interactive skill graph browser.
+func cmdBrowse(args []string) {
+	input := ""
+	port := "9116"
+	noBrowser := false
+	var paths []string
+	recursive := false
+	includeHome := false
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--input":
+			if i+1 < len(args) {
+				i++
+				input = args[i]
+			}
+		case "--port":
+			if i+1 < len(args) {
+				i++
+				port = args[i]
+			}
+		case "--path":
+			if i+1 < len(args) {
+				i++
+				paths = append(paths, args[i])
+			}
+		case "--recursive":
+			recursive = true
+		case "--include-home":
+			includeHome = true
+		case "--no-browser":
+			noBrowser = true
+		default:
+			if args[i] != "" && args[i][0] != '-' {
+				input = args[i]
+			} else {
+				fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
+				os.Exit(1)
+			}
+		}
+	}
+
+	var inv *model.Inventory
+	var err error
+
+	if input != "" {
+		inv, err = loadInventory(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading inventory: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		if len(paths) == 0 {
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error getting working directory: %v\n", err)
+				os.Exit(1)
+			}
+			paths = []string{cwd}
+		}
+		sc := &scanner.Scanner{
+			Paths:       paths,
+			Recursive:   recursive,
+			IncludeHome: includeHome,
+		}
+		inv, err = sc.Scan()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Scan error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "Scanned %d skills across %d projects\n", inv.TotalCount, len(inv.ByProject))
+	}
+
+	// Compute inventory hash for cache staleness detection.
+	invJSON, err := json.Marshal(inv)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling inventory for hash: %v\n", err)
+		os.Exit(1)
+	}
+	invHash := hasher.ContentHash(invJSON)
+
+	// Open graph store.
+	store, err := browse.OpenGraphStore(browse.DefaultGraphDBPath())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not open graph store: %v (building without cache)\n", err)
+		// Fall back to uncached path.
+		addr := ":" + port
+		srv := browse.NewServer(addr, inv)
+		srv.NoBrowser = noBrowser
+		if err := srv.Start(); err != nil {
+			fmt.Fprintf(os.Stderr, "Server error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	defer store.Close()
+
+	var graph *browse.SkillGraph
+
+	if !store.IsStale(invHash) {
+		// Cache hit — load graph from SQLite.
+		fmt.Fprintf(os.Stderr, "Loading cached graph...\n")
+		graph, err = store.LoadGraph()
+		if err != nil || graph == nil {
+			// Fallback: rebuild if load fails.
+			fmt.Fprintf(os.Stderr, "Cache load failed, rebuilding graph...\n")
+			graph = browse.BuildGraph(inv)
+			if err := store.SaveGraphWithHash(graph, invHash); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not save graph to cache: %v\n", err)
+			}
+		}
+	} else {
+		// Cache miss — build and persist.
+		fmt.Fprintf(os.Stderr, "Building graph...\n")
+		graph = browse.BuildGraph(inv)
+		if err := store.SaveGraphWithHash(graph, invHash); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not save graph to cache: %v\n", err)
+		}
+	}
+
+	addr := ":" + port
+	srv := browse.NewServerWithCache(addr, inv, graph, store, invHash)
+	srv.NoBrowser = noBrowser
+
+	if err := srv.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "Server error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// cmdConsolidate analyzes skill sprawl across scanned directories and suggests
+// consolidation actions (duplicates, annotation gaps, naming issues).
+func cmdConsolidate(args []string) {
+	input := ""
+	var paths []string
+	recursive := false
+	includeHome := false
+	reportOnly := false
+	fix := false
+	output := "text"
+	outFile := ""
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--input":
+			if i+1 < len(args) {
+				i++
+				input = args[i]
+			}
+		case "--path":
+			if i+1 < len(args) {
+				i++
+				paths = append(paths, args[i])
+			}
+		case "--recursive":
+			recursive = true
+		case "--include-home":
+			includeHome = true
+		case "--report-only":
+			reportOnly = true
+		case "--fix":
+			fix = true
+		case "--output":
+			if i+1 < len(args) {
+				i++
+				output = args[i]
+			}
+		case "--out":
+			if i+1 < len(args) {
+				i++
+				outFile = args[i]
+			}
+		default:
+			if args[i] != "" && args[i][0] != '-' {
+				input = args[i]
+			} else {
+				fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
+				os.Exit(1)
+			}
+		}
+	}
+
+	// Load inventory from --input or run live scan.
+	var inv *model.Inventory
+	var err error
+
+	if input != "" {
+		inv, err = loadInventory(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading inventory: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		if len(paths) == 0 {
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error getting working directory: %v\n", err)
+				os.Exit(1)
+			}
+			paths = []string{cwd}
+		}
+		sc := &scanner.Scanner{
+			Paths:       paths,
+			Recursive:   recursive,
+			IncludeHome: includeHome,
+		}
+		inv, err = sc.Scan()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Scan error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "Scanned %d skills across %d projects\n", inv.TotalCount, len(inv.ByProject))
+	}
+
+	// Analyze the inventory for consolidation opportunities.
+	rpt := consolidate.Analyze(inv)
+
+	// Determine output writer.
+	w := os.Stdout
+	if outFile != "" {
+		f, err := os.Create(outFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating output file: %v\n", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		w = f
+	}
+
+	// Render output based on format.
+	switch output {
+	case "text":
+		fmt.Fprint(w, consolidate.FormatTerminal(rpt))
+	case "md":
+		fmt.Fprint(w, consolidate.FormatMarkdown(rpt))
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rpt); err != nil {
+			fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown output format: %s (use text, md, or json)\n", output)
+		os.Exit(1)
+	}
+
+	if outFile != "" {
+		fmt.Fprintf(os.Stderr, "Consolidation report written to %s\n", outFile)
+	}
+
+	// If --fix is set and --report-only is NOT set, offer to fix annotation gaps.
+	if fix && !reportOnly {
+		if len(rpt.AnnotationGaps) == 0 {
+			fmt.Fprintln(os.Stderr, "No annotation gaps to fix.")
+			return
+		}
+		fmt.Fprintf(os.Stderr, "\nFound %d annotation gaps. Apply frontmatter fixes? [y/N] ", len(rpt.AnnotationGaps))
+		var answer string
+		fmt.Scanln(&answer)
+		if answer == "y" || answer == "Y" || answer == "yes" {
+			fixed, skipped, err := consolidate.FixAnnotationGaps(rpt.AnnotationGaps)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error fixing annotation gaps: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Fprintf(os.Stderr, "Fixed %d skills, skipped %d\n", fixed, skipped)
+		} else {
+			fmt.Fprintln(os.Stderr, "Skipped. Re-run with --fix to apply later.")
+		}
+	}
+}
+
+// cmdDiff compares two scan snapshots and outputs a delta report.
+func cmdDiff(args []string) {
+	output := "text"
+	outFile := ""
+	var positional []string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--output":
+			if i+1 < len(args) {
+				i++
+				output = args[i]
+			}
+		case "--out":
+			if i+1 < len(args) {
+				i++
+				outFile = args[i]
+			}
+		default:
+			if args[i] != "" && args[i][0] != '-' {
+				positional = append(positional, args[i])
+			} else {
+				fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
+				os.Exit(1)
+			}
+		}
+	}
+
+	if len(positional) < 2 {
+		fmt.Fprintln(os.Stderr, "Usage: skillctl diff <scan1.json> <scan2.json> [--output json|md|html|text] [--out <file>]")
+		os.Exit(1)
+	}
+
+	baseline, err := loadInventory(positional[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading baseline %s: %v\n", positional[0], err)
+		os.Exit(1)
+	}
+	current, err := loadInventory(positional[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading current %s: %v\n", positional[1], err)
+		os.Exit(1)
+	}
+
+	dr := delta.ComputeDelta(baseline, current)
+	dr.BaselinePath = positional[0]
+	dr.CurrentPath = positional[1]
+
+	// Determine output writer.
+	w := os.Stdout
+	if outFile != "" {
+		f, err := os.Create(outFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating output file: %v\n", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		w = f
+	}
+
+	switch output {
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(dr); err != nil {
+			fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
+			os.Exit(1)
+		}
+	case "md":
+		fmt.Fprint(w, delta.FormatMarkdown(dr))
+	case "html":
+		if err := report.GenerateDeltaReportHTML(w, dr); err != nil {
+			fmt.Fprintf(os.Stderr, "Error generating HTML: %v\n", err)
+			os.Exit(1)
+		}
+	case "text":
+		fmt.Fprint(w, delta.FormatSummary(dr))
+		if len(dr.Entries) > 0 {
+			fmt.Fprintln(w)
+			for _, e := range dr.Entries {
+				switch e.DeltaType {
+				case delta.DeltaAdded:
+					fmt.Fprintf(w, "  + %-30s  %s\n", e.SkillName, e.CurrentPath)
+				case delta.DeltaRemoved:
+					fmt.Fprintf(w, "  - %-30s  %s\n", e.SkillName, e.BaselinePath)
+				case delta.DeltaModified:
+					fmt.Fprintf(w, "  ~ %-30s  %s -> %s\n", e.SkillName, truncate(e.BaselineHash, 8), truncate(e.CurrentHash, 8))
+				case delta.DeltaMoved:
+					fmt.Fprintf(w, "  > %-30s  %s -> %s\n", e.SkillName, e.BaselinePath, e.CurrentPath)
+				}
+			}
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown output format: %s (use json, md, html, or text)\n", output)
+		os.Exit(1)
+	}
+
+	if outFile != "" {
+		fmt.Fprintf(os.Stderr, "Delta report (%d changes) written to %s\n", dr.Summary.Total, outFile)
+	}
+}
+
+// cmdSeal manages sealed inventory baselines.
+func cmdSeal(args []string) {
+	input := ""
+	sealedBy := ""
+	listSeals := false
+	showLatest := false
+	showStatus := false
+	var paths []string
+	includeHome := false
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--input":
+			if i+1 < len(args) {
+				i++
+				input = args[i]
+			}
+		case "--by":
+			if i+1 < len(args) {
+				i++
+				sealedBy = args[i]
+			}
+		case "--path":
+			if i+1 < len(args) {
+				i++
+				paths = append(paths, args[i])
+			}
+		case "--include-home":
+			includeHome = true
+		case "--list":
+			listSeals = true
+		case "--latest":
+			showLatest = true
+		case "--status":
+			showStatus = true
+		default:
+			if args[i] != "" && args[i][0] != '-' {
+				input = args[i]
+			} else {
+				fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
+				os.Exit(1)
+			}
+		}
+	}
+
+	store, err := delta.NewSealStore()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening seal store: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Default sealed-by to current OS user.
+	if sealedBy == "" {
+		if u, err := user.Current(); err == nil {
+			sealedBy = u.Username
+		} else {
+			sealedBy = "unknown"
+		}
+	}
+
+	switch {
+	case listSeals:
+		seals, err := store.ListSeals()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing seals: %v\n", err)
+			os.Exit(1)
+		}
+		if len(seals) == 0 {
+			fmt.Println("No seals found.")
+			return
+		}
+		fmt.Printf("%-28s  %-20s  %6s  %s\n", "SEAL ID", "SEALED AT", "SKILLS", "HASH")
+		for _, s := range seals {
+			hash := s.InventoryHash
+			if len(hash) > 12 {
+				hash = hash[:12]
+			}
+			fmt.Printf("%-28s  %-20s  %6d  %s\n", s.SealID, s.SealedAt, s.SkillCount, hash)
+		}
+
+	case showLatest:
+		record, _, err := store.LatestSeal()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading latest seal: %v\n", err)
+			os.Exit(1)
+		}
+		if record == nil {
+			fmt.Println("No seals found.")
+			return
+		}
+		fmt.Printf("Seal ID:    %s\n", record.SealID)
+		fmt.Printf("Sealed at:  %s\n", record.SealedAt)
+		fmt.Printf("Sealed by:  %s\n", record.SealedBy)
+		fmt.Printf("Skills:     %d\n", record.SkillCount)
+		fmt.Printf("Hash:       %s\n", record.InventoryHash)
+		fmt.Printf("Inventory:  %s\n", record.InventoryPath)
+
+	case showStatus:
+		record, baselineInv, err := store.LatestSeal()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading latest seal: %v\n", err)
+			os.Exit(1)
+		}
+		if record == nil {
+			fmt.Fprintln(os.Stderr, "No baseline seal found. Run 'skillctl seal' first.")
+			os.Exit(1)
+		}
+
+		// Scan current state.
+		scanPaths := paths
+		if len(scanPaths) == 0 {
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error getting working directory: %v\n", err)
+				os.Exit(1)
+			}
+			scanPaths = []string{cwd}
+		}
+		sc := &scanner.Scanner{
+			Paths:       scanPaths,
+			Recursive:   true,
+			IncludeHome: includeHome,
+		}
+		currentInv, err := sc.Scan()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Scan error: %v\n", err)
+			os.Exit(1)
+		}
+
+		dr := delta.ComputeDelta(baselineInv, currentInv)
+		dr.BaselinePath = record.InventoryPath
+		dr.CurrentPath = "(live scan)"
+
+		fmt.Printf("Baseline: %s (%s)\n\n", record.SealID, record.SealedAt)
+		fmt.Print(delta.FormatSummary(dr))
+		if len(dr.Entries) > 0 {
+			fmt.Println()
+			for _, e := range dr.Entries {
+				switch e.DeltaType {
+				case delta.DeltaAdded:
+					fmt.Printf("  + %-30s  %s\n", e.SkillName, e.CurrentPath)
+				case delta.DeltaRemoved:
+					fmt.Printf("  - %-30s  %s\n", e.SkillName, e.BaselinePath)
+				case delta.DeltaModified:
+					fmt.Printf("  ~ %-30s  %s -> %s\n", e.SkillName, truncate(e.BaselineHash, 8), truncate(e.CurrentHash, 8))
+				case delta.DeltaMoved:
+					fmt.Printf("  > %-30s  %s -> %s\n", e.SkillName, e.BaselinePath, e.CurrentPath)
+				}
+			}
+		}
+
+	default:
+		// Seal: create a new baseline.
+		var inv *model.Inventory
+
+		if input != "" {
+			// Seal from existing scan JSON.
+			inv, err = loadInventory(input)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error loading inventory %s: %v\n", input, err)
+				os.Exit(1)
+			}
+		} else {
+			// Run a scan, then seal.
+			scanPaths := paths
+			if len(scanPaths) == 0 {
+				cwd, err := os.Getwd()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error getting working directory: %v\n", err)
+					os.Exit(1)
+				}
+				scanPaths = []string{cwd}
+			}
+			sc := &scanner.Scanner{
+				Paths:       scanPaths,
+				Recursive:   true,
+				IncludeHome: includeHome,
+			}
+			inv, err = sc.Scan()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Scan error: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Fprintf(os.Stderr, "Scanned %d skills across %d projects\n", inv.TotalCount, len(inv.ByProject))
+		}
+
+		record, err := store.Seal(inv, sealedBy)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error sealing inventory: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Sealed %d skills as %s\n", record.SkillCount, record.SealID)
+		fmt.Printf("  Sealed by: %s\n", record.SealedBy)
+		fmt.Printf("  Hash:      %s\n", record.InventoryHash)
+		fmt.Printf("  Inventory: %s\n", record.InventoryPath)
+	}
+}
+
+// loadInventory reads and parses an inventory JSON file.
+func loadInventory(path string) (*model.Inventory, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+	var inv model.Inventory
+	if err := json.Unmarshal(data, &inv); err != nil {
+		return nil, fmt.Errorf("parsing JSON: %w", err)
+	}
+	return &inv, nil
+}
+
+// truncate returns the first n characters of s, or s itself if shorter.
+func truncate(s string, n int) string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}
+
+// cmdImport pushes a skill inventory to the aims-core skill profile API.
+func cmdImport(args []string) {
+	target := ""
+	apiKey := ""
+	userID := "" // BUG-0084: Required for aims-core auth
+	input := ""
+	var paths []string
+	recursive := false
+	includeHome := false
+	dryRun := false
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--target":
+			if i+1 < len(args) {
+				i++
+				target = args[i]
+			}
+		case "--api-key":
+			if i+1 < len(args) {
+				i++
+				apiKey = args[i]
+			}
+		case "--user-id":
+			if i+1 < len(args) {
+				i++
+				userID = args[i]
+			}
+		case "--input":
+			if i+1 < len(args) {
+				i++
+				input = args[i]
+			}
+		case "--path":
+			if i+1 < len(args) {
+				i++
+				paths = append(paths, args[i])
+			}
+		case "--recursive":
+			recursive = true
+		case "--include-home":
+			includeHome = true
+		case "--dry-run":
+			dryRun = true
+		default:
+			if args[i] != "" && args[i][0] != '-' {
+				input = args[i]
+			} else {
+				fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
+				os.Exit(1)
+			}
+		}
+	}
+
+	// --target is required.
+	if target == "" {
+		fmt.Fprintln(os.Stderr, "Error: --target <url> is required")
+		fmt.Fprintln(os.Stderr, "Usage: skillctl import --target <url> [--api-key <key>] [--input <scan.json>] [--dry-run]")
+		os.Exit(1)
+	}
+
+	// Resolve API key: flag > env var > session file.
+	if apiKey == "" {
+		apiKey = os.Getenv("M3C_API_KEY")
+	}
+	if apiKey == "" {
+		apiKey = readAPIKeyFromSession()
+	}
+
+	// BUG-0084: Resolve user ID: flag > env var.
+	if userID == "" {
+		userID = os.Getenv("ER1_CONTEXT_ID")
+	}
+
+	// Load inventory from --input or run live scan.
+	var inv *model.Inventory
+	var err error
+
+	if input != "" {
+		inv, err = loadInventory(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading inventory: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		if len(paths) == 0 {
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error getting working directory: %v\n", err)
+				os.Exit(1)
+			}
+			paths = []string{cwd}
+		}
+		sc := &scanner.Scanner{
+			Paths:       paths,
+			Recursive:   recursive,
+			IncludeHome: includeHome,
+		}
+		inv, err = sc.Scan()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Scan error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "Scanned %d skills across %d projects\n", inv.TotalCount, len(inv.ByProject))
+	}
+
+	// Create API client.
+	client, err := importer.NewClient(target, apiKey, userID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Dry-run mode: print summary and exit.
+	if dryRun {
+		fmt.Print(client.DryRun(inv))
+		return
+	}
+
+	// Health check before import.
+	fmt.Fprintf(os.Stderr, "Checking connectivity to %s ...\n", target)
+	if err := client.HealthCheck(); err != nil {
+		fmt.Fprintf(os.Stderr, "Health check failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stderr, "Health check OK")
+
+	// Import.
+	fmt.Fprintf(os.Stderr, "Importing %d skills ...\n", len(inv.Skills))
+	resp, err := client.Import(inv)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Import failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print result summary.
+	fmt.Printf("Import complete:\n")
+	fmt.Printf("  Imported:       %d\n", resp.Imported)
+	fmt.Printf("  New candidates: %d\n", resp.NewCandidates)
+	fmt.Printf("  Already known:  %d\n", resp.AlreadyKnown)
+	if resp.Message != "" {
+		fmt.Printf("  Message:        %s\n", resp.Message)
+	}
+}
+
+// readAPIKeyFromSession attempts to read the api_key field from
+// ~/.m3c-tools/er1_session.json. Returns empty string on any error.
+func readAPIKeyFromSession() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".m3c-tools", "er1_session.json"))
+	if err != nil {
+		return ""
+	}
+	var session struct {
+		APIKey string `json:"api_key"`
+	}
+	if err := json.Unmarshal(data, &session); err != nil {
+		return ""
+	}
+	return session.APIKey
+}
+
+// cmdAudit inspects a single skill in detail (Phase 2 stub).
+func cmdAudit(args []string) {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "Usage: skillctl audit <skill-id>")
+		os.Exit(1)
+	}
+	// TODO: Phase 2 — deep inspection of a single skill: dependencies, conflicts,
+	// version history, content diff, frontmatter validation.
+	fmt.Fprintln(os.Stderr, "audit: not yet implemented (Phase 2)")
+	os.Exit(0)
+}
+
+// cmdSyncUsage reads unsynced skill usage events from the local SQLite database
+// and POSTs each to aims-core /api/v2/skills/usage. Successfully synced rows are
+// marked synced=1 so they are not re-sent.
+func cmdSyncUsage(args []string) {
+	target := ""
+	apiKey := ""
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--target":
+			if i+1 < len(args) {
+				i++
+				target = args[i]
+			}
+		case "--api-key":
+			if i+1 < len(args) {
+				i++
+				apiKey = args[i]
+			}
+		default:
+			fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
+			os.Exit(1)
+		}
+	}
+
+	// Resolve target URL: flag > env var > default.
+	if target == "" {
+		target = os.Getenv("M3C_API_URL")
+	}
+	if target == "" {
+		target = "https://onboarding.guide"
+	}
+	target = strings.TrimRight(target, "/")
+
+	// Resolve API key: flag > env var > session file.
+	if apiKey == "" {
+		apiKey = os.Getenv("M3C_API_KEY")
+	}
+	if apiKey == "" {
+		apiKey = readAPIKeyFromSession()
+	}
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "Error: no API key found (use --api-key, M3C_API_KEY, or ~/.m3c-tools/er1_session.json)")
+		os.Exit(1)
+	}
+
+	// Open the local usage database.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting home directory: %v\n", err)
+		os.Exit(1)
+	}
+	dbPath := filepath.Join(home, ".m3c-tools", "skill-usage.db")
+
+	db, err := sql.Open(dbdriver.DriverName(), dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening usage database: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	// Read all unsynced rows.
+	rows, err := db.Query("SELECT id, skill_id, user_id, timestamp, project, session_id FROM skill_usage WHERE synced = 0 ORDER BY id")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error querying unsynced events: %v\n", err)
+		os.Exit(1)
+	}
+
+	type usageRow struct {
+		ID        int64
+		SkillID   string
+		UserID    string
+		Timestamp string
+		Project   string
+		SessionID string
+	}
+
+	var pending []usageRow
+	for rows.Next() {
+		var r usageRow
+		if err := rows.Scan(&r.ID, &r.SkillID, &r.UserID, &r.Timestamp, &r.Project, &r.SessionID); err != nil {
+			fmt.Fprintf(os.Stderr, "Error scanning row: %v\n", err)
+			continue
+		}
+		pending = append(pending, r)
+	}
+	rows.Close()
+
+	if len(pending) == 0 {
+		fmt.Println("No unsynced usage events.")
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "Found %d unsynced usage events. Syncing to %s ...\n", len(pending), target)
+
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	synced := 0
+
+	for _, r := range pending {
+		event := map[string]interface{}{
+			"skill_id":  r.SkillID,
+			"user_id":   r.UserID,
+			"timestamp": r.Timestamp,
+			"context": map[string]string{
+				"project":    r.Project,
+				"session_id": r.SessionID,
+				"source":     "claude_code_hook",
+			},
+		}
+
+		body, err := json.Marshal(event)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  [SKIP] id=%d: marshal error: %v\n", r.ID, err)
+			continue
+		}
+
+		url := target + "/api/v2/skills/usage"
+		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  [SKIP] id=%d: request error: %v\n", r.ID, err)
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-API-KEY", apiKey)
+		req.Header.Set("X-User-ID", r.UserID)
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  [FAIL] id=%d (%s): %v\n", r.ID, r.SkillID, err)
+			continue
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			now := time.Now().UTC().Format(time.RFC3339)
+			_, err := db.Exec("UPDATE skill_usage SET synced = 1, synced_at = ? WHERE id = ?", now, r.ID)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "  [WARN] id=%d: synced but failed to update local DB: %v\n", r.ID, err)
+			}
+			synced++
+		} else {
+			fmt.Fprintf(os.Stderr, "  [FAIL] id=%d (%s): HTTP %d\n", r.ID, r.SkillID, resp.StatusCode)
+		}
+	}
+
+	fmt.Printf("Synced %d/%d usage events\n", synced, len(pending))
+}
+

--- a/internal/dbdriver/driver_cgo.go
+++ b/internal/dbdriver/driver_cgo.go
@@ -1,0 +1,13 @@
+// driver_cgo.go — SQLite driver registration for cgo-enabled builds.
+// Uses github.com/mattn/go-sqlite3 (C-backed, faster, production-tested).
+//
+//go:build cgo
+
+package dbdriver
+
+import (
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// DriverName returns the SQL driver name for sql.Open().
+func DriverName() string { return "sqlite3" }

--- a/internal/dbdriver/driver_nocgo.go
+++ b/internal/dbdriver/driver_nocgo.go
@@ -1,0 +1,13 @@
+// driver_nocgo.go — SQLite driver registration for pure-Go builds.
+// Uses modernc.org/sqlite (no C compiler required, cross-platform).
+//
+//go:build !cgo
+
+package dbdriver
+
+import (
+	_ "modernc.org/sqlite"
+)
+
+// DriverName returns the SQL driver name for sql.Open().
+func DriverName() string { return "sqlite" }

--- a/pkg/auth/headers.go
+++ b/pkg/auth/headers.go
@@ -1,0 +1,34 @@
+package auth
+
+import (
+	"net/http"
+	"os"
+)
+
+// ApplyAuth sets the correct authentication header on an HTTP request.
+// Device token (Bearer) takes priority over API key (X-API-KEY).
+// The apiKey parameter is the caller's local API key for backward compat;
+// the device token is read from the ER1_DEVICE_TOKEN env var (set at startup).
+func ApplyAuth(req *http.Request, apiKey string) {
+	if token := os.Getenv("ER1_DEVICE_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	} else if apiKey != "" {
+		req.Header.Set("X-API-KEY", apiKey)
+	}
+}
+
+// HasAuth returns true if any authentication method is available.
+func HasAuth(apiKey string) bool {
+	return os.Getenv("ER1_DEVICE_TOKEN") != "" || apiKey != ""
+}
+
+// AuthMethod returns the name of the active authentication method.
+func AuthMethod() string {
+	if os.Getenv("ER1_DEVICE_TOKEN") != "" {
+		return "device token"
+	}
+	if os.Getenv("ER1_API_KEY") != "" {
+		return "API key"
+	}
+	return "none"
+}

--- a/pkg/auth/headers_test.go
+++ b/pkg/auth/headers_test.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestApplyAuth_PrefersDeviceToken(t *testing.T) {
+	t.Setenv("ER1_DEVICE_TOKEN", "test-bearer-token")
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	ApplyAuth(req, "some-api-key")
+
+	if got := req.Header.Get("Authorization"); got != "Bearer test-bearer-token" {
+		t.Errorf("Authorization = %q, want Bearer test-bearer-token", got)
+	}
+	if got := req.Header.Get("X-API-KEY"); got != "" {
+		t.Errorf("X-API-KEY = %q, want empty (token takes priority)", got)
+	}
+}
+
+func TestApplyAuth_FallsBackToAPIKey(t *testing.T) {
+	t.Setenv("ER1_DEVICE_TOKEN", "")
+	os.Unsetenv("ER1_DEVICE_TOKEN")
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	ApplyAuth(req, "my-api-key")
+
+	if got := req.Header.Get("X-API-KEY"); got != "my-api-key" {
+		t.Errorf("X-API-KEY = %q, want my-api-key", got)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization = %q, want empty (no token)", got)
+	}
+}
+
+func TestApplyAuth_NoAuth(t *testing.T) {
+	t.Setenv("ER1_DEVICE_TOKEN", "")
+	os.Unsetenv("ER1_DEVICE_TOKEN")
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	ApplyAuth(req, "")
+
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization = %q, want empty", got)
+	}
+	if got := req.Header.Get("X-API-KEY"); got != "" {
+		t.Errorf("X-API-KEY = %q, want empty", got)
+	}
+}
+
+func TestHasAuth_TokenOnly(t *testing.T) {
+	t.Setenv("ER1_DEVICE_TOKEN", "some-token")
+	if !HasAuth("") {
+		t.Error("HasAuth should return true when device token is set")
+	}
+}
+
+func TestHasAuth_APIKeyOnly(t *testing.T) {
+	t.Setenv("ER1_DEVICE_TOKEN", "")
+	os.Unsetenv("ER1_DEVICE_TOKEN")
+	if !HasAuth("some-key") {
+		t.Error("HasAuth should return true when API key is provided")
+	}
+}
+
+func TestHasAuth_Neither(t *testing.T) {
+	t.Setenv("ER1_DEVICE_TOKEN", "")
+	os.Unsetenv("ER1_DEVICE_TOKEN")
+	if HasAuth("") {
+		t.Error("HasAuth should return false when neither token nor key exists")
+	}
+}
+
+func TestAuthMethod_Token(t *testing.T) {
+	t.Setenv("ER1_DEVICE_TOKEN", "tok")
+	if got := AuthMethod(); got != "device token" {
+		t.Errorf("AuthMethod() = %q, want 'device token'", got)
+	}
+}
+
+func TestAuthMethod_APIKey(t *testing.T) {
+	t.Setenv("ER1_DEVICE_TOKEN", "")
+	os.Unsetenv("ER1_DEVICE_TOKEN")
+	t.Setenv("ER1_API_KEY", "key")
+	if got := AuthMethod(); got != "API key" {
+		t.Errorf("AuthMethod() = %q, want 'API key'", got)
+	}
+}
+
+func TestAuthMethod_None(t *testing.T) {
+	t.Setenv("ER1_DEVICE_TOKEN", "")
+	os.Unsetenv("ER1_DEVICE_TOKEN")
+	t.Setenv("ER1_API_KEY", "")
+	os.Unsetenv("ER1_API_KEY")
+	if got := AuthMethod(); got != "none" {
+		t.Errorf("AuthMethod() = %q, want 'none'", got)
+	}
+}

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -1,0 +1,167 @@
+// Package auth handles device token storage and retrieval for m3c-tools.
+// Tokens are stored encrypted on disk using AES-256-GCM with a key derived
+// from device-specific material (hostname + user ID).
+package auth
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// DeviceToken holds the token and metadata received from aims-core after login.
+type DeviceToken struct {
+	Token     string `json:"token"`
+	UserID    string `json:"user_id"`
+	ContextID string `json:"context_id"`
+	UserName  string `json:"user_name,omitempty"`
+	UserEmail string `json:"user_email,omitempty"`
+	DeviceID  string `json:"device_id"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+	SavedAt   string `json:"saved_at"`
+}
+
+// IsExpired returns true if the token has passed its expiration time.
+func (t *DeviceToken) IsExpired() bool {
+	if t.ExpiresAt == "" {
+		return false
+	}
+	exp, err := time.Parse(time.RFC3339, t.ExpiresAt)
+	if err != nil {
+		return true // treat unparseable as expired
+	}
+	return time.Now().After(exp)
+}
+
+// tokenDir returns the directory for token storage.
+func tokenDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	dir := filepath.Join(home, ".m3c-tools")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("create config directory: %w", err)
+	}
+	return dir, nil
+}
+
+// tokenPath returns the path to the encrypted token file.
+func tokenPath() (string, error) {
+	dir, err := tokenDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "device-token.enc"), nil
+}
+
+// deriveKey creates a 256-bit encryption key from the device ID and user ID.
+// This ensures the encrypted file is tied to this specific device+user combination.
+func deriveKey(deviceID, userID string) []byte {
+	h := sha256.Sum256([]byte("m3c-device-token:" + deviceID + ":" + userID))
+	return h[:]
+}
+
+// Save encrypts and writes the device token to disk.
+func Save(token *DeviceToken) error {
+	path, err := tokenPath()
+	if err != nil {
+		return err
+	}
+
+	plaintext, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("marshal token: %w", err)
+	}
+
+	key := deriveKey(token.DeviceID, token.UserID)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return fmt.Errorf("create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return fmt.Errorf("create GCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return fmt.Errorf("generate nonce: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+	if err := os.WriteFile(path, ciphertext, 0600); err != nil {
+		return fmt.Errorf("write token file: %w", err)
+	}
+	return nil
+}
+
+// Load reads and decrypts the device token from disk.
+// Returns nil, nil if no token file exists.
+func Load(deviceID, userID string) (*DeviceToken, error) {
+	path, err := tokenPath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // no token saved
+		}
+		return nil, fmt.Errorf("read token file: %w", err)
+	}
+
+	key := deriveKey(deviceID, userID)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create GCM: %w", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return nil, fmt.Errorf("token file too short")
+	}
+
+	plaintext, err := gcm.Open(nil, data[:nonceSize], data[nonceSize:], nil)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt token (wrong device or corrupted): %w", err)
+	}
+
+	var token DeviceToken
+	if err := json.Unmarshal(plaintext, &token); err != nil {
+		return nil, fmt.Errorf("unmarshal token: %w", err)
+	}
+	return &token, nil
+}
+
+// Clear removes the stored device token.
+func Clear() error {
+	path, err := tokenPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove token: %w", err)
+	}
+	return nil
+}
+
+// DeviceID returns a stable identifier for this machine.
+func DeviceID() string {
+	name, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return name
+}

--- a/pkg/skillctl/browse/builder.go
+++ b/pkg/skillctl/browse/builder.go
@@ -1,0 +1,337 @@
+package browse
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// BuildGraph constructs a SkillGraph from a skill Inventory.
+// Phase A: structural edges (belongs_to, tagged_with, in_category).
+// Phase B: inferred edges (references, similar_to, colocated).
+func BuildGraph(inv *model.Inventory) *SkillGraph {
+	g := &SkillGraph{
+		Nodes: make([]Node, 0, inv.TotalCount*2),
+		Edges: make([]Edge, 0, inv.TotalCount*3),
+	}
+
+	projectSet := make(map[string]bool)
+	categorySet := make(map[string]bool)
+	tagSet := make(map[string]bool)
+	typeSet := make(map[string]bool)
+
+	// Phase A: Create skill nodes and structural edges.
+	seenIDs := make(map[string]int)
+	for _, sk := range inv.Skills {
+		baseID := fmt.Sprintf("skill:%s/%s", sk.SourceProject, sk.Name)
+		skillID := baseID
+		if seenIDs[baseID] > 0 {
+			skillID = fmt.Sprintf("%s_%d", baseID, seenIDs[baseID])
+		}
+		seenIDs[baseID]++
+
+		var desc, category string
+		var tags []string
+		if sk.Frontmatter != nil {
+			desc = sk.Frontmatter.Description
+			category = sk.Frontmatter.Category
+			tags = sk.Frontmatter.Tags
+
+			// Extract from nested metadata block if top-level is empty.
+			if sk.Frontmatter.Metadata != nil {
+				if category == "" {
+					if c, ok := sk.Frontmatter.Metadata["category"].(string); ok {
+						category = c
+					}
+				}
+				if len(tags) == 0 {
+					if rawTags, ok := sk.Frontmatter.Metadata["tags"]; ok {
+						if tagSlice, ok := rawTags.([]interface{}); ok {
+							for _, t := range tagSlice {
+								if s, ok := t.(string); ok {
+									tags = append(tags, s)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// Map skill type to the proper node kind.
+		kind := NodeSkill
+		switch sk.Type {
+		case model.SkillTypeAgent:
+			kind = NodeAgent
+		case model.SkillTypeSkillIndex:
+			kind = NodeSkillIndex
+		case model.SkillTypeCommand:
+			kind = NodeCommand
+		}
+
+		node := Node{
+			ID:          skillID,
+			Label:       sk.Name,
+			Kind:        kind,
+			SkillType:   string(sk.Type),
+			Project:     sk.SourceProject,
+			Description: desc,
+			SizeBytes:   sk.ContentSizeBytes,
+			SourcePath:  sk.SourcePath,
+			Tags:        tags,
+			Category:    category,
+			HasFM:       sk.HasYAMLFrontmatter,
+		}
+		g.Nodes = append(g.Nodes, node)
+		typeSet[string(sk.Type)] = true
+
+		// belongs_to: skill → project
+		projID := fmt.Sprintf("project:%s", sk.SourceProject)
+		if !projectSet[sk.SourceProject] {
+			projectSet[sk.SourceProject] = true
+			g.Nodes = append(g.Nodes, Node{
+				ID:    projID,
+				Label: sk.SourceProject,
+				Kind:  NodeProject,
+			})
+		}
+		g.Edges = append(g.Edges, Edge{
+			Source: skillID,
+			Target: projID,
+			Kind:   EdgeBelongsTo,
+			Weight: 1.0,
+		})
+
+		// in_category: skill → category
+		if category != "" {
+			catID := fmt.Sprintf("category:%s", category)
+			if !categorySet[category] {
+				categorySet[category] = true
+				g.Nodes = append(g.Nodes, Node{
+					ID:    catID,
+					Label: category,
+					Kind:  NodeCategory,
+				})
+			}
+			g.Edges = append(g.Edges, Edge{
+				Source: skillID,
+				Target: catID,
+				Kind:   EdgeInCategory,
+				Weight: 0.9,
+			})
+		}
+
+		// tagged_with: skill → tag
+		for _, tag := range tags {
+			tag = strings.TrimSpace(tag)
+			if tag == "" {
+				continue
+			}
+			tagID := fmt.Sprintf("tag:%s", tag)
+			if !tagSet[tag] {
+				tagSet[tag] = true
+				g.Nodes = append(g.Nodes, Node{
+					ID:    tagID,
+					Label: tag,
+					Kind:  NodeTag,
+				})
+			}
+			g.Edges = append(g.Edges, Edge{
+				Source: skillID,
+				Target: tagID,
+				Kind:   EdgeTaggedWith,
+				Weight: 0.8,
+			})
+		}
+	}
+
+	// Phase B: Inferred edges (relationship inference).
+
+	// Collect content nodes (skills, agents, commands, skill indexes) for inference passes.
+	var skillNodes []Node
+	for _, n := range g.Nodes {
+		if n.Kind.IsContentNode() {
+			skillNodes = append(skillNodes, n)
+		}
+	}
+
+	// B-1: Cross-reference edges (references, weight 0.7).
+	// Build a map of skill name → skill ID for lookup.
+	nameToID := make(map[string]string, len(skillNodes))
+	for _, n := range skillNodes {
+		if n.Label != "" {
+			nameToID[strings.ToLower(n.Label)] = n.ID
+		}
+	}
+	// Read each skill's source file and check for mentions of other skills.
+	for _, n := range skillNodes {
+		if n.SourcePath == "" {
+			continue
+		}
+		data, err := os.ReadFile(n.SourcePath)
+		if err != nil {
+			continue // skip files that can't be read
+		}
+		contentLower := strings.ToLower(string(data))
+		for otherName, otherID := range nameToID {
+			if otherID == n.ID {
+				continue // skip self-references
+			}
+			if strings.Contains(contentLower, otherName) {
+				g.Edges = append(g.Edges, Edge{
+					Source:   n.ID,
+					Target:   otherID,
+					Kind:     EdgeReferences,
+					Weight:   0.7,
+					Evidence: fmt.Sprintf("content mentions '%s'", otherName),
+				})
+			}
+		}
+	}
+
+	// B-2: Shared-tag similarity edges (similar_to, weight 0.3-0.6).
+	// Pre-build a set of existing same-project pairs to skip.
+	type nodePair struct{ a, b string }
+	sameProjectPairs := make(map[nodePair]bool)
+	for i := 0; i < len(skillNodes); i++ {
+		for j := i + 1; j < len(skillNodes); j++ {
+			if skillNodes[i].Project == skillNodes[j].Project {
+				sameProjectPairs[nodePair{skillNodes[i].ID, skillNodes[j].ID}] = true
+			}
+		}
+	}
+	for i := 0; i < len(skillNodes); i++ {
+		if len(skillNodes[i].Tags) == 0 {
+			continue
+		}
+		tagsA := make(map[string]bool, len(skillNodes[i].Tags))
+		for _, t := range skillNodes[i].Tags {
+			tagsA[strings.TrimSpace(t)] = true
+		}
+		for j := i + 1; j < len(skillNodes); j++ {
+			if len(skillNodes[j].Tags) == 0 {
+				continue
+			}
+			// Skip pairs already connected by a stronger edge (same project).
+			if sameProjectPairs[nodePair{skillNodes[i].ID, skillNodes[j].ID}] {
+				continue
+			}
+			// Count shared tags.
+			var shared []string
+			for _, t := range skillNodes[j].Tags {
+				t = strings.TrimSpace(t)
+				if tagsA[t] {
+					shared = append(shared, t)
+				}
+			}
+			if len(shared) < 2 {
+				continue
+			}
+			maxLen := len(skillNodes[i].Tags)
+			if len(skillNodes[j].Tags) > maxLen {
+				maxLen = len(skillNodes[j].Tags)
+			}
+			weight := float64(len(shared)) / float64(maxLen)
+			if weight > 0.6 {
+				weight = 0.6
+			}
+			g.Edges = append(g.Edges, Edge{
+				Source:   skillNodes[i].ID,
+				Target:   skillNodes[j].ID,
+				Kind:     EdgeSimilarTo,
+				Weight:   weight,
+				Evidence: fmt.Sprintf("shared tags: %s", strings.Join(shared, ", ")),
+			})
+		}
+	}
+
+	// B-3: Colocated edges (colocated, weight 0.2).
+	// Pre-build a set of existing category-edge pairs to avoid duplicates.
+	categoryPairs := make(map[nodePair]bool)
+	for i := 0; i < len(skillNodes); i++ {
+		if skillNodes[i].Category == "" {
+			continue
+		}
+		for j := i + 1; j < len(skillNodes); j++ {
+			if skillNodes[j].Category == "" {
+				continue
+			}
+			if skillNodes[i].Category == skillNodes[j].Category {
+				categoryPairs[nodePair{skillNodes[i].ID, skillNodes[j].ID}] = true
+			}
+		}
+	}
+	for i := 0; i < len(skillNodes); i++ {
+		for j := i + 1; j < len(skillNodes); j++ {
+			if skillNodes[i].Project != skillNodes[j].Project {
+				continue
+			}
+			if skillNodes[i].SkillType != skillNodes[j].SkillType {
+				continue
+			}
+			// Skip if they already share a category edge.
+			if categoryPairs[nodePair{skillNodes[i].ID, skillNodes[j].ID}] {
+				continue
+			}
+			g.Edges = append(g.Edges, Edge{
+				Source:   skillNodes[i].ID,
+				Target:   skillNodes[j].ID,
+				Kind:     EdgeColocated,
+				Weight:   0.2,
+				Evidence: "same project + same type",
+			})
+		}
+	}
+
+	// Compute node degrees.
+	degreeMap := make(map[string]int)
+	for _, e := range g.Edges {
+		degreeMap[e.Source]++
+		degreeMap[e.Target]++
+	}
+	for i := range g.Nodes {
+		g.Nodes[i].Degree = degreeMap[g.Nodes[i].ID]
+	}
+
+	// Collect sorted filter lists.
+	g.Projects = sortedKeys(projectSet)
+	g.Categories = sortedKeys(categorySet)
+	g.Tags = sortedKeys(tagSet)
+	g.SkillTypes = sortedKeys(typeSet)
+
+	// Compute stats.
+	for _, n := range g.Nodes {
+		switch n.Kind {
+		case NodeSkill:
+			g.Stats.SkillNodes++
+		case NodeAgent:
+			g.Stats.AgentNodes++
+		case NodeSkillIndex:
+			g.Stats.SkillIndexNodes++
+		case NodeCommand:
+			g.Stats.CommandNodes++
+		case NodeProject:
+			g.Stats.ProjectNodes++
+		case NodeCategory:
+			g.Stats.CategoryNodes++
+		case NodeTag:
+			g.Stats.TagNodes++
+		}
+	}
+	g.Stats.TotalNodes = len(g.Nodes)
+	g.Stats.TotalEdges = len(g.Edges)
+
+	return g
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/skillctl/browse/graph.go
+++ b/pkg/skillctl/browse/graph.go
@@ -1,0 +1,86 @@
+// Package browse provides an interactive D3.js skill graph browser.
+package browse
+
+// NodeKind classifies nodes in the skill graph.
+type NodeKind string
+
+const (
+	NodeSkill      NodeKind = "skill"
+	NodeAgent      NodeKind = "agent"
+	NodeSkillIndex NodeKind = "skill_index"
+	NodeCommand    NodeKind = "command"
+	NodeProject    NodeKind = "project"
+	NodeCategory   NodeKind = "category"
+	NodeTag        NodeKind = "tag"
+)
+
+// IsContentNode returns true for skill-like nodes (skills, agents, commands, skill indexes).
+func (k NodeKind) IsContentNode() bool {
+	switch k {
+	case NodeSkill, NodeAgent, NodeSkillIndex, NodeCommand:
+		return true
+	}
+	return false
+}
+
+// EdgeKind classifies relationships between nodes.
+type EdgeKind string
+
+const (
+	EdgeBelongsTo  EdgeKind = "belongs_to"
+	EdgeTaggedWith EdgeKind = "tagged_with"
+	EdgeInCategory EdgeKind = "in_category"
+	EdgeDependsOn  EdgeKind = "depends_on"
+	EdgeSimilarTo  EdgeKind = "similar_to"
+	EdgeReferences EdgeKind = "references"
+	EdgeColocated  EdgeKind = "colocated"
+)
+
+// Node represents a vertex in the skill graph.
+type Node struct {
+	ID          string   `json:"id"`
+	Label       string   `json:"label"`
+	Kind        NodeKind `json:"kind"`
+	SkillType   string   `json:"skill_type,omitempty"`
+	Project     string   `json:"project,omitempty"`
+	Description string   `json:"description,omitempty"`
+	SizeBytes   int64    `json:"size_bytes,omitempty"`
+	SourcePath  string   `json:"source_path,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Category    string   `json:"category,omitempty"`
+	HasFM       bool     `json:"has_frontmatter"`
+	Degree      int      `json:"degree"`
+}
+
+// Edge represents a directed relationship between two nodes.
+type Edge struct {
+	Source   string   `json:"source"`
+	Target   string   `json:"target"`
+	Kind     EdgeKind `json:"kind"`
+	Weight   float64  `json:"weight"`
+	Evidence string   `json:"evidence,omitempty"`
+}
+
+// GraphStats provides summary metrics.
+type GraphStats struct {
+	TotalNodes      int `json:"total_nodes"`
+	SkillNodes      int `json:"skill_nodes"`
+	AgentNodes      int `json:"agent_nodes"`
+	SkillIndexNodes int `json:"skill_index_nodes"`
+	CommandNodes    int `json:"command_nodes"`
+	ProjectNodes    int `json:"project_nodes"`
+	CategoryNodes   int `json:"category_nodes"`
+	TagNodes        int `json:"tag_nodes"`
+	TotalEdges      int `json:"total_edges"`
+}
+
+// SkillGraph is the complete graph sent to the frontend.
+type SkillGraph struct {
+	Nodes      []Node     `json:"nodes"`
+	Edges      []Edge     `json:"edges"`
+	Stats      GraphStats `json:"stats"`
+	Projects   []string   `json:"projects"`
+	Categories []string   `json:"categories"`
+	Tags       []string   `json:"tags"`
+	SkillTypes []string   `json:"skill_types"`
+}

--- a/pkg/skillctl/browse/server.go
+++ b/pkg/skillctl/browse/server.go
@@ -1,0 +1,333 @@
+package browse
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+//go:embed ui.html
+var uiHTML []byte
+
+// Server serves the skill graph browser UI and API.
+type Server struct {
+	Addr      string
+	NoBrowser bool
+
+	mu    sync.RWMutex
+	graph *SkillGraph
+	inv   *model.Inventory
+	store *GraphStore
+	hash  string // current inventory hash for rebuild staleness check
+}
+
+// NewServer creates a browse server from a pre-built inventory.
+func NewServer(addr string, inv *model.Inventory) *Server {
+	if addr == "" {
+		addr = ":9116"
+	}
+	graph := BuildGraph(inv)
+	return &Server{
+		Addr:  addr,
+		graph: graph,
+		inv:   inv,
+	}
+}
+
+// NewServerWithCache creates a browse server using a pre-loaded graph and
+// an open GraphStore. The store is used by the /api/graph/rebuild endpoint
+// to persist refreshed graphs.
+func NewServerWithCache(addr string, inv *model.Inventory, graph *SkillGraph, store *GraphStore, inventoryHash string) *Server {
+	if addr == "" {
+		addr = ":9116"
+	}
+	return &Server{
+		Addr:  addr,
+		graph: graph,
+		inv:   inv,
+		store: store,
+		hash:  inventoryHash,
+	}
+}
+
+// Start registers routes and starts the HTTP server. Blocks until shutdown.
+func (s *Server) Start() error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleUI)
+	mux.HandleFunc("/api/graph", s.handleGraph)
+	mux.HandleFunc("/api/graph/filter", s.handleFilter)
+	mux.HandleFunc("/api/graph/search", s.handleSearch)
+	mux.HandleFunc("/api/graph/rebuild", s.handleRebuild)
+	mux.HandleFunc("/api/health", s.handleHealth)
+
+	host := s.Addr
+	if strings.HasPrefix(host, ":") {
+		host = "localhost" + host
+	}
+	url := "http://" + host
+
+	fmt.Fprintf(os.Stderr, "skillctl browse server listening on %s\n", url)
+
+	if !s.NoBrowser {
+		go func() {
+			time.Sleep(300 * time.Millisecond)
+			openBrowserURL(url)
+		}()
+	}
+
+	return http.ListenAndServe(s.Addr, mux)
+}
+
+func (s *Server) handleUI(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write(uiHTML)
+}
+
+func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s.mu.RLock()
+	g := s.graph
+	s.mu.RUnlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(g)
+}
+
+func (s *Server) handleFilter(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	q := r.URL.Query()
+	projects := splitParam(q.Get("project"))
+	types := splitParam(q.Get("type"))
+	categories := splitParam(q.Get("category"))
+	tags := splitParam(q.Get("tag"))
+
+	s.mu.RLock()
+	g := s.graph
+	s.mu.RUnlock()
+
+	filtered := filterGraph(g, projects, types, categories, tags)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(filtered)
+}
+
+func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	query := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("q")))
+	if query == "" {
+		http.Error(w, "missing q parameter", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.RLock()
+	g := s.graph
+	s.mu.RUnlock()
+
+	var matches []Node
+	for _, n := range g.Nodes {
+		if strings.Contains(strings.ToLower(n.Label), query) ||
+			strings.Contains(strings.ToLower(n.Description), query) {
+			matches = append(matches, n)
+		}
+	}
+	if matches == nil {
+		matches = []Node{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(matches)
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"status":"ok","service":"skillctl-browse"}`))
+}
+
+func (s *Server) handleRebuild(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.RLock()
+	inv := s.inv
+	s.mu.RUnlock()
+
+	if inv == nil {
+		http.Error(w, "no inventory loaded", http.StatusInternalServerError)
+		return
+	}
+
+	graph := BuildGraph(inv)
+
+	s.mu.Lock()
+	s.graph = graph
+	s.mu.Unlock()
+
+	// Persist to SQLite if a store is available.
+	if s.store != nil && s.hash != "" {
+		if err := s.store.SaveGraphWithHash(graph, s.hash); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to persist rebuilt graph: %v\n", err)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":     "rebuilt",
+		"node_count": len(graph.Nodes),
+		"edge_count": len(graph.Edges),
+	})
+}
+
+// filterGraph returns a subgraph with only matching skill nodes and their connections.
+func filterGraph(g *SkillGraph, projects, types, categories, tags []string) *SkillGraph {
+	if len(projects) == 0 && len(types) == 0 && len(categories) == 0 && len(tags) == 0 {
+		return g
+	}
+
+	// Determine which content nodes pass the filter.
+	keepSkills := make(map[string]bool)
+	for _, n := range g.Nodes {
+		if !n.Kind.IsContentNode() {
+			continue
+		}
+		if len(projects) > 0 && !contains(projects, n.Project) {
+			continue
+		}
+		if len(types) > 0 && !contains(types, n.SkillType) {
+			continue
+		}
+		if len(categories) > 0 && !contains(categories, n.Category) {
+			continue
+		}
+		if len(tags) > 0 && !hasAny(tags, n.Tags) {
+			continue
+		}
+		keepSkills[n.ID] = true
+	}
+
+	// Collect all nodes reachable from kept skills via edges.
+	keepNodes := make(map[string]bool)
+	for id := range keepSkills {
+		keepNodes[id] = true
+	}
+	var edges []Edge
+	for _, e := range g.Edges {
+		if keepSkills[e.Source] || keepSkills[e.Target] {
+			keepNodes[e.Source] = true
+			keepNodes[e.Target] = true
+			edges = append(edges, e)
+		}
+	}
+
+	var nodes []Node
+	for _, n := range g.Nodes {
+		if keepNodes[n.ID] {
+			nodes = append(nodes, n)
+		}
+	}
+	if nodes == nil {
+		nodes = []Node{}
+	}
+	if edges == nil {
+		edges = []Edge{}
+	}
+
+	fg := &SkillGraph{
+		Nodes:      nodes,
+		Edges:      edges,
+		Projects:   g.Projects,
+		Categories: g.Categories,
+		Tags:       g.Tags,
+		SkillTypes: g.SkillTypes,
+	}
+	for _, n := range nodes {
+		fg.Stats.TotalNodes++
+		switch n.Kind {
+		case NodeSkill:
+			fg.Stats.SkillNodes++
+		case NodeProject:
+			fg.Stats.ProjectNodes++
+		case NodeCategory:
+			fg.Stats.CategoryNodes++
+		case NodeTag:
+			fg.Stats.TagNodes++
+		}
+	}
+	fg.Stats.TotalEdges = len(edges)
+	return fg
+}
+
+func splitParam(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	var out []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func contains(list []string, val string) bool {
+	for _, v := range list {
+		if v == val {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAny(needles []string, haystack []string) bool {
+	for _, n := range needles {
+		for _, h := range haystack {
+			if n == h {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func openBrowserURL(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		return
+	}
+	cmd.Start()
+}

--- a/pkg/skillctl/browse/store.go
+++ b/pkg/skillctl/browse/store.go
@@ -1,0 +1,432 @@
+package browse
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/internal/dbdriver"
+)
+
+// DefaultGraphDBPath returns the default path for the skill graph database.
+func DefaultGraphDBPath() string {
+	if v := os.Getenv("M3C_SKILL_GRAPH_DB"); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".m3c-tools", "skill-graph.db")
+	}
+	return filepath.Join(home, ".m3c-tools", "skill-graph.db")
+}
+
+// GraphStore provides SQLite-backed persistence for the skill graph.
+type GraphStore struct {
+	db     *sql.DB
+	dbPath string
+}
+
+// OpenGraphStore opens or creates the skill graph database at the given path.
+func OpenGraphStore(dbPath string) (*GraphStore, error) {
+	dir := filepath.Dir(dbPath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("create db dir: %w", err)
+	}
+
+	db, err := sql.Open(dbdriver.DriverName(), dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+
+	s := &GraphStore{db: db, dbPath: dbPath}
+	if err := s.migrate(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate: %w", err)
+	}
+	return s, nil
+}
+
+// Close closes the database connection.
+func (s *GraphStore) Close() error {
+	return s.db.Close()
+}
+
+func (s *GraphStore) migrate() error {
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS graph_meta (
+			key   TEXT PRIMARY KEY,
+			value TEXT NOT NULL
+		);
+
+		CREATE TABLE IF NOT EXISTS nodes (
+			id          TEXT PRIMARY KEY,
+			label       TEXT NOT NULL,
+			kind        TEXT NOT NULL,
+			skill_type  TEXT DEFAULT '',
+			project     TEXT DEFAULT '',
+			description TEXT DEFAULT '',
+			size_bytes  INTEGER DEFAULT 0,
+			source_path TEXT DEFAULT '',
+			category    TEXT DEFAULT '',
+			has_fm      INTEGER DEFAULT 0,
+			degree      INTEGER DEFAULT 0
+		);
+
+		CREATE TABLE IF NOT EXISTS node_tags (
+			node_id TEXT NOT NULL,
+			tag     TEXT NOT NULL,
+			PRIMARY KEY (node_id, tag)
+		);
+
+		CREATE TABLE IF NOT EXISTS edges (
+			source   TEXT NOT NULL,
+			target   TEXT NOT NULL,
+			kind     TEXT NOT NULL,
+			weight   REAL DEFAULT 1.0,
+			evidence TEXT DEFAULT '',
+			PRIMARY KEY (source, target, kind)
+		);
+	`)
+	return err
+}
+
+// SaveGraph persists the full graph to SQLite, replacing any previous data.
+// All writes are wrapped in a single transaction.
+func (s *GraphStore) SaveGraph(g *SkillGraph) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Clear existing data.
+	for _, table := range []string{"edges", "node_tags", "nodes", "graph_meta"} {
+		if _, err := tx.Exec("DELETE FROM " + table); err != nil {
+			return fmt.Errorf("clear %s: %w", table, err)
+		}
+	}
+
+	// Insert nodes.
+	nodeStmt, err := tx.Prepare(`INSERT INTO nodes (id, label, kind, skill_type, project, description, size_bytes, source_path, category, has_fm, degree)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare node insert: %w", err)
+	}
+	defer nodeStmt.Close()
+
+	tagStmt, err := tx.Prepare(`INSERT OR IGNORE INTO node_tags (node_id, tag) VALUES (?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare tag insert: %w", err)
+	}
+	defer tagStmt.Close()
+
+	for _, n := range g.Nodes {
+		_, err := nodeStmt.Exec(n.ID, n.Label, string(n.Kind), n.SkillType, n.Project,
+			n.Description, n.SizeBytes, n.SourcePath, n.Category, boolToInt(n.HasFM), n.Degree)
+		if err != nil {
+			return fmt.Errorf("insert node %s: %w", n.ID, err)
+		}
+		for _, tag := range n.Tags {
+			if _, err := tagStmt.Exec(n.ID, tag); err != nil {
+				return fmt.Errorf("insert tag for %s: %w", n.ID, err)
+			}
+		}
+	}
+
+	// Insert edges.
+	edgeStmt, err := tx.Prepare(`INSERT OR IGNORE INTO edges (source, target, kind, weight, evidence)
+		VALUES (?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare edge insert: %w", err)
+	}
+	defer edgeStmt.Close()
+
+	for _, e := range g.Edges {
+		if _, err := edgeStmt.Exec(e.Source, e.Target, string(e.Kind), e.Weight, e.Evidence); err != nil {
+			return fmt.Errorf("insert edge %s->%s: %w", e.Source, e.Target, err)
+		}
+	}
+
+	// Write metadata.
+	metaStmt, err := tx.Prepare(`INSERT INTO graph_meta (key, value) VALUES (?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare meta insert: %w", err)
+	}
+	defer metaStmt.Close()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	meta := map[string]string{
+		"built_at":   now,
+		"node_count": strconv.Itoa(len(g.Nodes)),
+		"edge_count": strconv.Itoa(len(g.Edges)),
+	}
+	for k, v := range meta {
+		if _, err := metaStmt.Exec(k, v); err != nil {
+			return fmt.Errorf("insert meta %s: %w", k, err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// SaveGraphWithHash persists the graph and records the inventory hash for
+// staleness detection via IsStale.
+func (s *GraphStore) SaveGraphWithHash(g *SkillGraph, inventoryHash string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Clear existing data.
+	for _, table := range []string{"edges", "node_tags", "nodes", "graph_meta"} {
+		if _, err := tx.Exec("DELETE FROM " + table); err != nil {
+			return fmt.Errorf("clear %s: %w", table, err)
+		}
+	}
+
+	// Insert nodes.
+	nodeStmt, err := tx.Prepare(`INSERT INTO nodes (id, label, kind, skill_type, project, description, size_bytes, source_path, category, has_fm, degree)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare node insert: %w", err)
+	}
+	defer nodeStmt.Close()
+
+	tagStmt, err := tx.Prepare(`INSERT OR IGNORE INTO node_tags (node_id, tag) VALUES (?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare tag insert: %w", err)
+	}
+	defer tagStmt.Close()
+
+	for _, n := range g.Nodes {
+		_, err := nodeStmt.Exec(n.ID, n.Label, string(n.Kind), n.SkillType, n.Project,
+			n.Description, n.SizeBytes, n.SourcePath, n.Category, boolToInt(n.HasFM), n.Degree)
+		if err != nil {
+			return fmt.Errorf("insert node %s: %w", n.ID, err)
+		}
+		for _, tag := range n.Tags {
+			if _, err := tagStmt.Exec(n.ID, tag); err != nil {
+				return fmt.Errorf("insert tag for %s: %w", n.ID, err)
+			}
+		}
+	}
+
+	// Insert edges.
+	edgeStmt, err := tx.Prepare(`INSERT OR IGNORE INTO edges (source, target, kind, weight, evidence)
+		VALUES (?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare edge insert: %w", err)
+	}
+	defer edgeStmt.Close()
+
+	for _, e := range g.Edges {
+		if _, err := edgeStmt.Exec(e.Source, e.Target, string(e.Kind), e.Weight, e.Evidence); err != nil {
+			return fmt.Errorf("insert edge %s->%s: %w", e.Source, e.Target, err)
+		}
+	}
+
+	// Write metadata including inventory hash.
+	metaStmt, err := tx.Prepare(`INSERT INTO graph_meta (key, value) VALUES (?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare meta insert: %w", err)
+	}
+	defer metaStmt.Close()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	meta := map[string]string{
+		"inventory_hash": inventoryHash,
+		"built_at":       now,
+		"node_count":     strconv.Itoa(len(g.Nodes)),
+		"edge_count":     strconv.Itoa(len(g.Edges)),
+	}
+	for k, v := range meta {
+		if _, err := metaStmt.Exec(k, v); err != nil {
+			return fmt.Errorf("insert meta %s: %w", k, err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// LoadGraph reads the full graph from the database and recomputes stats
+// and filter lists. Returns nil if the database is empty.
+func (s *GraphStore) LoadGraph() (*SkillGraph, error) {
+	// Check whether we have any data.
+	var nodeCount int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM nodes").Scan(&nodeCount); err != nil {
+		return nil, fmt.Errorf("count nodes: %w", err)
+	}
+	if nodeCount == 0 {
+		return nil, nil
+	}
+
+	g := &SkillGraph{
+		Nodes: make([]Node, 0, nodeCount),
+		Edges: make([]Edge, 0),
+	}
+
+	// Load nodes.
+	rows, err := s.db.Query(`SELECT id, label, kind, skill_type, project, description,
+		size_bytes, source_path, category, has_fm, degree FROM nodes`)
+	if err != nil {
+		return nil, fmt.Errorf("query nodes: %w", err)
+	}
+	defer rows.Close()
+
+	nodeIndex := make(map[string]int) // node ID -> index in g.Nodes
+	for rows.Next() {
+		var n Node
+		var kind string
+		var hasFM int
+		if err := rows.Scan(&n.ID, &n.Label, &kind, &n.SkillType, &n.Project,
+			&n.Description, &n.SizeBytes, &n.SourcePath, &n.Category, &hasFM, &n.Degree); err != nil {
+			return nil, fmt.Errorf("scan node: %w", err)
+		}
+		n.Kind = NodeKind(kind)
+		n.HasFM = hasFM != 0
+		nodeIndex[n.ID] = len(g.Nodes)
+		g.Nodes = append(g.Nodes, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate nodes: %w", err)
+	}
+
+	// Load tags and attach to their nodes.
+	tagRows, err := s.db.Query(`SELECT node_id, tag FROM node_tags ORDER BY node_id, tag`)
+	if err != nil {
+		return nil, fmt.Errorf("query node_tags: %w", err)
+	}
+	defer tagRows.Close()
+
+	for tagRows.Next() {
+		var nodeID, tag string
+		if err := tagRows.Scan(&nodeID, &tag); err != nil {
+			return nil, fmt.Errorf("scan tag: %w", err)
+		}
+		if idx, ok := nodeIndex[nodeID]; ok {
+			g.Nodes[idx].Tags = append(g.Nodes[idx].Tags, tag)
+		}
+	}
+	if err := tagRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate tags: %w", err)
+	}
+
+	// Load edges.
+	edgeRows, err := s.db.Query(`SELECT source, target, kind, weight, evidence FROM edges`)
+	if err != nil {
+		return nil, fmt.Errorf("query edges: %w", err)
+	}
+	defer edgeRows.Close()
+
+	for edgeRows.Next() {
+		var e Edge
+		var kind string
+		if err := edgeRows.Scan(&e.Source, &e.Target, &kind, &e.Weight, &e.Evidence); err != nil {
+			return nil, fmt.Errorf("scan edge: %w", err)
+		}
+		e.Kind = EdgeKind(kind)
+		g.Edges = append(g.Edges, e)
+	}
+	if err := edgeRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate edges: %w", err)
+	}
+
+	// Recompute stats and filter lists from loaded data.
+	recomputeStats(g)
+
+	return g, nil
+}
+
+// IsStale returns true if the stored inventory hash differs from the given
+// hash, or if no graph has been persisted yet. This lets callers skip
+// expensive rebuilds when the inventory hasn't changed.
+func (s *GraphStore) IsStale(inventoryHash string) bool {
+	var stored string
+	err := s.db.QueryRow("SELECT value FROM graph_meta WHERE key = 'inventory_hash'").Scan(&stored)
+	if err != nil {
+		// No hash stored (empty DB or missing key) means stale.
+		return true
+	}
+	return stored != inventoryHash
+}
+
+// BuiltAt returns the timestamp when the graph was last persisted,
+// or the zero time if no graph has been saved.
+func (s *GraphStore) BuiltAt() time.Time {
+	var raw string
+	err := s.db.QueryRow("SELECT value FROM graph_meta WHERE key = 'built_at'").Scan(&raw)
+	if err != nil {
+		return time.Time{}
+	}
+	t, _ := time.Parse(time.RFC3339, raw)
+	return t
+}
+
+// recomputeStats rebuilds Stats, Projects, Categories, Tags, and SkillTypes
+// from the loaded node and edge data.
+func recomputeStats(g *SkillGraph) {
+	projectSet := make(map[string]bool)
+	categorySet := make(map[string]bool)
+	tagSet := make(map[string]bool)
+	typeSet := make(map[string]bool)
+
+	for _, n := range g.Nodes {
+		switch n.Kind {
+		case NodeSkill:
+			g.Stats.SkillNodes++
+			if n.SkillType != "" {
+				typeSet[n.SkillType] = true
+			}
+		case NodeProject:
+			g.Stats.ProjectNodes++
+		case NodeCategory:
+			g.Stats.CategoryNodes++
+		case NodeTag:
+			g.Stats.TagNodes++
+		}
+
+		if n.Project != "" {
+			projectSet[n.Project] = true
+		}
+		if n.Category != "" {
+			categorySet[n.Category] = true
+		}
+		for _, t := range n.Tags {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				tagSet[t] = true
+			}
+		}
+	}
+
+	g.Stats.TotalNodes = len(g.Nodes)
+	g.Stats.TotalEdges = len(g.Edges)
+
+	g.Projects = sortedKeysFromMap(projectSet)
+	g.Categories = sortedKeysFromMap(categorySet)
+	g.Tags = sortedKeysFromMap(tagSet)
+	g.SkillTypes = sortedKeysFromMap(typeSet)
+}
+
+// sortedKeysFromMap returns sorted keys from a bool map.
+func sortedKeysFromMap(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/pkg/skillctl/browse/ui.html
+++ b/pkg/skillctl/browse/ui.html
@@ -1,0 +1,1214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>skillctl — Skill Graph Browser</title>
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-muted: #8b949e;
+    --accent: #7c3aed;
+    --accent-light: #a78bfa;
+    --green: #3fb950;
+    --orange: #d29922;
+    --red: #f85149;
+    --cyan: #39d2c0;
+    --blue: #58a6ff;
+    --pink: #f778ba;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    overflow: hidden;
+    height: 100vh;
+  }
+
+  /* Header */
+  .header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.6rem 1.2rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    z-index: 10;
+    position: relative;
+  }
+  .header h1 {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--accent-light);
+    white-space: nowrap;
+  }
+  .header h1 span { color: var(--text-muted); font-weight: 400; }
+  .stat-chips {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .chip {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 0.15rem 0.6rem;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+  }
+  .chip strong { color: var(--accent-light); margin-right: 0.3rem; }
+  .chip.ref-chip strong { color: var(--red); }
+  .search-box {
+    margin-left: auto;
+    position: relative;
+  }
+  .search-box input {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    padding: 0.3rem 0.6rem 0.3rem 1.8rem;
+    font-size: 0.85rem;
+    width: 220px;
+    outline: none;
+  }
+  .search-box input:focus { border-color: var(--accent); }
+  .search-box::before {
+    content: '/';
+    position: absolute;
+    left: 0.6rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    pointer-events: none;
+  }
+
+  /* Filter bar */
+  .filter-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 1.2rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    font-size: 0.8rem;
+    flex-wrap: wrap;
+  }
+  .filter-bar label { color: var(--text-muted); }
+  .filter-bar select {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    padding: 0.2rem 0.4rem;
+    font-size: 0.8rem;
+    outline: none;
+  }
+  .filter-bar select:focus { border-color: var(--accent); }
+  .filter-btn {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    color: var(--text-muted);
+    padding: 0.15rem 0.5rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+  }
+  .filter-btn:hover { border-color: var(--accent); color: var(--text); }
+  .filter-btn.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+
+  /* Edge toggle buttons */
+  .edge-toggle {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    color: var(--text-muted);
+    padding: 0.1rem 0.4rem;
+    font-size: 0.65rem;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .edge-toggle:hover { border-color: var(--accent); color: var(--text); }
+  .edge-toggle.active { background: rgba(124, 58, 237, 0.3); color: var(--accent-light); border-color: var(--accent); }
+  .edge-toggle[data-edge="references"].active { background: rgba(248, 81, 73, 0.3); color: var(--red); border-color: var(--red); }
+
+  /* Graph canvas */
+  #graph-container {
+    width: 100%;
+    height: calc(100vh - 80px);
+    position: relative;
+  }
+  svg { width: 100%; height: 100%; }
+
+  /* Tooltip */
+  .tooltip {
+    position: absolute;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.5rem 0.7rem;
+    font-size: 0.8rem;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+    max-width: 320px;
+    z-index: 20;
+  }
+  .tooltip.visible { opacity: 1; }
+  .tooltip .tt-name { font-weight: 700; color: var(--accent-light); }
+  .tooltip .tt-kind { color: var(--text-muted); font-size: 0.7rem; }
+  .tooltip .tt-desc { margin-top: 0.3rem; color: var(--text-muted); font-size: 0.75rem; line-height: 1.4; }
+  .tooltip .tt-edges { margin-top: 0.3rem; font-size: 0.7rem; color: var(--text-muted); }
+  .tooltip .tt-edges span { color: var(--accent-light); }
+  .tooltip .tt-edges .ref-count { color: var(--red); }
+
+  /* Detail panel */
+  .detail-panel {
+    position: absolute;
+    top: 0;
+    right: -400px;
+    width: 380px;
+    height: 100%;
+    background: var(--surface);
+    border-left: 1px solid var(--border);
+    transition: right 0.25s ease;
+    z-index: 15;
+    overflow-y: auto;
+    padding: 1rem;
+  }
+  .detail-panel.open { right: 0; }
+  .detail-panel .close-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 1.2rem;
+    cursor: pointer;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .detail-panel .close-btn:hover { background: var(--bg); color: var(--text); }
+  .detail-panel h2 { font-size: 1.1rem; color: var(--accent-light); margin-bottom: 0.5rem; padding-right: 2rem; }
+  .detail-panel .badge {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    border-radius: 10px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    margin-right: 0.3rem;
+    margin-bottom: 0.3rem;
+  }
+  .detail-panel .meta-row {
+    margin: 0.5rem 0;
+    font-size: 0.85rem;
+  }
+  .detail-panel .meta-row .label { color: var(--text-muted); min-width: 70px; display: inline-block; }
+  .detail-panel .meta-row .value { color: var(--text); }
+  .detail-panel .desc {
+    margin: 0.8rem 0;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    white-space: pre-wrap;
+  }
+  .detail-panel .connections { margin-top: 1rem; }
+  .detail-panel .connections h3 { font-size: 0.85rem; color: var(--text-muted); margin-bottom: 0.4rem; }
+  .detail-panel .conn-item {
+    padding: 0.2rem 0;
+    font-size: 0.8rem;
+    cursor: pointer;
+    color: var(--blue);
+  }
+  .detail-panel .conn-item:hover { text-decoration: underline; }
+  .detail-panel .conn-kind { color: var(--text-muted); font-size: 0.7rem; margin-left: 0.3rem; }
+  .detail-panel .path {
+    margin-top: 0.5rem;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    word-break: break-all;
+    cursor: pointer;
+  }
+  .detail-panel .path:hover { color: var(--text); }
+
+  /* Legend */
+  .legend {
+    position: absolute;
+    bottom: 1rem;
+    left: 1rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.6rem 0.8rem;
+    font-size: 0.75rem;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .legend-item { display: flex; align-items: center; gap: 0.4rem; color: var(--text-muted); }
+  .legend-dot { width: 10px; height: 10px; border-radius: 50%; }
+  .legend-star { width: 12px; height: 12px; clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%); }
+  .legend-square { width: 10px; height: 10px; border-radius: 2px; }
+  .legend-triangle { width: 12px; height: 10px; clip-path: polygon(50% 0%, 100% 100%, 0% 100%); }
+  .legend-pentagon { width: 12px; height: 12px; clip-path: polygon(50% 0%, 100% 38%, 82% 100%, 18% 100%, 0% 38%); }
+  .legend-octagon { width: 12px; height: 12px; clip-path: polygon(30% 0%, 70% 0%, 100% 30%, 100% 70%, 70% 100%, 30% 100%, 0% 70%, 0% 30%); }
+  .legend-hex { width: 12px; height: 10px; clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%); }
+  .legend-diamond { width: 10px; height: 10px; transform: rotate(45deg); border-radius: 1px; }
+  .legend-rect { width: 14px; height: 8px; border-radius: 2px; }
+  .legend-line { width: 20px; height: 0; border-top: 2px solid; }
+  .legend-line.dashed { border-top-style: dashed; }
+  .legend-line.dotted { border-top-style: dotted; }
+
+  /* Node shapes in SVG */
+  .node-label {
+    fill: var(--text-muted);
+    font-size: 9px;
+    text-anchor: middle;
+    pointer-events: none;
+    user-select: none;
+  }
+  .node-label-small {
+    fill: var(--text-muted);
+    font-size: 7px;
+    text-anchor: middle;
+    pointer-events: none;
+    user-select: none;
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+  .edge-line {
+    stroke: var(--border);
+    stroke-opacity: 0.3;
+    fill: none;
+  }
+  .edge-hit-area {
+    stroke: transparent;
+    stroke-width: 10;
+    fill: none;
+    pointer-events: stroke;
+    cursor: pointer;
+  }
+
+  /* Edge tooltip */
+  .edge-tooltip {
+    position: absolute;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.4rem 0.6rem;
+    font-size: 0.75rem;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+    max-width: 280px;
+    z-index: 21;
+  }
+  .edge-tooltip.visible { opacity: 1; }
+  .edge-tooltip .et-kind { font-weight: 700; color: var(--accent-light); }
+  .edge-tooltip .et-weight { color: var(--text-muted); margin-left: 0.5rem; }
+  .edge-tooltip .et-evidence { margin-top: 0.25rem; color: var(--text-muted); font-size: 0.7rem; line-height: 1.3; }
+
+  /* Help overlay */
+  .help-overlay {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .help-overlay.hidden { display: none; }
+  .help-box {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1.5rem 2rem;
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 0.85rem;
+    color: var(--text);
+    min-width: 300px;
+  }
+  .help-box h3 {
+    color: var(--accent-light);
+    font-size: 1rem;
+    margin-bottom: 0.3rem;
+  }
+  .help-box .help-divider {
+    color: var(--border);
+    margin-bottom: 0.6rem;
+  }
+  .help-box .help-row {
+    display: flex;
+    gap: 1.5rem;
+    padding: 0.2rem 0;
+  }
+  .help-box .help-key {
+    color: var(--accent-light);
+    min-width: 40px;
+    text-align: right;
+  }
+  .help-box .help-desc {
+    color: var(--text-muted);
+  }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>skillctl <span>Skill Graph</span></h1>
+  <div class="stat-chips" id="stats"></div>
+  <div class="search-box">
+    <input type="text" id="search" placeholder="Search skills..." />
+  </div>
+  <button id="export-png" class="filter-btn" title="Export as PNG">PNG</button>
+</div>
+
+<div class="filter-bar" id="filter-bar">
+  <button class="filter-btn active" data-kind="all">All</button>
+  <button class="filter-btn" data-kind="skill">Skills</button>
+  <button class="filter-btn" data-kind="project">Projects</button>
+  <button class="filter-btn" data-kind="category">Categories</button>
+  <button class="filter-btn" data-kind="tag">Tags</button>
+  <span style="margin-left:0.5rem">|</span>
+  <label>Project</label>
+  <select id="f-project"><option value="">all</option></select>
+  <label>Type</label>
+  <select id="f-type"><option value="">all</option></select>
+  <span style="margin-left:0.5rem">|</span>
+  <label>Edges</label>
+  <button class="edge-toggle active" data-edge="belongs_to">belongs_to</button>
+  <button class="edge-toggle active" data-edge="in_category">category</button>
+  <button class="edge-toggle active" data-edge="tagged_with">tags</button>
+  <button class="edge-toggle active" data-edge="references">references</button>
+  <button class="edge-toggle active" data-edge="similar_to">similar</button>
+  <button class="edge-toggle" data-edge="colocated">colocated</button>
+</div>
+
+<div class="help-overlay hidden" id="help-overlay">
+  <div class="help-box">
+    <h3>Keyboard Shortcuts</h3>
+    <div class="help-divider">─────────────────</div>
+    <div class="help-row"><span class="help-key">/</span><span class="help-desc">Search</span></div>
+    <div class="help-row"><span class="help-key">Esc</span><span class="help-desc">Close panel</span></div>
+    <div class="help-row"><span class="help-key">r</span><span class="help-desc">Reset zoom</span></div>
+    <div class="help-row"><span class="help-key">e</span><span class="help-desc">Cycle edge presets</span></div>
+    <div class="help-row"><span class="help-key">1-5</span><span class="help-desc">Filter by kind</span></div>
+    <div class="help-row"><span class="help-key">?</span><span class="help-desc">Toggle this help</span></div>
+  </div>
+</div>
+
+<div id="graph-container">
+  <svg id="graph-svg"></svg>
+  <div class="tooltip" id="tooltip"></div>
+  <div class="edge-tooltip" id="edge-tooltip"></div>
+  <div class="detail-panel" id="detail-panel">
+    <button class="close-btn" id="close-detail">&times;</button>
+    <div id="detail-content"></div>
+  </div>
+  <div class="legend" id="legend"></div>
+</div>
+
+<script>
+const TYPE_COLORS = {
+  claude_code_skill: '#7c3aed',
+  skill_index: '#ffd93d',
+  command: '#3fb950',
+  agent: '#58a6ff',
+  mcp_server: '#f85149',
+  synthesis_template: '#39d2c0',
+};
+const TYPE_SHAPES = {
+  claude_code_skill: 'circle',
+  skill_index: 'star',
+  command: 'square',
+  agent: 'triangle',
+  mcp_server: 'pentagon',
+  synthesis_template: 'octagon',
+  // Also match by node kind (for agent/command/skill_index kinds)
+  skill: 'circle',
+};
+const KIND_COLORS = {
+  project: '#a78bfa',
+  category: '#8b949e',
+  tag: '#656d76',
+};
+
+// Edge type visual configuration
+const EDGE_STYLES = {
+  belongs_to:  { dash: null,    opacity: 0.2,  width: 1,   color: null },
+  tagged_with: { dash: '4 2',   opacity: 0.15, width: 0.8, color: null },
+  in_category: { dash: null,    opacity: 0.25, width: 1.5, color: null },
+  references:  { dash: null,    opacity: 0.4,  width: 1.5, color: '#f85149' },
+  similar_to:  { dash: '2 2',   opacity: 0.2,  width: 0.8, color: null },
+  colocated:   { dash: null,    opacity: 0.08, width: 0.5, color: null },
+};
+
+let graphData = null;
+let simulation = null;
+let activeFilter = 'all';
+let currentZoomScale = 1;
+
+// Track which edge types are visible
+let visibleEdgeTypes = new Set(['belongs_to', 'in_category', 'tagged_with', 'references', 'similar_to']);
+// Note: colocated is OFF by default
+
+async function init() {
+  const resp = await fetch('/api/graph');
+  graphData = await resp.json();
+  renderStats(graphData);
+  populateFilters(graphData);
+  renderLegend();
+  renderGraph(graphData);
+  setupSearch();
+  setupFilterButtons();
+  setupDropdowns();
+  setupEdgeToggles();
+  setupKeyboard();
+}
+
+function renderStats(data) {
+  const s = data.stats;
+  // Count references edges
+  const refCount = (data.edges || []).filter(e => e.kind === 'references').length;
+  document.getElementById('stats').innerHTML = `
+    <span class="chip"><strong>${s.total_nodes}</strong> nodes</span>
+    <span class="chip"><strong>${s.skill_nodes}</strong> skills</span>
+    <span class="chip"><strong>${s.agent_nodes || 0}</strong> agents</span>
+    <span class="chip"><strong>${s.project_nodes}</strong> projects</span>
+    <span class="chip"><strong>${s.total_edges}</strong> edges</span>
+    <span class="chip ref-chip"><strong>${refCount}</strong> references</span>
+  `;
+}
+
+function populateFilters(g) {
+  const fp = document.getElementById('f-project');
+  g.projects.forEach(p => { const o = document.createElement('option'); o.value = p; o.text = p; fp.add(o); });
+  const ft = document.getElementById('f-type');
+  g.skill_types.forEach(t => { const o = document.createElement('option'); o.value = t; o.text = t; ft.add(o); });
+}
+
+function renderLegend() {
+  const nodeItems = [
+    { shape: 'dot', color: TYPE_COLORS.claude_code_skill, label: 'Skill' },
+    { shape: 'star', color: TYPE_COLORS.skill_index, label: 'Skill Index' },
+    { shape: 'square', color: TYPE_COLORS.command, label: 'Command' },
+    { shape: 'triangle', color: TYPE_COLORS.agent, label: 'Agent' },
+    { shape: 'pentagon', color: TYPE_COLORS.mcp_server, label: 'MCP Server' },
+    { shape: 'octagon', color: TYPE_COLORS.synthesis_template, label: 'Synthesis' },
+    { shape: 'hex', color: KIND_COLORS.project, label: 'Project' },
+    { shape: 'rect', color: KIND_COLORS.category, label: 'Category' },
+    { shape: 'diamond', color: KIND_COLORS.tag, label: 'Tag' },
+  ];
+  const edgeItems = [
+    { style: 'solid', color: 'var(--border)', label: 'belongs_to' },
+    { style: 'solid', color: 'var(--border)', label: 'in_category', thick: true },
+    { style: 'dashed', color: 'var(--border)', label: 'tagged_with' },
+    { style: 'solid', color: '#f85149', label: 'references' },
+    { style: 'dotted', color: 'var(--border)', label: 'similar_to' },
+  ];
+
+  let html = nodeItems.map(i => `
+    <div class="legend-item">
+      <div class="legend-${i.shape}" style="background:${i.color}"></div>
+      <span>${i.label}</span>
+    </div>
+  `).join('');
+
+  html += '<div style="height:4px"></div>';
+
+  html += edgeItems.map(i => `
+    <div class="legend-item">
+      <div class="legend-line ${i.style === 'dashed' ? 'dashed' : i.style === 'dotted' ? 'dotted' : ''}" style="border-color:${i.color};${i.thick ? 'border-top-width:3px;' : ''}"></div>
+      <span>${i.label}</span>
+    </div>
+  `).join('');
+
+  document.getElementById('legend').innerHTML = html;
+}
+
+function nodeColor(d) {
+  // Content node kinds map directly to their type color.
+  if (d.kind === 'agent') return TYPE_COLORS.agent;
+  if (d.kind === 'skill_index') return TYPE_COLORS.skill_index;
+  if (d.kind === 'command') return TYPE_COLORS.command;
+  if (d.kind === 'skill') return TYPE_COLORS[d.skill_type] || '#7c3aed';
+  return KIND_COLORS[d.kind] || '#656d76';
+}
+
+function nodeRadius(d) {
+  if (d.kind === 'project') return 16 + Math.min(d.degree, 30) * 0.3;
+  if (d.kind === 'category') return 10;
+  if (d.kind === 'tag') return 6;
+  if (d.kind === 'agent') return Math.max(7, 4 + Math.sqrt(d.degree) * 2);
+  if (d.kind === 'skill_index') return Math.max(8, 5 + Math.sqrt(d.degree) * 2);
+  return Math.max(5, 3 + Math.sqrt(d.degree) * 2);
+}
+
+// Get edge breakdown for a node
+function getEdgeBreakdown(nodeId, edges) {
+  const counts = {};
+  edges.forEach(e => {
+    const s = typeof e.source === 'object' ? e.source.id : e.source;
+    const t = typeof e.target === 'object' ? e.target.id : e.target;
+    if (s === nodeId || t === nodeId) {
+      counts[e.kind] = (counts[e.kind] || 0) + 1;
+    }
+  });
+  return counts;
+}
+
+function renderGraph(data) {
+  const container = document.getElementById('graph-container');
+  const width = container.clientWidth;
+  const height = container.clientHeight;
+  const svg = d3.select('#graph-svg');
+  svg.selectAll('*').remove();
+
+  // SVG defs: glow filter for cluster highlighting
+  const defs = svg.append('defs');
+  const glowFilter = defs.append('filter').attr('id', 'glow');
+  glowFilter.append('feGaussianBlur').attr('stdDeviation', '3').attr('result', 'blur');
+  const glowMerge = glowFilter.append('feMerge');
+  glowMerge.append('feMergeNode').attr('in', 'blur');
+  glowMerge.append('feMergeNode').attr('in', 'SourceGraphic');
+
+  const g = svg.append('g');
+
+  // Zoom
+  const zoom = d3.zoom()
+    .scaleExtent([0.1, 6])
+    .on('zoom', (e) => {
+      g.attr('transform', e.transform);
+      currentZoomScale = e.transform.k;
+      // Fade in small labels when zoomed in past 1.5
+      g.selectAll('.node-label-small')
+        .attr('opacity', currentZoomScale >= 1.5 ? Math.min(1, (currentZoomScale - 1.5) / 0.5) : 0);
+    });
+  svg.call(zoom);
+
+  // Apply edge style based on kind
+  function applyEdgeStyle(selection) {
+    selection
+      .attr('stroke', d => {
+        const style = EDGE_STYLES[d.kind];
+        return style && style.color ? style.color : null;
+      })
+      .attr('stroke-dasharray', d => {
+        const style = EDGE_STYLES[d.kind];
+        return style && style.dash ? style.dash : null;
+      })
+      .attr('stroke-opacity', d => {
+        const style = EDGE_STYLES[d.kind];
+        return style ? style.opacity : 0.2;
+      })
+      .attr('stroke-width', d => {
+        const style = EDGE_STYLES[d.kind];
+        const base = style ? style.width : 1;
+        return Math.max(base, d.weight * base);
+      })
+      .style('display', d => visibleEdgeTypes.has(d.kind) ? null : 'none');
+  }
+
+  // Edges
+  const link = g.append('g')
+    .selectAll('line')
+    .data(data.edges)
+    .join('line')
+    .attr('class', 'edge-line');
+
+  applyEdgeStyle(link);
+
+  // Edge hit areas (invisible wide lines for hover detection)
+  const edgeTooltip = document.getElementById('edge-tooltip');
+  const linkHitArea = g.append('g')
+    .selectAll('line')
+    .data(data.edges)
+    .join('line')
+    .attr('class', 'edge-hit-area')
+    .style('display', d => visibleEdgeTypes.has(d.kind) ? null : 'none')
+    .on('mouseover', (e, d) => {
+      let html = `<span class="et-kind">${d.kind}</span><span class="et-weight">weight: ${d.weight}</span>`;
+      if (d.evidence) {
+        html += `<div class="et-evidence">${truncate(d.evidence, 150)}</div>`;
+      }
+      edgeTooltip.innerHTML = html;
+      edgeTooltip.classList.add('visible');
+      edgeTooltip.style.left = (e.pageX + 12) + 'px';
+      edgeTooltip.style.top = (e.pageY - 12) + 'px';
+    })
+    .on('mousemove', (e) => {
+      edgeTooltip.style.left = (e.pageX + 12) + 'px';
+      edgeTooltip.style.top = (e.pageY - 12) + 'px';
+    })
+    .on('mouseout', () => {
+      edgeTooltip.classList.remove('visible');
+    });
+
+  // Nodes
+  const node = g.append('g')
+    .selectAll('g')
+    .data(data.nodes)
+    .join('g')
+    .attr('cursor', 'pointer')
+    .call(d3.drag()
+      .on('start', dragStart)
+      .on('drag', dragging)
+      .on('end', dragEnd));
+
+  // Draw shapes per kind and type
+  node.each(function(d) {
+    const el = d3.select(this);
+    const r = nodeRadius(d);
+    const color = nodeColor(d);
+
+    if (d.kind === 'project') {
+      el.append('path').attr('d', polyPath(r, 6, Math.PI/6)).attr('fill', color).attr('fill-opacity', 0.7).attr('stroke', color).attr('stroke-width', 1.5);
+    } else if (d.kind === 'category') {
+      el.append('rect').attr('x', -r).attr('y', -r*0.6).attr('width', r*2).attr('height', r*1.2).attr('rx', 3).attr('fill', color).attr('fill-opacity', 0.6).attr('stroke', color).attr('stroke-width', 1);
+    } else if (d.kind === 'tag') {
+      el.append('rect').attr('x', -r).attr('y', -r).attr('width', r*2).attr('height', r*2).attr('rx', 1).attr('fill', color).attr('fill-opacity', 0.5).attr('stroke', color).attr('stroke-width', 0.5).attr('transform', 'rotate(45)');
+    } else {
+      // Content nodes (skill, agent, command, skill_index): shape by type
+      const shape = TYPE_SHAPES[d.skill_type] || TYPE_SHAPES[d.kind] || 'circle';
+      switch (shape) {
+        case 'star':
+          el.append('path').attr('d', starPath(r)).attr('fill', color).attr('fill-opacity', 0.7).attr('stroke', color).attr('stroke-width', 1.5);
+          break;
+        case 'square':
+          el.append('rect').attr('x', -r).attr('y', -r).attr('width', r*2).attr('height', r*2).attr('rx', 2).attr('fill', color).attr('fill-opacity', 0.7).attr('stroke', color).attr('stroke-width', 1.5);
+          break;
+        case 'triangle':
+          el.append('path').attr('d', polyPath(r, 3, -Math.PI/2)).attr('fill', color).attr('fill-opacity', 0.7).attr('stroke', color).attr('stroke-width', 1.5);
+          break;
+        case 'pentagon':
+          el.append('path').attr('d', polyPath(r, 5, -Math.PI/2)).attr('fill', color).attr('fill-opacity', 0.7).attr('stroke', color).attr('stroke-width', 1.5);
+          break;
+        case 'octagon':
+          el.append('path').attr('d', polyPath(r, 8, Math.PI/8)).attr('fill', color).attr('fill-opacity', 0.7).attr('stroke', color).attr('stroke-width', 1.5);
+          break;
+        default:
+          el.append('circle').attr('r', r).attr('fill', color).attr('fill-opacity', 0.7).attr('stroke', color).attr('stroke-width', 1.5);
+      }
+    }
+  });
+
+  // Labels: always-visible for project, category, and high-degree skills
+  node.filter(d => d.kind === 'project' || d.kind === 'category' || d.degree > 3)
+    .append('text')
+    .attr('class', 'node-label')
+    .attr('dy', d => nodeRadius(d) + 12)
+    .text(d => d.label.length > 20 ? d.label.slice(0, 18) + '...' : d.label);
+
+  // Small labels for ALL skill nodes (fade in on zoom > 1.5)
+  node.filter(d => d.kind === 'skill' && d.degree <= 3)
+    .append('text')
+    .attr('class', 'node-label-small')
+    .attr('dy', d => nodeRadius(d) + 10)
+    .attr('opacity', 0)
+    .text(d => d.label.length > 22 ? d.label.slice(0, 20) + '...' : d.label);
+
+  // Tooltip
+  const tooltip = document.getElementById('tooltip');
+  node.on('mouseover', (e, d) => {
+    // Get edge breakdown for this node
+    const breakdown = getEdgeBreakdown(d.id, data.edges);
+    const breakdownParts = Object.entries(breakdown).map(([kind, count]) => {
+      if (kind === 'references') return `<span class="ref-count">${count} ${kind}</span>`;
+      return `<span>${count} ${kind}</span>`;
+    });
+    const edgeInfo = breakdownParts.length > 0
+      ? `<div class="tt-edges">&rarr; ${breakdownParts.join(' | ')}</div>`
+      : '';
+
+    tooltip.innerHTML = `
+      <div class="tt-name">${d.label}</div>
+      <div class="tt-kind">${d.kind}${d.skill_type ? ' &middot; ' + d.skill_type : ''}</div>
+      ${d.description ? '<div class="tt-desc">' + truncate(d.description, 120) + '</div>' : ''}
+      ${edgeInfo}
+    `;
+    tooltip.classList.add('visible');
+    tooltip.style.left = (e.pageX + 12) + 'px';
+    tooltip.style.top = (e.pageY - 12) + 'px';
+
+    // Highlight connected
+    const connected = new Set();
+    connected.add(d.id);
+    data.edges.forEach(edge => {
+      if (edge.source.id === d.id || edge.source === d.id) connected.add(typeof edge.target === 'object' ? edge.target.id : edge.target);
+      if (edge.target.id === d.id || edge.target === d.id) connected.add(typeof edge.source === 'object' ? edge.source.id : edge.source);
+    });
+    node.style('opacity', n => connected.has(n.id) ? 1 : 0.1);
+    link.style('stroke-opacity', l => {
+      const s = typeof l.source === 'object' ? l.source.id : l.source;
+      const t = typeof l.target === 'object' ? l.target.id : l.target;
+      if (s === d.id || t === d.id) {
+        const style = EDGE_STYLES[l.kind];
+        return style ? Math.min(0.8, style.opacity * 2.5) : 0.6;
+      }
+      return 0.03;
+    });
+  })
+  .on('mousemove', (e) => {
+    tooltip.style.left = (e.pageX + 12) + 'px';
+    tooltip.style.top = (e.pageY - 12) + 'px';
+  })
+  .on('mouseout', () => {
+    tooltip.classList.remove('visible');
+    node.style('opacity', 1);
+    // Restore edge opacities based on their styles
+    link.each(function(d) {
+      const style = EDGE_STYLES[d.kind];
+      d3.select(this).style('stroke-opacity', style ? style.opacity : 0.2);
+    });
+  })
+  .on('click', (e, d) => {
+    e.stopPropagation();
+    showDetail(d, data);
+
+    // Cluster glow: when clicking a project node, highlight its skills
+    node.style('filter', null); // clear previous glow
+    if (d.kind === 'project') {
+      const clusterIds = new Set();
+      clusterIds.add(d.id);
+      data.edges.forEach(edge => {
+        const s = typeof edge.source === 'object' ? edge.source.id : edge.source;
+        const t = typeof edge.target === 'object' ? edge.target.id : edge.target;
+        if (edge.kind === 'belongs_to') {
+          if (t === d.id) clusterIds.add(s);
+          if (s === d.id) clusterIds.add(t);
+        }
+      });
+      node.style('filter', n => clusterIds.has(n.id) ? 'url(#glow)' : null);
+    }
+  });
+
+  // Click background to close panel and remove glow
+  svg.on('click', () => {
+    closeDetail();
+    node.style('filter', null);
+  });
+
+  // Store references on data for edge toggle and export access
+  data._link = link;
+  data._linkHitArea = linkHitArea;
+  data._applyEdgeStyle = applyEdgeStyle;
+
+  // Simulation
+  simulation = d3.forceSimulation(data.nodes)
+    .force('link', d3.forceLink(data.edges)
+      .id(d => d.id)
+      .distance(d => {
+        if (d.kind === 'belongs_to') return 50;
+        if (d.kind === 'in_category') return 80;
+        if (d.kind === 'tagged_with') return 100;
+        return 120;
+      })
+      .strength(d => d.weight * 0.2))
+    .force('charge', d3.forceManyBody()
+      .strength(d => d.kind === 'project' ? -300 : d.kind === 'category' ? -100 : -30))
+    .force('center', d3.forceCenter(width / 2, height / 2))
+    .force('collide', d3.forceCollide().radius(d => nodeRadius(d) + 3))
+    .on('tick', () => {
+      link
+        .attr('x1', d => d.source.x)
+        .attr('y1', d => d.source.y)
+        .attr('x2', d => d.target.x)
+        .attr('y2', d => d.target.y);
+      linkHitArea
+        .attr('x1', d => d.source.x)
+        .attr('y1', d => d.source.y)
+        .attr('x2', d => d.target.x)
+        .attr('y2', d => d.target.y);
+      node.attr('transform', d => `translate(${d.x},${d.y})`);
+    });
+
+  // Initial zoom to fit
+  setTimeout(() => {
+    const bounds = g.node().getBBox();
+    if (bounds.width > 0 && bounds.height > 0) {
+      const dx = bounds.width, dy = bounds.height;
+      const x = bounds.x + dx / 2, y = bounds.y + dy / 2;
+      const scale = 0.85 / Math.max(dx / width, dy / height);
+      const translate = [width / 2 - scale * x, height / 2 - scale * y];
+      svg.transition().duration(750)
+        .call(zoom.transform, d3.zoomIdentity.translate(translate[0], translate[1]).scale(scale));
+    }
+  }, 2000);
+
+  function dragStart(e, d) {
+    if (!e.active) simulation.alphaTarget(0.3).restart();
+    d.fx = d.x; d.fy = d.y;
+  }
+  function dragging(e, d) { d.fx = e.x; d.fy = e.y; }
+  function dragEnd(e, d) {
+    if (!e.active) simulation.alphaTarget(0);
+    d.fx = null; d.fy = null;
+  }
+}
+
+function polyPath(r, sides, offset) {
+  const a = (2 * Math.PI) / sides;
+  let pts = [];
+  for (let i = 0; i < sides; i++) {
+    pts.push([r * Math.cos(a * i + (offset || 0)), r * Math.sin(a * i + (offset || 0))]);
+  }
+  return 'M' + pts.map(p => p.join(',')).join('L') + 'Z';
+}
+
+function starPath(r) {
+  const pts = [];
+  for (let i = 0; i < 6; i++) {
+    const angle = (Math.PI / 3) * i - Math.PI / 2;
+    pts.push([r * Math.cos(angle), r * Math.sin(angle)]);
+    const inner = angle + Math.PI / 6;
+    pts.push([r * 0.5 * Math.cos(inner), r * 0.5 * Math.sin(inner)]);
+  }
+  return 'M' + pts.map(p => p.join(',')).join('L') + 'Z';
+}
+
+function truncate(s, n) {
+  if (!s) return '';
+  s = s.replace(/\n/g, ' ').trim();
+  return s.length > n ? s.slice(0, n) + '...' : s;
+}
+
+// Detail panel
+function showDetail(d, data) {
+  const panel = document.getElementById('detail-panel');
+  const content = document.getElementById('detail-content');
+
+  const kindBadge = `<span class="badge" style="background:${nodeColor(d)}33;color:${nodeColor(d)}">${d.kind}</span>`;
+  const typeBadge = d.skill_type ? `<span class="badge" style="background:${TYPE_COLORS[d.skill_type]}33;color:${TYPE_COLORS[d.skill_type]}">${d.skill_type}</span>` : '';
+
+  // Find connections
+  const connections = [];
+  data.edges.forEach(e => {
+    const s = typeof e.source === 'object' ? e.source.id : e.source;
+    const t = typeof e.target === 'object' ? e.target.id : e.target;
+    if (s === d.id) {
+      const target = data.nodes.find(n => n.id === t);
+      if (target) connections.push({ node: target, kind: e.kind, dir: 'out' });
+    }
+    if (t === d.id) {
+      const source = data.nodes.find(n => n.id === s);
+      if (source) connections.push({ node: source, kind: e.kind, dir: 'in' });
+    }
+  });
+
+  // Group connections by kind
+  const groups = {};
+  connections.forEach(c => {
+    if (!groups[c.kind]) groups[c.kind] = [];
+    groups[c.kind].push(c);
+  });
+
+  let connectionsHTML = '';
+  for (const [kind, conns] of Object.entries(groups)) {
+    connectionsHTML += `<h3>${kind} (${conns.length})</h3>`;
+    conns.forEach(c => {
+      connectionsHTML += `<div class="conn-item" data-id="${c.node.id}">${c.node.label}<span class="conn-kind">${c.node.kind}</span></div>`;
+    });
+  }
+
+  const tagsHTML = (d.tags || []).map(t =>
+    `<span class="badge" style="background:#656d7633;color:#656d76">${t}</span>`
+  ).join('');
+
+  content.innerHTML = `
+    <h2>${d.label}</h2>
+    <div>${kindBadge}${typeBadge}</div>
+    ${d.category ? `<div class="meta-row"><span class="label">Category</span><span class="value">${d.category}</span></div>` : ''}
+    ${d.project ? `<div class="meta-row"><span class="label">Project</span><span class="value">${d.project}</span></div>` : ''}
+    ${d.size_bytes ? `<div class="meta-row"><span class="label">Size</span><span class="value">${formatBytes(d.size_bytes)}</span></div>` : ''}
+    ${d.has_frontmatter !== undefined ? `<div class="meta-row"><span class="label">Frontmatter</span><span class="value">${d.has_frontmatter ? 'yes' : 'no'}</span></div>` : ''}
+    <div class="meta-row"><span class="label">Degree</span><span class="value">${d.degree} connections</span></div>
+    ${tagsHTML ? `<div style="margin-top:0.5rem">${tagsHTML}</div>` : ''}
+    ${d.description ? `<div class="desc">${d.description}</div>` : ''}
+    ${d.source_path ? `<div class="path" title="Click to copy">${d.source_path}</div>` : ''}
+    <div class="connections">${connectionsHTML}</div>
+  `;
+
+  // Wire up connection clicks
+  content.querySelectorAll('.conn-item').forEach(el => {
+    el.addEventListener('click', () => {
+      const target = data.nodes.find(n => n.id === el.dataset.id);
+      if (target) showDetail(target, data);
+    });
+  });
+
+  // Wire up path copy
+  const pathEl = content.querySelector('.path');
+  if (pathEl) {
+    pathEl.addEventListener('click', () => {
+      navigator.clipboard.writeText(d.source_path);
+      pathEl.style.color = '#3fb950';
+      setTimeout(() => pathEl.style.color = '', 1000);
+    });
+  }
+
+  panel.classList.add('open');
+}
+
+function closeDetail() {
+  document.getElementById('detail-panel').classList.remove('open');
+}
+
+function formatBytes(b) {
+  if (b >= 1024 * 1024) return (b / (1024 * 1024)).toFixed(1) + ' MB';
+  if (b >= 1024) return (b / 1024).toFixed(1) + ' KB';
+  return b + ' B';
+}
+
+// Search
+function setupSearch() {
+  const input = document.getElementById('search');
+  input.addEventListener('input', () => {
+    const q = input.value.toLowerCase().trim();
+    if (!q) {
+      d3.selectAll('#graph-svg g g').style('opacity', 1);
+      return;
+    }
+    d3.selectAll('#graph-svg g g').style('opacity', d => {
+      if (!d) return 1;
+      return (d.label && d.label.toLowerCase().includes(q)) ||
+             (d.description && d.description.toLowerCase().includes(q)) ? 1 : 0.08;
+    });
+  });
+}
+
+// Filter buttons (node kind)
+function setupFilterButtons() {
+  document.querySelectorAll('.filter-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      activeFilter = btn.dataset.kind;
+      applyVisibilityFilter();
+    });
+  });
+}
+
+function applyVisibilityFilter() {
+  d3.selectAll('#graph-svg g g').style('opacity', d => {
+    if (!d || activeFilter === 'all') return 1;
+    return d.kind === activeFilter ? 1 : 0.08;
+  });
+}
+
+// Edge toggle buttons
+function setupEdgeToggles() {
+  document.querySelectorAll('.edge-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const edgeType = btn.dataset.edge;
+      btn.classList.toggle('active');
+      if (btn.classList.contains('active')) {
+        visibleEdgeTypes.add(edgeType);
+      } else {
+        visibleEdgeTypes.delete(edgeType);
+      }
+      // Update edge visibility
+      updateEdgeVisibility();
+    });
+  });
+}
+
+function updateEdgeVisibility() {
+  d3.selectAll('#graph-svg .edge-line').each(function(d) {
+    const visible = visibleEdgeTypes.has(d.kind);
+    d3.select(this).style('display', visible ? null : 'none');
+  });
+  d3.selectAll('#graph-svg .edge-hit-area').each(function(d) {
+    const visible = visibleEdgeTypes.has(d.kind);
+    d3.select(this).style('display', visible ? null : 'none');
+  });
+}
+
+// Dropdown filters
+function setupDropdowns() {
+  document.getElementById('f-project').addEventListener('change', applyDropdownFilter);
+  document.getElementById('f-type').addEventListener('change', applyDropdownFilter);
+}
+
+async function applyDropdownFilter() {
+  const project = document.getElementById('f-project').value;
+  const type = document.getElementById('f-type').value;
+
+  if (!project && !type) {
+    // Reset to full graph
+    renderStats(graphData);
+    renderGraph(graphData);
+    return;
+  }
+
+  let url = '/api/graph/filter?';
+  if (project) url += 'project=' + encodeURIComponent(project) + '&';
+  if (type) url += 'type=' + encodeURIComponent(type);
+
+  const resp = await fetch(url);
+  const filtered = await resp.json();
+  renderStats(filtered);
+  renderGraph(filtered);
+}
+
+// Edge preset cycling
+const EDGE_PRESETS = [
+  { label: 'all on', types: ['belongs_to', 'in_category', 'tagged_with', 'references', 'similar_to', 'colocated'] },
+  { label: 'structural only', types: ['belongs_to', 'in_category'] },
+  { label: 'references only', types: ['references'] },
+  { label: 'all off', types: [] },
+];
+let edgePresetIndex = -1; // -1 means custom/manual state
+
+function cycleEdgePreset() {
+  edgePresetIndex = (edgePresetIndex + 1) % EDGE_PRESETS.length;
+  const preset = EDGE_PRESETS[edgePresetIndex];
+  visibleEdgeTypes = new Set(preset.types);
+  // Sync toggle buttons to match preset
+  document.querySelectorAll('.edge-toggle').forEach(btn => {
+    const edgeType = btn.dataset.edge;
+    if (visibleEdgeTypes.has(edgeType)) {
+      btn.classList.add('active');
+    } else {
+      btn.classList.remove('active');
+    }
+  });
+  updateEdgeVisibility();
+}
+
+// Help overlay
+function toggleHelp() {
+  const overlay = document.getElementById('help-overlay');
+  overlay.classList.toggle('hidden');
+}
+
+// Keyboard shortcuts
+function setupKeyboard() {
+  document.addEventListener('keydown', (e) => {
+    // Close help overlay on any key if open
+    const helpOverlay = document.getElementById('help-overlay');
+    if (!helpOverlay.classList.contains('hidden') && e.key !== '?') {
+      helpOverlay.classList.add('hidden');
+      if (e.key === 'Escape') return;
+    }
+
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') {
+      if (e.key === 'Escape') { e.target.blur(); closeDetail(); }
+      return;
+    }
+    switch (e.key) {
+      case '/':
+        e.preventDefault();
+        document.getElementById('search').focus();
+        break;
+      case 'Escape':
+        closeDetail();
+        break;
+      case 'r':
+        // Reset zoom
+        const svg = d3.select('#graph-svg');
+        svg.transition().duration(500).call(
+          d3.zoom().transform, d3.zoomIdentity
+        );
+        break;
+      case '?':
+        e.preventDefault();
+        toggleHelp();
+        break;
+      case 'e':
+        cycleEdgePreset();
+        break;
+      case '1': case '2': case '3': case '4': case '5': {
+        const kindMap = { '1': 'all', '2': 'skill', '3': 'project', '4': 'category', '5': 'tag' };
+        const kind = kindMap[e.key];
+        const btn = document.querySelector(`.filter-btn[data-kind="${kind}"]`);
+        if (btn) btn.click();
+        break;
+      }
+    }
+  });
+}
+
+document.getElementById('close-detail').addEventListener('click', closeDetail);
+
+// PNG export
+document.getElementById('export-png').addEventListener('click', () => {
+  const svgEl = document.getElementById('graph-svg');
+  const serializer = new XMLSerializer();
+  let svgString = serializer.serializeToString(svgEl);
+
+  // Inject computed styles for self-contained rendering
+  const styleString = `<style>
+    .edge-line { stroke: #30363d; fill: none; }
+    .edge-hit-area { display: none; }
+    .node-label { fill: #8b949e; font-size: 9px; text-anchor: middle; font-family: sans-serif; }
+    .node-label-small { fill: #8b949e; font-size: 7px; text-anchor: middle; font-family: sans-serif; }
+  </style>`;
+  svgString = svgString.replace('</svg>', styleString + '</svg>');
+
+  // Ensure SVG has width/height for rendering
+  const rect = svgEl.getBoundingClientRect();
+  const w = rect.width * 2;  // 2x for retina
+  const h = rect.height * 2;
+
+  if (!svgString.match(/xmlns="http:\/\/www\.w3\.org\/2000\/svg"/)) {
+    svgString = svgString.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
+  }
+
+  const blob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const img = new Image();
+
+  img.onload = () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+
+    // Fill background
+    ctx.fillStyle = '#0d1117';
+    ctx.fillRect(0, 0, w, h);
+
+    // Draw SVG
+    ctx.drawImage(img, 0, 0, w, h);
+    URL.revokeObjectURL(url);
+
+    // Trigger download
+    canvas.toBlob((pngBlob) => {
+      const pngUrl = URL.createObjectURL(pngBlob);
+      const a = document.createElement('a');
+      const date = new Date().toISOString().slice(0, 10);
+      a.download = `skill-graph-${date}.png`;
+      a.href = pngUrl;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(pngUrl);
+    }, 'image/png');
+  };
+
+  img.src = url;
+});
+
+// Close help overlay on background click
+document.getElementById('help-overlay').addEventListener('click', (e) => {
+  if (e.target === e.currentTarget) toggleHelp();
+});
+
+init();
+</script>
+</body>
+</html>

--- a/pkg/skillctl/consolidate/analyzer.go
+++ b/pkg/skillctl/consolidate/analyzer.go
@@ -1,0 +1,311 @@
+// Package consolidate analyzes a skill inventory for duplicates, orphans,
+// drift, and missing frontmatter — then optionally fixes annotation gaps.
+package consolidate
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/delta"
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// DuplicateGroup represents a set of skills sharing the same lowercased name.
+type DuplicateGroup struct {
+	Name      string
+	Instances []model.SkillDescriptor
+	Canonical *model.SkillDescriptor // recommended canonical (highest priority)
+	AllMatch  bool                   // true if all content hashes are identical
+}
+
+// OrphanSkill is a skill that lives outside any known git repository.
+type OrphanSkill struct {
+	Skill  model.SkillDescriptor
+	Reason string // "no git repo" or "user-global only"
+}
+
+// DriftPair describes a skill whose user-global copy diverged from the
+// project copy.
+type DriftPair struct {
+	SkillName string
+	Source    model.SkillDescriptor // project copy (canonical)
+	Copy     model.SkillDescriptor // user-global copy
+	Diff     string                // unified diff
+}
+
+// AnnotationGap flags a skill that lacks YAML frontmatter and suggests
+// category/tags based on its file path.
+type AnnotationGap struct {
+	Skill         model.SkillDescriptor
+	SuggestedName string
+	SuggestedCat  string
+	SuggestedTags []string
+}
+
+// Summary holds aggregate counts for the consolidation report.
+type Summary struct {
+	DuplicateGroups    int
+	TotalDuplicates    int
+	OrphanCount        int
+	DriftCount         int
+	MissingFrontmatter int
+}
+
+// ConsolidationReport is the complete output of the consolidation analysis.
+type ConsolidationReport struct {
+	AnalyzedAt      string
+	TotalSkills     int
+	DuplicateGroups []DuplicateGroup
+	Orphans         []OrphanSkill
+	DriftPairs      []DriftPair
+	AnnotationGaps  []AnnotationGap
+	Summary         Summary
+}
+
+// Analyze inspects an inventory for duplicates, orphans, drift, and
+// annotation gaps, returning a full consolidation report.
+func Analyze(inv *model.Inventory) *ConsolidationReport {
+	r := &ConsolidationReport{
+		AnalyzedAt:  time.Now().UTC().Format(time.RFC3339),
+		TotalSkills: inv.TotalCount,
+	}
+
+	r.DuplicateGroups = findDuplicates(inv)
+	r.Orphans = findOrphans(inv)
+	r.DriftPairs = findDrift(r.DuplicateGroups)
+	r.AnnotationGaps = findAnnotationGaps(inv)
+
+	// Compute summary.
+	totalDups := 0
+	for _, g := range r.DuplicateGroups {
+		totalDups += len(g.Instances)
+	}
+	r.Summary = Summary{
+		DuplicateGroups:    len(r.DuplicateGroups),
+		TotalDuplicates:    totalDups,
+		OrphanCount:        len(r.Orphans),
+		DriftCount:         len(r.DriftPairs),
+		MissingFrontmatter: len(r.AnnotationGaps),
+	}
+
+	return r
+}
+
+// findDuplicates groups skills by lowercased name and returns groups with 2+
+// entries. Within each group, the canonical skill is chosen by priority:
+// has frontmatter > in git repo > in project .claude/ > in user-global ~/.claude/.
+func findDuplicates(inv *model.Inventory) []DuplicateGroup {
+	groups := make(map[string][]model.SkillDescriptor)
+	for _, s := range inv.Skills {
+		key := strings.ToLower(s.Name)
+		groups[key] = append(groups[key], s)
+	}
+
+	var result []DuplicateGroup
+	for name, instances := range groups {
+		if len(instances) < 2 {
+			continue
+		}
+
+		g := DuplicateGroup{
+			Name:      name,
+			Instances: instances,
+		}
+
+		// Pick canonical by priority.
+		g.Canonical = pickCanonical(instances)
+
+		// Check if all content hashes match.
+		g.AllMatch = true
+		if len(instances) > 0 {
+			first := instances[0].ContentHash
+			for _, inst := range instances[1:] {
+				if inst.ContentHash != first {
+					g.AllMatch = false
+					break
+				}
+			}
+		}
+
+		result = append(result, g)
+	}
+	return result
+}
+
+// pickCanonical selects the best representative from a group of duplicates.
+// Priority: has frontmatter > known project (not "unknown") > project .claude/ > user-global.
+func pickCanonical(instances []model.SkillDescriptor) *model.SkillDescriptor {
+	best := &instances[0]
+	bestScore := canonicalScore(&instances[0])
+
+	for i := 1; i < len(instances); i++ {
+		s := canonicalScore(&instances[i])
+		if s > bestScore {
+			best = &instances[i]
+			bestScore = s
+		}
+	}
+	return best
+}
+
+// canonicalScore assigns a numeric priority to a skill descriptor for
+// canonical selection. Higher is better.
+func canonicalScore(s *model.SkillDescriptor) int {
+	score := 0
+	if s.HasYAMLFrontmatter {
+		score += 100
+	}
+	if s.SourceProject != "unknown" && s.SourceProject != "user-global" {
+		score += 50
+	}
+	if s.SourceProject != "unknown" {
+		score += 20
+	}
+	// Prefer project .claude/ over user-global.
+	if strings.Contains(s.SourcePath, "/.claude/") && s.SourceProject != "user-global" {
+		score += 10
+	}
+	return score
+}
+
+// findOrphans returns skills whose SourceProject is "unknown", meaning they
+// are not inside any recognized git repository.
+func findOrphans(inv *model.Inventory) []OrphanSkill {
+	var result []OrphanSkill
+	for _, s := range inv.Skills {
+		if s.SourceProject == "unknown" {
+			reason := "no git repo"
+			result = append(result, OrphanSkill{
+				Skill:  s,
+				Reason: reason,
+			})
+		}
+	}
+	return result
+}
+
+// findDrift looks through duplicate groups for pairs where one copy is in a
+// real project and another is in user-global, with differing content hashes.
+// It reads both files from disk and produces a unified diff.
+func findDrift(groups []DuplicateGroup) []DriftPair {
+	var result []DriftPair
+	for _, g := range groups {
+		// Collect user-global and project copies.
+		var globals []model.SkillDescriptor
+		var projects []model.SkillDescriptor
+		for _, inst := range g.Instances {
+			if inst.SourceProject == "user-global" {
+				globals = append(globals, inst)
+			} else if inst.SourceProject != "unknown" {
+				projects = append(projects, inst)
+			}
+		}
+
+		// For each global+project pair with differing hashes, generate a diff.
+		for _, gl := range globals {
+			for _, pr := range projects {
+				if gl.ContentHash == pr.ContentHash {
+					continue
+				}
+
+				diff := computeFileDiff(pr.SourcePath, gl.SourcePath)
+				result = append(result, DriftPair{
+					SkillName: g.Name,
+					Source:    pr,
+					Copy:     gl,
+					Diff:     diff,
+				})
+			}
+		}
+	}
+	return result
+}
+
+// computeFileDiff reads two files from disk and returns a unified diff.
+func computeFileDiff(sourcePath, copyPath string) string {
+	sourceData, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return "(could not read source: " + err.Error() + ")"
+	}
+	copyData, err := os.ReadFile(copyPath)
+	if err != nil {
+		return "(could not read copy: " + err.Error() + ")"
+	}
+	return delta.GenerateUnifiedDiff(
+		string(sourceData), string(copyData),
+		sourcePath, copyPath,
+	)
+}
+
+// findAnnotationGaps returns skills that lack YAML frontmatter and are not
+// skill index files, along with suggested annotations.
+func findAnnotationGaps(inv *model.Inventory) []AnnotationGap {
+	var result []AnnotationGap
+	for _, s := range inv.Skills {
+		if s.HasYAMLFrontmatter || s.Type == model.SkillTypeSkillIndex {
+			continue
+		}
+
+		cat, tags := suggestCategoryAndTags(s.SourcePath, s.Name)
+		result = append(result, AnnotationGap{
+			Skill:         s,
+			SuggestedName: s.Name,
+			SuggestedCat:  cat,
+			SuggestedTags: tags,
+		})
+	}
+	return result
+}
+
+// suggestCategoryAndTags infers a category and tag set from the skill's file
+// path and name using a keyword mapping.
+func suggestCategoryAndTags(path, name string) (string, []string) {
+	lp := strings.ToLower(path)
+	ln := strings.ToLower(name)
+	combined := lp + " " + ln
+
+	type rule struct {
+		keyword  string
+		category string
+		tag      string
+	}
+
+	rules := []rule{
+		{"deploy", "ops", "deploy"},
+		{"build", "ops", "build"},
+		{"release", "ops", "release"},
+		{"test", "quality", "test"},
+		{"review", "quality", "review"},
+		{"lint", "quality", "lint"},
+		{"check", "quality", "check"},
+		{"security", "security", "security"},
+		{"scan", "security", "scan"},
+		{"cohort", "education", "cohort"},
+		{"session", "education", "session"},
+		{"survey", "education", "survey"},
+	}
+
+	category := "uncategorized"
+	var tags []string
+	seen := make(map[string]bool)
+
+	for _, r := range rules {
+		if strings.Contains(combined, r.keyword) {
+			if category == "uncategorized" {
+				category = r.category
+			}
+			if !seen[r.tag] {
+				tags = append(tags, r.tag)
+				seen[r.tag] = true
+			}
+		}
+	}
+
+	// Always include the skill name as a tag if not already present.
+	if !seen[ln] {
+		tags = append(tags, ln)
+	}
+
+	return category, tags
+}

--- a/pkg/skillctl/consolidate/fixer.go
+++ b/pkg/skillctl/consolidate/fixer.go
@@ -1,0 +1,108 @@
+package consolidate
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// FixAnnotationGaps iterates over annotation gaps, generates frontmatter for
+// each, and prepends it to the file on disk. Returns the count of fixed and
+// skipped files.
+func FixAnnotationGaps(gaps []AnnotationGap) (fixed int, skipped int, err error) {
+	for _, gap := range gaps {
+		fm := generateFrontmatter(gap)
+		if err := prependFrontmatter(gap.Skill.SourcePath, fm); err != nil {
+			// Log the error but continue with the rest.
+			fmt.Fprintf(os.Stderr, "skipping %s: %v\n", gap.Skill.SourcePath, err)
+			skipped++
+			continue
+		}
+		fixed++
+	}
+	return fixed, skipped, nil
+}
+
+// generateFrontmatter builds a YAML frontmatter block from the annotation
+// gap's suggested values and the first meaningful line of the file content.
+func generateFrontmatter(gap AnnotationGap) string {
+	description := extractDescription(gap.Skill.SourcePath)
+
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString(fmt.Sprintf("name: %s\n", gap.SuggestedName))
+	b.WriteString("description: |\n")
+	b.WriteString(fmt.Sprintf("  %s\n", description))
+	b.WriteString("metadata:\n")
+	b.WriteString("  version: 1.0.0\n")
+	b.WriteString(fmt.Sprintf("  category: %s\n", gap.SuggestedCat))
+
+	// Format tags as a YAML flow sequence.
+	tagParts := make([]string, len(gap.SuggestedTags))
+	copy(tagParts, gap.SuggestedTags)
+	b.WriteString(fmt.Sprintf("  tags: [%s]\n", strings.Join(tagParts, ", ")))
+	b.WriteString("---\n")
+
+	return b.String()
+}
+
+// extractDescription reads the file at path and returns its first
+// non-empty, non-heading line as a short description.
+func extractDescription(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "No description available."
+	}
+
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		// Skip markdown headings and YAML frontmatter delimiters.
+		if strings.HasPrefix(trimmed, "#") || trimmed == "---" {
+			continue
+		}
+		// Clean up: remove leading markdown list markers.
+		trimmed = strings.TrimPrefix(trimmed, "- ")
+		trimmed = strings.TrimPrefix(trimmed, "* ")
+		// Limit length.
+		if len(trimmed) > 120 {
+			trimmed = trimmed[:120] + "..."
+		}
+		return trimmed
+	}
+
+	return "No description available."
+}
+
+// prependFrontmatter reads the file at path, prepends the frontmatter string,
+// and writes the result back to the same file.
+func prependFrontmatter(path string, fm string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	content := string(data)
+
+	// Safety check: do not prepend if the file already starts with frontmatter.
+	if strings.HasPrefix(strings.TrimSpace(content), "---") {
+		return fmt.Errorf("file already has frontmatter delimiter")
+	}
+
+	newContent := fm + "\n" + content
+
+	// Write back with the same permissions.
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	if err := os.WriteFile(path, []byte(newContent), info.Mode()); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+
+	return nil
+}

--- a/pkg/skillctl/consolidate/report.go
+++ b/pkg/skillctl/consolidate/report.go
@@ -1,0 +1,162 @@
+package consolidate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FormatTerminal renders a ConsolidationReport as readable terminal text.
+func FormatTerminal(r *ConsolidationReport) string {
+	var b strings.Builder
+
+	// Header.
+	b.WriteString(fmt.Sprintf("Skill Consolidation Report  %s\n\n", r.AnalyzedAt))
+
+	// Summary block.
+	b.WriteString("Summary:\n")
+	b.WriteString(fmt.Sprintf("  Duplicate groups:    %3d  (%d total copies)\n",
+		r.Summary.DuplicateGroups, r.Summary.TotalDuplicates))
+	b.WriteString(fmt.Sprintf("  Orphan skills:       %3d  (not in any git repo)\n",
+		r.Summary.OrphanCount))
+	b.WriteString(fmt.Sprintf("  Drifted copies:      %3d  (user-global differs from source)\n",
+		r.Summary.DriftCount))
+	b.WriteString(fmt.Sprintf("  Missing frontmatter: %3d  (need annotation)\n",
+		r.Summary.MissingFrontmatter))
+
+	// Duplicates section.
+	b.WriteString(fmt.Sprintf("\n--- Duplicates (%d groups) ---\n", r.Summary.DuplicateGroups))
+	for _, g := range r.DuplicateGroups {
+		b.WriteString(fmt.Sprintf("  %s (%d copies)\n", g.Name, len(g.Instances)))
+		for _, inst := range g.Instances {
+			marker := " "
+			suffix := ""
+
+			isCanonical := g.Canonical != nil && inst.ID == g.Canonical.ID
+			if isCanonical {
+				marker = "*"
+				suffix = "  [canonical"
+				if inst.HasYAMLFrontmatter {
+					suffix += ", has FM"
+				}
+				suffix += "]"
+			} else {
+				// Show whether this copy matches the canonical.
+				if g.Canonical != nil && inst.ContentHash == g.Canonical.ContentHash {
+					suffix = "  (identical)"
+				} else {
+					suffix = "  (content differs)"
+				}
+			}
+
+			b.WriteString(fmt.Sprintf("    %s %s%s\n", marker, inst.SourcePath, suffix))
+		}
+	}
+
+	// Orphans section.
+	b.WriteString(fmt.Sprintf("\n--- Orphans (%d skills) ---\n", r.Summary.OrphanCount))
+	for _, o := range r.Orphans {
+		b.WriteString(fmt.Sprintf("  %s  (%s)  %s\n", o.Skill.Name, o.Skill.Type, o.Skill.SourcePath))
+	}
+
+	// Drift section.
+	b.WriteString(fmt.Sprintf("\n--- Drift (%d pairs) ---\n", r.Summary.DriftCount))
+	for _, d := range r.DriftPairs {
+		b.WriteString(fmt.Sprintf("  %s: user-global vs %s (content differs)\n",
+			d.SkillName, d.Source.SourceProject))
+	}
+
+	// Annotation gaps section.
+	b.WriteString(fmt.Sprintf("\n--- Annotation Gaps (%d skills) ---\n", r.Summary.MissingFrontmatter))
+	for _, ag := range r.AnnotationGaps {
+		tagStr := strings.Join(ag.SuggestedTags, ", ")
+		b.WriteString(fmt.Sprintf("  %s (%s)  %s\n", ag.Skill.Name, ag.Skill.Type, ag.Skill.SourceProject))
+		b.WriteString(fmt.Sprintf("    suggested: category=%s, tags=[%s]\n", ag.SuggestedCat, tagStr))
+	}
+
+	return b.String()
+}
+
+// FormatMarkdown renders a ConsolidationReport as Markdown suitable for
+// writing to a file.
+func FormatMarkdown(r *ConsolidationReport) string {
+	var b strings.Builder
+
+	b.WriteString("# Skill Consolidation Report\n\n")
+	b.WriteString(fmt.Sprintf("Analyzed at: %s\n\n", r.AnalyzedAt))
+	b.WriteString(fmt.Sprintf("Total skills: %d\n\n", r.TotalSkills))
+
+	// Summary table.
+	b.WriteString("## Summary\n\n")
+	b.WriteString("| Metric | Count |\n|--------|-------|\n")
+	b.WriteString(fmt.Sprintf("| Duplicate groups | %d |\n", r.Summary.DuplicateGroups))
+	b.WriteString(fmt.Sprintf("| Total duplicates | %d |\n", r.Summary.TotalDuplicates))
+	b.WriteString(fmt.Sprintf("| Orphan skills | %d |\n", r.Summary.OrphanCount))
+	b.WriteString(fmt.Sprintf("| Drifted copies | %d |\n", r.Summary.DriftCount))
+	b.WriteString(fmt.Sprintf("| Missing frontmatter | %d |\n", r.Summary.MissingFrontmatter))
+
+	// Duplicates.
+	b.WriteString(fmt.Sprintf("\n## Duplicates (%d groups)\n\n", r.Summary.DuplicateGroups))
+	for _, g := range r.DuplicateGroups {
+		allMatch := ""
+		if g.AllMatch {
+			allMatch = " (all identical)"
+		}
+		b.WriteString(fmt.Sprintf("### %s (%d copies)%s\n\n", g.Name, len(g.Instances), allMatch))
+		b.WriteString("| Path | Project | Hash | Canonical |\n|------|---------|------|-----------|\n")
+		for _, inst := range g.Instances {
+			canonical := ""
+			if g.Canonical != nil && inst.ID == g.Canonical.ID {
+				canonical = "yes"
+			}
+			hash := inst.ContentHash
+			if len(hash) > 12 {
+				hash = hash[:12]
+			}
+			b.WriteString(fmt.Sprintf("| `%s` | %s | %s | %s |\n",
+				inst.SourcePath, inst.SourceProject, hash, canonical))
+		}
+		b.WriteString("\n")
+	}
+
+	// Orphans.
+	b.WriteString(fmt.Sprintf("## Orphans (%d skills)\n\n", r.Summary.OrphanCount))
+	if len(r.Orphans) > 0 {
+		b.WriteString("| Skill | Type | Path | Reason |\n|-------|------|------|--------|\n")
+		for _, o := range r.Orphans {
+			b.WriteString(fmt.Sprintf("| %s | %s | `%s` | %s |\n",
+				o.Skill.Name, o.Skill.Type, o.Skill.SourcePath, o.Reason))
+		}
+		b.WriteString("\n")
+	}
+
+	// Drift.
+	b.WriteString(fmt.Sprintf("## Drift (%d pairs)\n\n", r.Summary.DriftCount))
+	for _, d := range r.DriftPairs {
+		b.WriteString(fmt.Sprintf("### %s\n\n", d.SkillName))
+		b.WriteString(fmt.Sprintf("- **Source**: `%s` (%s)\n", d.Source.SourcePath, d.Source.SourceProject))
+		b.WriteString(fmt.Sprintf("- **Copy**: `%s` (user-global)\n\n", d.Copy.SourcePath))
+		if d.Diff != "" {
+			b.WriteString("```diff\n")
+			b.WriteString(d.Diff)
+			if !strings.HasSuffix(d.Diff, "\n") {
+				b.WriteString("\n")
+			}
+			b.WriteString("```\n\n")
+		}
+	}
+
+	// Annotation gaps.
+	b.WriteString(fmt.Sprintf("## Annotation Gaps (%d skills)\n\n", r.Summary.MissingFrontmatter))
+	if len(r.AnnotationGaps) > 0 {
+		b.WriteString("| Skill | Type | Project | Suggested Category | Suggested Tags |\n")
+		b.WriteString("|-------|------|---------|-------------------|----------------|\n")
+		for _, ag := range r.AnnotationGaps {
+			tagStr := strings.Join(ag.SuggestedTags, ", ")
+			b.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s |\n",
+				ag.Skill.Name, ag.Skill.Type, ag.Skill.SourceProject,
+				ag.SuggestedCat, tagStr))
+		}
+	}
+
+	return b.String()
+}

--- a/pkg/skillctl/delta/delta.go
+++ b/pkg/skillctl/delta/delta.go
@@ -1,0 +1,363 @@
+// Package delta computes differences between two skill inventories and
+// provides seal/baseline management for tracking skill changes over time.
+package delta
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// DeltaType classifies a change between two inventory snapshots.
+type DeltaType string
+
+const (
+	DeltaAdded    DeltaType = "added"
+	DeltaModified DeltaType = "modified"
+	DeltaRemoved  DeltaType = "removed"
+	DeltaMoved    DeltaType = "moved"
+)
+
+// ReviewStatus tracks human review state for a delta entry.
+type ReviewStatus string
+
+const (
+	ReviewPending  ReviewStatus = "pending"
+	ReviewApproved ReviewStatus = "approved"
+	ReviewRejected ReviewStatus = "rejected"
+	ReviewDeferred ReviewStatus = "deferred"
+)
+
+// DeltaEntry describes a single change between two inventory snapshots.
+type DeltaEntry struct {
+	SkillID             string             `json:"skill_id"`
+	SkillName           string             `json:"skill_name"`
+	DeltaType           DeltaType          `json:"delta_type"`
+	BaselineHash        string             `json:"baseline_hash,omitempty"`
+	CurrentHash         string             `json:"current_hash,omitempty"`
+	BaselinePath        string             `json:"baseline_path,omitempty"`
+	CurrentPath         string             `json:"current_path,omitempty"`
+	BaselineFrontmatter *model.Frontmatter `json:"baseline_frontmatter,omitempty"`
+	CurrentFrontmatter  *model.Frontmatter `json:"current_frontmatter,omitempty"`
+	BaselineContent     string             `json:"baseline_content,omitempty"`
+	CurrentContent      string             `json:"current_content,omitempty"`
+	ContentDiff         string             `json:"content_diff"`
+	ReviewStatus        ReviewStatus       `json:"review_status"`
+	ReviewedBy          string             `json:"reviewed_by,omitempty"`
+	ReviewedAt          string             `json:"reviewed_at,omitempty"`
+}
+
+// DeltaReport holds the full result of comparing two inventories.
+type DeltaReport struct {
+	ComputedAt   string       `json:"computed_at"`
+	BaselinePath string       `json:"baseline_path"`
+	CurrentPath  string       `json:"current_path"`
+	Entries      []DeltaEntry `json:"entries"`
+	Summary      DeltaSummary `json:"summary"`
+}
+
+// DeltaSummary provides aggregate counts of changes.
+type DeltaSummary struct {
+	Added    int `json:"added"`
+	Modified int `json:"modified"`
+	Removed  int `json:"removed"`
+	Moved    int `json:"moved"`
+	Total    int `json:"total"`
+}
+
+// ComputeDelta compares two inventories and returns a report of all changes.
+// Skills are matched by ID (source_project/name). The algorithm also detects
+// moves: a removed+added pair where the content hash is the same but the
+// source path differs.
+func ComputeDelta(baseline, current *model.Inventory) *DeltaReport {
+	report := &DeltaReport{
+		ComputedAt: time.Now().UTC().Format(time.RFC3339),
+		Entries:    make([]DeltaEntry, 0),
+	}
+
+	// Index both inventories by skill ID.
+	baseMap := make(map[string]*model.SkillDescriptor, len(baseline.Skills))
+	for i := range baseline.Skills {
+		baseMap[baseline.Skills[i].ID] = &baseline.Skills[i]
+	}
+	currMap := make(map[string]*model.SkillDescriptor, len(current.Skills))
+	for i := range current.Skills {
+		currMap[current.Skills[i].ID] = &current.Skills[i]
+	}
+
+	// Track removed and added entries for move detection.
+	var removed []DeltaEntry
+	var added []DeltaEntry
+
+	// Find removed and modified skills.
+	for id, base := range baseMap {
+		curr, exists := currMap[id]
+		if !exists {
+			removed = append(removed, DeltaEntry{
+				SkillID:             id,
+				SkillName:           base.Name,
+				DeltaType:           DeltaRemoved,
+				BaselineHash:        base.ContentHash,
+				BaselinePath:        base.SourcePath,
+				BaselineFrontmatter: base.Frontmatter,
+				ReviewStatus:        ReviewPending,
+			})
+			continue
+		}
+		// Skill exists in both — check for modifications.
+		if base.ContentHash != curr.ContentHash {
+			diff := GenerateUnifiedDiff(base.ContentHash, curr.ContentHash,
+				fmt.Sprintf("baseline:%s", id), fmt.Sprintf("current:%s", id))
+
+			entry := DeltaEntry{
+				SkillID:             id,
+				SkillName:           curr.Name,
+				DeltaType:           DeltaModified,
+				BaselineHash:        base.ContentHash,
+				CurrentHash:         curr.ContentHash,
+				BaselinePath:        base.SourcePath,
+				CurrentPath:         curr.SourcePath,
+				BaselineFrontmatter: base.Frontmatter,
+				CurrentFrontmatter:  curr.Frontmatter,
+				ContentDiff:         diff,
+				ReviewStatus:        ReviewPending,
+			}
+			report.Entries = append(report.Entries, entry)
+		}
+	}
+
+	// Find added skills.
+	for id, curr := range currMap {
+		if _, exists := baseMap[id]; !exists {
+			added = append(added, DeltaEntry{
+				SkillID:            id,
+				SkillName:          curr.Name,
+				DeltaType:          DeltaAdded,
+				CurrentHash:        curr.ContentHash,
+				CurrentPath:        curr.SourcePath,
+				CurrentFrontmatter: curr.Frontmatter,
+				ReviewStatus:       ReviewPending,
+			})
+		}
+	}
+
+	// Detect moves: match removed+added pairs with the same content hash.
+	// A move is when a skill changed ID (project/name) but the content is identical.
+	movedRemovedIdx := make(map[int]bool)
+	movedAddedIdx := make(map[int]bool)
+
+	for ri, rem := range removed {
+		if movedRemovedIdx[ri] || rem.BaselineHash == "" {
+			continue
+		}
+		for ai, add := range added {
+			if movedAddedIdx[ai] || add.CurrentHash == "" {
+				continue
+			}
+			if rem.BaselineHash == add.CurrentHash {
+				// Same content, different ID — this is a move.
+				entry := DeltaEntry{
+					SkillID:             add.SkillID,
+					SkillName:           add.SkillName,
+					DeltaType:           DeltaMoved,
+					BaselineHash:        rem.BaselineHash,
+					CurrentHash:         add.CurrentHash,
+					BaselinePath:        rem.BaselinePath,
+					CurrentPath:         add.CurrentPath,
+					BaselineFrontmatter: rem.BaselineFrontmatter,
+					CurrentFrontmatter:  add.CurrentFrontmatter,
+					ContentDiff:         fmt.Sprintf("moved: %s -> %s", rem.BaselinePath, add.CurrentPath),
+					ReviewStatus:        ReviewPending,
+				}
+				report.Entries = append(report.Entries, entry)
+				movedRemovedIdx[ri] = true
+				movedAddedIdx[ai] = true
+				break
+			}
+		}
+	}
+
+	// Append remaining (non-moved) removed and added entries.
+	for i, entry := range removed {
+		if !movedRemovedIdx[i] {
+			report.Entries = append(report.Entries, entry)
+		}
+	}
+	for i, entry := range added {
+		if !movedAddedIdx[i] {
+			report.Entries = append(report.Entries, entry)
+		}
+	}
+
+	// Compute summary.
+	for _, e := range report.Entries {
+		switch e.DeltaType {
+		case DeltaAdded:
+			report.Summary.Added++
+		case DeltaModified:
+			report.Summary.Modified++
+		case DeltaRemoved:
+			report.Summary.Removed++
+		case DeltaMoved:
+			report.Summary.Moved++
+		}
+	}
+	report.Summary.Total = len(report.Entries)
+
+	return report
+}
+
+// GenerateUnifiedDiff produces a unified-diff-style string comparing two
+// text blocks. It performs a simple line-by-line comparison with context.
+func GenerateUnifiedDiff(oldContent, newContent, oldLabel, newLabel string) string {
+	oldLines := splitLines(oldContent)
+	newLines := splitLines(newContent)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "--- %s\n", oldLabel)
+	fmt.Fprintf(&b, "+++ %s\n", newLabel)
+
+	// Use a simple LCS-based diff to produce +/- hunks.
+	lcs := computeLCS(oldLines, newLines)
+	oi, ni, li := 0, 0, 0
+
+	for oi < len(oldLines) || ni < len(newLines) {
+		if li < len(lcs) && oi < len(oldLines) && ni < len(newLines) &&
+			oldLines[oi] == lcs[li] && newLines[ni] == lcs[li] {
+			// Common line.
+			fmt.Fprintf(&b, " %s\n", oldLines[oi])
+			oi++
+			ni++
+			li++
+		} else {
+			// Output removed lines from old until we hit the next LCS line.
+			for oi < len(oldLines) && (li >= len(lcs) || oldLines[oi] != lcs[li]) {
+				fmt.Fprintf(&b, "-%s\n", oldLines[oi])
+				oi++
+			}
+			// Output added lines from new until we hit the next LCS line.
+			for ni < len(newLines) && (li >= len(lcs) || newLines[ni] != lcs[li]) {
+				fmt.Fprintf(&b, "+%s\n", newLines[ni])
+				ni++
+			}
+		}
+	}
+
+	return b.String()
+}
+
+// splitLines splits text into lines, preserving empty trailing entries
+// only when the input is non-empty.
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	lines := strings.Split(s, "\n")
+	// Remove trailing empty element from a trailing newline.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// computeLCS returns the longest common subsequence of two string slices.
+func computeLCS(a, b []string) []string {
+	m, n := len(a), len(b)
+	// Build the LCS length table.
+	dp := make([][]int, m+1)
+	for i := range dp {
+		dp[i] = make([]int, n+1)
+	}
+	for i := 1; i <= m; i++ {
+		for j := 1; j <= n; j++ {
+			if a[i-1] == b[j-1] {
+				dp[i][j] = dp[i-1][j-1] + 1
+			} else if dp[i-1][j] >= dp[i][j-1] {
+				dp[i][j] = dp[i-1][j]
+			} else {
+				dp[i][j] = dp[i][j-1]
+			}
+		}
+	}
+	// Backtrack to find the LCS.
+	lcs := make([]string, 0, dp[m][n])
+	i, j := m, n
+	for i > 0 && j > 0 {
+		if a[i-1] == b[j-1] {
+			lcs = append(lcs, a[i-1])
+			i--
+			j--
+		} else if dp[i-1][j] >= dp[i][j-1] {
+			i--
+		} else {
+			j--
+		}
+	}
+	// Reverse.
+	for left, right := 0, len(lcs)-1; left < right; left, right = left+1, right-1 {
+		lcs[left], lcs[right] = lcs[right], lcs[left]
+	}
+	return lcs
+}
+
+// FormatSummary returns a human-readable summary string for a delta report.
+func FormatSummary(r *DeltaReport) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Delta Report  %s\n", r.ComputedAt)
+	fmt.Fprintf(&b, "  Baseline: %s\n", r.BaselinePath)
+	fmt.Fprintf(&b, "  Current:  %s\n", r.CurrentPath)
+	fmt.Fprintf(&b, "  Changes:  %d total\n", r.Summary.Total)
+	fmt.Fprintf(&b, "    Added:    %d\n", r.Summary.Added)
+	fmt.Fprintf(&b, "    Modified: %d\n", r.Summary.Modified)
+	fmt.Fprintf(&b, "    Removed:  %d\n", r.Summary.Removed)
+	fmt.Fprintf(&b, "    Moved:    %d\n", r.Summary.Moved)
+	return b.String()
+}
+
+// FormatMarkdown returns a Markdown-formatted delta report.
+func FormatMarkdown(r *DeltaReport) string {
+	var b strings.Builder
+	b.WriteString("# Skill Delta Report\n\n")
+	b.WriteString(fmt.Sprintf("Computed at: %s\n\n", r.ComputedAt))
+	b.WriteString("## Summary\n\n")
+	b.WriteString("| Change | Count |\n|--------|-------|\n")
+	b.WriteString(fmt.Sprintf("| Added | %d |\n", r.Summary.Added))
+	b.WriteString(fmt.Sprintf("| Modified | %d |\n", r.Summary.Modified))
+	b.WriteString(fmt.Sprintf("| Removed | %d |\n", r.Summary.Removed))
+	b.WriteString(fmt.Sprintf("| Moved | %d |\n", r.Summary.Moved))
+	b.WriteString(fmt.Sprintf("| **Total** | **%d** |\n", r.Summary.Total))
+
+	if len(r.Entries) == 0 {
+		b.WriteString("\nNo changes detected.\n")
+		return b.String()
+	}
+
+	b.WriteString("\n## Changes\n\n")
+	b.WriteString("| Skill | Type | Detail |\n|-------|------|--------|\n")
+	for _, e := range r.Entries {
+		detail := ""
+		switch e.DeltaType {
+		case DeltaAdded:
+			detail = e.CurrentPath
+		case DeltaRemoved:
+			detail = e.BaselinePath
+		case DeltaModified:
+			bh := e.BaselineHash
+			ch := e.CurrentHash
+			if len(bh) > 8 {
+				bh = bh[:8]
+			}
+			if len(ch) > 8 {
+				ch = ch[:8]
+			}
+			detail = fmt.Sprintf("%s -> %s", bh, ch)
+		case DeltaMoved:
+			detail = fmt.Sprintf("%s -> %s", e.BaselinePath, e.CurrentPath)
+		}
+		b.WriteString(fmt.Sprintf("| %s | %s | %s |\n", e.SkillName, e.DeltaType, detail))
+	}
+
+	return b.String()
+}

--- a/pkg/skillctl/delta/delta_test.go
+++ b/pkg/skillctl/delta/delta_test.go
@@ -1,0 +1,314 @@
+package delta
+
+import (
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// makeInventory is a helper to build an Inventory from skill descriptors.
+func makeInventory(skills ...model.SkillDescriptor) *model.Inventory {
+	inv := &model.Inventory{
+		ScannedAt: "2026-04-02T10:00:00Z",
+		ScanPaths: []string{"/tmp/test"},
+		Skills:    skills,
+		ByType:    make(map[string]int),
+		ByProject: make(map[string]int),
+	}
+	inv.TotalCount = len(skills)
+	return inv
+}
+
+func skill(id, name, hash, path string) model.SkillDescriptor {
+	return model.SkillDescriptor{
+		ID:            id,
+		Name:          name,
+		ContentHash:   hash,
+		SourcePath:    path,
+		SourceProject: "test-project",
+		Type:          model.SkillTypeClaudeCodeSkill,
+		Dependencies:  []string{},
+		ConflictsWith: []string{},
+	}
+}
+
+func TestAddedSkillsDetected(t *testing.T) {
+	baseline := makeInventory(
+		skill("proj/alpha", "alpha", "hash-a", "/skills/alpha.md"),
+	)
+	current := makeInventory(
+		skill("proj/alpha", "alpha", "hash-a", "/skills/alpha.md"),
+		skill("proj/beta", "beta", "hash-b", "/skills/beta.md"),
+	)
+
+	report := ComputeDelta(baseline, current)
+
+	if report.Summary.Added != 1 {
+		t.Errorf("added = %d, want 1", report.Summary.Added)
+	}
+	if report.Summary.Total != 1 {
+		t.Errorf("total = %d, want 1", report.Summary.Total)
+	}
+
+	found := false
+	for _, e := range report.Entries {
+		if e.DeltaType == DeltaAdded && e.SkillID == "proj/beta" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("added entry for proj/beta not found")
+	}
+}
+
+func TestRemovedSkillsDetected(t *testing.T) {
+	baseline := makeInventory(
+		skill("proj/alpha", "alpha", "hash-a", "/skills/alpha.md"),
+		skill("proj/beta", "beta", "hash-b", "/skills/beta.md"),
+	)
+	current := makeInventory(
+		skill("proj/alpha", "alpha", "hash-a", "/skills/alpha.md"),
+	)
+
+	report := ComputeDelta(baseline, current)
+
+	if report.Summary.Removed != 1 {
+		t.Errorf("removed = %d, want 1", report.Summary.Removed)
+	}
+
+	found := false
+	for _, e := range report.Entries {
+		if e.DeltaType == DeltaRemoved && e.SkillID == "proj/beta" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("removed entry for proj/beta not found")
+	}
+}
+
+func TestModifiedSkillsDetected(t *testing.T) {
+	baseline := makeInventory(
+		skill("proj/alpha", "alpha", "hash-a-v1", "/skills/alpha.md"),
+	)
+	current := makeInventory(
+		skill("proj/alpha", "alpha", "hash-a-v2", "/skills/alpha.md"),
+	)
+
+	report := ComputeDelta(baseline, current)
+
+	if report.Summary.Modified != 1 {
+		t.Errorf("modified = %d, want 1", report.Summary.Modified)
+	}
+
+	found := false
+	for _, e := range report.Entries {
+		if e.DeltaType == DeltaModified && e.SkillID == "proj/alpha" {
+			found = true
+			if e.BaselineHash != "hash-a-v1" {
+				t.Errorf("baseline hash = %q, want %q", e.BaselineHash, "hash-a-v1")
+			}
+			if e.CurrentHash != "hash-a-v2" {
+				t.Errorf("current hash = %q, want %q", e.CurrentHash, "hash-a-v2")
+			}
+		}
+	}
+	if !found {
+		t.Error("modified entry for proj/alpha not found")
+	}
+}
+
+func TestMovedSkillsDetected(t *testing.T) {
+	// Same content hash but different ID means the skill was moved/renamed.
+	baseline := makeInventory(
+		skill("proj/old-name", "old-name", "hash-same", "/skills/old.md"),
+	)
+	current := makeInventory(
+		skill("proj/new-name", "new-name", "hash-same", "/skills/new.md"),
+	)
+
+	report := ComputeDelta(baseline, current)
+
+	if report.Summary.Moved != 1 {
+		t.Errorf("moved = %d, want 1", report.Summary.Moved)
+	}
+	// Should not have separate added/removed entries.
+	if report.Summary.Added != 0 {
+		t.Errorf("added = %d, want 0 (should be detected as move)", report.Summary.Added)
+	}
+	if report.Summary.Removed != 0 {
+		t.Errorf("removed = %d, want 0 (should be detected as move)", report.Summary.Removed)
+	}
+
+	found := false
+	for _, e := range report.Entries {
+		if e.DeltaType == DeltaMoved {
+			found = true
+			if e.BaselinePath != "/skills/old.md" {
+				t.Errorf("baseline path = %q, want %q", e.BaselinePath, "/skills/old.md")
+			}
+			if e.CurrentPath != "/skills/new.md" {
+				t.Errorf("current path = %q, want %q", e.CurrentPath, "/skills/new.md")
+			}
+		}
+	}
+	if !found {
+		t.Error("moved entry not found")
+	}
+}
+
+func TestNoChangesProducesEmptyDelta(t *testing.T) {
+	skills := []model.SkillDescriptor{
+		skill("proj/alpha", "alpha", "hash-a", "/skills/alpha.md"),
+		skill("proj/beta", "beta", "hash-b", "/skills/beta.md"),
+	}
+	baseline := makeInventory(skills...)
+	current := makeInventory(skills...)
+
+	report := ComputeDelta(baseline, current)
+
+	if report.Summary.Total != 0 {
+		t.Errorf("total = %d, want 0 for identical inventories", report.Summary.Total)
+	}
+	if len(report.Entries) != 0 {
+		t.Errorf("entries = %d, want 0", len(report.Entries))
+	}
+}
+
+func TestMixedChanges(t *testing.T) {
+	baseline := makeInventory(
+		skill("proj/stable", "stable", "hash-s", "/skills/stable.md"),
+		skill("proj/changed", "changed", "hash-c-v1", "/skills/changed.md"),
+		skill("proj/deleted", "deleted", "hash-d", "/skills/deleted.md"),
+		skill("proj/old-loc", "old-loc", "hash-move", "/old/path.md"),
+	)
+	current := makeInventory(
+		skill("proj/stable", "stable", "hash-s", "/skills/stable.md"),
+		skill("proj/changed", "changed", "hash-c-v2", "/skills/changed.md"),
+		skill("proj/new-skill", "new-skill", "hash-n", "/skills/new.md"),
+		skill("proj/new-loc", "new-loc", "hash-move", "/new/path.md"),
+	)
+
+	report := ComputeDelta(baseline, current)
+
+	if report.Summary.Added != 1 {
+		t.Errorf("added = %d, want 1", report.Summary.Added)
+	}
+	if report.Summary.Modified != 1 {
+		t.Errorf("modified = %d, want 1", report.Summary.Modified)
+	}
+	if report.Summary.Removed != 1 {
+		t.Errorf("removed = %d, want 1", report.Summary.Removed)
+	}
+	if report.Summary.Moved != 1 {
+		t.Errorf("moved = %d, want 1", report.Summary.Moved)
+	}
+	if report.Summary.Total != 4 {
+		t.Errorf("total = %d, want 4", report.Summary.Total)
+	}
+}
+
+func TestEmptyInventories(t *testing.T) {
+	baseline := makeInventory()
+	current := makeInventory()
+
+	report := ComputeDelta(baseline, current)
+
+	if report.Summary.Total != 0 {
+		t.Errorf("total = %d, want 0", report.Summary.Total)
+	}
+}
+
+func TestGenerateUnifiedDiff(t *testing.T) {
+	old := "line1\nline2\nline3\n"
+	new := "line1\nline2-modified\nline3\nline4\n"
+
+	diff := GenerateUnifiedDiff(old, new, "a/file", "b/file")
+
+	if diff == "" {
+		t.Error("diff should not be empty")
+	}
+	// Should contain diff markers.
+	if !containsStr(diff, "---") {
+		t.Error("diff missing --- marker")
+	}
+	if !containsStr(diff, "+++") {
+		t.Error("diff missing +++ marker")
+	}
+	if !containsStr(diff, "-line2") {
+		t.Error("diff missing removed line")
+	}
+	if !containsStr(diff, "+line2-modified") {
+		t.Error("diff missing added line")
+	}
+}
+
+func TestGenerateUnifiedDiffIdentical(t *testing.T) {
+	content := "line1\nline2\n"
+	diff := GenerateUnifiedDiff(content, content, "a", "b")
+
+	// Should only contain header and context lines — no actual +/- diff lines.
+	// The headers (--- and +++) are expected; we check for non-header +/- lines.
+	lines := splitLines(diff)
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		if line[0] == '-' && !containsStr(line, "--- ") {
+			t.Errorf("unexpected removed line in identical diff: %q", line)
+		}
+		if line[0] == '+' && !containsStr(line, "+++ ") {
+			t.Errorf("unexpected added line in identical diff: %q", line)
+		}
+	}
+}
+
+func TestFormatSummary(t *testing.T) {
+	report := &DeltaReport{
+		ComputedAt:   "2026-04-02T10:00:00Z",
+		BaselinePath: "baseline.json",
+		CurrentPath:  "current.json",
+		Summary: DeltaSummary{
+			Added: 2, Modified: 1, Removed: 1, Moved: 0, Total: 4,
+		},
+	}
+
+	s := FormatSummary(report)
+	if !containsStr(s, "Added:    2") {
+		t.Error("summary missing added count")
+	}
+	if !containsStr(s, "Modified: 1") {
+		t.Error("summary missing modified count")
+	}
+}
+
+func TestFormatMarkdown(t *testing.T) {
+	report := &DeltaReport{
+		ComputedAt: "2026-04-02T10:00:00Z",
+		Entries: []DeltaEntry{
+			{SkillID: "p/a", SkillName: "a", DeltaType: DeltaAdded, CurrentPath: "/new.md"},
+		},
+		Summary: DeltaSummary{Added: 1, Total: 1},
+	}
+
+	md := FormatMarkdown(report)
+	if !containsStr(md, "# Skill Delta Report") {
+		t.Error("markdown missing title")
+	}
+	if !containsStr(md, "| Added | 1 |") {
+		t.Error("markdown missing added count")
+	}
+}
+
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && findSubstring(s, sub))
+}
+
+func findSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/skillctl/delta/seal.go
+++ b/pkg/skillctl/delta/seal.go
@@ -1,0 +1,189 @@
+package delta
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// SealRecord captures metadata about a sealed inventory baseline.
+type SealRecord struct {
+	SealID        string `json:"seal_id"`
+	SealedAt      string `json:"sealed_at"`
+	SealedBy      string `json:"sealed_by"`
+	SkillCount    int    `json:"skill_count"`
+	Approved      int    `json:"approved"`
+	Rejected      int    `json:"rejected"`
+	Deferred      int    `json:"deferred"`
+	InventoryHash string `json:"inventory_hash"`
+	InventoryPath string `json:"inventory_path"`
+}
+
+// SealStore manages persisted seal records and their associated inventories.
+type SealStore struct {
+	BaseDir string // defaults to ~/.m3c-tools/skill-seals/
+}
+
+// NewSealStore creates a SealStore with the default directory
+// (~/.m3c-tools/skill-seals/), creating it if needed.
+func NewSealStore() (*SealStore, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	dir := filepath.Join(home, ".m3c-tools", "skill-seals")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating seal store directory: %w", err)
+	}
+	return &SealStore{BaseDir: dir}, nil
+}
+
+// NewSealStoreAt creates a SealStore at a specific directory (useful for testing).
+func NewSealStoreAt(dir string) (*SealStore, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating seal store directory: %w", err)
+	}
+	return &SealStore{BaseDir: dir}, nil
+}
+
+// Seal persists an inventory as a sealed baseline. It writes both the
+// inventory JSON and a SealRecord JSON to the store directory.
+func (s *SealStore) Seal(inventory *model.Inventory, sealedBy string) (*SealRecord, error) {
+	now := time.Now().UTC()
+	ts := now.Format("20060102T150405.000Z")
+
+	// Serialize the inventory.
+	invData, err := json.MarshalIndent(inventory, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling inventory: %w", err)
+	}
+
+	// Compute hash of the inventory JSON.
+	h := sha256.Sum256(invData)
+	invHash := hex.EncodeToString(h[:])
+
+	// Write inventory file.
+	invPath := filepath.Join(s.BaseDir, fmt.Sprintf("inventory-%s.json", ts))
+	if err := os.WriteFile(invPath, invData, 0o644); err != nil {
+		return nil, fmt.Errorf("writing inventory: %w", err)
+	}
+
+	// Build seal record.
+	record := &SealRecord{
+		SealID:        fmt.Sprintf("seal-%s", ts),
+		SealedAt:      now.Format("2006-01-02T15:04:05.000Z07:00"),
+		SealedBy:      sealedBy,
+		SkillCount:    len(inventory.Skills),
+		InventoryHash: invHash,
+		InventoryPath: invPath,
+	}
+
+	// Write seal record.
+	sealData, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling seal record: %w", err)
+	}
+	sealPath := filepath.Join(s.BaseDir, fmt.Sprintf("seal-%s.json", ts))
+	if err := os.WriteFile(sealPath, sealData, 0o644); err != nil {
+		return nil, fmt.Errorf("writing seal record: %w", err)
+	}
+
+	return record, nil
+}
+
+// LatestSeal returns the most recent seal record and its associated inventory.
+// Returns nil, nil, nil if no seals exist.
+func (s *SealStore) LatestSeal() (*SealRecord, *model.Inventory, error) {
+	seals, err := s.ListSeals()
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(seals) == 0 {
+		return nil, nil, nil
+	}
+
+	latest := seals[len(seals)-1]
+	inv, err := s.loadInventory(latest.InventoryPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading inventory for seal %s: %w", latest.SealID, err)
+	}
+	return &latest, inv, nil
+}
+
+// ListSeals returns all seal records sorted by timestamp (oldest first).
+func (s *SealStore) ListSeals() ([]SealRecord, error) {
+	entries, err := os.ReadDir(s.BaseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading seal store: %w", err)
+	}
+
+	var seals []SealRecord
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), "seal-") || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		// Skip inventory files.
+		if strings.HasPrefix(e.Name(), "seal-") && !strings.Contains(e.Name(), "inventory") {
+			path := filepath.Join(s.BaseDir, e.Name())
+			data, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			var record SealRecord
+			if err := json.Unmarshal(data, &record); err != nil {
+				continue
+			}
+			seals = append(seals, record)
+		}
+	}
+
+	// Sort by SealedAt timestamp.
+	sort.Slice(seals, func(i, j int) bool {
+		return seals[i].SealedAt < seals[j].SealedAt
+	})
+
+	return seals, nil
+}
+
+// GetSeal loads a specific seal by its ID.
+func (s *SealStore) GetSeal(sealID string) (*SealRecord, *model.Inventory, error) {
+	seals, err := s.ListSeals()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, seal := range seals {
+		if seal.SealID == sealID {
+			inv, err := s.loadInventory(seal.InventoryPath)
+			if err != nil {
+				return nil, nil, fmt.Errorf("loading inventory for seal %s: %w", sealID, err)
+			}
+			return &seal, inv, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("seal %q not found", sealID)
+}
+
+// loadInventory reads and parses an inventory JSON file.
+func (s *SealStore) loadInventory(path string) (*model.Inventory, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading inventory file: %w", err)
+	}
+	var inv model.Inventory
+	if err := json.Unmarshal(data, &inv); err != nil {
+		return nil, fmt.Errorf("parsing inventory JSON: %w", err)
+	}
+	return &inv, nil
+}

--- a/pkg/skillctl/delta/seal_test.go
+++ b/pkg/skillctl/delta/seal_test.go
@@ -1,0 +1,253 @@
+package delta
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+func testInventory(skills ...model.SkillDescriptor) *model.Inventory {
+	return &model.Inventory{
+		ScannedAt:  "2026-04-02T10:00:00Z",
+		ScanPaths:  []string{"/tmp/test"},
+		Skills:     skills,
+		TotalCount: len(skills),
+		ByType:     map[string]int{},
+		ByProject:  map[string]int{},
+	}
+}
+
+func TestSealCreatesFiles(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSealStoreAt(dir)
+	if err != nil {
+		t.Fatalf("NewSealStoreAt: %v", err)
+	}
+
+	inv := testInventory(
+		skill("proj/alpha", "alpha", "hash-a", "/skills/alpha.md"),
+		skill("proj/beta", "beta", "hash-b", "/skills/beta.md"),
+	)
+
+	record, err := store.Seal(inv, "test-user")
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	// Verify record fields.
+	if record.SealID == "" {
+		t.Error("seal ID should not be empty")
+	}
+	if record.SealedBy != "test-user" {
+		t.Errorf("sealed by = %q, want %q", record.SealedBy, "test-user")
+	}
+	if record.SkillCount != 2 {
+		t.Errorf("skill count = %d, want 2", record.SkillCount)
+	}
+	if record.InventoryHash == "" {
+		t.Error("inventory hash should not be empty")
+	}
+
+	// Verify files were created.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+
+	sealFiles := 0
+	invFiles := 0
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".json" {
+			if len(e.Name()) > 5 && e.Name()[:5] == "seal-" {
+				sealFiles++
+			}
+			if len(e.Name()) > 10 && e.Name()[:10] == "inventory-" {
+				invFiles++
+			}
+		}
+	}
+	if sealFiles < 1 {
+		t.Error("no seal file created")
+	}
+	if invFiles < 1 {
+		t.Error("no inventory file created")
+	}
+}
+
+func TestLatestSealReturnsMostRecent(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSealStoreAt(dir)
+	if err != nil {
+		t.Fatalf("NewSealStoreAt: %v", err)
+	}
+
+	inv1 := testInventory(
+		skill("proj/alpha", "alpha", "hash-a", "/skills/alpha.md"),
+	)
+	_, err = store.Seal(inv1, "user1")
+	if err != nil {
+		t.Fatalf("Seal 1: %v", err)
+	}
+
+	// Small delay to ensure different timestamps.
+	time.Sleep(10 * time.Millisecond)
+
+	inv2 := testInventory(
+		skill("proj/alpha", "alpha", "hash-a", "/skills/alpha.md"),
+		skill("proj/beta", "beta", "hash-b", "/skills/beta.md"),
+	)
+	record2, err := store.Seal(inv2, "user2")
+	if err != nil {
+		t.Fatalf("Seal 2: %v", err)
+	}
+
+	latest, latestInv, err := store.LatestSeal()
+	if err != nil {
+		t.Fatalf("LatestSeal: %v", err)
+	}
+	if latest == nil {
+		t.Fatal("latest seal should not be nil")
+	}
+	if latest.SealID != record2.SealID {
+		t.Errorf("latest seal ID = %q, want %q", latest.SealID, record2.SealID)
+	}
+	if latest.SealedBy != "user2" {
+		t.Errorf("latest sealed by = %q, want %q", latest.SealedBy, "user2")
+	}
+	if latestInv == nil {
+		t.Fatal("latest inventory should not be nil")
+	}
+	if len(latestInv.Skills) != 2 {
+		t.Errorf("latest inventory skills = %d, want 2", len(latestInv.Skills))
+	}
+}
+
+func TestListSealsInOrder(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSealStoreAt(dir)
+	if err != nil {
+		t.Fatalf("NewSealStoreAt: %v", err)
+	}
+
+	// Create 3 seals with slight delays.
+	for i := 0; i < 3; i++ {
+		inv := testInventory(
+			skill("proj/alpha", "alpha", "hash-a", "/skills/alpha.md"),
+		)
+		_, err := store.Seal(inv, "user")
+		if err != nil {
+			t.Fatalf("Seal %d: %v", i, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	seals, err := store.ListSeals()
+	if err != nil {
+		t.Fatalf("ListSeals: %v", err)
+	}
+	if len(seals) != 3 {
+		t.Errorf("seal count = %d, want 3", len(seals))
+	}
+
+	// Verify chronological order.
+	for i := 1; i < len(seals); i++ {
+		if seals[i].SealedAt < seals[i-1].SealedAt {
+			t.Errorf("seal %d (%s) is before seal %d (%s)",
+				i, seals[i].SealedAt, i-1, seals[i-1].SealedAt)
+		}
+	}
+}
+
+func TestSealWithEmptyInventory(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSealStoreAt(dir)
+	if err != nil {
+		t.Fatalf("NewSealStoreAt: %v", err)
+	}
+
+	inv := testInventory()
+	record, err := store.Seal(inv, "test-user")
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	if record.SkillCount != 0 {
+		t.Errorf("skill count = %d, want 0", record.SkillCount)
+	}
+
+	// Should still be retrievable.
+	latest, latestInv, err := store.LatestSeal()
+	if err != nil {
+		t.Fatalf("LatestSeal: %v", err)
+	}
+	if latest == nil {
+		t.Fatal("latest seal should not be nil")
+	}
+	if latestInv == nil {
+		t.Fatal("latest inventory should not be nil")
+	}
+	if len(latestInv.Skills) != 0 {
+		t.Errorf("latest inventory skills = %d, want 0", len(latestInv.Skills))
+	}
+}
+
+func TestLatestSealReturnsNilWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSealStoreAt(dir)
+	if err != nil {
+		t.Fatalf("NewSealStoreAt: %v", err)
+	}
+
+	record, inv, err := store.LatestSeal()
+	if err != nil {
+		t.Fatalf("LatestSeal: %v", err)
+	}
+	if record != nil {
+		t.Error("expected nil record for empty store")
+	}
+	if inv != nil {
+		t.Error("expected nil inventory for empty store")
+	}
+}
+
+func TestGetSealByID(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSealStoreAt(dir)
+	if err != nil {
+		t.Fatalf("NewSealStoreAt: %v", err)
+	}
+
+	inv := testInventory(
+		skill("proj/alpha", "alpha", "hash-a", "/skills/alpha.md"),
+	)
+	record, err := store.Seal(inv, "user")
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	got, gotInv, err := store.GetSeal(record.SealID)
+	if err != nil {
+		t.Fatalf("GetSeal: %v", err)
+	}
+	if got.SealID != record.SealID {
+		t.Errorf("got seal ID = %q, want %q", got.SealID, record.SealID)
+	}
+	if gotInv == nil {
+		t.Fatal("got inventory should not be nil")
+	}
+}
+
+func TestGetSealNotFound(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSealStoreAt(dir)
+	if err != nil {
+		t.Fatalf("NewSealStoreAt: %v", err)
+	}
+
+	_, _, err = store.GetSeal("nonexistent")
+	if err == nil {
+		t.Error("GetSeal should return error for nonexistent seal")
+	}
+}

--- a/pkg/skillctl/hasher/hasher.go
+++ b/pkg/skillctl/hasher/hasher.go
@@ -1,0 +1,43 @@
+// Package hasher provides content hashing and duplicate detection for skills.
+package hasher
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// ContentHash returns the SHA256 hex digest of the raw data.
+func ContentHash(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// ContentID returns the SHA256 hex digest of normalized content
+// (trimmed whitespace and lowercased) for fuzzy duplicate detection.
+func ContentID(data []byte) string {
+	normalized := strings.ToLower(strings.TrimSpace(string(data)))
+	h := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(h[:])
+}
+
+// DetectDuplicates compares content hashes across skills and sets the
+// DuplicateOf field on any skill whose ContentHash matches an earlier skill.
+func DetectDuplicates(skills []model.SkillDescriptor) {
+	// Map from content hash to the ID of the first skill with that hash.
+	seen := make(map[string]string)
+	for i := range skills {
+		hash := skills[i].ContentHash
+		if hash == "" {
+			continue
+		}
+		if firstID, exists := seen[hash]; exists {
+			dup := firstID
+			skills[i].DuplicateOf = &dup
+		} else {
+			seen[hash] = skills[i].ID
+		}
+	}
+}

--- a/pkg/skillctl/importer/importer.go
+++ b/pkg/skillctl/importer/importer.go
@@ -1,0 +1,198 @@
+// Package importer handles communication with the aims-core skill profile API.
+// It uploads local skill inventories for server-side profile matching and
+// reports back how many skills were imported, already known, or newly discovered.
+package importer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/auth"
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// Client handles communication with the aims-core skill profile API.
+type Client struct {
+	BaseURL    string
+	APIKey     string
+	UserID     string // BUG-0084: Required by aims-core auth (X-User-ID header)
+	HTTPClient *http.Client
+}
+
+// ImportResponse is the JSON body returned by the API.
+type ImportResponse struct {
+	Imported      int    `json:"imported"`
+	NewCandidates int    `json:"new_candidates"`
+	AlreadyKnown  int    `json:"already_known"`
+	Message       string `json:"message,omitempty"`
+}
+
+// NewClient creates a Client with a 30-second timeout.
+// It validates that baseURL is a well-formed HTTP(S) URL.
+// BUG-0084: userID is required for aims-core auth (X-User-ID header).
+func NewClient(baseURL, apiKey, userID string) (*Client, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid target URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("target URL must use http or https scheme, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("target URL must include a host")
+	}
+
+	// Normalize: strip trailing slash.
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	return &Client{
+		BaseURL: baseURL,
+		APIKey:  apiKey,
+		UserID:  userID,
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}, nil
+}
+
+// HealthCheck verifies connectivity by calling GET /health on the target.
+func (c *Client) HealthCheck() error {
+	req, err := http.NewRequest(http.MethodGet, c.BaseURL+"/health", nil) // BUG-0085: was /api/health (404)
+	if err != nil {
+		return fmt.Errorf("creating health check request: %w", err)
+	}
+	auth.ApplyAuth(req, c.APIKey)
+	if c.UserID != "" {
+		req.Header.Set("X-User-ID", c.UserID) // BUG-0084
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("health check failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("health check returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	return nil
+}
+
+// Import sends the inventory's skills to the aims-core skill profile API.
+// It POSTs to /api/v2/skills/profile/import with an X-API-KEY header.
+func (c *Client) Import(inv *model.Inventory) (*ImportResponse, error) {
+	payload := struct {
+		Skills []model.SkillDescriptor `json:"skills"`
+	}{
+		Skills: inv.Skills,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling import payload: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.BaseURL+"/api/v2/skills/profile/import", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating import request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	auth.ApplyAuth(req, c.APIKey)
+	if c.UserID != "" {
+		req.Header.Set("X-User-ID", c.UserID) // BUG-0084
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("import request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return nil, fmt.Errorf("reading import response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("import returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var result ImportResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parsing import response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DryRun returns a human-readable summary of what would be imported
+// without actually sending data to the server.
+func (c *Client) DryRun(inv *model.Inventory) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "Dry-run import to %s\n", c.BaseURL)
+	fmt.Fprintf(&b, "Total skills: %d\n\n", len(inv.Skills))
+
+	// Skills by type.
+	byType := make(map[string]int)
+	for _, s := range inv.Skills {
+		byType[string(s.Type)]++
+	}
+	if len(byType) > 0 {
+		fmt.Fprintln(&b, "By type:")
+		for _, kv := range sortedMapEntries(byType) {
+			fmt.Fprintf(&b, "  %-25s %d\n", kv.key, kv.count)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	// Skills by project.
+	byProject := make(map[string]int)
+	for _, s := range inv.Skills {
+		proj := s.SourceProject
+		if proj == "" {
+			proj = "(unknown)"
+		}
+		byProject[proj]++
+	}
+	if len(byProject) > 0 {
+		fmt.Fprintln(&b, "By project:")
+		for _, kv := range sortedMapEntries(byProject) {
+			fmt.Fprintf(&b, "  %-25s %d\n", kv.key, kv.count)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	fmt.Fprintf(&b, "Target endpoint: POST %s/api/v2/skills/profile/import\n", c.BaseURL)
+	fmt.Fprintln(&b, "No data was sent (--dry-run).")
+
+	return b.String()
+}
+
+type mapEntry struct {
+	key   string
+	count int
+}
+
+func sortedMapEntries(m map[string]int) []mapEntry {
+	entries := make([]mapEntry, 0, len(m))
+	for k, v := range m {
+		entries = append(entries, mapEntry{k, v})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].count != entries[j].count {
+			return entries[i].count > entries[j].count
+		}
+		return entries[i].key < entries[j].key
+	})
+	return entries
+}

--- a/pkg/skillctl/model/skill.go
+++ b/pkg/skillctl/model/skill.go
@@ -47,10 +47,23 @@ type SkillDescriptor struct {
 	ConflictsWith      []string     `json:"conflicts_with"`
 	DuplicateOf        *string      `json:"duplicate_of"`
 	// SPEC-0189 additions (all omitempty for wire-compat).
-	Tier        string   `json:"tier,omitempty"`           // project | user | plugin
-	SkillMDPath string   `json:"skill_md_path,omitempty"`  // path to the SKILL.md anchor file
-	Shadows     []string `json:"shadows,omitempty"`        // ids of lower-tier skills shadowed by this one
-	ShadowedBy  []string `json:"shadowed_by,omitempty"`    // id of the higher-tier winner that shadows this
+	Tier        string             `json:"tier,omitempty"`           // project | user | plugin
+	SkillMDPath string             `json:"skill_md_path,omitempty"`  // path to the SKILL.md anchor file
+	Shadows     []string           `json:"shadows,omitempty"`        // ids of lower-tier skills shadowed by this one
+	ShadowedBy  []string           `json:"shadowed_by,omitempty"`    // id of the higher-tier winner that shadows this
+	Bundle      *BundleAttestation `json:"bundle,omitempty"`         // SPEC-0189 §6 trust cross-ref
+}
+
+// BundleAttestation is the SPEC-0189 §6 trust cross-reference block.
+// Populated by scanner.AnnotateTrust when --with-trust is requested.
+type BundleAttestation struct {
+	SKBPath                string `json:"skb_path,omitempty"`
+	BundleDigest           string `json:"bundle_digest,omitempty"`
+	Signed                 bool   `json:"signed"`
+	RegisteredInLocalTrust bool   `json:"registered_in_local_registry"`
+	TrustChain             string `json:"trust_chain"`
+	VerifierExitCode       int    `json:"verifier_exit_code,omitempty"`
+	VerifierError          string `json:"verifier_error,omitempty"`
 }
 
 // Inventory holds the complete results of a skill scan.

--- a/pkg/skillctl/model/skill.go
+++ b/pkg/skillctl/model/skill.go
@@ -1,0 +1,59 @@
+// Package model defines the data types for the skillctl skill inventory system.
+package model
+
+// SkillType classifies the kind of skill source discovered.
+type SkillType string
+
+const (
+	SkillTypeClaudeCodeSkill  SkillType = "claude_code_skill"
+	SkillTypeSkillIndex       SkillType = "skill_index"
+	SkillTypeCommand          SkillType = "command"
+	SkillTypeMCPServer        SkillType = "mcp_server"
+	SkillTypeAgent            SkillType = "agent"
+	SkillTypeSynthesisTemplate SkillType = "synthesis_template"
+)
+
+// Frontmatter holds parsed YAML frontmatter from skill markdown files.
+type Frontmatter struct {
+	Name         string                 `json:"name" yaml:"name"`
+	Version      string                 `json:"version,omitempty" yaml:"version"`
+	Description  string                 `json:"description,omitempty" yaml:"description"`
+	AllowedTools []string               `json:"allowed_tools,omitempty" yaml:"allowed-tools"`
+	Category     string                 `json:"category,omitempty" yaml:"category"`
+	Intent       string                 `json:"intent,omitempty" yaml:"intent"`
+	InputType    string                 `json:"input_type,omitempty" yaml:"input_type"`
+	OutputFormat string                 `json:"output_format,omitempty" yaml:"output_format"`
+	Tags         []string               `json:"tags,omitempty" yaml:"tags"`
+	Model        string                 `json:"model,omitempty" yaml:"model"`
+	Metadata     map[string]interface{} `json:"metadata,omitempty" yaml:"metadata"`
+}
+
+// SkillDescriptor represents a single discovered skill source.
+type SkillDescriptor struct {
+	ID                 string       `json:"id"`
+	Name               string       `json:"name"`
+	Type               SkillType    `json:"type"`
+	SourcePath         string       `json:"source_path"`
+	SourceProject      string       `json:"source_project"`
+	DiscoveredAt       string       `json:"discovered_at"`
+	Frontmatter        *Frontmatter `json:"frontmatter,omitempty"`
+	ContentHash        string       `json:"content_hash"`
+	ContentSizeBytes   int64        `json:"content_size_bytes"`
+	HasYAMLFrontmatter bool         `json:"has_yaml_frontmatter"`
+	Dependencies       []string     `json:"dependencies"`
+	ConflictsWith      []string     `json:"conflicts_with"`
+	DuplicateOf        *string      `json:"duplicate_of"`
+}
+
+// Inventory holds the complete results of a skill scan.
+type Inventory struct {
+	ScannedAt      string            `json:"scanned_at"`
+	ScanPaths      []string          `json:"scan_paths"`
+	Skills         []SkillDescriptor `json:"skills"`
+	TotalCount     int               `json:"total_count"`
+	ByType         map[string]int    `json:"by_type"`
+	ByProject      map[string]int    `json:"by_project"`
+	Duplicates     int               `json:"duplicates"`
+	NoFrontmatter  int               `json:"no_frontmatter"`
+	SkillIndexCount int              `json:"skill_index_count"`
+}

--- a/pkg/skillctl/model/skill.go
+++ b/pkg/skillctl/model/skill.go
@@ -25,7 +25,10 @@ type Frontmatter struct {
 	OutputFormat string                 `json:"output_format,omitempty" yaml:"output_format"`
 	Tags         []string               `json:"tags,omitempty" yaml:"tags"`
 	Model        string                 `json:"model,omitempty" yaml:"model"`
-	Metadata     map[string]interface{} `json:"metadata,omitempty" yaml:"metadata"`
+	// GovernanceLevel is the SPEC-0130 Ampel verdict (green | yellow | red).
+	// Promoted from Metadata to a typed field per SPEC-0189 §10 D2.
+	GovernanceLevel string `json:"governance_level,omitempty" yaml:"governance_level"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty" yaml:"metadata"`
 }
 
 // SkillDescriptor represents a single discovered skill source.
@@ -43,6 +46,11 @@ type SkillDescriptor struct {
 	Dependencies       []string     `json:"dependencies"`
 	ConflictsWith      []string     `json:"conflicts_with"`
 	DuplicateOf        *string      `json:"duplicate_of"`
+	// SPEC-0189 additions (all omitempty for wire-compat).
+	Tier        string   `json:"tier,omitempty"`           // project | user | plugin
+	SkillMDPath string   `json:"skill_md_path,omitempty"`  // path to the SKILL.md anchor file
+	Shadows     []string `json:"shadows,omitempty"`        // ids of lower-tier skills shadowed by this one
+	ShadowedBy  []string `json:"shadowed_by,omitempty"`    // id of the higher-tier winner that shadows this
 }
 
 // Inventory holds the complete results of a skill scan.

--- a/pkg/skillctl/parser/frontmatter.go
+++ b/pkg/skillctl/parser/frontmatter.go
@@ -1,0 +1,55 @@
+// Package parser extracts YAML frontmatter from markdown skill files.
+package parser
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+	"gopkg.in/yaml.v3"
+)
+
+// Parse extracts YAML frontmatter from content delimited by --- markers.
+// Returns the parsed Frontmatter, the remaining body text, and any error.
+// If no frontmatter is found, fm is nil and body is the full content.
+func Parse(content []byte) (fm *model.Frontmatter, body string, err error) {
+	s := string(content)
+
+	// Frontmatter must start at the very beginning of the file with ---
+	if !strings.HasPrefix(s, "---") {
+		return nil, s, nil
+	}
+
+	// Find the closing --- delimiter.
+	// Skip the first line (the opening ---) and look for \n---
+	rest := s[3:]
+	// Trim the newline after the opening ---
+	if len(rest) > 0 && rest[0] == '\n' {
+		rest = rest[1:]
+	} else if len(rest) > 1 && rest[0] == '\r' && rest[1] == '\n' {
+		rest = rest[2:]
+	}
+
+	closeIdx := strings.Index(rest, "\n---")
+	if closeIdx < 0 {
+		// No closing delimiter — treat as no frontmatter
+		return nil, s, nil
+	}
+
+	yamlBlock := rest[:closeIdx]
+	// Body starts after the closing ---\n
+	afterClose := rest[closeIdx+4:] // len("\n---") == 4
+	if len(afterClose) > 0 && afterClose[0] == '\n' {
+		afterClose = afterClose[1:]
+	} else if len(afterClose) > 1 && afterClose[0] == '\r' && afterClose[1] == '\n' {
+		afterClose = afterClose[2:]
+	}
+
+	var parsed model.Frontmatter
+	decoder := yaml.NewDecoder(bytes.NewReader([]byte(yamlBlock)))
+	if err := decoder.Decode(&parsed); err != nil {
+		return nil, s, err
+	}
+
+	return &parsed, afterClose, nil
+}

--- a/pkg/skillctl/parser/frontmatter_test.go
+++ b/pkg/skillctl/parser/frontmatter_test.go
@@ -1,0 +1,137 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestParseValidFrontmatter(t *testing.T) {
+	content := []byte(`---
+name: dev-cycle
+version: 2.0.0
+description: |
+  Local dev cycle for builds and testing.
+allowed-tools:
+  - Bash
+  - Read
+category: deployment
+tags:
+  - devops
+  - build
+---
+This is the body text.
+`)
+	fm, body, err := Parse(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("expected frontmatter, got nil")
+	}
+	if fm.Name != "dev-cycle" {
+		t.Errorf("name = %q, want %q", fm.Name, "dev-cycle")
+	}
+	if fm.Version != "2.0.0" {
+		t.Errorf("version = %q, want %q", fm.Version, "2.0.0")
+	}
+	if len(fm.AllowedTools) != 2 {
+		t.Errorf("allowed_tools len = %d, want 2", len(fm.AllowedTools))
+	} else {
+		if fm.AllowedTools[0] != "Bash" || fm.AllowedTools[1] != "Read" {
+			t.Errorf("allowed_tools = %v, want [Bash Read]", fm.AllowedTools)
+		}
+	}
+	if fm.Category != "deployment" {
+		t.Errorf("category = %q, want %q", fm.Category, "deployment")
+	}
+	if len(fm.Tags) != 2 || fm.Tags[0] != "devops" || fm.Tags[1] != "build" {
+		t.Errorf("tags = %v, want [devops build]", fm.Tags)
+	}
+	if body != "This is the body text.\n" {
+		t.Errorf("body = %q, want %q", body, "This is the body text.\n")
+	}
+}
+
+func TestParseNoFrontmatter(t *testing.T) {
+	content := []byte("# Just a markdown file\n\nNo frontmatter here.\n")
+	fm, body, err := Parse(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fm != nil {
+		t.Errorf("expected nil frontmatter, got %+v", fm)
+	}
+	if body != string(content) {
+		t.Errorf("body should equal original content")
+	}
+}
+
+func TestParseMalformedYAML(t *testing.T) {
+	content := []byte(`---
+name: [broken
+  yaml:: data
+---
+body text
+`)
+	fm, _, err := Parse(content)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML, got nil")
+	}
+	if fm != nil {
+		t.Errorf("expected nil frontmatter on error, got %+v", fm)
+	}
+}
+
+func TestParseNoClosingDelimiter(t *testing.T) {
+	content := []byte(`---
+name: orphaned
+version: 1.0.0
+This never closes
+`)
+	fm, body, err := Parse(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fm != nil {
+		t.Errorf("expected nil frontmatter (no closing ---), got %+v", fm)
+	}
+	if body != string(content) {
+		t.Errorf("body should equal original content when no closing delimiter")
+	}
+}
+
+func TestParseEmptyFrontmatter(t *testing.T) {
+	content := []byte(`---
+---
+body only
+`)
+	fm, body, err := Parse(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Empty YAML block: frontmatter is nil because yaml.Decode returns EOF
+	// on empty input; we treat that as "no frontmatter parsed"
+	if fm != nil && fm.Name != "" {
+		t.Errorf("expected empty/nil frontmatter, got %+v", fm)
+	}
+	_ = body
+}
+
+func TestParseMinimalFrontmatter(t *testing.T) {
+	content := []byte(`---
+name: simple
+---
+`)
+	fm, _, err := Parse(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("expected frontmatter, got nil")
+	}
+	if fm.Name != "simple" {
+		t.Errorf("name = %q, want %q", fm.Name, "simple")
+	}
+	if fm.Version != "" {
+		t.Errorf("version should be empty, got %q", fm.Version)
+	}
+}

--- a/pkg/skillctl/report/delta.html.tmpl
+++ b/pkg/skillctl/report/delta.html.tmpl
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Skill Delta Report</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-muted: #8b949e;
+    --accent: #7c3aed;
+    --accent-light: #a78bfa;
+    --green: #3fb950;
+    --green-bg: rgba(63, 185, 80, 0.1);
+    --orange: #d29922;
+    --orange-bg: rgba(210, 153, 34, 0.1);
+    --red: #f85149;
+    --red-bg: rgba(248, 81, 73, 0.1);
+    --cyan: #39d2c0;
+    --cyan-bg: rgba(57, 210, 192, 0.1);
+    --blue: #58a6ff;
+    --blue-bg: rgba(88, 166, 255, 0.1);
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    padding: 2rem;
+  }
+  h1 {
+    font-size: 1.8rem;
+    margin-bottom: 0.5rem;
+    color: var(--accent-light);
+  }
+  h2 {
+    font-size: 1.3rem;
+    margin: 2rem 0 1rem;
+    color: var(--accent-light);
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.5rem;
+  }
+  .meta {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    margin-bottom: 2rem;
+  }
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  .stat-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem 1.2rem;
+  }
+  .stat-card .label {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .stat-card .value {
+    font-size: 1.8rem;
+    font-weight: 700;
+  }
+  .stat-card .value.added { color: var(--green); }
+  .stat-card .value.modified { color: var(--orange); }
+  .stat-card .value.removed { color: var(--red); }
+  .stat-card .value.moved { color: var(--blue); }
+  .stat-card .value.total { color: var(--accent-light); }
+  .stat-card .value.zero { color: var(--text-muted); }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 2rem;
+    font-size: 0.9rem;
+  }
+  th {
+    background: var(--bg);
+    text-align: left;
+    padding: 0.6rem 0.8rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  td {
+    padding: 0.5rem 0.8rem;
+    border-top: 1px solid var(--border);
+    vertical-align: top;
+  }
+  tr:hover td { background: rgba(124, 58, 237, 0.05); }
+  .badge {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+  .badge-added { background: var(--green-bg); color: var(--green); }
+  .badge-modified { background: var(--orange-bg); color: var(--orange); }
+  .badge-removed { background: var(--red-bg); color: var(--red); }
+  .badge-moved { background: var(--blue-bg); color: var(--blue); }
+  .badge-pending { background: rgba(139, 148, 158, 0.2); color: var(--text-muted); }
+  .badge-approved { background: var(--green-bg); color: var(--green); }
+  .badge-rejected { background: var(--red-bg); color: var(--red); }
+  .badge-deferred { background: var(--orange-bg); color: var(--orange); }
+  .diff-block {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.8rem;
+    margin: 0.5rem 0;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 0.8rem;
+    white-space: pre-wrap;
+    overflow-x: auto;
+  }
+  .diff-block .line-add { color: var(--green); }
+  .diff-block .line-del { color: var(--red); }
+  .diff-block .line-ctx { color: var(--text-muted); }
+  .diff-block .line-hdr { color: var(--cyan); font-weight: 600; }
+  .entry-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem 1.2rem;
+    margin-bottom: 1rem;
+  }
+  .entry-card.type-added { border-left: 3px solid var(--green); }
+  .entry-card.type-modified { border-left: 3px solid var(--orange); }
+  .entry-card.type-removed { border-left: 3px solid var(--red); }
+  .entry-card.type-moved { border-left: 3px solid var(--blue); }
+  .entry-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+  .entry-header h3 {
+    font-size: 1rem;
+    margin: 0;
+  }
+  .entry-meta {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    margin-bottom: 0.5rem;
+  }
+  .fm-diff {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+  }
+  .fm-col { padding: 0.5rem; background: var(--bg); border-radius: 4px; }
+  .fm-col h4 { color: var(--text-muted); margin-bottom: 0.3rem; font-size: 0.75rem; }
+  .fm-field { margin: 0.2rem 0; }
+  .fm-label { color: var(--text-muted); }
+  .fm-value { color: var(--text); }
+  .no-changes {
+    text-align: center;
+    padding: 3rem;
+    color: var(--green);
+    font-size: 1.2rem;
+  }
+  footer {
+    margin-top: 3rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 0.8rem;
+  }
+</style>
+</head>
+<body>
+<h1>Skill Delta Report</h1>
+<div class="meta">
+  Computed at: {{.ComputedAt}}<br>
+  Baseline: {{.BaselinePath}}<br>
+  Current: {{.CurrentPath}}
+</div>
+
+<div class="stats">
+  <div class="stat-card">
+    <div class="label">Added</div>
+    <div class="value {{if gt .Summary.Added 0}}added{{else}}zero{{end}}">{{.Summary.Added}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Modified</div>
+    <div class="value {{if gt .Summary.Modified 0}}modified{{else}}zero{{end}}">{{.Summary.Modified}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Removed</div>
+    <div class="value {{if gt .Summary.Removed 0}}removed{{else}}zero{{end}}">{{.Summary.Removed}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Moved</div>
+    <div class="value {{if gt .Summary.Moved 0}}moved{{else}}zero{{end}}">{{.Summary.Moved}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Total</div>
+    <div class="value total">{{.Summary.Total}}</div>
+  </div>
+</div>
+
+{{if eq .Summary.Total 0}}
+<div class="no-changes">No changes detected between baseline and current inventory.</div>
+{{else}}
+
+{{if gt .Summary.Total 0}}
+<h2>Change Summary</h2>
+<table>
+  <thead>
+    <tr>
+      <th>Skill</th>
+      <th>Change</th>
+      <th>Baseline Hash</th>
+      <th>Current Hash</th>
+      <th>Review</th>
+    </tr>
+  </thead>
+  <tbody>
+  {{range .Entries}}
+    <tr>
+      <td><strong>{{.SkillName}}</strong><br><span style="font-size:0.8rem;color:var(--text-muted);">{{.SkillID}}</span></td>
+      <td><span class="badge badge-{{deltaClass .DeltaType}}">{{.DeltaType}}</span></td>
+      <td style="font-family:monospace;font-size:0.8rem;">{{truncHash .BaselineHash}}</td>
+      <td style="font-family:monospace;font-size:0.8rem;">{{truncHash .CurrentHash}}</td>
+      <td><span class="badge badge-{{reviewClass .ReviewStatus}}">{{.ReviewStatus}}</span></td>
+    </tr>
+  {{end}}
+  </tbody>
+</table>
+{{end}}
+
+<h2>Change Details</h2>
+{{range .Entries}}
+<div class="entry-card type-{{deltaClass .DeltaType}}">
+  <div class="entry-header">
+    <h3>{{.SkillName}}</h3>
+    <span class="badge badge-{{deltaClass .DeltaType}}">{{.DeltaType}}</span>
+  </div>
+  <div class="entry-meta">
+    ID: {{.SkillID}}
+    {{if .BaselinePath}} | Baseline: {{.BaselinePath}}{{end}}
+    {{if .CurrentPath}} | Current: {{.CurrentPath}}{{end}}
+  </div>
+
+  {{if and .BaselineFrontmatter .CurrentFrontmatter}}
+  <div class="fm-diff">
+    <div class="fm-col">
+      <h4>Baseline Frontmatter</h4>
+      {{if .BaselineFrontmatter.Name}}<div class="fm-field"><span class="fm-label">name:</span> <span class="fm-value">{{.BaselineFrontmatter.Name}}</span></div>{{end}}
+      {{if .BaselineFrontmatter.Version}}<div class="fm-field"><span class="fm-label">version:</span> <span class="fm-value">{{.BaselineFrontmatter.Version}}</span></div>{{end}}
+      {{if .BaselineFrontmatter.Category}}<div class="fm-field"><span class="fm-label">category:</span> <span class="fm-value">{{.BaselineFrontmatter.Category}}</span></div>{{end}}
+      {{if .BaselineFrontmatter.Description}}<div class="fm-field"><span class="fm-label">description:</span> <span class="fm-value">{{.BaselineFrontmatter.Description}}</span></div>{{end}}
+    </div>
+    <div class="fm-col">
+      <h4>Current Frontmatter</h4>
+      {{if .CurrentFrontmatter.Name}}<div class="fm-field"><span class="fm-label">name:</span> <span class="fm-value">{{.CurrentFrontmatter.Name}}</span></div>{{end}}
+      {{if .CurrentFrontmatter.Version}}<div class="fm-field"><span class="fm-label">version:</span> <span class="fm-value">{{.CurrentFrontmatter.Version}}</span></div>{{end}}
+      {{if .CurrentFrontmatter.Category}}<div class="fm-field"><span class="fm-label">category:</span> <span class="fm-value">{{.CurrentFrontmatter.Category}}</span></div>{{end}}
+      {{if .CurrentFrontmatter.Description}}<div class="fm-field"><span class="fm-label">description:</span> <span class="fm-value">{{.CurrentFrontmatter.Description}}</span></div>{{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{if .ContentDiff}}
+  <div class="diff-block">{{formatDiff .ContentDiff}}</div>
+  {{end}}
+</div>
+{{end}}
+
+{{end}}
+
+<footer>
+  Generated by skillctl v0.2.0 | github.com/kamir/m3c-tools
+</footer>
+</body>
+</html>

--- a/pkg/skillctl/report/html.go
+++ b/pkg/skillctl/report/html.go
@@ -1,0 +1,207 @@
+// Package report generates HTML and Markdown reports from skill inventories.
+package report
+
+import (
+	_ "embed"
+	"fmt"
+	"html/template"
+	"io"
+	"strings"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/delta"
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+//go:embed report.html.tmpl
+var htmlTemplate string
+
+//go:embed delta.html.tmpl
+var deltaHTMLTemplate string
+
+// funcMap provides template helper functions.
+var funcMap = template.FuncMap{
+	"badgeClass": badgeClass,
+	"barWidth":   barWidth,
+	"formatBytes": formatBytes,
+	"deref":      deref,
+	"string":     toString,
+}
+
+// badgeClass returns a CSS class name for a skill type string.
+func badgeClass(t string) string {
+	switch {
+	case strings.Contains(t, "index"):
+		return "badge-index"
+	case strings.Contains(t, "skill"):
+		return "badge-skill"
+	case strings.Contains(t, "command"):
+		return "badge-cmd"
+	case strings.Contains(t, "mcp"):
+		return "badge-mcp"
+	case strings.Contains(t, "agent"):
+		return "badge-agent"
+	case strings.Contains(t, "claude"):
+		return "badge-claude"
+	case strings.Contains(t, "synthesis"):
+		return "badge-synth"
+	default:
+		return ""
+	}
+}
+
+// barWidth computes the pixel width of a proportional bar (max 200px).
+func barWidth(count, total int) int {
+	if total == 0 {
+		return 4
+	}
+	w := (count * 200) / total
+	if w < 4 {
+		w = 4
+	}
+	return w
+}
+
+// formatBytes returns a human-readable byte size string.
+func formatBytes(b int64) string {
+	switch {
+	case b >= 1024*1024:
+		return fmt.Sprintf("%.1f MB", float64(b)/(1024*1024))
+	case b >= 1024:
+		return fmt.Sprintf("%.1f KB", float64(b)/1024)
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}
+
+// deref safely dereferences a string pointer.
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// toString converts a SkillType to string for template use.
+func toString(s model.SkillType) string {
+	return string(s)
+}
+
+// GenerateHTML writes a self-contained HTML report to the writer.
+func GenerateHTML(w io.Writer, inv *model.Inventory) error {
+	tmpl, err := template.New("report").Funcs(funcMap).Parse(htmlTemplate)
+	if err != nil {
+		return fmt.Errorf("parsing template: %w", err)
+	}
+	return tmpl.Execute(w, inv)
+}
+
+// deltaFuncMap provides template helper functions for delta reports.
+var deltaFuncMap = template.FuncMap{
+	"deltaClass":  deltaClass,
+	"reviewClass": reviewClass,
+	"truncHash":   truncHash,
+	"formatDiff":  formatDiffHTML,
+	"formatBytes": formatBytes,
+}
+
+// deltaClass returns a CSS class suffix for a delta type.
+func deltaClass(dt delta.DeltaType) string {
+	return string(dt)
+}
+
+// reviewClass returns a CSS class suffix for a review status.
+func reviewClass(rs delta.ReviewStatus) string {
+	return string(rs)
+}
+
+// truncHash returns the first 8 characters of a hash, or the full string if shorter.
+func truncHash(h string) string {
+	if len(h) > 8 {
+		return h[:8]
+	}
+	return h
+}
+
+// formatDiffHTML converts a unified diff string into HTML with colored lines.
+func formatDiffHTML(diff string) template.HTML {
+	if diff == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, line := range strings.Split(diff, "\n") {
+		if line == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++"):
+			fmt.Fprintf(&b, "<span class=\"line-hdr\">%s</span>\n", template.HTMLEscapeString(line))
+		case strings.HasPrefix(line, "+"):
+			fmt.Fprintf(&b, "<span class=\"line-add\">%s</span>\n", template.HTMLEscapeString(line))
+		case strings.HasPrefix(line, "-"):
+			fmt.Fprintf(&b, "<span class=\"line-del\">%s</span>\n", template.HTMLEscapeString(line))
+		default:
+			fmt.Fprintf(&b, "<span class=\"line-ctx\">%s</span>\n", template.HTMLEscapeString(line))
+		}
+	}
+	return template.HTML(b.String())
+}
+
+// GenerateDeltaReportHTML writes a self-contained HTML delta report to the writer.
+func GenerateDeltaReportHTML(w io.Writer, dr *delta.DeltaReport) error {
+	tmpl, err := template.New("delta").Funcs(deltaFuncMap).Parse(deltaHTMLTemplate)
+	if err != nil {
+		return fmt.Errorf("parsing delta template: %w", err)
+	}
+	return tmpl.Execute(w, dr)
+}
+
+// GenerateMarkdown writes a Markdown report to the writer.
+func GenerateMarkdown(w io.Writer, inv *model.Inventory) error {
+	fmt.Fprintf(w, "# Skill Inventory Report\n\n")
+	fmt.Fprintf(w, "Scanned at: %s\n\n", inv.ScannedAt)
+	fmt.Fprintf(w, "## Summary\n\n")
+	fmt.Fprintf(w, "| Metric | Value |\n|--------|-------|\n")
+	fmt.Fprintf(w, "| Total Skills | %d |\n", inv.TotalCount)
+	fmt.Fprintf(w, "| Projects | %d |\n", len(inv.ByProject))
+	fmt.Fprintf(w, "| Duplicates | %d |\n", inv.Duplicates)
+	fmt.Fprintf(w, "| No Frontmatter | %d |\n", inv.NoFrontmatter)
+	fmt.Fprintf(w, "\n## By Type\n\n")
+	for t, c := range inv.ByType {
+		fmt.Fprintf(w, "- **%s**: %d\n", t, c)
+	}
+	fmt.Fprintf(w, "\n## By Project\n\n")
+	for p, c := range inv.ByProject {
+		fmt.Fprintf(w, "- **%s**: %d\n", p, c)
+	}
+	fmt.Fprintf(w, "\n## Skills\n\n")
+	fmt.Fprintf(w, "| Name | Type | Project | Frontmatter | Size |\n")
+	fmt.Fprintf(w, "|------|------|---------|-------------|------|\n")
+	for _, sk := range inv.Skills {
+		hasFM := "no"
+		if sk.HasYAMLFrontmatter {
+			hasFM = "yes"
+		}
+		fmt.Fprintf(w, "| %s | %s | %s | %s | %s |\n",
+			sk.Name, sk.Type, sk.SourceProject, hasFM, formatBytes(sk.ContentSizeBytes))
+	}
+
+	if inv.Duplicates > 0 {
+		fmt.Fprintf(w, "\n## Duplicates\n\n")
+		for _, sk := range inv.Skills {
+			if sk.DuplicateOf != nil {
+				fmt.Fprintf(w, "- **%s** is duplicate of **%s**\n", sk.Name, *sk.DuplicateOf)
+			}
+		}
+	}
+
+	if inv.NoFrontmatter > 0 {
+		fmt.Fprintf(w, "\n## Skills Without Frontmatter\n\n")
+		for _, sk := range inv.Skills {
+			if !sk.HasYAMLFrontmatter {
+				fmt.Fprintf(w, "- %s (%s) — `%s`\n", sk.Name, sk.Type, sk.SourcePath)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/skillctl/report/report.html.tmpl
+++ b/pkg/skillctl/report/report.html.tmpl
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Skill Inventory Report</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-muted: #8b949e;
+    --accent: #7c3aed;
+    --accent-light: #a78bfa;
+    --green: #3fb950;
+    --orange: #d29922;
+    --red: #f85149;
+    --cyan: #39d2c0;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    padding: 2rem;
+  }
+  h1 {
+    font-size: 1.8rem;
+    margin-bottom: 0.5rem;
+    color: var(--accent-light);
+  }
+  h2 {
+    font-size: 1.3rem;
+    margin: 2rem 0 1rem;
+    color: var(--accent-light);
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.5rem;
+  }
+  .meta {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    margin-bottom: 2rem;
+  }
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  .stat-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem 1.2rem;
+  }
+  .stat-card .label {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .stat-card .value {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--accent-light);
+  }
+  .stat-card .value.warn { color: var(--orange); }
+  .stat-card .value.danger { color: var(--red); }
+  .stat-card .value.good { color: var(--green); }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 2rem;
+    font-size: 0.9rem;
+  }
+  th {
+    background: var(--bg);
+    text-align: left;
+    padding: 0.6rem 0.8rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  td {
+    padding: 0.5rem 0.8rem;
+    border-top: 1px solid var(--border);
+    vertical-align: top;
+  }
+  tr:hover td { background: rgba(124, 58, 237, 0.05); }
+  .badge {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+  .badge-skill { background: #7c3aed33; color: var(--accent-light); }
+  .badge-cmd { background: #39d2c033; color: var(--cyan); }
+  .badge-mcp { background: #d2992233; color: var(--orange); }
+  .badge-agent { background: #3fb95033; color: var(--green); }
+  .badge-claude { background: #f8514933; color: var(--red); }
+  .badge-index { background: #d2992233; color: var(--orange); }
+  .badge-synth { background: #8b949e33; color: var(--text-muted); }
+  .badge-yes { background: #3fb95033; color: var(--green); }
+  .badge-no { background: #f8514933; color: var(--red); }
+  .dup-marker { color: var(--orange); font-weight: 600; }
+  .type-breakdown { margin-bottom: 1rem; }
+  .type-breakdown li {
+    list-style: none;
+    padding: 0.3rem 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .bar {
+    height: 6px;
+    background: var(--accent);
+    border-radius: 3px;
+    min-width: 4px;
+  }
+  footer {
+    margin-top: 3rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 0.8rem;
+  }
+</style>
+</head>
+<body>
+<h1>Skill Inventory Report</h1>
+<div class="meta">Scanned at: {{.ScannedAt}} | Paths: {{range $i, $p := .ScanPaths}}{{if $i}}, {{end}}{{$p}}{{end}}</div>
+
+<div class="stats">
+  <div class="stat-card">
+    <div class="label">Total Skills</div>
+    <div class="value">{{.TotalCount}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Projects</div>
+    <div class="value">{{len .ByProject}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Duplicates</div>
+    <div class="value{{if gt .Duplicates 0}} warn{{end}}">{{.Duplicates}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">No Frontmatter</div>
+    <div class="value{{if gt .NoFrontmatter 0}} warn{{end}}">{{.NoFrontmatter}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Skill Indexes</div>
+    <div class="value">{{.SkillIndexCount}}</div>
+  </div>
+</div>
+
+<h2>By Type</h2>
+<ul class="type-breakdown">
+{{range $type, $count := .ByType}}
+  <li>
+    <span class="badge {{badgeClass $type}}">{{$type}}</span>
+    <div class="bar" style="width: {{barWidth $count $.TotalCount}}px;"></div>
+    <span>{{$count}}</span>
+  </li>
+{{end}}
+</ul>
+
+<h2>By Project</h2>
+<ul class="type-breakdown">
+{{range $proj, $count := .ByProject}}
+  <li>
+    <span style="min-width:120px;display:inline-block;">{{$proj}}</span>
+    <div class="bar" style="width: {{barWidth $count $.TotalCount}}px;"></div>
+    <span>{{$count}}</span>
+  </li>
+{{end}}
+</ul>
+
+<h2>All Skills</h2>
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Project</th>
+      <th>Category</th>
+      <th>Frontmatter</th>
+      <th>Size</th>
+      <th>Duplicate</th>
+    </tr>
+  </thead>
+  <tbody>
+  {{range .Skills}}
+    <tr>
+      <td><strong>{{.Name}}</strong></td>
+      <td><span class="badge {{badgeClass (string .Type)}}">{{.Type}}</span></td>
+      <td>{{.SourceProject}}</td>
+      <td>{{if .Frontmatter}}{{.Frontmatter.Category}}{{else}}-{{end}}</td>
+      <td>{{if .HasYAMLFrontmatter}}<span class="badge badge-yes">yes</span>{{else}}<span class="badge badge-no">no</span>{{end}}</td>
+      <td>{{formatBytes .ContentSizeBytes}}</td>
+      <td>{{if .DuplicateOf}}<span class="dup-marker">dup of {{deref .DuplicateOf}}</span>{{else}}-{{end}}</td>
+    </tr>
+  {{end}}
+  </tbody>
+</table>
+
+{{if gt .Duplicates 0}}
+<h2>Duplicates</h2>
+<table>
+  <thead>
+    <tr><th>Skill</th><th>Duplicate Of</th><th>Path</th></tr>
+  </thead>
+  <tbody>
+  {{range .Skills}}{{if .DuplicateOf}}
+    <tr>
+      <td>{{.Name}}</td>
+      <td>{{deref .DuplicateOf}}</td>
+      <td style="font-size:0.8rem;color:var(--text-muted);">{{.SourcePath}}</td>
+    </tr>
+  {{end}}{{end}}
+  </tbody>
+</table>
+{{end}}
+
+{{if gt .SkillIndexCount 0}}
+<h2>Skill Indexes (CLAUDE.md)</h2>
+<table>
+  <thead>
+    <tr><th>Project</th><th>Path</th><th>Size</th></tr>
+  </thead>
+  <tbody>
+  {{range .Skills}}{{if eq (string .Type) "skill_index"}}
+    <tr>
+      <td><strong>{{.SourceProject}}</strong></td>
+      <td style="font-size:0.8rem;color:var(--text-muted);">{{.SourcePath}}</td>
+      <td>{{formatBytes .ContentSizeBytes}}</td>
+    </tr>
+  {{end}}{{end}}
+  </tbody>
+</table>
+{{end}}
+
+{{if gt .NoFrontmatter 0}}
+<h2>Skills Without Frontmatter</h2>
+<table>
+  <thead>
+    <tr><th>Name</th><th>Type</th><th>Path</th></tr>
+  </thead>
+  <tbody>
+  {{range .Skills}}{{if and (not .HasYAMLFrontmatter) (ne (string .Type) "skill_index")}}
+    <tr>
+      <td>{{.Name}}</td>
+      <td><span class="badge {{badgeClass (string .Type)}}">{{.Type}}</span></td>
+      <td style="font-size:0.8rem;color:var(--text-muted);">{{.SourcePath}}</td>
+    </tr>
+  {{end}}{{end}}
+  </tbody>
+</table>
+{{end}}
+
+<footer>
+  Generated by skillctl v0.1.0 | github.com/kamir/m3c-tools
+</footer>
+</body>
+</html>

--- a/pkg/skillctl/report/report_test.go
+++ b/pkg/skillctl/report/report_test.go
@@ -1,0 +1,201 @@
+package report
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+func sampleInventory() *model.Inventory {
+	dupOf := "test-project/deploy-stage"
+	return &model.Inventory{
+		ScannedAt: "2026-04-02T10:00:00Z",
+		ScanPaths: []string{"/tmp/test-project"},
+		Skills: []model.SkillDescriptor{
+			{
+				ID:                 "test-project/deploy-stage",
+				Name:               "deploy-stage",
+				Type:               model.SkillTypeClaudeCodeSkill,
+				SourcePath:         "/tmp/test-project/.claude/skills/deploy/deploy.md",
+				SourceProject:      "test-project",
+				DiscoveredAt:       "2026-04-02T10:00:00Z",
+				ContentHash:        "abc123",
+				ContentSizeBytes:   1024,
+				HasYAMLFrontmatter: true,
+				Frontmatter: &model.Frontmatter{
+					Name:     "deploy-stage",
+					Version:  "1.0.0",
+					Category: "deployment",
+				},
+				Dependencies:  []string{},
+				ConflictsWith: []string{},
+			},
+			{
+				ID:                 "test-project/review",
+				Name:               "review",
+				Type:               model.SkillTypeCommand,
+				SourcePath:         "/tmp/test-project/.claude/commands/review.md",
+				SourceProject:      "test-project",
+				DiscoveredAt:       "2026-04-02T10:00:00Z",
+				ContentHash:        "def456",
+				ContentSizeBytes:   512,
+				HasYAMLFrontmatter: false,
+				Dependencies:       []string{},
+				ConflictsWith:      []string{},
+			},
+			{
+				ID:                 "test-project/mcp-filesystem",
+				Name:               "filesystem",
+				Type:               model.SkillTypeMCPServer,
+				SourcePath:         "/tmp/test-project/.claude/settings.json",
+				SourceProject:      "test-project",
+				DiscoveredAt:       "2026-04-02T10:00:00Z",
+				ContentHash:        "ghi789",
+				ContentSizeBytes:   256,
+				HasYAMLFrontmatter: false,
+				Dependencies:       []string{},
+				ConflictsWith:      []string{},
+			},
+			{
+				ID:                 "other-project/deploy-copy",
+				Name:               "deploy-copy",
+				Type:               model.SkillTypeClaudeCodeSkill,
+				SourcePath:         "/tmp/other-project/.claude/skills/deploy/deploy.md",
+				SourceProject:      "other-project",
+				DiscoveredAt:       "2026-04-02T10:00:00Z",
+				ContentHash:        "abc123", // same hash = duplicate
+				ContentSizeBytes:   1024,
+				HasYAMLFrontmatter: true,
+				DuplicateOf:        &dupOf,
+				Frontmatter: &model.Frontmatter{
+					Name:     "deploy-copy",
+					Version:  "1.0.0",
+					Category: "deployment",
+				},
+				Dependencies:  []string{},
+				ConflictsWith: []string{},
+			},
+		},
+		TotalCount:    4,
+		ByType:        map[string]int{"claude_code_skill": 2, "command": 1, "mcp_server": 1},
+		ByProject:     map[string]int{"test-project": 3, "other-project": 1},
+		Duplicates:    1,
+		NoFrontmatter: 2,
+	}
+}
+
+func TestGenerateHTML(t *testing.T) {
+	inv := sampleInventory()
+	var buf bytes.Buffer
+
+	err := GenerateHTML(&buf, inv)
+	if err != nil {
+		t.Fatalf("GenerateHTML error: %v", err)
+	}
+
+	html := buf.String()
+
+	// Check basic structure.
+	if !strings.Contains(html, "<title>Skill Inventory Report</title>") {
+		t.Error("missing title")
+	}
+	if !strings.Contains(html, "deploy-stage") {
+		t.Error("missing deploy-stage skill name")
+	}
+	if !strings.Contains(html, "2026-04-02T10:00:00Z") {
+		t.Error("missing scanned at timestamp")
+	}
+	if !strings.Contains(html, "test-project") {
+		t.Error("missing project name")
+	}
+
+	// Check duplicates section appears.
+	if !strings.Contains(html, "Duplicates") {
+		t.Error("missing duplicates section")
+	}
+	if !strings.Contains(html, "deploy-copy") {
+		t.Error("missing duplicate skill name")
+	}
+
+	// Check no frontmatter section appears.
+	if !strings.Contains(html, "Without Frontmatter") {
+		t.Error("missing no-frontmatter section")
+	}
+
+	// Check CSS is embedded.
+	if !strings.Contains(html, "<style>") {
+		t.Error("missing embedded CSS")
+	}
+}
+
+func TestGenerateMarkdown(t *testing.T) {
+	inv := sampleInventory()
+	var buf bytes.Buffer
+
+	err := GenerateMarkdown(&buf, inv)
+	if err != nil {
+		t.Fatalf("GenerateMarkdown error: %v", err)
+	}
+
+	md := buf.String()
+
+	if !strings.Contains(md, "# Skill Inventory Report") {
+		t.Error("missing report title")
+	}
+	if !strings.Contains(md, "deploy-stage") {
+		t.Error("missing deploy-stage")
+	}
+	if !strings.Contains(md, "| Total Skills | 4 |") {
+		t.Error("missing total skills count")
+	}
+	if !strings.Contains(md, "## Duplicates") {
+		t.Error("missing duplicates section")
+	}
+	if !strings.Contains(md, "## Skills Without Frontmatter") {
+		t.Error("missing no-frontmatter section")
+	}
+}
+
+func TestGenerateHTMLEmpty(t *testing.T) {
+	inv := &model.Inventory{
+		ScannedAt:     "2026-04-02T10:00:00Z",
+		ScanPaths:     []string{"/tmp/empty"},
+		Skills:        []model.SkillDescriptor{},
+		TotalCount:    0,
+		ByType:        map[string]int{},
+		ByProject:     map[string]int{},
+		Duplicates:    0,
+		NoFrontmatter: 0,
+	}
+
+	var buf bytes.Buffer
+	err := GenerateHTML(&buf, inv)
+	if err != nil {
+		t.Fatalf("GenerateHTML error on empty inventory: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Total Skills") {
+		t.Error("missing stats in empty report")
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{2560, "2.5 KB"},
+		{1048576, "1.0 MB"},
+		{1572864, "1.5 MB"},
+	}
+	for _, tc := range tests {
+		got := formatBytes(tc.input)
+		if got != tc.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/pkg/skillctl/review/server.go
+++ b/pkg/skillctl/review/server.go
@@ -1,0 +1,362 @@
+// Package review provides a local HTTP server for reviewing skill delta reports.
+package review
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/delta"
+)
+
+//go:embed ui.html
+var uiHTML []byte
+
+// Server serves the review UI and API endpoints.
+type Server struct {
+	Addr      string // listen address, default ":9115"
+	DeltaPath string // path to delta report JSON
+	NoBrowser bool   // skip opening browser on start
+
+	mu        sync.Mutex
+	report    *delta.DeltaReport
+	sealStore *delta.SealStore
+}
+
+// NewServer creates a review server with sensible defaults.
+func NewServer(addr, deltaPath string) *Server {
+	if addr == "" {
+		addr = ":9115"
+	}
+	return &Server{
+		Addr:      addr,
+		DeltaPath: deltaPath,
+	}
+}
+
+// loadDelta reads a DeltaReport from a JSON file on disk.
+func loadDelta(path string) (*delta.DeltaReport, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading delta report: %w", err)
+	}
+	var dr delta.DeltaReport
+	if err := json.Unmarshal(data, &dr); err != nil {
+		return nil, fmt.Errorf("parsing delta report: %w", err)
+	}
+	return &dr, nil
+}
+
+// LoadDelta reads the delta report from the configured path.
+func (s *Server) LoadDelta(path string) error {
+	dr, err := loadDelta(path)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.report = dr
+	s.mu.Unlock()
+	return nil
+}
+
+// Start initialises routes, loads the delta, and starts the HTTP server.
+// It blocks until the server is shut down.
+func (s *Server) Start() error {
+	if err := s.LoadDelta(s.DeltaPath); err != nil {
+		return fmt.Errorf("loading delta: %w", err)
+	}
+
+	store, err := delta.NewSealStore()
+	if err != nil {
+		return fmt.Errorf("initialising seal store: %w", err)
+	}
+	s.sealStore = store
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleUI)
+	mux.HandleFunc("/api/delta", s.handleGetDelta)
+	mux.HandleFunc("/api/delta/", s.handleReviewEntry)
+	mux.HandleFunc("/api/seal", s.handleSeal)
+	mux.HandleFunc("/api/seals", s.handleListSeals)
+	mux.HandleFunc("/api/health", s.handleHealth)
+
+	host := s.Addr
+	if strings.HasPrefix(host, ":") {
+		host = "localhost" + host
+	}
+	url := "http://" + host
+
+	fmt.Fprintf(os.Stderr, "skillctl review server listening on %s\n", url)
+
+	if !s.NoBrowser {
+		go func() {
+			time.Sleep(300 * time.Millisecond)
+			openBrowser(url)
+		}()
+	}
+
+	return http.ListenAndServe(s.Addr, mux)
+}
+
+// handleUI serves the embedded HTML page.
+func (s *Server) handleUI(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write(uiHTML)
+}
+
+// deltaJSON is the JSON shape served to the UI, adding per-entry indices
+// and using summary field names the frontend expects.
+type deltaJSON struct {
+	ComputedAt    string           `json:"computed_at"`
+	BaselinePath  string           `json:"baseline_path"`
+	CurrentPath   string           `json:"current_path"`
+	Entries       []entryJSON      `json:"entries"`
+	TotalAdded    int              `json:"total_added"`
+	TotalModified int              `json:"total_modified"`
+	TotalRemoved  int              `json:"total_removed"`
+	TotalMoved    int              `json:"total_moved"`
+}
+
+type entryJSON struct {
+	Index          int                    `json:"index"`
+	delta.DeltaEntry
+}
+
+func buildDeltaJSON(dr *delta.DeltaReport) *deltaJSON {
+	dj := &deltaJSON{
+		ComputedAt:    dr.ComputedAt,
+		BaselinePath:  dr.BaselinePath,
+		CurrentPath:   dr.CurrentPath,
+		TotalAdded:    dr.Summary.Added,
+		TotalModified: dr.Summary.Modified,
+		TotalRemoved:  dr.Summary.Removed,
+		TotalMoved:    dr.Summary.Moved,
+		Entries:       make([]entryJSON, len(dr.Entries)),
+	}
+	for i := range dr.Entries {
+		dj.Entries[i] = entryJSON{
+			Index:      i,
+			DeltaEntry: dr.Entries[i],
+		}
+	}
+	return dj
+}
+
+// handleGetDelta returns the current DeltaReport as JSON.
+func (s *Server) handleGetDelta(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s.mu.Lock()
+	d := s.report
+	s.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(buildDeltaJSON(d))
+}
+
+// reviewRequest is the JSON body for updating a review status.
+type reviewRequest struct {
+	Status string `json:"status"`
+}
+
+// handleReviewEntry updates the review status for a single delta entry.
+// PUT /api/delta/{index}/review
+func (s *Server) handleReviewEntry(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Parse index from path: /api/delta/0/review
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/delta/"), "/")
+	if len(parts) != 2 || parts[1] != "review" {
+		http.Error(w, "invalid path: expected /api/delta/{index}/review", http.StatusBadRequest)
+		return
+	}
+	idx, err := strconv.Atoi(parts[0])
+	if err != nil {
+		http.Error(w, "invalid index", http.StatusBadRequest)
+		return
+	}
+
+	var req reviewRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	var status delta.ReviewStatus
+	switch req.Status {
+	case "approved":
+		status = delta.ReviewApproved
+	case "rejected":
+		status = delta.ReviewRejected
+	case "deferred":
+		status = delta.ReviewDeferred
+	case "pending":
+		status = delta.ReviewPending
+	default:
+		http.Error(w, "invalid status: use approved, rejected, deferred, or pending", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.report == nil || idx < 0 || idx >= len(s.report.Entries) {
+		http.Error(w, "index out of range", http.StatusNotFound)
+		return
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	s.report.Entries[idx].ReviewStatus = status
+	s.report.Entries[idx].ReviewedAt = now
+	s.report.Entries[idx].ReviewedBy = os.Getenv("USER")
+
+	entry := entryJSON{Index: idx, DeltaEntry: s.report.Entries[idx]}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(entry)
+}
+
+// sealResponse is the JSON returned after sealing.
+type sealResponse struct {
+	SealID   string `json:"seal_id"`
+	SealedAt string `json:"sealed_at"`
+	SealedBy string `json:"sealed_by"`
+	Approved int    `json:"approved"`
+	Rejected int    `json:"rejected"`
+	Deferred int    `json:"deferred"`
+	Total    int    `json:"total"`
+}
+
+// handleSeal creates a new seal from the current reviewed delta.
+func (s *Server) handleSeal(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.Lock()
+	d := s.report
+	s.mu.Unlock()
+
+	if d == nil {
+		http.Error(w, "no delta loaded", http.StatusBadRequest)
+		return
+	}
+
+	// Check that all entries are reviewed (not pending).
+	for _, e := range d.Entries {
+		if e.ReviewStatus == delta.ReviewPending {
+			http.Error(w, "all entries must be reviewed before sealing", http.StatusConflict)
+			return
+		}
+	}
+
+	// Count review decisions.
+	approved, rejected, deferred := 0, 0, 0
+	for _, e := range d.Entries {
+		switch e.ReviewStatus {
+		case delta.ReviewApproved:
+			approved++
+		case delta.ReviewRejected:
+			rejected++
+		case delta.ReviewDeferred:
+			deferred++
+		}
+	}
+
+	now := time.Now().UTC()
+	resp := sealResponse{
+		SealID:   fmt.Sprintf("seal-%s", now.Format("20060102T150405Z")),
+		SealedAt: now.Format(time.RFC3339),
+		SealedBy: os.Getenv("USER"),
+		Approved: approved,
+		Rejected: rejected,
+		Deferred: deferred,
+		Total:    len(d.Entries),
+	}
+
+	// Write the seal record to the seal store as a minimal record.
+	if s.sealStore != nil {
+		sealRecord := delta.SealRecord{
+			SealID:     resp.SealID,
+			SealedAt:   resp.SealedAt,
+			SealedBy:   resp.SealedBy,
+			SkillCount: resp.Total,
+			Approved:   approved,
+			Rejected:   rejected,
+			Deferred:   deferred,
+		}
+		sealData, err := json.MarshalIndent(sealRecord, "", "  ")
+		if err == nil {
+			sealPath := fmt.Sprintf("%s/%s.json", s.sealStore.BaseDir, resp.SealID)
+			os.WriteFile(sealPath, sealData, 0644)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleListSeals returns all seal records.
+func (s *Server) handleListSeals(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if s.sealStore == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("[]"))
+		return
+	}
+
+	seals, err := s.sealStore.ListSeals()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("listing seals: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if seals == nil {
+		seals = []delta.SealRecord{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(seals)
+}
+
+// handleHealth returns a simple health check response.
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"status":"ok","service":"skillctl-review"}`))
+}
+
+// openBrowser opens the given URL in the default browser.
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		return
+	}
+	cmd.Start()
+}

--- a/pkg/skillctl/review/server_test.go
+++ b/pkg/skillctl/review/server_test.go
@@ -1,0 +1,289 @@
+package review
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/delta"
+)
+
+// createTestDelta writes a minimal delta report to a temp file and returns the path.
+func createTestDelta(t *testing.T) string {
+	t.Helper()
+	dr := delta.DeltaReport{
+		ComputedAt:   "2026-04-02T10:00:00Z",
+		BaselinePath: "baseline.json",
+		CurrentPath:  "current.json",
+		Entries: []delta.DeltaEntry{
+			{
+				SkillID:      "proj/alpha",
+				SkillName:    "alpha",
+				DeltaType:    delta.DeltaAdded,
+				CurrentHash:  "abc123",
+				CurrentPath:  "/skills/alpha.md",
+				ContentDiff:  "new skill content",
+				ReviewStatus: delta.ReviewPending,
+			},
+			{
+				SkillID:      "proj/beta",
+				SkillName:    "beta",
+				DeltaType:    delta.DeltaModified,
+				BaselineHash: "old-hash",
+				CurrentHash:  "new-hash",
+				BaselinePath: "/skills/beta.md",
+				CurrentPath:  "/skills/beta.md",
+				ContentDiff:  "-old line\n+new line\n context",
+				ReviewStatus: delta.ReviewPending,
+			},
+			{
+				SkillID:      "proj/gamma",
+				SkillName:    "gamma",
+				DeltaType:    delta.DeltaRemoved,
+				BaselineHash: "rem-hash",
+				BaselinePath: "/skills/gamma.md",
+				ReviewStatus: delta.ReviewPending,
+			},
+		},
+		Summary: delta.DeltaSummary{
+			Added:    1,
+			Modified: 1,
+			Removed:  1,
+			Total:    3,
+		},
+	}
+
+	data, err := json.MarshalIndent(dr, "", "  ")
+	if err != nil {
+		t.Fatalf("marshalling test delta: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "delta.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("writing test delta: %v", err)
+	}
+	return path
+}
+
+func setupServer(t *testing.T) *Server {
+	t.Helper()
+	deltaPath := createTestDelta(t)
+	s := NewServer(":0", deltaPath)
+	if err := s.LoadDelta(deltaPath); err != nil {
+		t.Fatalf("LoadDelta: %v", err)
+	}
+	// Use temp dir for seal store.
+	store, err := delta.NewSealStoreAt(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewSealStoreAt: %v", err)
+	}
+	s.sealStore = store
+	return s
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	s := setupServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	w := httptest.NewRecorder()
+	s.handleHealth(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("health status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp["status"] != "ok" {
+		t.Errorf("health status = %q, want %q", resp["status"], "ok")
+	}
+}
+
+func TestGetDeltaEndpoint(t *testing.T) {
+	s := setupServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/delta", nil)
+	w := httptest.NewRecorder()
+	s.handleGetDelta(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("delta status = %d, want 200", w.Code)
+	}
+
+	var resp deltaJSON
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(resp.Entries) != 3 {
+		t.Errorf("entries = %d, want 3", len(resp.Entries))
+	}
+	if resp.TotalAdded != 1 {
+		t.Errorf("total_added = %d, want 1", resp.TotalAdded)
+	}
+	if resp.TotalModified != 1 {
+		t.Errorf("total_modified = %d, want 1", resp.TotalModified)
+	}
+	// Verify indices are set.
+	for i, e := range resp.Entries {
+		if e.Index != i {
+			t.Errorf("entry[%d].index = %d, want %d", i, e.Index, i)
+		}
+	}
+}
+
+func TestReviewEntryEndpoint(t *testing.T) {
+	s := setupServer(t)
+
+	body := strings.NewReader(`{"status":"approved"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/delta/0/review", body)
+	w := httptest.NewRecorder()
+	s.handleReviewEntry(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("review status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+
+	var resp entryJSON
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp.ReviewStatus != delta.ReviewApproved {
+		t.Errorf("review_status = %q, want %q", resp.ReviewStatus, delta.ReviewApproved)
+	}
+	if resp.ReviewedAt == "" {
+		t.Error("reviewed_at should be set")
+	}
+}
+
+func TestReviewEntryInvalidStatus(t *testing.T) {
+	s := setupServer(t)
+
+	body := strings.NewReader(`{"status":"invalid"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/delta/0/review", body)
+	w := httptest.NewRecorder()
+	s.handleReviewEntry(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestReviewEntryOutOfRange(t *testing.T) {
+	s := setupServer(t)
+
+	body := strings.NewReader(`{"status":"approved"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/delta/99/review", body)
+	w := httptest.NewRecorder()
+	s.handleReviewEntry(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestSealRequiresAllReviewed(t *testing.T) {
+	s := setupServer(t)
+
+	// Try sealing with pending entries.
+	req := httptest.NewRequest(http.MethodPost, "/api/seal", nil)
+	w := httptest.NewRecorder()
+	s.handleSeal(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("seal status = %d, want 409 (entries still pending)", w.Code)
+	}
+}
+
+func TestSealAfterFullReview(t *testing.T) {
+	s := setupServer(t)
+
+	// Approve all entries.
+	for i := 0; i < 3; i++ {
+		body := strings.NewReader(`{"status":"approved"}`)
+		req := httptest.NewRequest(http.MethodPut, "/api/delta/"+string(rune('0'+i))+"/review", body)
+		w := httptest.NewRecorder()
+		s.handleReviewEntry(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("review entry %d: status = %d", i, w.Code)
+		}
+	}
+
+	// Now seal.
+	req := httptest.NewRequest(http.MethodPost, "/api/seal", nil)
+	w := httptest.NewRecorder()
+	s.handleSeal(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("seal status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+
+	var resp sealResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp.Approved != 3 {
+		t.Errorf("approved = %d, want 3", resp.Approved)
+	}
+	if resp.SealID == "" {
+		t.Error("seal_id should not be empty")
+	}
+}
+
+func TestListSealsEndpoint(t *testing.T) {
+	s := setupServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/seals", nil)
+	w := httptest.NewRecorder()
+	s.handleListSeals(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("seals status = %d, want 200", w.Code)
+	}
+
+	var seals []delta.SealRecord
+	if err := json.Unmarshal(w.Body.Bytes(), &seals); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	// Initially empty.
+	if len(seals) != 0 {
+		t.Errorf("seals = %d, want 0 initially", len(seals))
+	}
+}
+
+func TestGetDeltaMethodNotAllowed(t *testing.T) {
+	s := setupServer(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/delta", nil)
+	w := httptest.NewRecorder()
+	s.handleGetDelta(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestUIEndpointServesHTML(t *testing.T) {
+	s := setupServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	s.handleUI(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("UI status = %d, want 200", w.Code)
+	}
+	ct := w.Header().Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+	if !strings.Contains(w.Body.String(), "skillctl") {
+		t.Error("UI response should contain 'skillctl'")
+	}
+}

--- a/pkg/skillctl/review/ui.html
+++ b/pkg/skillctl/review/ui.html
@@ -1,0 +1,1155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>skillctl - Delta Review</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --surface-hover: #1c2333;
+    --border: #30363d;
+    --border-light: #3d444d;
+    --text: #e6edf3;
+    --text-muted: #8b949e;
+    --text-dim: #656d76;
+    --accent: #7c3aed;
+    --accent-light: #a78bfa;
+    --green: #3fb950;
+    --green-bg: rgba(46, 204, 113, 0.15);
+    --green-border: rgba(46, 204, 113, 0.4);
+    --yellow: #d29922;
+    --yellow-bg: rgba(243, 156, 18, 0.15);
+    --yellow-border: rgba(243, 156, 18, 0.4);
+    --red: #f85149;
+    --red-bg: rgba(231, 76, 60, 0.15);
+    --red-border: rgba(231, 76, 60, 0.4);
+    --blue: #58a6ff;
+    --blue-bg: rgba(52, 152, 219, 0.15);
+    --blue-border: rgba(52, 152, 219, 0.4);
+    --grey: #8b949e;
+    --grey-bg: rgba(149, 165, 166, 0.15);
+    --grey-border: rgba(149, 165, 166, 0.4);
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    min-height: 100vh;
+  }
+
+  /* Header */
+  .header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 1rem 2rem;
+  }
+  .header-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.75rem;
+  }
+  .header h1 {
+    font-size: 1.4rem;
+    color: var(--accent-light);
+    font-weight: 600;
+  }
+  .header h1 span {
+    color: var(--text-muted);
+    font-weight: 400;
+    font-size: 0.85rem;
+    margin-left: 0.5rem;
+  }
+  .header-meta {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+  }
+
+  /* Stats bar */
+  .stats-bar {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .stat-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.6rem;
+    border-radius: 16px;
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+  .stat-chip.added { background: var(--green-bg); color: var(--green); }
+  .stat-chip.modified { background: var(--yellow-bg); color: var(--yellow); }
+  .stat-chip.removed { background: var(--red-bg); color: var(--red); }
+  .stat-chip.moved { background: var(--blue-bg); color: var(--blue); }
+
+  /* Filter bar */
+  .filter-bar {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.75rem 2rem;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    flex-wrap: wrap;
+    position: sticky;
+    top: 90px;
+    z-index: 99;
+  }
+  .filter-btn {
+    padding: 0.3rem 0.7rem;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .filter-btn:hover {
+    border-color: var(--border-light);
+    color: var(--text);
+    background: var(--surface);
+  }
+  .filter-btn.active {
+    border-color: var(--accent);
+    color: var(--accent-light);
+    background: rgba(124, 58, 237, 0.15);
+  }
+  .filter-btn .count {
+    display: inline-block;
+    min-width: 1.2em;
+    text-align: center;
+    margin-left: 0.3rem;
+    padding: 0 0.3rem;
+    border-radius: 8px;
+    background: rgba(255,255,255,0.08);
+    font-size: 0.75rem;
+  }
+  .filter-sep {
+    width: 1px;
+    background: var(--border);
+    margin: 0 0.25rem;
+    align-self: stretch;
+  }
+
+  /* Main content */
+  .content {
+    padding: 1.5rem 2rem;
+    padding-bottom: 6rem;
+    max-width: 960px;
+    margin: 0 auto;
+  }
+
+  /* Cards */
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    margin-bottom: 1rem;
+    overflow: hidden;
+    transition: border-color 0.2s, box-shadow 0.2s;
+  }
+  .card.selected {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 1px var(--accent);
+  }
+  .card.status-approved { border-left: 3px solid var(--green); }
+  .card.status-rejected { border-left: 3px solid var(--red); }
+  .card.status-deferred { border-left: 3px solid var(--grey); }
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    user-select: none;
+  }
+  .card-header:hover { background: var(--surface-hover); }
+  .card-header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-width: 0;
+  }
+  .card-header-right {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+  .delta-badge {
+    display: inline-block;
+    padding: 0.15rem 0.55rem;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    flex-shrink: 0;
+  }
+  .delta-badge.added { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+  .delta-badge.modified { background: var(--yellow-bg); color: var(--yellow); border: 1px solid var(--yellow-border); }
+  .delta-badge.removed { background: var(--red-bg); color: var(--red); border: 1px solid var(--red-border); }
+  .delta-badge.moved { background: var(--blue-bg); color: var(--blue); border: 1px solid var(--blue-border); }
+  .skill-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .skill-meta {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    padding: 0 1rem 0.5rem;
+  }
+  .review-indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 2px solid var(--border-light);
+    flex-shrink: 0;
+  }
+  .review-indicator.approved { background: var(--green); border-color: var(--green); }
+  .review-indicator.rejected { background: var(--red); border-color: var(--red); }
+  .review-indicator.deferred { background: var(--grey); border-color: var(--grey); }
+  .expand-arrow {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    transition: transform 0.2s;
+  }
+  .card.expanded .expand-arrow { transform: rotate(90deg); }
+
+  /* Card body (collapsible) */
+  .card-body {
+    display: none;
+    border-top: 1px solid var(--border);
+  }
+  .card.expanded .card-body { display: block; }
+
+  /* Sections inside card */
+  .card-section {
+    padding: 0.75rem 1rem;
+    border-top: 1px solid var(--border);
+  }
+  .card-section:first-child { border-top: none; }
+  .card-section-title {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+  }
+
+  /* Frontmatter changes */
+  .fm-change {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+    padding: 0.2rem 0;
+    font-size: 0.85rem;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+  }
+  .fm-field {
+    color: var(--accent-light);
+    min-width: 100px;
+  }
+  .fm-old {
+    color: var(--red);
+    text-decoration: line-through;
+  }
+  .fm-arrow { color: var(--text-dim); }
+  .fm-new { color: var(--green); }
+  .fm-added::before {
+    content: '+';
+    color: var(--green);
+    margin-right: 0.25rem;
+  }
+  .fm-removed::before {
+    content: '-';
+    color: var(--red);
+    margin-right: 0.25rem;
+  }
+
+  /* Diff view */
+  .diff-view {
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+  .diff-line {
+    padding: 0.1rem 0.75rem;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  .diff-line.add {
+    background: var(--green-bg);
+    color: var(--green);
+  }
+  .diff-line.add::before {
+    content: '+ ';
+    font-weight: 700;
+  }
+  .diff-line.del {
+    background: var(--red-bg);
+    color: var(--red);
+  }
+  .diff-line.del::before {
+    content: '- ';
+    font-weight: 700;
+  }
+  .diff-line.ctx {
+    color: var(--text-muted);
+  }
+  .diff-line.ctx::before {
+    content: '  ';
+  }
+  .diff-line.hunk {
+    color: var(--blue);
+    background: var(--blue-bg);
+    font-weight: 600;
+  }
+
+  /* Full content view (for added/removed) */
+  .full-content {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    padding: 0.75rem;
+    border-radius: 4px;
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  .full-content.added-bg {
+    background: var(--green-bg);
+    color: var(--green);
+  }
+  .full-content.removed-bg {
+    background: var(--red-bg);
+    color: var(--red);
+    text-decoration: line-through;
+    text-decoration-color: rgba(231, 76, 60, 0.4);
+  }
+
+  /* Move path */
+  .move-path {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 0.85rem;
+    padding: 0.5rem 0;
+  }
+  .move-path .old-path {
+    color: var(--red);
+    text-decoration: line-through;
+  }
+  .move-path .arrow {
+    color: var(--text-muted);
+    margin: 0 0.5rem;
+  }
+  .move-path .new-path {
+    color: var(--green);
+  }
+
+  /* Action buttons */
+  .card-actions {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border-top: 1px solid var(--border);
+    background: rgba(0,0,0,0.15);
+  }
+  .action-btn {
+    padding: 0.35rem 0.8rem;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text);
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.15s;
+    font-weight: 500;
+  }
+  .action-btn:hover { filter: brightness(1.2); }
+  .action-btn.approve {
+    border-color: var(--green-border);
+    color: var(--green);
+  }
+  .action-btn.approve:hover {
+    background: var(--green-bg);
+  }
+  .action-btn.approve.active {
+    background: var(--green);
+    color: #000;
+    border-color: var(--green);
+  }
+  .action-btn.reject {
+    border-color: var(--red-border);
+    color: var(--red);
+  }
+  .action-btn.reject:hover {
+    background: var(--red-bg);
+  }
+  .action-btn.reject.active {
+    background: var(--red);
+    color: #000;
+    border-color: var(--red);
+  }
+  .action-btn.defer {
+    border-color: var(--grey-border);
+    color: var(--grey);
+  }
+  .action-btn.defer:hover {
+    background: var(--grey-bg);
+  }
+  .action-btn.defer.active {
+    background: var(--grey);
+    color: #000;
+    border-color: var(--grey);
+  }
+
+  /* Bottom action bar */
+  .bottom-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: var(--surface);
+    border-top: 1px solid var(--border);
+    padding: 0.75rem 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    z-index: 100;
+  }
+  .progress-section {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  .progress-text {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+  .progress-text strong {
+    color: var(--text);
+  }
+  .progress-bar-wrapper {
+    width: 200px;
+    height: 6px;
+    background: var(--border);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+  .progress-bar-fill {
+    height: 100%;
+    background: var(--accent);
+    border-radius: 3px;
+    transition: width 0.3s;
+  }
+  .seal-btn {
+    padding: 0.5rem 1.2rem;
+    border-radius: 8px;
+    border: none;
+    background: var(--accent);
+    color: white;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .seal-btn:hover:not(:disabled) {
+    background: var(--accent-light);
+    color: #000;
+  }
+  .seal-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  /* Keyboard shortcuts help */
+  .shortcuts-hint {
+    color: var(--text-dim);
+    font-size: 0.75rem;
+  }
+  kbd {
+    display: inline-block;
+    padding: 0.1rem 0.35rem;
+    font-family: 'SF Mono', monospace;
+    font-size: 0.7rem;
+    background: var(--border);
+    border-radius: 3px;
+    color: var(--text-muted);
+  }
+
+  /* Modal */
+  .modal-overlay {
+    display: none;
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.6);
+    z-index: 200;
+    justify-content: center;
+    align-items: center;
+  }
+  .modal-overlay.visible { display: flex; }
+  .modal {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    max-width: 480px;
+    width: 90%;
+  }
+  .modal h2 {
+    color: var(--accent-light);
+    font-size: 1.1rem;
+    margin-bottom: 1rem;
+  }
+  .modal p {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    margin-bottom: 1rem;
+  }
+  .modal-stats {
+    display: flex;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+  .modal-stat {
+    text-align: center;
+  }
+  .modal-stat .num {
+    font-size: 1.5rem;
+    font-weight: 700;
+  }
+  .modal-stat .lbl {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+  }
+  .modal-stat .num.green { color: var(--green); }
+  .modal-stat .num.red { color: var(--red); }
+  .modal-stat .num.grey { color: var(--grey); }
+  .modal-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+  }
+  .modal-btn {
+    padding: 0.45rem 1rem;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text);
+    transition: all 0.15s;
+  }
+  .modal-btn:hover { background: var(--surface-hover); }
+  .modal-btn.primary {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: white;
+  }
+  .modal-btn.primary:hover { background: var(--accent-light); color: #000; }
+
+  /* Empty state */
+  .empty-state {
+    text-align: center;
+    padding: 4rem 2rem;
+    color: var(--text-muted);
+  }
+  .empty-state h2 {
+    font-size: 1.2rem;
+    color: var(--text);
+    margin-bottom: 0.5rem;
+  }
+
+  /* Toast */
+  .toast {
+    position: fixed;
+    bottom: 5rem;
+    right: 2rem;
+    padding: 0.6rem 1rem;
+    border-radius: 8px;
+    background: var(--green);
+    color: #000;
+    font-size: 0.85rem;
+    font-weight: 600;
+    z-index: 300;
+    opacity: 0;
+    transform: translateY(10px);
+    transition: all 0.3s;
+    pointer-events: none;
+  }
+  .toast.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .toast.error {
+    background: var(--red);
+    color: white;
+  }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div class="header-top">
+    <h1>skillctl <span>Delta Review</span></h1>
+    <div class="shortcuts-hint">
+      <kbd>j</kbd>/<kbd>k</kbd> navigate
+      <kbd>a</kbd> approve
+      <kbd>r</kbd> reject
+      <kbd>d</kbd> defer
+      <kbd>Enter</kbd> expand
+    </div>
+  </div>
+  <div class="stats-bar" id="statsBar"></div>
+</div>
+
+<div class="filter-bar" id="filterBar"></div>
+
+<div class="content" id="content"></div>
+
+<div class="bottom-bar">
+  <div class="progress-section">
+    <span class="progress-text" id="progressText">0/0 reviewed</span>
+    <div class="progress-bar-wrapper">
+      <div class="progress-bar-fill" id="progressBar" style="width: 0%"></div>
+    </div>
+  </div>
+  <button class="seal-btn" id="sealBtn" disabled>Seal &amp; Sign Off</button>
+</div>
+
+<div class="modal-overlay" id="sealModal">
+  <div class="modal">
+    <h2>Seal &amp; Sign Off</h2>
+    <p>This will create an immutable seal record from your review decisions. Approved changes become the new baseline.</p>
+    <div class="modal-stats" id="modalStats"></div>
+    <div class="modal-actions">
+      <button class="modal-btn" id="modalCancel">Cancel</button>
+      <button class="modal-btn primary" id="modalConfirm">Confirm Seal</button>
+    </div>
+  </div>
+</div>
+
+<div class="toast" id="toast"></div>
+
+<script>
+(function() {
+  'use strict';
+
+  let deltaReport = null;
+  let selectedIndex = -1;
+  let activeFilter = 'all';
+  let refreshTimer = null;
+
+  // ---- API calls ----
+  async function fetchDelta() {
+    const resp = await fetch('/api/delta');
+    if (!resp.ok) throw new Error('Failed to fetch delta');
+    return resp.json();
+  }
+
+  async function updateReview(index, status) {
+    const resp = await fetch('/api/delta/' + index + '/review', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: status })
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(text);
+    }
+    return resp.json();
+  }
+
+  async function createSeal() {
+    const resp = await fetch('/api/seal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(text);
+    }
+    return resp.json();
+  }
+
+  // ---- Toast ----
+  function showToast(msg, isError) {
+    const t = document.getElementById('toast');
+    t.textContent = msg;
+    t.className = 'toast visible' + (isError ? ' error' : '');
+    setTimeout(function() { t.className = 'toast'; }, 2500);
+  }
+
+  // ---- Render ----
+  function getFilteredEntries() {
+    if (!deltaReport || !deltaReport.entries) return [];
+    return deltaReport.entries.filter(function(e) {
+      if (activeFilter === 'all') return true;
+      if (activeFilter === 'pending') return e.review_status === 'pending';
+      if (activeFilter === 'approved') return e.review_status === 'approved';
+      if (activeFilter === 'rejected') return e.review_status === 'rejected';
+      return e.delta_type === activeFilter;
+    });
+  }
+
+  function renderStats() {
+    const bar = document.getElementById('statsBar');
+    if (!deltaReport) { bar.innerHTML = ''; return; }
+    const d = deltaReport;
+    let html = '';
+    if (d.total_added > 0) html += '<span class="stat-chip added">' + d.total_added + ' Added</span>';
+    if (d.total_modified > 0) html += '<span class="stat-chip modified">' + d.total_modified + ' Modified</span>';
+    if (d.total_removed > 0) html += '<span class="stat-chip removed">' + d.total_removed + ' Removed</span>';
+    if (d.total_moved > 0) html += '<span class="stat-chip moved">' + d.total_moved + ' Moved</span>';
+    if (!html) html = '<span class="stat-chip" style="color:var(--text-muted);">No changes detected</span>';
+    bar.innerHTML = html;
+  }
+
+  function renderFilters() {
+    const bar = document.getElementById('filterBar');
+    if (!deltaReport || !deltaReport.entries) { bar.innerHTML = ''; return; }
+    const entries = deltaReport.entries;
+    const counts = { all: entries.length, added: 0, modified: 0, removed: 0, moved: 0, pending: 0, approved: 0, rejected: 0 };
+    entries.forEach(function(e) {
+      counts[e.delta_type] = (counts[e.delta_type] || 0) + 1;
+      counts[e.review_status] = (counts[e.review_status] || 0) + 1;
+    });
+
+    const typeFilters = [
+      { key: 'all', label: 'All' },
+      { key: 'added', label: 'Added' },
+      { key: 'modified', label: 'Modified' },
+      { key: 'removed', label: 'Removed' },
+      { key: 'moved', label: 'Moved' }
+    ];
+    const statusFilters = [
+      { key: 'pending', label: 'Pending' },
+      { key: 'approved', label: 'Approved' },
+      { key: 'rejected', label: 'Rejected' }
+    ];
+
+    let html = '';
+    typeFilters.forEach(function(f) {
+      if (f.key !== 'all' && !counts[f.key]) return;
+      html += '<button class="filter-btn' + (activeFilter === f.key ? ' active' : '') + '" data-filter="' + f.key + '">';
+      html += f.label + '<span class="count">' + (counts[f.key] || 0) + '</span></button>';
+    });
+    html += '<div class="filter-sep"></div>';
+    statusFilters.forEach(function(f) {
+      if (!counts[f.key]) return;
+      html += '<button class="filter-btn' + (activeFilter === f.key ? ' active' : '') + '" data-filter="' + f.key + '">';
+      html += f.label + '<span class="count">' + (counts[f.key] || 0) + '</span></button>';
+    });
+    bar.innerHTML = html;
+
+    bar.querySelectorAll('.filter-btn').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        activeFilter = btn.dataset.filter;
+        renderFilters();
+        renderCards();
+      });
+    });
+  }
+
+  function escapeHtml(text) {
+    var div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  function renderDiffLines(diffText) {
+    if (!diffText) return '<div class="diff-line ctx">(no diff available)</div>';
+    var lines = diffText.split('\n');
+    var html = '';
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      var cls = 'ctx';
+      if (line.indexOf('@@') === 0) cls = 'hunk';
+      else if (line.indexOf('+') === 0 && line.indexOf('+++') !== 0) cls = 'add';
+      else if (line.indexOf('-') === 0 && line.indexOf('---') !== 0) cls = 'del';
+      html += '<div class="diff-line ' + cls + '">' + escapeHtml(line) + '</div>';
+    }
+    return html;
+  }
+
+  // Extract project from skill_id (format: "project/name")
+  function extractProject(entry) {
+    if (entry.skill_id && entry.skill_id.indexOf('/') !== -1) {
+      return entry.skill_id.substring(0, entry.skill_id.indexOf('/'));
+    }
+    return '';
+  }
+
+  // Compute frontmatter changes by comparing baseline and current frontmatter objects
+  function computeFrontmatterChanges(entry) {
+    var base = entry.baseline_frontmatter || {};
+    var curr = entry.current_frontmatter || {};
+    if (!entry.baseline_frontmatter && !entry.current_frontmatter) return [];
+    var changes = [];
+    var fields = ['name', 'version', 'description', 'category', 'intent', 'input_type', 'output_format', 'model'];
+    fields.forEach(function(f) {
+      var bv = base[f] || '';
+      var cv = curr[f] || '';
+      if (bv !== cv) {
+        changes.push({ field: f, old_value: bv, new_value: cv });
+      }
+    });
+    // Compare array fields
+    var arrayFields = ['allowed_tools', 'tags'];
+    arrayFields.forEach(function(f) {
+      var bv = (base[f] || []).join(', ');
+      var cv = (curr[f] || []).join(', ');
+      if (bv !== cv) {
+        changes.push({ field: f, old_value: bv, new_value: cv });
+      }
+    });
+    return changes;
+  }
+
+  function renderFrontmatterChanges(changes) {
+    if (!changes || changes.length === 0) return '';
+    var html = '<div class="card-section"><div class="card-section-title">Frontmatter Changes</div>';
+    changes.forEach(function(ch) {
+      html += '<div class="fm-change">';
+      html += '<span class="fm-field">' + escapeHtml(ch.field) + ':</span> ';
+      if (ch.old_value && ch.new_value) {
+        html += '<span class="fm-old">' + escapeHtml(ch.old_value) + '</span>';
+        html += '<span class="fm-arrow"> &rarr; </span>';
+        html += '<span class="fm-new">' + escapeHtml(ch.new_value) + '</span>';
+      } else if (ch.new_value) {
+        html += '<span class="fm-added">' + escapeHtml(ch.new_value) + '</span>';
+      } else if (ch.old_value) {
+        html += '<span class="fm-removed">' + escapeHtml(ch.old_value) + '</span>';
+      }
+      html += '</div>';
+    });
+    html += '</div>';
+    return html;
+  }
+
+  function renderCardBody(entry) {
+    var html = '';
+
+    // Frontmatter changes (computed from baseline/current frontmatter)
+    var fmChanges = computeFrontmatterChanges(entry);
+    html += renderFrontmatterChanges(fmChanges);
+
+    // Content section varies by delta type
+    if (entry.delta_type === 'added') {
+      html += '<div class="card-section">';
+      html += '<div class="card-section-title">New Skill Content</div>';
+      html += '<div class="full-content added-bg">' + escapeHtml(entry.content_diff || '(content not available)') + '</div>';
+      html += '</div>';
+    } else if (entry.delta_type === 'removed') {
+      html += '<div class="card-section">';
+      html += '<div class="card-section-title">Removed Skill Content</div>';
+      html += '<div class="full-content removed-bg">' + escapeHtml(entry.content_diff || '(content not available)') + '</div>';
+      html += '</div>';
+    } else if (entry.delta_type === 'moved') {
+      html += '<div class="card-section">';
+      html += '<div class="card-section-title">Path Change</div>';
+      html += '<div class="move-path">';
+      html += '<span class="old-path">' + escapeHtml(entry.baseline_path || '?') + '</span>';
+      html += '<span class="arrow">&rarr;</span>';
+      html += '<span class="new-path">' + escapeHtml(entry.current_path || '?') + '</span>';
+      html += '</div></div>';
+    } else if (entry.delta_type === 'modified') {
+      html += '<div class="card-section">';
+      html += '<div class="card-section-title">Content Diff</div>';
+      html += '<div class="diff-view">' + renderDiffLines(entry.content_diff) + '</div>';
+      html += '</div>';
+    }
+
+    // Hash info
+    html += '<div class="card-section" style="display:flex;gap:2rem;font-size:0.75rem;color:var(--text-dim);">';
+    if (entry.baseline_hash) html += '<span>Baseline: ' + escapeHtml(entry.baseline_hash.substring(0, 12)) + '</span>';
+    if (entry.current_hash) html += '<span>Current: ' + escapeHtml(entry.current_hash.substring(0, 12)) + '</span>';
+    html += '</div>';
+
+    return html;
+  }
+
+  function renderCards() {
+    var container = document.getElementById('content');
+    var entries = getFilteredEntries();
+
+    if (entries.length === 0) {
+      container.innerHTML = '<div class="empty-state"><h2>No entries match the current filter</h2><p>Try selecting a different filter above.</p></div>';
+      return;
+    }
+
+    var html = '';
+    entries.forEach(function(entry, idx) {
+      var statusClass = entry.review_status !== 'pending' ? ' status-' + entry.review_status : '';
+      var expandedClass = '';
+      var selectedClass = (selectedIndex === entry.index) ? ' selected' : '';
+
+      html += '<div class="card' + statusClass + selectedClass + expandedClass + '" data-index="' + entry.index + '" id="card-' + entry.index + '">';
+
+      // Header
+      html += '<div class="card-header" data-index="' + entry.index + '">';
+      html += '<div class="card-header-left">';
+      html += '<span class="delta-badge ' + entry.delta_type + '">' + entry.delta_type + '</span>';
+      html += '<span class="skill-name">' + escapeHtml(entry.skill_name) + '</span>';
+      html += '</div>';
+      html += '<div class="card-header-right">';
+      html += '<span class="review-indicator ' + entry.review_status + '"></span>';
+      html += '<span class="expand-arrow">&#9654;</span>';
+      html += '</div>';
+      html += '</div>';
+
+      // Meta
+      html += '<div class="skill-meta">';
+      var project = extractProject(entry);
+      if (project) html += escapeHtml(project);
+      var path = entry.current_path || entry.baseline_path || '';
+      if (path) html += ' &bull; <span style="font-family:monospace;font-size:0.75rem;">' + escapeHtml(path) + '</span>';
+      html += '</div>';
+
+      // Body (hidden until expanded)
+      html += '<div class="card-body">';
+      html += renderCardBody(entry);
+
+      // Actions
+      html += '<div class="card-actions">';
+      html += '<button class="action-btn approve' + (entry.review_status === 'approved' ? ' active' : '') + '" data-index="' + entry.index + '" data-action="approved">&#10003; Approve</button>';
+      html += '<button class="action-btn reject' + (entry.review_status === 'rejected' ? ' active' : '') + '" data-index="' + entry.index + '" data-action="rejected">&#10007; Reject</button>';
+      html += '<button class="action-btn defer' + (entry.review_status === 'deferred' ? ' active' : '') + '" data-index="' + entry.index + '" data-action="deferred">&#9719; Defer</button>';
+      html += '</div>';
+
+      html += '</div>'; // card-body
+      html += '</div>'; // card
+    });
+
+    container.innerHTML = html;
+
+    // Wire up click handlers
+    container.querySelectorAll('.card-header').forEach(function(hdr) {
+      hdr.addEventListener('click', function() {
+        var idx = parseInt(hdr.dataset.index);
+        toggleCard(idx);
+      });
+    });
+
+    container.querySelectorAll('.action-btn').forEach(function(btn) {
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        var idx = parseInt(btn.dataset.index);
+        var action = btn.dataset.action;
+        doReview(idx, action);
+      });
+    });
+  }
+
+  function toggleCard(index) {
+    var card = document.getElementById('card-' + index);
+    if (!card) return;
+    selectedIndex = index;
+    // Remove selected from all
+    document.querySelectorAll('.card.selected').forEach(function(c) { c.classList.remove('selected'); });
+    card.classList.add('selected');
+    card.classList.toggle('expanded');
+  }
+
+  function selectCard(index) {
+    var entries = getFilteredEntries();
+    if (index < 0 || index >= entries.length) return;
+    var entry = entries[index];
+    selectedIndex = entry.index;
+    // Remove old selection
+    document.querySelectorAll('.card.selected').forEach(function(c) { c.classList.remove('selected'); });
+    var card = document.getElementById('card-' + entry.index);
+    if (card) {
+      card.classList.add('selected');
+      card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }
+
+  function getSelectedFilterIndex() {
+    var entries = getFilteredEntries();
+    for (var i = 0; i < entries.length; i++) {
+      if (entries[i].index === selectedIndex) return i;
+    }
+    return -1;
+  }
+
+  async function doReview(index, status) {
+    try {
+      var updated = await updateReview(index, status);
+      // Update local state
+      for (var i = 0; i < deltaReport.entries.length; i++) {
+        if (deltaReport.entries[i].index === index) {
+          deltaReport.entries[i].review_status = updated.review_status;
+          deltaReport.entries[i].reviewed_at = updated.reviewed_at;
+          break;
+        }
+      }
+      renderCards();
+      renderFilters();
+      updateProgress();
+      showToast(status.charAt(0).toUpperCase() + status.slice(1) + ': ' + (updated.skill_name || '#' + index));
+    } catch (err) {
+      showToast('Error: ' + err.message, true);
+    }
+  }
+
+  function updateProgress() {
+    if (!deltaReport || !deltaReport.entries) return;
+    var total = deltaReport.entries.length;
+    var reviewed = 0;
+    deltaReport.entries.forEach(function(e) {
+      if (e.review_status !== 'pending') reviewed++;
+    });
+
+    document.getElementById('progressText').innerHTML = '<strong>' + reviewed + '/' + total + '</strong> reviewed';
+    var pct = total > 0 ? (reviewed / total * 100) : 0;
+    document.getElementById('progressBar').style.width = pct + '%';
+    document.getElementById('sealBtn').disabled = (reviewed < total || total === 0);
+  }
+
+  // ---- Seal modal ----
+  function showSealModal() {
+    if (!deltaReport) return;
+    var approved = 0, rejected = 0, deferred = 0;
+    deltaReport.entries.forEach(function(e) {
+      if (e.review_status === 'approved') approved++;
+      else if (e.review_status === 'rejected') rejected++;
+      else if (e.review_status === 'deferred') deferred++;
+    });
+    document.getElementById('modalStats').innerHTML =
+      '<div class="modal-stat"><div class="num green">' + approved + '</div><div class="lbl">Approved</div></div>' +
+      '<div class="modal-stat"><div class="num red">' + rejected + '</div><div class="lbl">Rejected</div></div>' +
+      '<div class="modal-stat"><div class="num grey">' + deferred + '</div><div class="lbl">Deferred</div></div>';
+    document.getElementById('sealModal').classList.add('visible');
+  }
+
+  function hideSealModal() {
+    document.getElementById('sealModal').classList.remove('visible');
+  }
+
+  async function doSeal() {
+    try {
+      var seal = await createSeal();
+      hideSealModal();
+      showToast('Sealed: ' + seal.seal_id);
+      document.getElementById('sealBtn').disabled = true;
+    } catch (err) {
+      hideSealModal();
+      showToast('Seal failed: ' + err.message, true);
+    }
+  }
+
+  // ---- Keyboard shortcuts ----
+  document.addEventListener('keydown', function(e) {
+    // Ignore if modal is open
+    if (document.getElementById('sealModal').classList.contains('visible')) {
+      if (e.key === 'Escape') hideSealModal();
+      return;
+    }
+    // Ignore if typing in an input
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+
+    var entries = getFilteredEntries();
+    var fi = getSelectedFilterIndex();
+
+    switch(e.key) {
+      case 'j':
+        e.preventDefault();
+        selectCard(fi + 1);
+        break;
+      case 'k':
+        e.preventDefault();
+        selectCard(fi - 1);
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (selectedIndex >= 0) toggleCard(selectedIndex);
+        break;
+      case 'a':
+        e.preventDefault();
+        if (selectedIndex >= 0) doReview(selectedIndex, 'approved');
+        break;
+      case 'r':
+        e.preventDefault();
+        if (selectedIndex >= 0) doReview(selectedIndex, 'rejected');
+        break;
+      case 'd':
+        e.preventDefault();
+        if (selectedIndex >= 0) doReview(selectedIndex, 'deferred');
+        break;
+      case 'Escape':
+        // Collapse all
+        document.querySelectorAll('.card.expanded').forEach(function(c) { c.classList.remove('expanded'); });
+        break;
+    }
+  });
+
+  // ---- Seal button ----
+  document.getElementById('sealBtn').addEventListener('click', showSealModal);
+  document.getElementById('modalCancel').addEventListener('click', hideSealModal);
+  document.getElementById('modalConfirm').addEventListener('click', doSeal);
+  document.getElementById('sealModal').addEventListener('click', function(e) {
+    if (e.target === document.getElementById('sealModal')) hideSealModal();
+  });
+
+  // ---- Init ----
+  async function init() {
+    try {
+      deltaReport = await fetchDelta();
+      renderStats();
+      renderFilters();
+      renderCards();
+      updateProgress();
+      // Select first entry
+      if (deltaReport.entries && deltaReport.entries.length > 0) {
+        selectCard(0);
+      }
+    } catch (err) {
+      document.getElementById('content').innerHTML =
+        '<div class="empty-state"><h2>Failed to load delta report</h2><p>' + escapeHtml(err.message) + '</p></div>';
+    }
+  }
+
+  // Auto-refresh every 30 seconds
+  refreshTimer = setInterval(async function() {
+    try {
+      var newData = await fetchDelta();
+      // Only update if entries changed (avoid losing selection)
+      if (JSON.stringify(newData) !== JSON.stringify(deltaReport)) {
+        deltaReport = newData;
+        renderStats();
+        renderFilters();
+        renderCards();
+        updateProgress();
+      }
+    } catch(err) { /* silent */ }
+  }, 30000);
+
+  init();
+})();
+</script>
+</body>
+</html>

--- a/pkg/skillctl/scanner/plugins.go
+++ b/pkg/skillctl/scanner/plugins.go
@@ -1,0 +1,146 @@
+// Plugin-cache + marketplace walker — SPEC-0189 Phase 2.
+//
+// Walks ~/.claude/plugins/cache/<owner>/<plugin>/<version>/skills/ AND
+// ~/.claude/plugins/marketplaces/<m>/{skills,plugins/<p>/skills}/ to find
+// plugin-shipped skills. Reads installed_plugins.json (best effort) to
+// label installed-vs-marketplace.
+package scanner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// pluginScanRoots returns ScanRoots for every plugin-skill directory under
+// the given Claude Code config dir.
+func pluginScanRoots(configDir string) []ScanRoot {
+	pluginsDir := filepath.Join(configDir, "plugins")
+	if !pathExists(pluginsDir) {
+		return nil
+	}
+
+	var roots []ScanRoot
+	roots = append(roots, pluginCacheRoots(pluginsDir)...)
+	roots = append(roots, marketplaceRoots(pluginsDir)...)
+	return roots
+}
+
+// pluginCacheRoots walks ~/.claude/plugins/cache/<owner>/<plugin>/<version>/skills/.
+func pluginCacheRoots(pluginsDir string) []ScanRoot {
+	cacheDir := filepath.Join(pluginsDir, "cache")
+	if !pathExists(cacheDir) {
+		return nil
+	}
+
+	var roots []ScanRoot
+	owners, err := os.ReadDir(cacheDir)
+	if err != nil {
+		return nil
+	}
+	for _, owner := range owners {
+		if !owner.IsDir() {
+			continue
+		}
+		ownerDir := filepath.Join(cacheDir, owner.Name())
+		plugins, err := os.ReadDir(ownerDir)
+		if err != nil {
+			continue
+		}
+		for _, plugin := range plugins {
+			if !plugin.IsDir() {
+				continue
+			}
+			pluginDir := filepath.Join(ownerDir, plugin.Name())
+			versions, err := os.ReadDir(pluginDir)
+			if err != nil {
+				continue
+			}
+			for _, version := range versions {
+				if !version.IsDir() {
+					continue
+				}
+				skillsDir := filepath.Join(pluginDir, version.Name(), "skills")
+				if pathExists(skillsDir) {
+					roots = append(roots, ScanRoot{Path: skillsDir, Tier: TierPlugin})
+				}
+			}
+		}
+	}
+	return roots
+}
+
+// marketplaceRoots walks ~/.claude/plugins/marketplaces/<m>/skills/ AND
+// ~/.claude/plugins/marketplaces/<m>/plugins/<p>/skills/.
+func marketplaceRoots(pluginsDir string) []ScanRoot {
+	marketsDir := filepath.Join(pluginsDir, "marketplaces")
+	if !pathExists(marketsDir) {
+		return nil
+	}
+
+	var roots []ScanRoot
+	markets, err := os.ReadDir(marketsDir)
+	if err != nil {
+		return nil
+	}
+	for _, market := range markets {
+		if !market.IsDir() {
+			continue
+		}
+		marketDir := filepath.Join(marketsDir, market.Name())
+
+		// Direct: .../marketplaces/<m>/skills/
+		direct := filepath.Join(marketDir, "skills")
+		if pathExists(direct) {
+			roots = append(roots, ScanRoot{Path: direct, Tier: TierPlugin})
+		}
+
+		// Nested: .../marketplaces/<m>/plugins/<p>/skills/
+		nestedPlugins := filepath.Join(marketDir, "plugins")
+		if pluginsDirs, err := os.ReadDir(nestedPlugins); err == nil {
+			for _, p := range pluginsDirs {
+				if !p.IsDir() {
+					continue
+				}
+				skills := filepath.Join(nestedPlugins, p.Name(), "skills")
+				if pathExists(skills) {
+					roots = append(roots, ScanRoot{Path: skills, Tier: TierPlugin})
+				}
+			}
+		}
+	}
+	return roots
+}
+
+// installedPluginRecord is the relevant subset of an entry in
+// installed_plugins.json. The file is best-effort: if absent or malformed,
+// we proceed with empty annotation data.
+type installedPluginRecord struct {
+	Owner   string `json:"owner"`
+	Plugin  string `json:"plugin"`
+	Version string `json:"version"`
+	Source  string `json:"source"` // "marketplace" | "cache" | etc.
+}
+
+// loadInstalledPlugins reads ~/.claude/plugins/installed_plugins.json if
+// present. Returns nil on any error (missing file, bad JSON, etc.) — the
+// caller should treat that as "no annotation data available".
+func loadInstalledPlugins(configDir string) []installedPluginRecord {
+	path := filepath.Join(configDir, "plugins", "installed_plugins.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	// Tolerate either a top-level array or an object with a "plugins" key.
+	var arr []installedPluginRecord
+	if err := json.Unmarshal(data, &arr); err == nil {
+		return arr
+	}
+	var obj struct {
+		Plugins []installedPluginRecord `json:"plugins"`
+	}
+	if err := json.Unmarshal(data, &obj); err == nil {
+		return obj.Plugins
+	}
+	return nil
+}

--- a/pkg/skillctl/scanner/scanner.go
+++ b/pkg/skillctl/scanner/scanner.go
@@ -1,0 +1,364 @@
+// Package scanner walks directories to discover Claude Code skill sources.
+package scanner
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/hasher"
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+	"github.com/kamir/m3c-tools/pkg/skillctl/parser"
+)
+
+// skipDirs lists directory names to skip during traversal.
+var skipDirs = map[string]bool{
+	".git":        true,
+	"node_modules": true,
+	"__pycache__": true,
+	".venv":       true,
+	"vendor":      true,
+	"build":       true,
+}
+
+// Scanner walks filesystem paths to discover skill sources.
+type Scanner struct {
+	Paths       []string
+	Recursive   bool
+	IncludeHome bool
+
+	// visited tracks resolved real paths to avoid symlink loops.
+	visited map[string]bool
+}
+
+// Scan walks all configured paths and returns a complete Inventory.
+func (s *Scanner) Scan() (*model.Inventory, error) {
+	s.visited = make(map[string]bool)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	inv := &model.Inventory{
+		ScannedAt: now,
+		ScanPaths: make([]string, 0),
+		Skills:    make([]model.SkillDescriptor, 0),
+		ByType:    make(map[string]int),
+		ByProject: make(map[string]int),
+	}
+
+	// Scan provided paths.
+	for _, p := range s.Paths {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return nil, fmt.Errorf("resolving path %s: %w", p, err)
+		}
+		inv.ScanPaths = append(inv.ScanPaths, abs)
+		if err := s.scanDir(abs, inv); err != nil {
+			return nil, err
+		}
+	}
+
+	// Scan home directory if requested.
+	if s.IncludeHome {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			claudeHome := filepath.Join(home, ".claude")
+			inv.ScanPaths = append(inv.ScanPaths, claudeHome)
+			if err := s.scanHomeDir(claudeHome, inv); err != nil {
+				// Non-fatal: home dir may not have .claude
+				_ = err
+			}
+		}
+	}
+
+	// Run duplicate detection.
+	hasher.DetectDuplicates(inv.Skills)
+
+	// Compute summary stats.
+	inv.TotalCount = len(inv.Skills)
+	for _, sk := range inv.Skills {
+		inv.ByType[string(sk.Type)]++
+		inv.ByProject[sk.SourceProject]++
+		if sk.DuplicateOf != nil {
+			inv.Duplicates++
+		}
+		if sk.Type == model.SkillTypeSkillIndex {
+			inv.SkillIndexCount++
+		} else if !sk.HasYAMLFrontmatter {
+			inv.NoFrontmatter++
+		}
+	}
+
+	return inv, nil
+}
+
+// scanDir recursively walks a directory looking for skill sources.
+func (s *Scanner) scanDir(root string, inv *model.Inventory) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip inaccessible entries
+		}
+
+		// Skip blacklisted directories.
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			// Handle symlink loops.
+			if d.Type()&fs.ModeSymlink != 0 {
+				real, err := filepath.EvalSymlinks(path)
+				if err != nil {
+					return nil
+				}
+				if s.visited[real] {
+					return filepath.SkipDir
+				}
+				s.visited[real] = true
+			}
+			return nil
+		}
+
+		// Check for symlink on files too.
+		if d.Type()&fs.ModeSymlink != 0 {
+			real, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return nil
+			}
+			if s.visited[real] {
+				return nil
+			}
+			s.visited[real] = true
+		}
+
+		rel, _ := filepath.Rel(root, path)
+		parts := strings.Split(filepath.ToSlash(rel), "/")
+
+		// Detect skill type based on path pattern.
+		switch {
+		case s.matchClaudeSkill(parts, d.Name()):
+			s.addSkill(path, model.SkillTypeClaudeCodeSkill, inv)
+
+		case d.Name() == "CLAUDE.md":
+			s.addSkill(path, model.SkillTypeSkillIndex, inv)
+
+		case s.matchCommand(parts, d.Name()):
+			s.addSkill(path, model.SkillTypeCommand, inv)
+
+		case s.matchAgent(parts, d.Name()):
+			s.addSkill(path, model.SkillTypeAgent, inv)
+
+		case s.matchMCPConfig(parts, d.Name()):
+			s.addMCPServers(path, inv)
+		}
+
+		return nil
+	})
+}
+
+// scanHomeDir scans the user-global ~/.claude/ directory.
+func (s *Scanner) scanHomeDir(claudeDir string, inv *model.Inventory) error {
+	info, err := os.Stat(claudeDir)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+
+	// Skills: ~/.claude/skills/*/
+	skillsDir := filepath.Join(claudeDir, "skills")
+	if entries, err := os.ReadDir(skillsDir); err == nil {
+		for _, e := range entries {
+			if e.IsDir() {
+				subDir := filepath.Join(skillsDir, e.Name())
+				mdFiles, _ := filepath.Glob(filepath.Join(subDir, "*.md"))
+				for _, md := range mdFiles {
+					s.addSkillWithProject(md, model.SkillTypeClaudeCodeSkill, "user-global", inv)
+				}
+			}
+		}
+	}
+
+	// Commands: ~/.claude/commands/*.md
+	cmdsDir := filepath.Join(claudeDir, "commands")
+	if mdFiles, err := filepath.Glob(filepath.Join(cmdsDir, "*.md")); err == nil {
+		for _, md := range mdFiles {
+			s.addSkillWithProject(md, model.SkillTypeCommand, "user-global", inv)
+		}
+	}
+
+	// Agents: ~/.claude/agents/*.md
+	agentsDir := filepath.Join(claudeDir, "agents")
+	if mdFiles, err := filepath.Glob(filepath.Join(agentsDir, "*.md")); err == nil {
+		for _, md := range mdFiles {
+			s.addSkillWithProject(md, model.SkillTypeAgent, "user-global", inv)
+		}
+	}
+
+	// MCP configs
+	for _, name := range []string{"settings.json", "settings.local.json"} {
+		cfgPath := filepath.Join(claudeDir, name)
+		if _, err := os.Stat(cfgPath); err == nil {
+			s.addMCPServersWithProject(cfgPath, "user-global", inv)
+		}
+	}
+
+	return nil
+}
+
+// matchClaudeSkill checks if the path matches .claude/skills/<dir>/<file>.md
+// Parts example: [".claude", "skills", "deploy", "deploy.md"]
+func (s *Scanner) matchClaudeSkill(parts []string, name string) bool {
+	if len(parts) < 4 || !strings.HasSuffix(name, ".md") {
+		return false
+	}
+	// Look for ".claude" followed by "skills" anywhere in the path.
+	for i := 0; i < len(parts)-3; i++ {
+		if parts[i] == ".claude" && parts[i+1] == "skills" {
+			return true
+		}
+	}
+	return false
+}
+
+// matchCommand checks if the path matches .claude/commands/<file>.md
+// Parts example: [".claude", "commands", "review.md"]
+func (s *Scanner) matchCommand(parts []string, name string) bool {
+	if len(parts) < 3 || !strings.HasSuffix(name, ".md") {
+		return false
+	}
+	for i := 0; i < len(parts)-2; i++ {
+		if parts[i] == ".claude" && parts[i+1] == "commands" {
+			return true
+		}
+	}
+	return false
+}
+
+// matchAgent checks if the path matches .claude/agents/<file>.md
+// Parts example: [".claude", "agents", "researcher.md"]
+func (s *Scanner) matchAgent(parts []string, name string) bool {
+	if len(parts) < 3 || !strings.HasSuffix(name, ".md") {
+		return false
+	}
+	for i := 0; i < len(parts)-2; i++ {
+		if parts[i] == ".claude" && parts[i+1] == "agents" {
+			return true
+		}
+	}
+	return false
+}
+
+// matchMCPConfig checks if the path matches .claude/settings.json or .claude/settings.local.json
+func (s *Scanner) matchMCPConfig(parts []string, name string) bool {
+	if len(parts) < 2 {
+		return false
+	}
+	return parts[len(parts)-2] == ".claude" &&
+		(name == "settings.json" || name == "settings.local.json")
+}
+
+// addSkill reads a file, parses it, and adds it to the inventory.
+func (s *Scanner) addSkill(path string, skillType model.SkillType, inv *model.Inventory) {
+	project := detectProject(path)
+	s.addSkillWithProject(path, skillType, project, inv)
+}
+
+// addSkillWithProject reads a file, parses it, and adds it with a specified project name.
+func (s *Scanner) addSkillWithProject(path string, skillType model.SkillType, project string, inv *model.Inventory) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	hash := hasher.ContentHash(data)
+	name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+
+	desc := model.SkillDescriptor{
+		ID:               fmt.Sprintf("%s/%s", project, name),
+		Name:             name,
+		Type:             skillType,
+		SourcePath:       path,
+		SourceProject:    project,
+		DiscoveredAt:     now,
+		ContentHash:      hash,
+		ContentSizeBytes: int64(len(data)),
+		Dependencies:     make([]string, 0),
+		ConflictsWith:    make([]string, 0),
+	}
+
+	// Try parsing frontmatter for markdown files.
+	if strings.HasSuffix(path, ".md") {
+		fm, _, parseErr := parser.Parse(data)
+		if parseErr == nil && fm != nil {
+			desc.Frontmatter = fm
+			desc.HasYAMLFrontmatter = true
+			if fm.Name != "" {
+				desc.Name = fm.Name
+				desc.ID = fmt.Sprintf("%s/%s", project, fm.Name)
+			}
+		}
+	}
+
+	inv.Skills = append(inv.Skills, desc)
+}
+
+// addMCPServers parses a settings.json file and creates one SkillDescriptor per MCP server.
+func (s *Scanner) addMCPServers(path string, inv *model.Inventory) {
+	project := detectProject(path)
+	s.addMCPServersWithProject(path, project, inv)
+}
+
+// addMCPServersWithProject parses a settings.json file with a specified project.
+func (s *Scanner) addMCPServersWithProject(path string, project string, inv *model.Inventory) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	// Parse the JSON to extract mcpServers keys.
+	var settings struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	for serverName, rawConfig := range settings.MCPServers {
+		configData, _ := json.Marshal(rawConfig)
+		hash := hasher.ContentHash(configData)
+
+		desc := model.SkillDescriptor{
+			ID:               fmt.Sprintf("%s/mcp-%s", project, serverName),
+			Name:             serverName,
+			Type:             model.SkillTypeMCPServer,
+			SourcePath:       path,
+			SourceProject:    project,
+			DiscoveredAt:     now,
+			ContentHash:      hash,
+			ContentSizeBytes: int64(len(configData)),
+			Dependencies:     make([]string, 0),
+			ConflictsWith:    make([]string, 0),
+		}
+		inv.Skills = append(inv.Skills, desc)
+	}
+}
+
+// detectProject walks up from the file path to find the nearest .git/ directory
+// and returns the containing directory name as the project name.
+func detectProject(path string) string {
+	dir := filepath.Dir(path)
+	for {
+		gitDir := filepath.Join(dir, ".git")
+		if info, err := os.Stat(gitDir); err == nil && info.IsDir() {
+			return filepath.Base(dir)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "unknown"
+}

--- a/pkg/skillctl/scanner/scanner.go
+++ b/pkg/skillctl/scanner/scanner.go
@@ -26,7 +26,23 @@ var skipDirs = map[string]bool{
 }
 
 // Scanner walks filesystem paths to discover skill sources.
+//
+// Two modes:
+//   - SPEC-0189 tier-aware mode: populate Roots (via ResolveDefaults or
+//     explicit ScanRoot list). Discovery is anchored on SKILL.md and
+//     descriptors get Tier + SkillMDPath. Shadow resolution applied at
+//     the end (project > user > plugin).
+//   - Legacy SPEC-0115 mode (used by `skillctl scan --source projects`):
+//     populate Paths/Recursive/IncludeHome. Discovery uses the original
+//     glob-on-*.md path. No tier annotation, no shadow resolution.
+//
+// Both modes share the duplicate-detection + summary-stat tail.
 type Scanner struct {
+	// SPEC-0189 tier-aware fields.
+	Roots           []ScanRoot
+	IncludeShadowed bool
+
+	// Legacy SPEC-0115 fields.
 	Paths       []string
 	Recursive   bool
 	IncludeHome bool
@@ -36,6 +52,9 @@ type Scanner struct {
 }
 
 // Scan walks all configured paths and returns a complete Inventory.
+//
+// If Roots is non-empty, runs the SPEC-0189 tier-aware scan. Otherwise
+// falls back to the legacy SPEC-0115 paths/home-dir glob.
 func (s *Scanner) Scan() (*model.Inventory, error) {
 	s.visited = make(map[string]bool)
 
@@ -48,32 +67,46 @@ func (s *Scanner) Scan() (*model.Inventory, error) {
 		ByProject: make(map[string]int),
 	}
 
-	// Scan provided paths.
-	for _, p := range s.Paths {
-		abs, err := filepath.Abs(p)
-		if err != nil {
-			return nil, fmt.Errorf("resolving path %s: %w", p, err)
+	if len(s.Roots) > 0 {
+		// Tier-aware mode (SPEC-0189). Anchor on SKILL.md.
+		for _, r := range s.Roots {
+			abs, err := filepath.Abs(r.Path)
+			if err != nil {
+				return nil, fmt.Errorf("resolving root %s: %w", r.Path, err)
+			}
+			inv.ScanPaths = append(inv.ScanPaths, abs)
+			rooted := ScanRoot{Path: abs, Tier: r.Tier}
+			if err := s.scanTierRoot(rooted, inv); err != nil {
+				return nil, err
+			}
 		}
-		inv.ScanPaths = append(inv.ScanPaths, abs)
-		if err := s.scanDir(abs, inv); err != nil {
-			return nil, err
+		applyShadowing(inv, s.IncludeShadowed)
+	} else {
+		// Legacy SPEC-0115 mode — preserved for `--source projects`.
+		for _, p := range s.Paths {
+			abs, err := filepath.Abs(p)
+			if err != nil {
+				return nil, fmt.Errorf("resolving path %s: %w", p, err)
+			}
+			inv.ScanPaths = append(inv.ScanPaths, abs)
+			if err := s.scanDir(abs, inv); err != nil {
+				return nil, err
+			}
 		}
-	}
-
-	// Scan home directory if requested.
-	if s.IncludeHome {
-		home, err := os.UserHomeDir()
-		if err == nil {
-			claudeHome := filepath.Join(home, ".claude")
-			inv.ScanPaths = append(inv.ScanPaths, claudeHome)
-			if err := s.scanHomeDir(claudeHome, inv); err != nil {
-				// Non-fatal: home dir may not have .claude
-				_ = err
+		if s.IncludeHome {
+			home, err := os.UserHomeDir()
+			if err == nil {
+				claudeHome := filepath.Join(home, ".claude")
+				inv.ScanPaths = append(inv.ScanPaths, claudeHome)
+				if err := s.scanHomeDir(claudeHome, inv); err != nil {
+					// Non-fatal: home dir may not have .claude
+					_ = err
+				}
 			}
 		}
 	}
 
-	// Run duplicate detection.
+	// Run duplicate detection (shared by both modes).
 	hasher.DetectDuplicates(inv.Skills)
 
 	// Compute summary stats.

--- a/pkg/skillctl/scanner/scanner.go
+++ b/pkg/skillctl/scanner/scanner.go
@@ -41,6 +41,7 @@ type Scanner struct {
 	// SPEC-0189 tier-aware fields.
 	Roots           []ScanRoot
 	IncludeShadowed bool
+	WithTrust       bool // SPEC-0189 §6: annotate each skill with sibling-.skb trust state
 
 	// Legacy SPEC-0115 fields.
 	Paths       []string
@@ -107,6 +108,11 @@ func (s *Scanner) Scan() (*model.Inventory, error) {
 	}
 
 	// Run duplicate detection (shared by both modes).
+	// SPEC-0189 §6: cross-reference each skill with sibling-.skb trust state.
+	if s.WithTrust {
+		_ = AnnotateTrust(inv)
+	}
+
 	hasher.DetectDuplicates(inv.Skills)
 
 	// Compute summary stats.

--- a/pkg/skillctl/scanner/scanner_test.go
+++ b/pkg/skillctl/scanner/scanner_test.go
@@ -1,0 +1,265 @@
+package scanner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// setupTestTree creates a temporary directory tree mimicking a project with
+// Claude Code skills, commands, agents, CLAUDE.md, and MCP settings.
+func setupTestTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	// Create a fake .git directory so project detection works.
+	os.MkdirAll(filepath.Join(root, ".git"), 0o755)
+
+	// Claude Code skill: .claude/skills/deploy/deploy.md
+	skillDir := filepath.Join(root, ".claude", "skills", "deploy")
+	os.MkdirAll(skillDir, 0o755)
+	os.WriteFile(filepath.Join(skillDir, "deploy.md"), []byte(`---
+name: deploy-stage
+version: 1.0.0
+description: Deploy to staging
+allowed-tools:
+  - Bash
+category: deployment
+---
+Deploy the application to the staging environment.
+`), 0o644)
+
+	// Command: .claude/commands/review.md
+	cmdDir := filepath.Join(root, ".claude", "commands")
+	os.MkdirAll(cmdDir, 0o755)
+	os.WriteFile(filepath.Join(cmdDir, "review.md"), []byte(`# Review command
+Review all changes before merge.
+`), 0o644)
+
+	// Agent: .claude/agents/researcher.md
+	agentDir := filepath.Join(root, ".claude", "agents")
+	os.MkdirAll(agentDir, 0o755)
+	os.WriteFile(filepath.Join(agentDir, "researcher.md"), []byte(`---
+name: researcher
+description: Research agent
+---
+Research topics thoroughly.
+`), 0o644)
+
+	// CLAUDE.md at root
+	os.WriteFile(filepath.Join(root, "CLAUDE.md"), []byte(`# Project Instructions
+Build stuff.
+`), 0o644)
+
+	// MCP settings: .claude/settings.json
+	settings := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"filesystem": map[string]string{
+				"command": "npx",
+			},
+			"github": map[string]string{
+				"command": "gh-mcp",
+			},
+		},
+	}
+	settingsData, _ := json.Marshal(settings)
+	os.WriteFile(filepath.Join(root, ".claude", "settings.json"), settingsData, 0o644)
+
+	return root
+}
+
+func TestScanFindsAllTypes(t *testing.T) {
+	root := setupTestTree(t)
+
+	sc := &Scanner{
+		Paths:     []string{root},
+		Recursive: true,
+	}
+
+	inv, err := sc.Scan()
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+
+	if inv.TotalCount < 5 {
+		t.Errorf("total count = %d, want >= 5 (skill + command + agent + CLAUDE.md + 2 MCP)", inv.TotalCount)
+	}
+
+	// Check we found each type.
+	wantTypes := map[model.SkillType]bool{
+		model.SkillTypeClaudeCodeSkill: false,
+		model.SkillTypeSkillIndex:        false,
+		model.SkillTypeCommand:         false,
+		model.SkillTypeMCPServer:       false,
+		model.SkillTypeAgent:           false,
+	}
+	for _, sk := range inv.Skills {
+		wantTypes[sk.Type] = true
+	}
+	for st, found := range wantTypes {
+		if !found {
+			t.Errorf("type %s not found in scan results", st)
+		}
+	}
+}
+
+func TestScanFrontmatterParsed(t *testing.T) {
+	root := setupTestTree(t)
+
+	sc := &Scanner{
+		Paths:     []string{root},
+		Recursive: true,
+	}
+
+	inv, err := sc.Scan()
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+
+	var deploySkill *model.SkillDescriptor
+	for i := range inv.Skills {
+		if inv.Skills[i].Type == model.SkillTypeClaudeCodeSkill {
+			deploySkill = &inv.Skills[i]
+			break
+		}
+	}
+
+	if deploySkill == nil {
+		t.Fatal("deploy skill not found")
+	}
+	if !deploySkill.HasYAMLFrontmatter {
+		t.Error("deploy skill should have YAML frontmatter")
+	}
+	if deploySkill.Frontmatter == nil {
+		t.Fatal("deploy skill frontmatter is nil")
+	}
+	if deploySkill.Frontmatter.Name != "deploy-stage" {
+		t.Errorf("name = %q, want %q", deploySkill.Frontmatter.Name, "deploy-stage")
+	}
+	if deploySkill.Name != "deploy-stage" {
+		t.Errorf("skill name = %q, want %q (should use frontmatter name)", deploySkill.Name, "deploy-stage")
+	}
+}
+
+func TestScanNoFrontmatterCounted(t *testing.T) {
+	root := setupTestTree(t)
+
+	sc := &Scanner{
+		Paths:     []string{root},
+		Recursive: true,
+	}
+
+	inv, err := sc.Scan()
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+
+	if inv.NoFrontmatter == 0 {
+		t.Error("expected at least one skill without frontmatter (review.md, CLAUDE.md)")
+	}
+}
+
+func TestScanSkipsBlacklistedDirs(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, ".git"), 0o755)
+
+	// Put a skill file inside node_modules — should be skipped.
+	nmDir := filepath.Join(root, "node_modules", ".claude", "skills", "bad")
+	os.MkdirAll(nmDir, 0o755)
+	os.WriteFile(filepath.Join(nmDir, "bad.md"), []byte("# bad"), 0o644)
+
+	// Also put a valid one at the root level.
+	skillDir := filepath.Join(root, ".claude", "skills", "good")
+	os.MkdirAll(skillDir, 0o755)
+	os.WriteFile(filepath.Join(skillDir, "good.md"), []byte("# good"), 0o644)
+
+	sc := &Scanner{
+		Paths:     []string{root},
+		Recursive: true,
+	}
+	inv, err := sc.Scan()
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+
+	for _, sk := range inv.Skills {
+		if sk.Name == "bad" {
+			t.Error("found skill inside node_modules — should have been skipped")
+		}
+	}
+
+	foundGood := false
+	for _, sk := range inv.Skills {
+		if sk.Name == "good" {
+			foundGood = true
+		}
+	}
+	if !foundGood {
+		t.Error("good skill not found")
+	}
+}
+
+func TestScanMCPServers(t *testing.T) {
+	root := setupTestTree(t)
+
+	sc := &Scanner{
+		Paths:     []string{root},
+		Recursive: true,
+	}
+
+	inv, err := sc.Scan()
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+
+	mcpCount := 0
+	for _, sk := range inv.Skills {
+		if sk.Type == model.SkillTypeMCPServer {
+			mcpCount++
+		}
+	}
+	if mcpCount != 2 {
+		t.Errorf("MCP server count = %d, want 2", mcpCount)
+	}
+}
+
+func TestScanEmptyDir(t *testing.T) {
+	root := t.TempDir()
+
+	sc := &Scanner{
+		Paths:     []string{root},
+		Recursive: true,
+	}
+
+	inv, err := sc.Scan()
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+	if inv.TotalCount != 0 {
+		t.Errorf("total count = %d, want 0 for empty dir", inv.TotalCount)
+	}
+}
+
+func TestScanProjectDetection(t *testing.T) {
+	root := setupTestTree(t)
+
+	sc := &Scanner{
+		Paths:     []string{root},
+		Recursive: true,
+	}
+
+	inv, err := sc.Scan()
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+
+	projectName := filepath.Base(root)
+	for _, sk := range inv.Skills {
+		if sk.SourceProject != projectName {
+			t.Errorf("skill %q project = %q, want %q", sk.Name, sk.SourceProject, projectName)
+		}
+	}
+}

--- a/pkg/skillctl/scanner/tiers.go
+++ b/pkg/skillctl/scanner/tiers.go
@@ -1,0 +1,217 @@
+// Tier-aware scanning + shadow detection — SPEC-0189 Phase 1.
+//
+// Scans a ScanRoot anchored on SKILL.md (not loose *.md), then runs a
+// shadow-merge across the union of inventories from all roots so that
+// project-tier skills win over user-tier, which win over plugin-tier.
+package scanner
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/hasher"
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+	"github.com/kamir/m3c-tools/pkg/skillctl/parser"
+)
+
+// scanTierRoot walks a single ScanRoot and emits one descriptor per
+// directory containing a SKILL.md file. Loose markdown files inside a
+// skill dir are NOT separate skills (per SPEC-0189 §3).
+func (s *Scanner) scanTierRoot(root ScanRoot, inv *model.Inventory) error {
+	info, err := os.Stat(root.Path)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+
+	return filepath.WalkDir(root.Path, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		// Only look at files literally named SKILL.md.
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			// Symlink-loop guard.
+			if d.Type()&fs.ModeSymlink != 0 {
+				real, err := filepath.EvalSymlinks(path)
+				if err != nil {
+					return nil
+				}
+				if s.visited[real] {
+					return filepath.SkipDir
+				}
+				s.visited[real] = true
+			}
+			return nil
+		}
+		if d.Name() != "SKILL.md" {
+			return nil
+		}
+		// File-level symlink guard.
+		if d.Type()&fs.ModeSymlink != 0 {
+			real, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return nil
+			}
+			if s.visited[real] {
+				return nil
+			}
+			s.visited[real] = true
+		}
+		s.addClaudeSkillTiered(path, root.Tier, inv)
+		return nil
+	})
+}
+
+// addClaudeSkillTiered reads a SKILL.md file and adds a descriptor with
+// Tier + SkillMDPath populated.
+func (s *Scanner) addClaudeSkillTiered(skillMDPath string, tier Tier, inv *model.Inventory) {
+	data, err := os.ReadFile(skillMDPath)
+	if err != nil {
+		return
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	hash := hasher.ContentHash(data)
+
+	// The skill name is the parent directory's basename (the conventional
+	// Claude Code shape: <name>/SKILL.md).
+	parentDir := filepath.Dir(skillMDPath)
+	name := filepath.Base(parentDir)
+	project := projectLabelForTier(skillMDPath, tier)
+
+	desc := model.SkillDescriptor{
+		ID:               fmt.Sprintf("%s/%s", tier, name),
+		Name:             name,
+		Type:             model.SkillTypeClaudeCodeSkill,
+		SourcePath:       parentDir,
+		SourceProject:    project,
+		DiscoveredAt:     now,
+		ContentHash:      hash,
+		ContentSizeBytes: int64(len(data)),
+		Dependencies:     make([]string, 0),
+		ConflictsWith:    make([]string, 0),
+		Tier:             string(tier),
+		SkillMDPath:      skillMDPath,
+	}
+
+	// Parse frontmatter — same path as the legacy mode.
+	fm, _, parseErr := parser.Parse(data)
+	if parseErr == nil && fm != nil {
+		desc.Frontmatter = fm
+		desc.HasYAMLFrontmatter = true
+		// For tiered scans we deliberately do NOT override desc.Name from
+		// fm.Name — the directory name is the canonical identifier in
+		// Claude Code resolution. fm.Name often duplicates the dir name.
+		if fm.GovernanceLevel == "" {
+			// Backwards-compat: lift governance_level out of legacy
+			// Metadata bag if present.
+			if v, ok := fm.Metadata["governance_level"].(string); ok {
+				fm.GovernanceLevel = v
+			}
+		}
+	}
+	inv.Skills = append(inv.Skills, desc)
+}
+
+// projectLabelForTier produces a useful SourceProject label for tier-scoped
+// skills. For TierProject the existing detectProject (nearest .git) wins;
+// for TierUser the label is "user-global"; for TierPlugin we extract the
+// plugin owner/name/version from the path.
+func projectLabelForTier(skillMDPath string, tier Tier) string {
+	switch tier {
+	case TierUser:
+		return "user-global"
+	case TierPlugin:
+		return pluginLabel(skillMDPath)
+	default:
+		return detectProject(skillMDPath)
+	}
+}
+
+// pluginLabel extracts a "<owner>/<plugin>@<version>" label from a path
+// shaped ~/.claude/plugins/cache/<o>/<p>/<v>/skills/<n>/SKILL.md, or
+// "marketplace:<m>" for marketplace-tier paths.
+func pluginLabel(skillMDPath string) string {
+	parts := strings.Split(filepath.ToSlash(skillMDPath), "/")
+	for i := 0; i < len(parts); i++ {
+		if parts[i] == "cache" && i+3 < len(parts) {
+			return parts[i+1] + "/" + parts[i+2] + "@" + parts[i+3]
+		}
+		if parts[i] == "marketplaces" && i+1 < len(parts) {
+			return "marketplace:" + parts[i+1]
+		}
+	}
+	return "plugin-unknown"
+}
+
+// applyShadowing walks the inventory and resolves tier precedence per
+// skill name: project > user > plugin. The winner per name keeps its
+// row and gets Shadows[] populated; losers get ShadowedBy[] populated.
+// If IncludeShadowed is false, losers are removed from inv.Skills.
+//
+// Only TierClaudeCodeSkill descriptors participate; other types
+// (commands, agents, MCP, etc.) are passed through unchanged.
+func applyShadowing(inv *model.Inventory, includeShadowed bool) {
+	tierRank := map[string]int{
+		string(TierProject): 3,
+		string(TierUser):    2,
+		string(TierPlugin):  1,
+	}
+
+	// Group claude_code_skills by name; non-claude rows pass through.
+	type idx struct {
+		i    int
+		rank int
+	}
+	groups := map[string][]idx{}
+	for i, sk := range inv.Skills {
+		if sk.Type != model.SkillTypeClaudeCodeSkill || sk.Tier == "" {
+			continue
+		}
+		groups[sk.Name] = append(groups[sk.Name], idx{i: i, rank: tierRank[sk.Tier]})
+	}
+
+	dropIdx := map[int]bool{}
+	for name, members := range groups {
+		if len(members) <= 1 {
+			continue
+		}
+		// Find winner: highest rank; tie-break on first-seen.
+		winner := members[0]
+		for _, m := range members[1:] {
+			if m.rank > winner.rank {
+				winner = m
+			}
+		}
+		// Annotate winner + losers.
+		for _, m := range members {
+			if m.i == winner.i {
+				continue
+			}
+			loserID := inv.Skills[m.i].ID
+			inv.Skills[m.i].ShadowedBy = []string{inv.Skills[winner.i].ID}
+			inv.Skills[winner.i].Shadows = append(inv.Skills[winner.i].Shadows, loserID)
+			if !includeShadowed {
+				dropIdx[m.i] = true
+			}
+		}
+		_ = name
+	}
+
+	if len(dropIdx) == 0 {
+		return
+	}
+	out := make([]model.SkillDescriptor, 0, len(inv.Skills)-len(dropIdx))
+	for i, sk := range inv.Skills {
+		if dropIdx[i] {
+			continue
+		}
+		out = append(out, sk)
+	}
+	inv.Skills = out
+}

--- a/pkg/skillctl/scanner/tiers_test.go
+++ b/pkg/skillctl/scanner/tiers_test.go
@@ -1,0 +1,321 @@
+// SPEC-0189 S1 tests — tier resolution, plugin walker, shadow merge,
+// SKILL.md anchoring, symlink-loop guard.
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// makeSkillDir creates a Claude Code-conventional skill directory:
+//
+//	<root>/<name>/SKILL.md   (with optional frontmatter body)
+//	<root>/<name>/scripts/foo.sh   (loose file — must NOT be a separate skill)
+func makeSkillDir(t *testing.T, root, name, frontmatterBody string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(frontmatterBody), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "scripts"), 0o755); err != nil {
+		t.Fatalf("mkdir scripts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "scripts", "foo.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write foo.sh: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "REFERENCES.md"), []byte("# refs\n"), 0o644); err != nil {
+		t.Fatalf("write REFERENCES.md: %v", err)
+	}
+}
+
+// TestTierAware_AnchorsOnSkillMD verifies that the tier-aware path discovers
+// EXACTLY one descriptor per directory containing SKILL.md, even when loose
+// .md files (e.g. REFERENCES.md) exist alongside.
+func TestTierAware_AnchorsOnSkillMD(t *testing.T) {
+	tmp := t.TempDir()
+	makeSkillDir(t, tmp, "alpha", "---\nname: alpha\ngovernance_level: green\n---\n")
+	makeSkillDir(t, tmp, "beta", "")
+
+	s := &Scanner{Roots: []ScanRoot{{Path: tmp, Tier: TierUser}}}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got := len(inv.Skills); got != 2 {
+		t.Fatalf("expected 2 skills (alpha, beta), got %d: %+v", got, summarize(inv.Skills))
+	}
+	for _, sk := range inv.Skills {
+		if sk.Tier != string(TierUser) {
+			t.Errorf("skill %s has tier %q, want %q", sk.Name, sk.Tier, TierUser)
+		}
+		if sk.SkillMDPath == "" {
+			t.Errorf("skill %s missing SkillMDPath", sk.Name)
+		}
+		if sk.Type != model.SkillTypeClaudeCodeSkill {
+			t.Errorf("skill %s has type %q", sk.Name, sk.Type)
+		}
+	}
+}
+
+// TestTierAware_GovernanceLevel verifies that governance_level in frontmatter
+// is lifted into Frontmatter.GovernanceLevel.
+func TestTierAware_GovernanceLevel(t *testing.T) {
+	tmp := t.TempDir()
+	makeSkillDir(t, tmp, "trusted", "---\nname: trusted\ngovernance_level: green\n---\n")
+	makeSkillDir(t, tmp, "review", "---\nname: review\ngovernance_level: yellow\n---\n")
+
+	s := &Scanner{Roots: []ScanRoot{{Path: tmp, Tier: TierUser}}}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	gov := map[string]string{}
+	for _, sk := range inv.Skills {
+		if sk.Frontmatter != nil {
+			gov[sk.Name] = sk.Frontmatter.GovernanceLevel
+		}
+	}
+	if gov["trusted"] != "green" {
+		t.Errorf("trusted governance_level = %q, want green", gov["trusted"])
+	}
+	if gov["review"] != "yellow" {
+		t.Errorf("review governance_level = %q, want yellow", gov["review"])
+	}
+}
+
+// TestApplyShadowing verifies project > user > plugin precedence and
+// shadow annotations.
+func TestApplyShadowing(t *testing.T) {
+	tmp := t.TempDir()
+	projDir := filepath.Join(tmp, "project")
+	userDir := filepath.Join(tmp, "user")
+	plugDir := filepath.Join(tmp, "plugin")
+	makeSkillDir(t, projDir, "qa", "")
+	makeSkillDir(t, userDir, "qa", "")
+	makeSkillDir(t, userDir, "didactic-session", "")
+	makeSkillDir(t, plugDir, "qa", "")
+	makeSkillDir(t, plugDir, "seed", "")
+
+	s := &Scanner{
+		Roots: []ScanRoot{
+			{Path: projDir, Tier: TierProject},
+			{Path: userDir, Tier: TierUser},
+			{Path: plugDir, Tier: TierPlugin},
+		},
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	// Without IncludeShadowed: 3 winners (qa/project, didactic-session/user, seed/plugin).
+	winners := map[string]string{}
+	for _, sk := range inv.Skills {
+		winners[sk.Name] = sk.Tier
+	}
+	if winners["qa"] != string(TierProject) {
+		t.Errorf("qa winner tier = %q, want project", winners["qa"])
+	}
+	if winners["didactic-session"] != string(TierUser) {
+		t.Errorf("didactic-session winner tier = %q, want user", winners["didactic-session"])
+	}
+	if winners["seed"] != string(TierPlugin) {
+		t.Errorf("seed winner tier = %q, want plugin", winners["seed"])
+	}
+	if got := len(inv.Skills); got != 3 {
+		t.Errorf("default IncludeShadowed=false: expected 3 winners, got %d", got)
+	}
+
+	// Check Shadows array on the qa winner.
+	for _, sk := range inv.Skills {
+		if sk.Name == "qa" && sk.Tier == string(TierProject) {
+			if len(sk.Shadows) != 2 {
+				t.Errorf("project/qa Shadows count = %d, want 2", len(sk.Shadows))
+			}
+		}
+	}
+}
+
+// TestApplyShadowing_IncludeAll verifies IncludeShadowed=true emits all
+// occurrences with ShadowedBy populated on losers.
+func TestApplyShadowing_IncludeAll(t *testing.T) {
+	tmp := t.TempDir()
+	projDir := filepath.Join(tmp, "project")
+	userDir := filepath.Join(tmp, "user")
+	makeSkillDir(t, projDir, "qa", "")
+	makeSkillDir(t, userDir, "qa", "")
+
+	s := &Scanner{
+		IncludeShadowed: true,
+		Roots: []ScanRoot{
+			{Path: projDir, Tier: TierProject},
+			{Path: userDir, Tier: TierUser},
+		},
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got := len(inv.Skills); got != 2 {
+		t.Fatalf("IncludeShadowed=true: expected 2 rows, got %d", got)
+	}
+	var winnerID string
+	for _, sk := range inv.Skills {
+		if sk.Tier == string(TierProject) {
+			winnerID = sk.ID
+		}
+	}
+	for _, sk := range inv.Skills {
+		if sk.Tier == string(TierUser) {
+			if len(sk.ShadowedBy) != 1 || sk.ShadowedBy[0] != winnerID {
+				t.Errorf("user/qa ShadowedBy = %v, want [%s]", sk.ShadowedBy, winnerID)
+			}
+		}
+	}
+}
+
+// TestPluginCacheRoots verifies the plugin walker discovers a typical
+// ~/.claude/plugins/cache/<o>/<p>/<v>/skills/ layout.
+func TestPluginCacheRoots(t *testing.T) {
+	tmp := t.TempDir()
+	pluginsDir := filepath.Join(tmp, "plugins")
+	skillsDir := filepath.Join(pluginsDir, "cache", "ouroboros", "ouroboros", "0.20.0", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	makeSkillDir(t, skillsDir, "seed", "")
+
+	roots := pluginCacheRoots(pluginsDir)
+	if len(roots) != 1 {
+		t.Fatalf("expected 1 plugin cache root, got %d: %+v", len(roots), roots)
+	}
+	if roots[0].Tier != TierPlugin {
+		t.Errorf("plugin root tier = %q, want %q", roots[0].Tier, TierPlugin)
+	}
+}
+
+// TestMarketplaceRoots verifies both nested and direct marketplace layouts.
+func TestMarketplaceRoots(t *testing.T) {
+	tmp := t.TempDir()
+	pluginsDir := filepath.Join(tmp, "plugins")
+	directSkills := filepath.Join(pluginsDir, "marketplaces", "official", "skills")
+	nestedSkills := filepath.Join(pluginsDir, "marketplaces", "official", "plugins", "foo", "skills")
+	if err := os.MkdirAll(directSkills, 0o755); err != nil {
+		t.Fatalf("mkdir direct: %v", err)
+	}
+	if err := os.MkdirAll(nestedSkills, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+
+	roots := marketplaceRoots(pluginsDir)
+	if len(roots) != 2 {
+		t.Fatalf("expected 2 marketplace roots (direct+nested), got %d: %+v", len(roots), roots)
+	}
+	for _, r := range roots {
+		if r.Tier != TierPlugin {
+			t.Errorf("marketplace root tier = %q, want %q", r.Tier, TierPlugin)
+		}
+	}
+}
+
+// TestResolveDefaults_SourceClaude_IncludesUserAndPlugin verifies that
+// SourceClaude expands to user + plugin per SPEC-0189 §10 D3.
+func TestResolveDefaults_SourceClaude_IncludesUserAndPlugin(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", tmp)
+
+	// Set up user skills + a plugin cache.
+	if err := os.MkdirAll(filepath.Join(tmp, "skills"), 0o755); err != nil {
+		t.Fatalf("mkdir user skills: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, "plugins", "cache", "o", "p", "v", "skills"), 0o755); err != nil {
+		t.Fatalf("mkdir plugin: %v", err)
+	}
+
+	roots := ResolveDefaults([]Source{SourceClaude})
+	tierCounts := map[Tier]int{}
+	for _, r := range roots {
+		tierCounts[r.Tier]++
+	}
+	if tierCounts[TierUser] < 1 {
+		t.Errorf("SourceClaude should yield ≥1 user-tier root; got %d", tierCounts[TierUser])
+	}
+	if tierCounts[TierPlugin] < 1 {
+		t.Errorf("SourceClaude should yield ≥1 plugin-tier root; got %d", tierCounts[TierPlugin])
+	}
+}
+
+// TestResolveDefaults_SourceUser_OnlyUser verifies SourceUser does NOT
+// include plugin tier (matches SPEC-0189 §4 — user-only on demand).
+func TestResolveDefaults_SourceUser_OnlyUser(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, "skills"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, "plugins", "cache", "o", "p", "v", "skills"), 0o755); err != nil {
+		t.Fatalf("mkdir plugin: %v", err)
+	}
+	roots := ResolveDefaults([]Source{SourceUser})
+	for _, r := range roots {
+		if r.Tier == TierPlugin {
+			t.Errorf("SourceUser should not include plugin tier, got %v", r)
+		}
+	}
+}
+
+// TestSymlinkLoop_NoInfiniteWalk creates a symlink that points back into
+// the scanned tree and asserts the scanner does not loop. macOS-only —
+// Windows symlinks need elevated perms in some configurations.
+func TestSymlinkLoop_NoInfiniteWalk(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test requires POSIX")
+	}
+	tmp := t.TempDir()
+	makeSkillDir(t, tmp, "real", "")
+	if err := os.Symlink(filepath.Join(tmp, "real"), filepath.Join(tmp, "loop")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// Add another symlink that points up — this would loop without guard.
+	if err := os.Symlink(tmp, filepath.Join(tmp, "self")); err != nil {
+		t.Fatalf("symlink self: %v", err)
+	}
+
+	done := make(chan *model.Inventory, 1)
+	errc := make(chan error, 1)
+	go func() {
+		s := &Scanner{Roots: []ScanRoot{{Path: tmp, Tier: TierUser}}}
+		inv, err := s.Scan()
+		if err != nil {
+			errc <- err
+			return
+		}
+		done <- inv
+	}()
+	select {
+	case <-done:
+		// Pass: scan completed without hanging.
+	case err := <-errc:
+		t.Fatalf("scan errored: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatalf("scan did not complete within 5s — symlink-loop guard regressed")
+	}
+}
+
+func summarize(skills []model.SkillDescriptor) []string {
+	out := make([]string, 0, len(skills))
+	for _, sk := range skills {
+		out = append(out, sk.Tier+":"+sk.Name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/skillctl/scanner/trust.go
+++ b/pkg/skillctl/scanner/trust.go
@@ -1,0 +1,184 @@
+// Trust cross-reference for SPEC-0189 §6 (`--with-trust`).
+//
+// For each scanned skill, look for a sibling <name>-<version>.skb in the
+// same parent directory (or in ../.archive/) per Decision D1: the on-disk
+// `.skb` is the canonical signal — there is no separate per-machine
+// install ledger. Recompute the bundle digest, look for the matching
+// detached author signature, and annotate the descriptor.
+//
+// "verified" — .skb present, digest matches the digest in the sig
+// filename, and the sig file is the expected 64 raw bytes. The author
+// signature itself is not cryptographically verified here (that needs
+// a network round-trip to the registry to fetch the signer's pubkey,
+// which is the v2 of `--with-trust`); but "matches its own digest
+// envelope" is a strong local-only signal that nothing was tampered
+// after install.
+//
+// "unverified" — no sibling .skb (skill was hand-authored, not
+// installed via `skillctl install`).
+//
+// "broken" — .skb present but digest computation fails, sig file
+// missing, or sig file wrong size.
+package scanner
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// trust_chain values.
+const (
+	TrustVerified   = "verified"
+	TrustUnverified = "unverified"
+	TrustBroken     = "broken"
+)
+
+// AnnotateTrust walks every claude_code_skill in the inventory and
+// populates the SkillDescriptor.Bundle block. Errors per skill are
+// recorded on the descriptor (TrustChain="broken" + VerifierError);
+// the function itself only returns an error if the inventory pointer
+// is nil.
+//
+// Cache: results keyed by ContentHash; skills with the same SKILL.md
+// hash share an answer (cheap protection against re-scanning a
+// symlinked skill twice).
+func AnnotateTrust(inv *model.Inventory) error {
+	if inv == nil {
+		return fmt.Errorf("nil inventory")
+	}
+	cache := map[string]*model.BundleAttestation{}
+	for i := range inv.Skills {
+		sk := &inv.Skills[i]
+		if sk.Type != model.SkillTypeClaudeCodeSkill || sk.Tier == "" {
+			continue
+		}
+		if cached, ok := cache[sk.ContentHash]; ok {
+			// Clone so each descriptor has its own pointer (callers may
+			// mutate, e.g. CLI `--verbose` annotations downstream).
+			cp := *cached
+			sk.Bundle = &cp
+			continue
+		}
+		ba := annotateSkillTrust(sk)
+		sk.Bundle = ba
+		cache[sk.ContentHash] = ba
+	}
+	return nil
+}
+
+// annotateSkillTrust does the per-skill probe.
+func annotateSkillTrust(sk *model.SkillDescriptor) *model.BundleAttestation {
+	parent := filepath.Dir(sk.SourcePath) // ~/.claude/skills/<name>'s parent (skills/)
+	skbPath, found := findSiblingSKB(parent, sk.Name)
+	if !found {
+		return &model.BundleAttestation{
+			Signed:     false,
+			TrustChain: TrustUnverified,
+		}
+	}
+
+	digest, err := computeSKBDigest(skbPath)
+	if err != nil {
+		return &model.BundleAttestation{
+			SKBPath:       skbPath,
+			Signed:        false,
+			TrustChain:    TrustBroken,
+			VerifierError: fmt.Sprintf("digest compute failed: %v", err),
+		}
+	}
+
+	// Look for sibling sig file: <skbPath>.<digest>.author.sig.
+	expectedSig := fmt.Sprintf("%s.%s.author.sig", skbPath, digest)
+	sigInfo, err := os.Stat(expectedSig)
+	if err != nil {
+		return &model.BundleAttestation{
+			SKBPath:       skbPath,
+			BundleDigest:  "sha256:" + digest,
+			Signed:        false,
+			TrustChain:    TrustBroken,
+			VerifierError: fmt.Sprintf("expected sig file missing: %s", expectedSig),
+		}
+	}
+	// Sig file must be exactly 64 raw bytes (ed25519 detached).
+	if sigInfo.Size() != 64 {
+		return &model.BundleAttestation{
+			SKBPath:          skbPath,
+			BundleDigest:     "sha256:" + digest,
+			Signed:           false,
+			TrustChain:       TrustBroken,
+			VerifierExitCode: 11, // verify.ExitAuthorSigInvalid
+			VerifierError:    fmt.Sprintf("sig file size = %d, expected 64", sigInfo.Size()),
+		}
+	}
+
+	return &model.BundleAttestation{
+		SKBPath:                skbPath,
+		BundleDigest:           "sha256:" + digest,
+		Signed:                 true,
+		RegisteredInLocalTrust: false, // populated only when a registry round-trip is run
+		TrustChain:             TrustVerified,
+	}
+}
+
+// findSiblingSKB looks for `<name>-*.skb` in `parent` and `parent/../.archive/`.
+// Returns the first match. If multiple versions exist, picks the
+// lex-largest (a rough proxy for "newest" without parsing semver).
+func findSiblingSKB(parent, name string) (string, bool) {
+	candidates := []string{parent, filepath.Join(filepath.Dir(parent), ".archive")}
+	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(name) + `-.*\.skb$`)
+
+	var best string
+	for _, dir := range candidates {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			if !pattern.MatchString(e.Name()) {
+				continue
+			}
+			candidate := filepath.Join(dir, e.Name())
+			if best == "" || strings.Compare(e.Name(), filepath.Base(best)) > 0 {
+				best = candidate
+			}
+		}
+	}
+	if best == "" {
+		return "", false
+	}
+	return best, true
+}
+
+// computeSKBDigest streams the file through SHA-256 and returns the
+// lowercase hex digest (no `sha256:` prefix). 1 MiB chunks to avoid
+// pulling a large bundle into memory.
+func computeSKBDigest(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	buf := make([]byte, 1<<20)
+	if _, err := io.CopyBuffer(h, f, buf); err != nil {
+		return "", err
+	}
+	sum := h.Sum(nil)
+	const hex = "0123456789abcdef"
+	out := make([]byte, len(sum)*2)
+	for i, b := range sum {
+		out[2*i] = hex[b>>4]
+		out[2*i+1] = hex[b&0x0f]
+	}
+	return string(out), nil
+}

--- a/pkg/skillctl/scanner/trust_test.go
+++ b/pkg/skillctl/scanner/trust_test.go
@@ -1,0 +1,180 @@
+// SPEC-0189 §6 trust cross-reference tests.
+package scanner
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/model"
+)
+
+// makeBundleDir builds a Claude Code-conventional skill dir at <tier-root>/<name>
+// with SKILL.md frontmatter, plus optionally a sibling .skb + .author.sig.
+func makeBundleDir(t *testing.T, tierRoot, name string, withBundle, validSig bool) {
+	t.Helper()
+	skillDir := filepath.Join(tierRoot, name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: "+name+"\n---\n# "+name+"\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	if !withBundle {
+		return
+	}
+	// Make a fake .skb (just some bytes — content doesn't matter for the
+	// digest-pattern check).
+	skbContent := []byte("fake .skb content for " + name)
+	skbPath := filepath.Join(tierRoot, name+"-1.0.0.skb")
+	if err := os.WriteFile(skbPath, skbContent, 0o644); err != nil {
+		t.Fatalf("write .skb: %v", err)
+	}
+	digest := sha256.Sum256(skbContent)
+	const hex = "0123456789abcdef"
+	hexDigest := make([]byte, len(digest)*2)
+	for i, b := range digest {
+		hexDigest[2*i] = hex[b>>4]
+		hexDigest[2*i+1] = hex[b&0x0f]
+	}
+	sigPath := fmt.Sprintf("%s.%s.author.sig", skbPath, string(hexDigest))
+	sigSize := 64
+	if !validSig {
+		sigSize = 32 // wrong size triggers TrustBroken
+	}
+	if err := os.WriteFile(sigPath, make([]byte, sigSize), 0o644); err != nil {
+		t.Fatalf("write sig: %v", err)
+	}
+}
+
+// TestAnnotateTrust_Verified — sibling .skb + correct-size sig → verified.
+func TestAnnotateTrust_Verified(t *testing.T) {
+	tmp := t.TempDir()
+	makeBundleDir(t, tmp, "fetch-contract", true, true)
+
+	s := &Scanner{
+		Roots:     []ScanRoot{{Path: tmp, Tier: TierUser}},
+		WithTrust: true,
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(inv.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(inv.Skills))
+	}
+	sk := inv.Skills[0]
+	if sk.Bundle == nil {
+		t.Fatal("Bundle block missing — AnnotateTrust didn't run?")
+	}
+	if sk.Bundle.TrustChain != TrustVerified {
+		t.Errorf("trust_chain = %q, want verified; err=%q", sk.Bundle.TrustChain, sk.Bundle.VerifierError)
+	}
+	if !sk.Bundle.Signed {
+		t.Errorf("signed = false; want true for verified bundle")
+	}
+	if sk.Bundle.SKBPath == "" {
+		t.Errorf("SKBPath empty")
+	}
+	if sk.Bundle.BundleDigest == "" || sk.Bundle.BundleDigest[:7] != "sha256:" {
+		t.Errorf("BundleDigest = %q, want 'sha256:<hex>'", sk.Bundle.BundleDigest)
+	}
+}
+
+// TestAnnotateTrust_Unverified — no sibling .skb → unverified.
+func TestAnnotateTrust_Unverified(t *testing.T) {
+	tmp := t.TempDir()
+	makeBundleDir(t, tmp, "hand-authored", false, false)
+
+	s := &Scanner{
+		Roots:     []ScanRoot{{Path: tmp, Tier: TierUser}},
+		WithTrust: true,
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	sk := inv.Skills[0]
+	if sk.Bundle == nil || sk.Bundle.TrustChain != TrustUnverified {
+		t.Errorf("trust_chain = %v, want unverified", sk.Bundle)
+	}
+	if sk.Bundle.Signed {
+		t.Errorf("signed = true; want false for hand-authored skill")
+	}
+}
+
+// TestAnnotateTrust_Broken — sibling .skb but sig file wrong size → broken.
+func TestAnnotateTrust_Broken(t *testing.T) {
+	tmp := t.TempDir()
+	makeBundleDir(t, tmp, "tampered", true, false /* sig wrong size */)
+
+	s := &Scanner{
+		Roots:     []ScanRoot{{Path: tmp, Tier: TierUser}},
+		WithTrust: true,
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	sk := inv.Skills[0]
+	if sk.Bundle == nil || sk.Bundle.TrustChain != TrustBroken {
+		t.Errorf("trust_chain = %v, want broken", sk.Bundle)
+	}
+	if sk.Bundle.VerifierError == "" {
+		t.Errorf("VerifierError empty for broken bundle")
+	}
+}
+
+// TestAnnotateTrust_NoTrust — without WithTrust=true, Bundle stays nil.
+func TestAnnotateTrust_NoTrust(t *testing.T) {
+	tmp := t.TempDir()
+	makeBundleDir(t, tmp, "untouched", true, true)
+
+	s := &Scanner{
+		Roots: []ScanRoot{{Path: tmp, Tier: TierUser}},
+		// WithTrust: false (default)
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	sk := inv.Skills[0]
+	if sk.Bundle != nil {
+		t.Errorf("Bundle populated without WithTrust=true")
+	}
+}
+
+// TestAnnotateTrust_CacheByContentHash — two skills with identical
+// SKILL.md content share an answer (sanity check the cache path).
+func TestAnnotateTrust_CacheByContentHash(t *testing.T) {
+	tmp := t.TempDir()
+	makeBundleDir(t, tmp, "twin-a", false, false)
+	makeBundleDir(t, tmp, "twin-b", false, false)
+	// Twin SKILL.md content — overwrite to identical bytes.
+	bytes := []byte("same content\n")
+	_ = os.WriteFile(filepath.Join(tmp, "twin-a", "SKILL.md"), bytes, 0o644)
+	_ = os.WriteFile(filepath.Join(tmp, "twin-b", "SKILL.md"), bytes, 0o644)
+
+	s := &Scanner{
+		Roots:     []ScanRoot{{Path: tmp, Tier: TierUser}},
+		WithTrust: true,
+	}
+	inv, err := s.Scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(inv.Skills) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(inv.Skills))
+	}
+	for _, sk := range inv.Skills {
+		if sk.Bundle == nil {
+			t.Errorf("%s missing Bundle block", sk.Name)
+		} else if sk.Bundle.TrustChain != TrustUnverified {
+			t.Errorf("%s trust_chain = %q, want unverified", sk.Name, sk.Bundle.TrustChain)
+		}
+	}
+	// Suppress unused-var warning.
+	_ = model.SkillTypeClaudeCodeSkill
+}

--- a/pkg/skillctl/scanner/types.go
+++ b/pkg/skillctl/scanner/types.go
@@ -1,0 +1,109 @@
+// Tier + Source types and ResolveDefaults — SPEC-0189 Phase 1.
+//
+// Claude Code resolves skills from three precedence tiers (project > user >
+// plugin). This file defines the canonical Tier and Source values and the
+// path-resolution helper that maps a Source set to scan roots.
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Tier is the precedence layer a skill comes from. Project wins over user,
+// user wins over plugin. See SPEC-0189 §3.
+type Tier string
+
+const (
+	TierProject Tier = "project"
+	TierUser    Tier = "user"
+	TierPlugin  Tier = "plugin"
+)
+
+// Source is a logical scan-root selector. The CLI exposes this as
+// `--source <claude|user|projects|plugins|all>` per SPEC-0189 §4.
+type Source string
+
+const (
+	// SourceClaude is the default — user tier + plugin tier (matches
+	// what Claude Code itself resolves at runtime per SPEC-0189 §10 D3).
+	SourceClaude   Source = "claude"
+	SourceUser     Source = "user"
+	SourceProjects Source = "projects" // legacy SPEC-0115 mode
+	SourcePlugins  Source = "plugins"
+	SourceAll      Source = "all"
+)
+
+// ScanRoot pairs a filesystem path with the Tier of skills found beneath it.
+type ScanRoot struct {
+	Path string
+	Tier Tier
+}
+
+// ResolveDefaults returns the Claude Code conventional roots for the
+// requested source set. Honours $HOME and $CLAUDE_CONFIG_DIR overrides.
+//
+// User tier:    $CLAUDE_CONFIG_DIR/skills/  or  ~/.claude/skills/
+// Plugin tier:  $CLAUDE_CONFIG_DIR/plugins/cache/<o>/<p>/<v>/skills/
+//               $CLAUDE_CONFIG_DIR/plugins/marketplaces/<m>/skills/
+//               $CLAUDE_CONFIG_DIR/plugins/marketplaces/<m>/plugins/<p>/skills/
+// Project tier: caller supplies via explicit path arg (not auto-resolved).
+//
+// SourceClaude expands to user + plugin (SPEC-0189 §10 D3).
+// SourceAll expands to user + plugin only (project tier requires explicit
+// paths from the caller; auto-discovery is intentionally out of scope —
+// see SPEC-0189 §12).
+func ResolveDefaults(sources []Source) []ScanRoot {
+	configDir := claudeConfigDir()
+	if configDir == "" {
+		return nil
+	}
+
+	wantUser := false
+	wantPlugins := false
+	for _, src := range sources {
+		switch src {
+		case SourceClaude:
+			wantUser = true
+			wantPlugins = true
+		case SourceUser:
+			wantUser = true
+		case SourcePlugins:
+			wantPlugins = true
+		case SourceAll:
+			wantUser = true
+			wantPlugins = true
+		}
+	}
+
+	var roots []ScanRoot
+	if wantUser {
+		userSkills := filepath.Join(configDir, "skills")
+		if pathExists(userSkills) {
+			roots = append(roots, ScanRoot{Path: userSkills, Tier: TierUser})
+		}
+	}
+	if wantPlugins {
+		pluginRoots := pluginScanRoots(configDir)
+		roots = append(roots, pluginRoots...)
+	}
+	return roots
+}
+
+// claudeConfigDir returns the resolved Claude Code config dir. Honours
+// $CLAUDE_CONFIG_DIR if set, else falls back to $HOME/.claude.
+func claudeConfigDir() string {
+	if dir := os.Getenv("CLAUDE_CONFIG_DIR"); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude")
+}
+
+func pathExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}


### PR DESCRIPTION
Lands the full SPEC-0189 chain — scanner refactor + tier/shadow + plugin walker (S1) + trust cross-ref (S2) + CLI flag plumbing + tabwriter renderer (S3) + the scanner-family baseline import (S0a). Companion to SPEC-0188.

Acceptance:
- §9.1: skillctl scan default → user + plugin tiers (one row per name) ✓
- §9.2: --source projects reproduces SPEC-0115 inventory ✓
- §9.3: plugin-tier annotated correctly ✓
- §9.4: --with-trust verified/unverified/broken classification ✓
- §9.5: JSON record matches §5 ✓
- §9.6: MCP skill_scan() — pending fast-follow

Tests: 23 scanner tests (15 SPEC-0189 + 8 SPEC-0115 regression) + cmd/skillctl + parser + model + report + consolidate + install + registry + review + signing + verify all green.

Includes the master/main reconciliation gap (Decision (b) in PLAN-SPEC-0189-parallel-execution.md): scanner family + mcp-skill-server + pack baseline imported as a chore commit (S0a).