### PR TITLE
feat(spec-0189-s3b): MCP skill_scan args pass-through

### DIFF
--- a/mcp-skill-server/server.py
+++ b/mcp-skill-server/server.py
@@ -63,21 +63,44 @@ mcp = FastMCP(
 
 @mcp.tool()
 async def skill_scan(
-    path: str = "",
-    recursive: bool = True,
-    include_home: bool = True,
+    source: str = "claude",
+    path: list[str] | None = None,
+    with_trust: bool = False,
+    include_shadowed: bool = False,
+    # Legacy SPEC-0115 args (preserved for backwards compat).
+    recursive: bool = False,
+    include_home: bool = False,
 ) -> str:
-    """Scan directories for Claude Code skills, commands, agents, and skill indexes.
-    Returns a summary of discovered skills by type and project."""
-    args = [SKILLCTL, "scan", "--output", "json"]
-    if path:
-        args += ["--path", path]
-    else:
-        args += ["--path", str(Path.home())]
-    if recursive:
-        args.append("--recursive")
-    if include_home:
-        args.append("--include-home")
+    """Scan Claude Code skill surfaces (user, project, plugin) per SPEC-0189.
+
+    Args:
+        source: One of "claude" (default — user + plugin tiers, matches what
+            Claude Code resolves at runtime), "user" (user tier only),
+            "projects" (legacy SPEC-0115 mode — requires path), "plugins"
+            (plugin tier only), or "all" (union).
+        path: Additional roots to scan as project tier (repeatable).
+        with_trust: If True, cross-reference each skill against SPEC-0188
+            install state via the sibling .skb. Adds Bundle{TrustChain}
+            block per skill.
+        include_shadowed: If True, emit ALL occurrences across tiers
+            (default emits winners only — project > user > plugin).
+
+    Returns a summary by type/project + tier breakdown. JSON output is
+    available via the `skillctl scan --format json` CLI directly.
+    """
+    args = [SKILLCTL, "scan", "--source", source, "--format", "json"]
+    if with_trust:
+        args.append("--with-trust")
+    if include_shadowed:
+        args.append("--include-shadowed")
+    for p in path or []:
+        args += ["--path", p]
+    # Legacy flags only emitted if explicitly set + source=projects.
+    if source == "projects":
+        if recursive:
+            args.append("--recursive")
+        if include_home:
+            args.append("--include-home")
 
     result = await _run_skillctl(args)
     if result.get("error"):
@@ -88,10 +111,29 @@ async def skill_scan(
     by_type = inv.get("by_type", {})
     by_project = inv.get("by_project", {})
 
-    lines = [f"Scanned {total} skills across {len(by_project)} projects\n"]
+    # SPEC-0189 tier breakdown.
+    by_tier: dict[str, int] = {}
+    trust_breakdown: dict[str, int] = {}
+    for sk in inv.get("skills", []):
+        tier = sk.get("tier") or "untiered"
+        by_tier[tier] = by_tier.get(tier, 0) + 1
+        if with_trust and sk.get("bundle"):
+            tc = sk["bundle"].get("trust_chain", "unknown")
+            trust_breakdown[tc] = trust_breakdown.get(tc, 0) + 1
+
+    lines = [f"Scanned {total} skills across {len(by_project)} projects (source={source})\n"]
+    if by_tier:
+        lines.append("By tier:")
+        for t, c in sorted(by_tier.items(), key=lambda x: -x[1]):
+            lines.append(f"  {t}: {c}")
+        lines.append("")
     lines.append("By type:")
     for t, c in sorted(by_type.items(), key=lambda x: -x[1]):
         lines.append(f"  {t}: {c}")
+    if with_trust and trust_breakdown:
+        lines.append("\nTrust chain (SPEC-0188 cross-ref):")
+        for tc, c in sorted(trust_breakdown.items(), key=lambda x: -x[1]):
+            lines.append(f"  {tc}: {c}")
     lines.append("\nBy project:")
     for p, c in sorted(by_project.items(), key=lambda x: -x[1])[:15]:
         lines.append(f"  {p}: {c}")

--- a/mcp-skill-server/test_spec0189_tools.py
+++ b/mcp-skill-server/test_spec0189_tools.py
@@ -1,0 +1,190 @@
+"""Unit tests for the SPEC-0189 args added to the MCP `skill_scan` tool.
+
+The tool itself (server.skill_scan) is the same coroutine used in production;
+we exercise it by mocking `_run_skillctl` so we don't need a real Go binary.
+
+Each test asserts:
+  - the argv that flowed to `_run_skillctl` matches the SPEC-0189 §7 CLI shape
+  - the rendered text output contains the expected SPEC-0189 §6 fields
+    (tier breakdown when skills carry a tier, trust-chain breakdown when
+    `with_trust=True`)
+
+Run:
+    cd mcp-skill-server
+    python3 -m pytest test_spec0189_tools.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import patch, AsyncMock
+
+import server  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _ok(payload: dict) -> dict:
+    """Shape `_run_skillctl` returns on a clean exec."""
+    return {"stdout": json.dumps(payload), "stderr": "", "error": ""}
+
+
+# ---------- argv shape (SPEC-0189 §7 contract) ----------
+
+
+def test_default_source_claude_argv_is_clean():
+    """Default call → `skillctl scan --source claude --format json` and nothing else.
+    No legacy --path/--recursive/--include-home leaks through."""
+    captured = {}
+
+    async def fake_runner(argv):
+        captured["argv"] = argv
+        return _ok({"total_count": 0, "by_type": {}, "by_project": {}, "skills": []})
+
+    with patch("server._run_skillctl", side_effect=fake_runner):
+        _run(server.skill_scan())
+
+    argv = captured["argv"]
+    assert argv[1:] == ["scan", "--source", "claude", "--format", "json"]
+
+
+def test_source_user_passes_through():
+    captured = {}
+
+    async def fake_runner(argv):
+        captured["argv"] = argv
+        return _ok({"total_count": 0, "by_type": {}, "by_project": {}, "skills": []})
+
+    with patch("server._run_skillctl", side_effect=fake_runner):
+        _run(server.skill_scan(source="user"))
+
+    assert "--source" in captured["argv"]
+    assert captured["argv"][captured["argv"].index("--source") + 1] == "user"
+
+
+def test_with_trust_and_include_shadowed_emit_flags():
+    """SPEC-0189 §7: --with-trust + --include-shadowed emitted iff requested."""
+    captured = {}
+
+    async def fake_runner(argv):
+        captured["argv"] = argv
+        return _ok({"total_count": 0, "by_type": {}, "by_project": {}, "skills": []})
+
+    with patch("server._run_skillctl", side_effect=fake_runner):
+        _run(server.skill_scan(source="claude", with_trust=True, include_shadowed=True))
+
+    assert "--with-trust" in captured["argv"]
+    assert "--include-shadowed" in captured["argv"]
+
+
+def test_path_is_repeatable():
+    """SPEC-0189 §7: --path can repeat. The tool must emit one --path
+    per entry in the list."""
+    captured = {}
+
+    async def fake_runner(argv):
+        captured["argv"] = argv
+        return _ok({"total_count": 0, "by_type": {}, "by_project": {}, "skills": []})
+
+    with patch("server._run_skillctl", side_effect=fake_runner):
+        _run(server.skill_scan(source="all", path=["/repo/a", "/repo/b"]))
+
+    argv = captured["argv"]
+    # Each path argument appears as its own --path / value pair.
+    indices = [i for i, v in enumerate(argv) if v == "--path"]
+    assert len(indices) == 2
+    assert argv[indices[0] + 1] == "/repo/a"
+    assert argv[indices[1] + 1] == "/repo/b"
+
+
+def test_legacy_flags_only_with_source_projects():
+    """`recursive=True` / `include_home=True` ONLY emit the legacy flags
+    if `source='projects'` (SPEC-0115 mode). Under `source='claude'` they
+    must be silently ignored — otherwise we'd corrupt the new tier-aware
+    discovery path."""
+    captured = {}
+
+    async def fake_runner(argv):
+        captured["argv"] = argv
+        return _ok({"total_count": 0, "by_type": {}, "by_project": {}, "skills": []})
+
+    # Modern source: legacy flags ignored.
+    with patch("server._run_skillctl", side_effect=fake_runner):
+        _run(server.skill_scan(source="claude", recursive=True, include_home=True))
+    assert "--recursive" not in captured["argv"]
+    assert "--include-home" not in captured["argv"]
+
+    # Legacy source: flags emitted.
+    with patch("server._run_skillctl", side_effect=fake_runner):
+        _run(server.skill_scan(source="projects", path=["/x"], recursive=True, include_home=True))
+    assert "--recursive" in captured["argv"]
+    assert "--include-home" in captured["argv"]
+
+
+# ---------- output rendering (SPEC-0189 §6 fields) ----------
+
+
+def test_output_includes_tier_breakdown():
+    """When the inventory carries `tier` per skill, the rendered text
+    contains a `By tier:` section with the right counts."""
+    payload = {
+        "total_count": 3,
+        "by_type": {"claude_code_skill": 3},
+        "by_project": {"user-global": 2, "marketplace:foo": 1},
+        "skills": [
+            {"tier": "user", "name": "a"},
+            {"tier": "user", "name": "b"},
+            {"tier": "plugin", "name": "c"},
+        ],
+    }
+
+    async def fake_runner(argv):
+        return _ok(payload)
+
+    with patch("server._run_skillctl", side_effect=fake_runner):
+        out = _run(server.skill_scan(source="claude"))
+
+    assert "By tier:" in out
+    assert "user: 2" in out
+    assert "plugin: 1" in out
+    assert "(source=claude)" in out
+
+
+def test_output_includes_trust_chain_when_with_trust():
+    """If `with_trust=True` and the inventory carries bundle.trust_chain,
+    a `Trust chain` section is rendered."""
+    payload = {
+        "total_count": 2,
+        "by_type": {"claude_code_skill": 2},
+        "by_project": {"user-global": 2},
+        "skills": [
+            {"tier": "user", "name": "trusted-a", "bundle": {"trust_chain": "verified"}},
+            {"tier": "user", "name": "no-bundle", "bundle": {"trust_chain": "no_bundle"}},
+        ],
+    }
+
+    async def fake_runner(argv):
+        return _ok(payload)
+
+    with patch("server._run_skillctl", side_effect=fake_runner):
+        out = _run(server.skill_scan(source="claude", with_trust=True))
+
+    assert "Trust chain" in out
+    assert "verified: 1" in out
+    assert "no_bundle: 1" in out
+
+
+def test_runner_error_is_surfaced():
+    """If `_run_skillctl` returns an error, the tool returns a human
+    message rather than raising."""
+    async def fake_runner(argv):
+        return {"error": "skillctl not found at /nope", "stdout": "", "stderr": ""}
+
+    with patch("server._run_skillctl", side_effect=fake_runner):
+        out = _run(server.skill_scan(source="claude"))
+
+    assert out.startswith("Scan failed:")
+    assert "skillctl not found" in out


### PR DESCRIPTION
## Summary
- Extends MCP `skill_scan` tool with SPEC-0189 §7 args: `source`, `with_trust`, `include_shadowed`, repeatable `path`.
- Output rendering adds tier breakdown (always when present) and trust-chain breakdown (under `with_trust=True`).
- Legacy SPEC-0115 args preserved but only emitted under `source="projects"`.
- Closes the only item that was deferred from PR #14 (S3 stream).

## Tests
- [x] `test_spec0189_tools.py` — 8 new tests (argv shape + output rendering) — 8/8 pass.
- [x] `test_spec0188_tools.py` — 17/17 pass (no regression).
- [x] Live smoke: `python3 -c "import server; await server.skill_scan(source='claude')"` → 50 skills (36 plugin, 14 user) on the dev machine.

## SPEC-0189 §9 acceptance criterion 6
"MCP `skill_scan` tool accepts SPEC-0189 args" — now satisfied.

## Sequencing
Locked in `m3c-tools-maintenance/PLAN/skill-stack-next-steps-2026-05-06.md` as Option A step 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)