### PR TITLE
feat(verify): tenant-aware verifier — SPEC-0188 §7 step 5.5 (R-01 / S1.2)

### DIFF
--- a/cmd/skillctl/install_cmds.go
+++ b/cmd/skillctl/install_cmds.go
@@ -46,6 +46,7 @@ func runInstall(args []string, stdout, stderr io.Writer) int {
 	governanceMin := fs.String("governance-min", "", "Override the trust-root's governance_minimum (green | yellow). Empty = use trust-root.")
 	allowYellow := fs.Bool("allow-yellow", false, "Lower the gate from green to yellow for this install (audited).")
 	ignoreDeps := fs.Bool("ignore-deps", false, "Skip depends_on resolution (audited).")
+	tenantFlag := fs.String("tenant", "", "Pin this install to a tenant scope (SPEC-0188 §7 step 5.5). Overrides trust-roots tenant_scope. Empty = use trust-roots value or run untenanted.")
 	timeout := fs.Duration("timeout", registry.DefaultTimeout, "HTTP timeout for registry calls.")
 	verboseFlag := fs.Bool("verbose", false, "Print structured per-step log lines to stderr.")
 	homeOverride := fs.String("home", "", "Override the install root (advanced; defaults to $HOME).")
@@ -70,6 +71,7 @@ func runInstall(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "  13  governance below minimum")
 		fmt.Fprintln(stderr, "  14  depends_on unsatisfied")
 		fmt.Fprintln(stderr, "  15  blob missing")
+		fmt.Fprintln(stderr, "  16  tenant blocked (CISO console verdict)")
 		fs.PrintDefaults()
 	}
 
@@ -92,7 +94,12 @@ func runInstall(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, err)
 		return exitGeneric
 	}
-	_ = tr // tr is the parent struct; we only need the matched root below
+
+	// Tenant resolution (SPEC-0188 §7 step 5.5, G-18 closure 2026-05-06):
+	// the CLI flag wins over the trust-roots `tenant_scope:` value. Empty
+	// after this resolution = untenanted; the verifier's step 5.5 is a
+	// no-op.
+	tenant := resolveTenant(*tenantFlag, tr)
 
 	// Build a registry HTTP client targeting the matched trust root.
 	httpClient := install.HTTPClientOf(*timeout)
@@ -116,6 +123,7 @@ func runInstall(args []string, stdout, stderr io.Writer) int {
 		GovernanceMin: *governanceMin,
 		AllowYellow:   *allowYellow,
 		IgnoreDeps:    *ignoreDeps,
+		Tenant:        tenant,
 		AuditPoster:   auditPoster,
 		Logger:        logger,
 		Now:           time.Now,
@@ -148,6 +156,7 @@ func runVerify(args []string, stdout, stderr io.Writer) int {
 	registryURL := fs.String("registry", "", "Registry base URL. Required only when trust-roots has multiple registries pinned.")
 	governanceMin := fs.String("governance-min", "", "Override the trust-root's governance_minimum (green | yellow).")
 	allowYellow := fs.Bool("allow-yellow", false, "Permit yellow result against a green-required trust root (does NOT re-audit; --allow-yellow is per-install).")
+	tenantFlag := fs.String("tenant", "", "Pin this verify to a tenant scope (SPEC-0188 §7 step 5.5). Overrides trust-roots tenant_scope.")
 	timeout := fs.Duration("timeout", registry.DefaultTimeout, "HTTP timeout for registry calls.")
 	verboseFlag := fs.Bool("verbose", false, "Print structured per-step log lines to stderr.")
 	homeOverride := fs.String("home", "", "Override the install root.")
@@ -182,7 +191,10 @@ func runVerify(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, err)
 		return exitGeneric
 	}
-	_ = tr
+
+	// Same precedence as runInstall: --tenant wins over trust-roots
+	// tenant_scope; empty = untenanted (step 5.5 no-op).
+	tenant := resolveTenant(*tenantFlag, tr)
 
 	httpClient := install.HTTPClientOf(*timeout)
 	c := registry.New(root.RegistryURL, httpClient)
@@ -199,6 +211,7 @@ func runVerify(args []string, stdout, stderr io.Writer) int {
 		HomeDir:       *homeOverride,
 		GovernanceMin: *governanceMin,
 		AllowYellow:   *allowYellow,
+		Tenant:        tenant,
 		Logger:        logger,
 		Ctx:           context.Background(),
 	})
@@ -265,4 +278,22 @@ func loadAndPickRoot(registryFlag string) (*verify.TrustRoots, *verify.TrustRoot
 		return tr, &tr.Roots[0], nil
 	}
 	return nil, nil, fmt.Errorf("trust roots file %s pins multiple registries; pass --registry <url> to disambiguate", tr.Path)
+}
+
+// resolveTenant implements the SPEC-0188 §7 step 5.5 precedence rule:
+// `--tenant <id>` (cliFlag) wins over the trust-roots `tenant_scope:`
+// value (G-18 closure, 2026-05-06). Both empty → empty result, which the
+// verifier treats as "untenanted" and skips the tenant-block check.
+//
+// Whitespace is trimmed on both sides so a stray space in the YAML or on
+// the command line doesn't surprise an operator.
+func resolveTenant(cliFlag string, tr *verify.TrustRoots) string {
+	cliFlag = strings.TrimSpace(cliFlag)
+	if cliFlag != "" {
+		return cliFlag
+	}
+	if tr == nil {
+		return ""
+	}
+	return strings.TrimSpace(tr.TenantScope)
 }

--- a/cmd/skillctl/install_cmds_test.go
+++ b/cmd/skillctl/install_cmds_test.go
@@ -390,3 +390,44 @@ func buildSkillBundleTGZ(t *testing.T) []byte {
 	_ = gw.Close()
 	return gzBuf.Bytes()
 }
+
+// ----- SPEC-0188 §7 step 5.5: --tenant resolution precedence -----
+
+// TestResolveTenant_CLIBeatsTrustRoots locks the SPEC-0188 §4.4 G-18
+// precedence rule: --tenant <id> wins over the trust-roots tenant_scope:
+// value. Both empty → empty (verifier treats as untenanted).
+func TestResolveTenant_CLIBeatsTrustRoots(t *testing.T) {
+	cases := []struct {
+		name    string
+		cli     string
+		yaml    string
+		want    string
+	}{
+		{"both-empty", "", "", ""},
+		{"cli-only", "kup-berlin", "", "kup-berlin"},
+		{"yaml-only", "", "kup-berlin", "kup-berlin"},
+		{"cli-wins", "cflt", "kup-berlin", "cflt"},
+		{"cli-trim", "  kup-berlin  ", "ignored", "kup-berlin"},
+		{"yaml-trim", "", "  kup-berlin  ", "kup-berlin"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tr := &verify.TrustRoots{TenantScope: c.yaml}
+			if got := resolveTenant(c.cli, tr); got != c.want {
+				t.Errorf("resolveTenant(%q, yaml=%q) = %q, want %q", c.cli, c.yaml, got, c.want)
+			}
+		})
+	}
+}
+
+// TestResolveTenant_NilTrustRoots: defensive — if the CLI ever calls
+// resolveTenant before loadAndPickRoot returns a valid TrustRoots, the
+// helper must not panic.
+func TestResolveTenant_NilTrustRoots(t *testing.T) {
+	if got := resolveTenant("kup-berlin", nil); got != "kup-berlin" {
+		t.Errorf("resolveTenant with nil TrustRoots = %q, want kup-berlin", got)
+	}
+	if got := resolveTenant("", nil); got != "" {
+		t.Errorf("resolveTenant nil/empty = %q, want empty", got)
+	}
+}

--- a/pkg/skillctl/install/install.go
+++ b/pkg/skillctl/install/install.go
@@ -95,6 +95,15 @@ type Opts struct {
 	AllowYellow bool
 	IgnoreDeps  bool
 
+	// Tenant is the resolved tenant scope for this install/verify call
+	// (SPEC-0188 §7 step 5.5, G-18 closure 2026-05-06). The CLI resolves
+	// this from `--tenant <id>` with fallback to TrustRoots.TenantScope.
+	// Empty = untenanted; the verifier's tenant-block check is a no-op.
+	// Non-empty triggers a scan of BundleMeta.Attestations for tenant-
+	// scoped red verdicts; any match fails closed with verify.ErrTenantBlocked
+	// (exit code 16).
+	Tenant string
+
 	// AuditPoster, if non-nil, is called when AllowYellow or IgnoreDeps
 	// is set so the override is durably logged before the install
 	// proceeds. Production wires this to PostAuditEntry (overrides.go);
@@ -238,6 +247,7 @@ func Install(opts Opts) (*Result, error) {
 		GovernanceMin:   opts.GovernanceMin,
 		AllowYellow:     opts.AllowYellow,
 		IgnoreDeps:      opts.IgnoreDeps,
+		Tenant:          opts.Tenant,
 		Logger:          opts.Logger,
 	}
 	verRes, err := verify.Verify(verifyOpts)
@@ -370,6 +380,7 @@ func VerifyInstalled(opts Opts) (*verify.VerifyResult, error) {
 		GovernanceMin:   opts.GovernanceMin,
 		AllowYellow:     opts.AllowYellow,
 		IgnoreDeps:      opts.IgnoreDeps,
+		Tenant:          opts.Tenant,
 		Logger:          opts.Logger,
 	}
 	return verify.Verify(verifyOpts)

--- a/pkg/skillctl/registry/types.go
+++ b/pkg/skillctl/registry/types.go
@@ -147,6 +147,15 @@ type AttestationRow struct {
 	// the registry for audit; the registry's CurrentGovernance computation
 	// already excludes revoked rows, so this is informational.
 	Status string `json:"status,omitempty"`
+
+	// TenantScope, when non-empty, scopes this attestation to a specific
+	// tenant id (e.g. "kup-berlin"). Per SPEC-0188 §7 step 5.5 (G-18 closure,
+	// 2026-05-06) the verifier consults tenant-scoped attestations to allow
+	// a tenant CISO to block an otherwise-trusted bundle for THAT tenant
+	// without affecting other tenants. An empty TenantScope means the
+	// attestation is global / untenanted; the tenant-block step ignores
+	// global rows.
+	TenantScope string `json:"tenant_scope,omitempty"`
 }
 
 // SignatureRow is one entry in BundleMeta.Signatures. Mirrors the

--- a/pkg/skillctl/verify/errors.go
+++ b/pkg/skillctl/verify/errors.go
@@ -45,6 +45,12 @@ const (
 	// ExitBlobMissing — the registry has metadata for a digest but
 	// the actual blob is unreachable.
 	ExitBlobMissing = 15
+	// ExitTenantBlocked — at least one tenant-scoped governance attestation
+	// (SPEC-0188 §7 step 5.5, G-18 closure 2026-05-06) carries
+	// governance_level=red for the consumer's pinned tenant. The bundle is
+	// admitted globally but the tenant CISO has blocked it; the verifier
+	// fails closed.
+	ExitTenantBlocked = 16
 )
 
 // Sentinel errors so callers can `errors.Is(err, verify.ErrDigestMismatch)`
@@ -82,6 +88,14 @@ var (
 	// ErrBlobMissing — registry metadata exists but the blob storage
 	// returned 404 / unreachable. Exit code 15.
 	ErrBlobMissing = errors.New("blob missing")
+
+	// ErrTenantBlocked — a tenant-scoped governance attestation set
+	// governance_level=red for this bundle in the consumer's pinned
+	// tenant. SPEC-0188 §7 step 5.5 (G-18 closure, 2026-05-06).
+	// Exit code 16. The verifier MUST refuse the install/verify even
+	// when the global chain validates; the tenant CISO's block decision
+	// supersedes for THIS tenant only.
+	ErrTenantBlocked = errors.New("tenant blocked by tenant-scoped attestation")
 )
 
 // ExitCode maps a verifier error to its numeric process exit code.
@@ -93,6 +107,7 @@ var (
 //	wrapped ErrGovernanceBelowMin        → 13
 //	wrapped ErrDepsUnsatisfied           → 14
 //	wrapped ErrBlobMissing               → 15
+//	wrapped ErrTenantBlocked             → 16
 //	any other non-nil error              → 1 (generic)
 //
 // We deliberately do NOT return 2 (usage) here — that's the CLI's concern,
@@ -120,6 +135,8 @@ func ExitCode(err error) int {
 		return ExitDepsUnsatisfied
 	case errors.Is(err, ErrBlobMissing):
 		return ExitBlobMissing
+	case errors.Is(err, ErrTenantBlocked):
+		return ExitTenantBlocked
 	default:
 		return 1
 	}

--- a/pkg/skillctl/verify/trustroots.go
+++ b/pkg/skillctl/verify/trustroots.go
@@ -148,6 +148,17 @@ type TrustRoots struct {
 	// Roots is the list of pinned registries. Order matches file order.
 	Roots []TrustRoot `yaml:"trust_roots"`
 
+	// TenantScope, if non-empty, pins this consumer machine to a tenant id
+	// for the §7 step 5.5 tenant-block check (SPEC-0188 §4.4 G-18 closure,
+	// 2026-05-06). The CLI's `--tenant <id>` flag overrides this for the
+	// current invocation; an empty value means "untenanted / global" and
+	// step 5.5 is skipped.
+	//
+	// The field is intentionally top-level (not per-TrustRoot): a
+	// machine's tenant identity is a property of the consumer, not of the
+	// registry it talks to.
+	TenantScope string `yaml:"tenant_scope,omitempty"`
+
 	// Path is the resolved absolute file path used by Load (and by
 	// Save() on round-trip). Not serialized to YAML.
 	Path string `yaml:"-"`

--- a/pkg/skillctl/verify/verify.go
+++ b/pkg/skillctl/verify/verify.go
@@ -89,6 +89,17 @@ type VerifyOpts struct {
 	// future Python-wheel resolution.
 	IgnoreDeps bool
 
+	// Tenant is the resolved tenant scope for this verification (SPEC-0188
+	// §7 step 5.5, G-18 closure 2026-05-06). Empty means "untenanted /
+	// global" and step 5.5 is a no-op. The CLI resolves this from the
+	// `--tenant <id>` flag with fallback to TrustRoots.TenantScope from
+	// `~/.claude/skill-trust-roots.yaml`.
+	//
+	// When non-empty, the verifier scans BundleMeta.Attestations for any
+	// row with TenantScope == Tenant and Level == "red" and fails closed
+	// with ErrTenantBlocked.
+	Tenant string
+
 	// Logger receives one structured-log line per step when non-nil.
 	// `--verbose` in the CLI wires this to stderr; tests capture into a
 	// strings.Builder. Failure messages are returned as errors regardless.
@@ -174,6 +185,26 @@ func Verify(opts VerifyOpts) (*VerifyResult, error) {
 		return nil, err
 	}
 	logStep(opts.Logger, "registry_sig_ok", "key=%s", regKeyID)
+
+	// Step 5.5 — tenant-block check (SPEC-0188 §7 step 5.5, G-18 closure
+	// 2026-05-06). When a tenant scope is in effect, look for any tenant-
+	// scoped attestation with governance_level=red for this bundle. If
+	// present, fail closed with ErrTenantBlocked (exit 16). This is how
+	// SPEC-0192 CISO-console block verdicts propagate to the client
+	// verifier; the global chain may validate but the tenant CISO has
+	// withdrawn admission for THIS tenant.
+	//
+	// Order: AFTER registry signature verification (we don't want to
+	// surface tenant-block errors to a chain that didn't even pass the
+	// registry signature gate) and BEFORE the governance-minimum check
+	// (so a global yellow + tenant red still surfaces as tenant_blocked,
+	// which is the more actionable diagnostic for an operator).
+	if err := stepTenantBlockCheck(opts.BundleMeta, opts.Tenant); err != nil {
+		return nil, err
+	}
+	if opts.Tenant != "" {
+		logStep(opts.Logger, "tenant_block_ok", "tenant=%s", opts.Tenant)
+	}
 
 	// Step 5 — governance gate.
 	govLevel, err := stepCheckGovernance(opts.BundleMeta, opts.TrustRoot, opts.GovernanceMin, opts.AllowYellow)
@@ -424,6 +455,71 @@ func stepCheckGovernance(meta *registry.BundleMeta, root *TrustRoot, override st
 		return "", fmt.Errorf("verify: bundle governance %q below minimum %q: %w", level, min, ErrGovernanceBelowMin)
 	}
 	return level, nil
+}
+
+// stepTenantBlockCheck implements SPEC-0188 §7 step 5.5: when the consumer
+// is pinned to a tenant (via --tenant <id> or TrustRoots.TenantScope), scan
+// BundleMeta.Attestations for any active row whose tenant_scope matches the
+// consumer's tenant AND whose governance_level is "red". If found, fail
+// closed with ErrTenantBlocked (exit code 16).
+//
+// Behavior contract:
+//   - tenant == "" → no-op, returns nil. Untenanted installs never see this
+//     gate.
+//   - rows with empty tenant_scope are GLOBAL and ignored here; the global
+//     gate is stepCheckGovernance via CurrentGovernance.
+//   - rows with status=="revoked" are skipped (revocation supersedes the
+//     verdict).
+//   - rows with tenant_scope != tenant are ignored (that's another tenant's
+//     CISO's decision).
+//   - any matching row with level=="red" fails closed; the error message
+//     cites attestation_id, reviewer_id, attested_at so an operator can
+//     trace the block back to a specific verdict in the SPEC-0192 console.
+//
+// We surface the FIRST matching red row in the error message; if a tenant
+// has multiple red verdicts on the same bundle the first one is enough to
+// identify the policy lineage. The verifier short-circuits on the first
+// failure either way.
+func stepTenantBlockCheck(meta *registry.BundleMeta, tenant string) error {
+	tenant = strings.TrimSpace(tenant)
+	if tenant == "" {
+		// No tenant pinned — step 5.5 is a no-op per SPEC §7.
+		return nil
+	}
+	for _, att := range meta.Attestations {
+		if att.Status == "revoked" {
+			continue
+		}
+		// Trim both sides: registry-supplied JSON might include surrounding
+		// whitespace from a hand-edited document. The CLI flag is trimmed
+		// in install_cmds.go's resolution helper.
+		if strings.TrimSpace(att.TenantScope) != tenant {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(att.Level)) != "red" {
+			// Tenant-scoped green / yellow attestations are advisory at
+			// this gate — they document approval, they don't block.
+			continue
+		}
+		return fmt.Errorf(
+			"verify: tenant %q is blocked by attestation %s (signed_by=%s, signed_at=%s): %w",
+			tenant,
+			nonEmpty(att.AttestationID, "<unknown>"),
+			nonEmpty(att.ReviewerID, "<unknown>"),
+			nonEmpty(att.AttestedAt, "<unknown>"),
+			ErrTenantBlocked,
+		)
+	}
+	return nil
+}
+
+// nonEmpty returns s when s != "", else fallback. Used to keep error
+// messages readable when a registry omits an optional attestation field.
+func nonEmpty(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
 }
 
 // stepResolveDeps checks the manifest's `depends_on` field for obvious

--- a/pkg/skillctl/verify/verify_tenant_test.go
+++ b/pkg/skillctl/verify/verify_tenant_test.go
@@ -1,0 +1,286 @@
+package verify
+
+// Tests for the SPEC-0188 §7 step 5.5 tenant-block check (G-18 closure,
+// 2026-05-06). The fixtures reuse the helpers (happyOpts, mustKeypair,
+// goodMeta, ...) from verify_test.go in this same package; we only add
+// what's specific to the tenant gate here.
+//
+// Coverage:
+//   - happy: tenant pinned, only green tenant-scoped attestation → ok
+//   - failure: tenant pinned, red tenant-scoped attestation → ErrTenantBlocked
+//                                                              + exit 16
+//   - non-target tenant: red attestation belongs to a DIFFERENT tenant → ok
+//   - global attestation: red attestation has empty tenant_scope → does NOT
+//     trip step 5.5 (the global gate is stepCheckGovernance, exercised
+//     elsewhere). Confirms we only block on tenant-scoped rows.
+//   - precedence: CLI tenant wins over trust-roots tenant (asserted at the
+//     CLI helper level — see TestResolveTenant_CLIBeatsTrustRoots in
+//     install_cmds_test.go for the integration; here we cover the verifier-
+//     level surface, which only sees one Tenant string).
+//   - exit-code mapping: ExitCode(ErrTenantBlocked) == 16 and the constant
+//     is distinct from the other six.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+)
+
+// withTenantAttestations returns a happyOpts (passing chain) with the given
+// list of tenant-scoped attestation rows appended to the bundle's
+// Attestations. The returned opts.Tenant is the caller's chosen pin.
+func withTenantAttestations(t *testing.T, tenant string, rows []registry.AttestationRow) VerifyOpts {
+	t.Helper()
+	opts, _ := happyOpts(t)
+	opts.Tenant = tenant
+	// happyOpts already seeds one global green attestation; append the
+	// tenant-scoped rows after it so the test mirrors the real registry
+	// shape (newest-first ordering is the registry's responsibility, not
+	// the verifier's).
+	opts.BundleMeta.Attestations = append(opts.BundleMeta.Attestations, rows...)
+	return opts
+}
+
+// TestVerifierAcceptsTenantWithGreenAttestation: a tenant-scoped GREEN
+// attestation is advisory at step 5.5 — it documents approval but does
+// not block. The chain still passes.
+func TestVerifierAcceptsTenantWithGreenAttestation(t *testing.T) {
+	opts := withTenantAttestations(t, "kup-berlin", []registry.AttestationRow{
+		{
+			AttestationID: "att:tenant-green-001",
+			Level:         "green",
+			ReviewerID:    "id:ciso@kup-berlin",
+			AttestedAt:    "2026-05-05T20:00:00Z",
+			TenantScope:   "kup-berlin",
+			Status:        "active",
+		},
+	})
+
+	res, err := Verify(opts)
+	if err != nil {
+		t.Fatalf("Verify with tenant-green attestation: %v", err)
+	}
+	if res.GovernanceLevel != "green" {
+		t.Errorf("GovernanceLevel = %q, want green", res.GovernanceLevel)
+	}
+}
+
+// TestVerifierRefusesTenantWithRedAttestation: the load-bearing case. A
+// tenant-scoped RED attestation MUST fail closed with ErrTenantBlocked
+// (exit 16), even though the global chain otherwise validates. The error
+// message MUST cite the attestation_id and reviewer_id for forensic
+// triage (per SPEC-0188 §7 step 5.5).
+func TestVerifierRefusesTenantWithRedAttestation(t *testing.T) {
+	opts := withTenantAttestations(t, "kup-berlin", []registry.AttestationRow{
+		{
+			AttestationID: "att:tenant-red-007",
+			Level:         "red",
+			ReviewerID:    "id:ciso@kup-berlin",
+			AttestedAt:    "2026-05-06T09:00:00Z",
+			TenantScope:   "kup-berlin",
+			Rationale:     "Skill performs an undeclared external POST.",
+			Status:        "active",
+		},
+	})
+
+	_, err := Verify(opts)
+	if err == nil {
+		t.Fatalf("Verify accepted a tenant-blocked bundle (want ErrTenantBlocked)")
+	}
+	if !errors.Is(err, ErrTenantBlocked) {
+		t.Fatalf("err is not ErrTenantBlocked: %v", err)
+	}
+	if got := ExitCode(err); got != ExitTenantBlocked {
+		t.Errorf("ExitCode = %d, want %d", got, ExitTenantBlocked)
+	}
+
+	// Forensic clarity: SPEC §7 step 5.5 mandates the stderr message
+	// cites attestation_id, signed_by, signed_at.
+	msg := err.Error()
+	for _, want := range []string{"att:tenant-red-007", "id:ciso@kup-berlin", "2026-05-06T09:00:00Z"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q; got: %s", want, msg)
+		}
+	}
+
+	// And the tenant being blocked is in the message so the operator
+	// knows WHICH tenant scope is in effect.
+	if !strings.Contains(msg, "kup-berlin") {
+		t.Errorf("error message missing tenant id; got: %s", msg)
+	}
+}
+
+// TestVerifierIgnoresAttestationsForOtherTenants: a red attestation scoped
+// to tenant=A must NOT block an install pinned to tenant=B. This is the
+// guarantee that one tenant CISO cannot brick another tenant's deploys.
+func TestVerifierIgnoresAttestationsForOtherTenants(t *testing.T) {
+	// We pin the install to tenant=cflt; the red attestation belongs to
+	// tenant=kup-berlin. Step 5.5 must not match.
+	opts := withTenantAttestations(t, "cflt", []registry.AttestationRow{
+		{
+			AttestationID: "att:other-tenant-red",
+			Level:         "red",
+			ReviewerID:    "id:ciso@kup-berlin",
+			AttestedAt:    "2026-05-05T20:00:00Z",
+			TenantScope:   "kup-berlin",
+			Status:        "active",
+		},
+	})
+
+	res, err := Verify(opts)
+	if err != nil {
+		t.Fatalf("Verify wrongly blocked on a foreign-tenant attestation: %v", err)
+	}
+	if res.GovernanceLevel != "green" {
+		t.Errorf("GovernanceLevel = %q, want green", res.GovernanceLevel)
+	}
+}
+
+// TestVerifierIgnoresAttestationsWithoutTenantScope: a GLOBAL attestation
+// (empty tenant_scope) is the registry's verdict, which feeds
+// CurrentGovernance and is gated by stepCheckGovernance. Step 5.5 must NOT
+// fire on global rows even when they're red — that path is covered by the
+// existing governance gate (exit 13), and routing a global red through
+// step 5.5 would emit the wrong exit code (16 instead of 13).
+//
+// We exercise this by pinning a tenant AND attaching a global red row; the
+// verifier should refuse the bundle with ErrGovernanceBelowMin (because
+// CurrentGovernance != red here — we've left the chain otherwise green —
+// and global red rows in Attestations don't, on their own, trigger 5.5).
+func TestVerifierIgnoresAttestationsWithoutTenantScope(t *testing.T) {
+	opts := withTenantAttestations(t, "kup-berlin", []registry.AttestationRow{
+		{
+			AttestationID: "att:global-red-not-step-55",
+			Level:         "red",
+			ReviewerID:    "id:reviewer@m3c",
+			AttestedAt:    "2026-05-05T20:00:00Z",
+			// TenantScope deliberately empty — this is a global row.
+			Status: "active",
+		},
+	})
+
+	// CurrentGovernance is still "green" (set by happyOpts/goodMeta) so
+	// the existing governance gate passes; the test asserts step 5.5
+	// does NOT block on the empty-tenant_scope row.
+	res, err := Verify(opts)
+	if err != nil {
+		t.Fatalf("step 5.5 wrongly tripped on a global attestation: %v", err)
+	}
+	if errors.Is(err, ErrTenantBlocked) {
+		t.Fatalf("global red attestation must not trigger ErrTenantBlocked")
+	}
+	if res.GovernanceLevel != "green" {
+		t.Errorf("GovernanceLevel = %q, want green", res.GovernanceLevel)
+	}
+}
+
+// TestVerifierUsesCliFlagOverTrustRootsTenant: the precedence rule lives
+// at the CLI boundary (resolveTenant in install_cmds.go). The verifier
+// itself takes a single Tenant string; this test asserts that whatever the
+// CLI passes is what gets honored.
+//
+// We mimic the "CLI flag overrides trust-roots" semantics by setting
+// opts.Tenant to "cflt" while the tenant-scoped red attestation in the
+// fixture is for "kup-berlin" (which would be the trust-roots-pinned
+// tenant in a real run). The verifier sees only "cflt" and lets the
+// install through — that's the desired precedence.
+//
+// The integration of resolveTenant() itself is exercised in
+// install_cmds_test.go (TestResolveTenant_*).
+func TestVerifierUsesCliFlagOverTrustRootsTenant(t *testing.T) {
+	opts := withTenantAttestations(t, "cflt", []registry.AttestationRow{
+		{
+			AttestationID: "att:tenant-red-007",
+			Level:         "red",
+			ReviewerID:    "id:ciso@kup-berlin",
+			AttestedAt:    "2026-05-06T09:00:00Z",
+			TenantScope:   "kup-berlin",
+			Status:        "active",
+		},
+	})
+
+	res, err := Verify(opts)
+	if err != nil {
+		t.Fatalf("Verify with --tenant=cflt wrongly tripped on a kup-berlin red row: %v", err)
+	}
+	if res.GovernanceLevel != "green" {
+		t.Errorf("GovernanceLevel = %q, want green", res.GovernanceLevel)
+	}
+}
+
+// TestVerifierExitCodeMapping: ErrTenantBlocked maps to 16, distinct from
+// the other six numbered codes (10..15). Pairs with TestExitCode_DistinctNumbers
+// in errors_test.go which only covers the original six.
+func TestVerifierExitCodeMapping(t *testing.T) {
+	if got := ExitCode(ErrTenantBlocked); got != ExitTenantBlocked {
+		t.Errorf("ExitCode(ErrTenantBlocked) = %d, want %d", got, ExitTenantBlocked)
+	}
+	// Wrapped sentinel survives.
+	wrapped := errors.Join(ErrTenantBlocked, errors.New("context"))
+	if got := ExitCode(wrapped); got != ExitTenantBlocked {
+		t.Errorf("ExitCode(wrapped ErrTenantBlocked) = %d, want %d", got, ExitTenantBlocked)
+	}
+
+	// Distinctness: 16 must not collide with any of the existing codes.
+	allCodes := map[int]string{
+		ExitDigestMismatch:     "ExitDigestMismatch",
+		ExitAuthorSigInvalid:   "ExitAuthorSigInvalid",
+		ExitRegistryNotTrusted: "ExitRegistryNotTrusted",
+		ExitGovernanceBelowMin: "ExitGovernanceBelowMin",
+		ExitDepsUnsatisfied:    "ExitDepsUnsatisfied",
+		ExitBlobMissing:        "ExitBlobMissing",
+		ExitTenantBlocked:      "ExitTenantBlocked",
+	}
+	if len(allCodes) != 7 {
+		t.Errorf("expected 7 distinct exit codes (10..16), got %d (collision)", len(allCodes))
+	}
+	if ExitTenantBlocked != 16 {
+		t.Errorf("ExitTenantBlocked = %d, want 16 (SPEC-0188 §11)", ExitTenantBlocked)
+	}
+}
+
+// TestVerifierStep55_NoOpWhenTenantEmpty asserts the explicit no-op contract:
+// when opts.Tenant == "", even a red tenant-scoped row in BundleMeta does
+// not block. The bundle's tenant-scoped governance only applies when the
+// consumer is pinned to that tenant — an untenanted machine does not see
+// per-tenant policy.
+func TestVerifierStep55_NoOpWhenTenantEmpty(t *testing.T) {
+	opts := withTenantAttestations(t, "", []registry.AttestationRow{
+		{
+			AttestationID: "att:should-be-ignored",
+			Level:         "red",
+			ReviewerID:    "id:ciso@kup-berlin",
+			AttestedAt:    "2026-05-06T09:00:00Z",
+			TenantScope:   "kup-berlin",
+			Status:        "active",
+		},
+	})
+
+	if _, err := Verify(opts); err != nil {
+		t.Fatalf("untenanted Verify wrongly blocked on a tenant-scoped red row: %v", err)
+	}
+}
+
+// TestVerifierStep55_RevokedAttestationDoesNotBlock asserts that a
+// tenant-scoped row whose status is "revoked" is skipped by step 5.5 —
+// revocation supersedes the verdict (matching the existing pattern in
+// pickSingleSignature). A re-attest-green by the same CISO would land as
+// a separate active row.
+func TestVerifierStep55_RevokedAttestationDoesNotBlock(t *testing.T) {
+	opts := withTenantAttestations(t, "kup-berlin", []registry.AttestationRow{
+		{
+			AttestationID: "att:revoked-red",
+			Level:         "red",
+			ReviewerID:    "id:ciso@kup-berlin",
+			AttestedAt:    "2026-05-06T09:00:00Z",
+			TenantScope:   "kup-berlin",
+			Status:        "revoked", // <-- key: not active
+		},
+	})
+
+	if _, err := Verify(opts); err != nil {
+		t.Fatalf("revoked tenant-scoped red row wrongly blocked the install: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes RED-severity risk **R-01** from `PROJECTS/Skill-Manager/DELIVERY-PLAN/04-RISK-REGISTER.md` and Sprint 1 critical-path story **S1.2** from `PROJECTS/Skill-Manager/DELIVERY-PLAN/01-BUILD-PLAN.md`.

The verifier now refuses any bundle for which a tenant-scoped attestation marks `governance_level=red`. Without the `--tenant` flag, the new step 5.5 is a no-op — global verification semantics preserved.

## What's in scope

- New `--tenant <id>` flag on `skillctl install` and `skillctl verify`
- Trust-roots.yaml `tenant_scope:` field (per SPEC-0188 §4.4)
- New verifier step 5.5 between registry-sig and governance gate
- New error sentinel `ErrTenantBlocked` mapped to exit code 16 (`tenant_blocked`)
- Stderr cites attestation_id + reviewer_id + attested_at + tenant on failure

## Tests

- 8 new tests in `pkg/skillctl/verify/verify_tenant_test.go` — all pass
- 6 mandated tests + 2 defensive (no-op-when-empty, revoked-attestation-doesn't-block)
- `go build ./...` clean; full `go test ./pkg/skillctl/...` passes

## Why human review (no auto-merge)

This is security-sensitive code — it's the line of defense that turns the SPEC-0192 CISO console from decoration into actual policy enforcement. Worth a careful read before merging.

## Test plan
- [ ] Reviewer reads `pkg/skillctl/verify/verify.go` step 5.5 implementation
- [ ] Reviewer confirms test coverage is sufficient
- [ ] Reviewer confirms `--tenant` flag semantics (CLI > trust-roots > absent = no-op)
- [ ] Run `go test ./pkg/skillctl/...` locally to confirm green

🤖 Generated with [Claude Code](https://claude.com/claude-code)