### PR TITLE
feat(verify): S1.1 — exit-code matrix wired end-to-end

### DIFF
--- a/cmd/skillctl/exit.go
+++ b/cmd/skillctl/exit.go
@@ -1,0 +1,67 @@
+package main
+
+// Centralised exit-code translation for SPEC-0188 §11 numbered codes.
+//
+// runWithExit is the single audit point that sits between a runner function
+// (runInstall, runVerify, ...) and os.Exit. It collapses two concerns:
+//
+//   1. The runner returns an integer exit code on its own (the existing
+//      pattern from S1 / S7 / S8). When wired through here, the runner's
+//      int return is the os.Exit value verbatim — so usage errors (2),
+//      generic errors (1), and ok (0) keep flowing through unchanged.
+//
+//   2. Some callers prefer `func() error` semantics — useful for callers
+//      that want to leverage verify.ExitCode mapping directly. The
+//      runWithExitErr variant handles that case: any non-nil error whose
+//      sentinel matches a §11 code is mapped via verify.ExitCode; all
+//      other errors map to exitGeneric (1).
+//
+// Why a single helper: SPEC-0188 §11 mandates that `skillctl install` and
+// `skillctl verify` MUST surface the numbered code. Threading that through
+// every subcommand by hand is brittle; one helper, one audit point, no
+// chance of an exit code getting silently re-mapped to 1 mid-flight.
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// runWithExit invokes fn (an existing runner that returns a numeric exit
+// code) and calls os.Exit with that code. This is the wiring shim main.go
+// uses for `install` and `verify` so the SPEC-0188 §11 numbered codes
+// surface verbatim through the process boundary.
+//
+// The runner is responsible for printing diagnostics to stderr; this helper
+// does NOT print anything additional — it just translates int → os.Exit.
+func runWithExit(fn func() int) {
+	os.Exit(fn())
+}
+
+// runWithExitErr is the error-shaped variant. It invokes fn and:
+//
+//	nil error                          → exit 0
+//	error matching a §11 sentinel      → exit 10..16 (verify.ExitCode)
+//	any other non-nil error            → exit 1 (generic), printed to stderr
+//
+// stderr is parameterised so tests can capture; production passes os.Stderr.
+//
+// Not currently wired into main.go — the existing runners return int
+// directly — but kept here as the canonical shape for future runners that
+// want to defer exit-code translation entirely.
+func runWithExitErr(fn func() error, stderr io.Writer) {
+	err := fn()
+	if err == nil {
+		os.Exit(exitOK)
+	}
+	if code := verify.ExitCode(err); code > exitGeneric {
+		// Sentinel match (10..16). Print + exit with the SPEC-0188 §11 code.
+		fmt.Fprintln(stderr, err)
+		os.Exit(code)
+	}
+	// Unknown error → generic.
+	fmt.Fprintln(stderr, err)
+	os.Exit(exitGeneric)
+}

--- a/cmd/skillctl/install_e2e_test.go
+++ b/cmd/skillctl/install_e2e_test.go
@@ -1,0 +1,489 @@
+package main
+
+// Subprocess-driven integration tests for the SPEC-0188 §11 exit-code
+// matrix. Each test:
+//
+//   1. Stands up an httptest mux that serves the registry surface
+//      (by-name, bundles, identities) shaped to trigger ONE specific
+//      failure mode.
+//   2. Writes a trust-roots.yaml under a per-test temp HOME pinning that
+//      mux's URL.
+//   3. Invokes the freshly-built skillctl binary as a subprocess with
+//      HOME=<temp> so the trust-roots resolution + verifier algorithm
+//      run end-to-end.
+//   4. Asserts the process exit code matches the SPEC-0188 §11 row.
+//
+// In-process tests (install_cmds_test.go) cover the same paths via the
+// runInstall() function, but ONLY the subprocess form proves that
+// runWithExit + os.Exit translate the verifier's sentinel error into the
+// numbered process exit code. CI consumers branch on $? — we test that
+// surface directly.
+//
+// Skipped codes: none. All seven (0/10/11/12/13/14/15/16) are exercised.
+// Exit 17 (revoked-bundle) is reserved for SPEC-0198 / S3.6 and is not
+// emitted by the current verifier.
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// ----- binary build (one per `go test` invocation) -----
+
+var (
+	binPathOnce sync.Once
+	binPath     string
+	binPathErr  error
+)
+
+// skillctlBin builds the skillctl binary once per test process and returns
+// its path. Subsequent tests reuse the same binary; t.Cleanup is per-test
+// so we cannot tie the binary lifetime to a single t — the build happens
+// in TestMain via the once.Do guard, the binary lives until the test
+// process exits and is tidied by the OS temp-dir reaper.
+func skillctlBin(t *testing.T) string {
+	t.Helper()
+	binPathOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "skillctl-e2e-bin-")
+		if err != nil {
+			binPathErr = err
+			return
+		}
+		out := filepath.Join(dir, "skillctl")
+		// Build from the cmd/skillctl package (CWD here).
+		cmd := exec.Command("go", "build", "-o", out, ".")
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			binPathErr = err
+			return
+		}
+		binPath = out
+	})
+	if binPathErr != nil {
+		t.Fatalf("build skillctl: %v", binPathErr)
+	}
+	return binPath
+}
+
+// runSkillctl invokes the built binary as a subprocess. Returns
+// (exitCode, stdout, stderr). HOME is forced to home so trust-roots
+// resolution stays scoped to the test temp dir.
+func runSkillctl(t *testing.T, home string, args ...string) (int, string, string) {
+	t.Helper()
+	bin := skillctlBin(t)
+	cmd := exec.Command(bin, args...)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		// On Linux, os.UserHomeDir prefers $HOME; Darwin same. Belt:
+		// also unset XDG so nothing overrides the trust-roots path.
+		"XDG_CONFIG_HOME=",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			code = ee.ExitCode()
+		} else {
+			t.Fatalf("run skillctl: %v", err)
+		}
+	}
+	return code, stdout.String(), stderr.String()
+}
+
+// ----- shared fixture builder -----
+
+// e2eFixture bundles everything the test mux needs: keys, a valid blob,
+// canonical signatures, and the digest string callers paste into the JSON
+// envelopes. Individual tests then mutate ONE field (e.g. swap the served
+// blob, swap the author sig) to trigger a specific exit code.
+type e2eFixture struct {
+	authorPub  ed25519.PublicKey
+	authorPriv ed25519.PrivateKey
+	regPub     ed25519.PublicKey
+	regPriv    ed25519.PrivateKey
+	blob       []byte
+	digest     [sha256.Size]byte
+	digestStr  string
+	authorSig  []byte
+	regSig     []byte
+}
+
+func newFixture(t *testing.T) *e2eFixture {
+	t.Helper()
+	authorPub, authorPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("authorKey: %v", err)
+	}
+	regPub, regPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("regKey: %v", err)
+	}
+	blob := buildSkillBundleTGZ(t)
+	digest := sha256.Sum256(blob)
+	digestStr := "sha256:" + hex.EncodeToString(digest[:])
+	return &e2eFixture{
+		authorPub:  authorPub,
+		authorPriv: authorPriv,
+		regPub:     regPub,
+		regPriv:    regPriv,
+		blob:       blob,
+		digest:     digest,
+		digestStr:  digestStr,
+		authorSig:  ed25519.Sign(authorPriv, digest[:]),
+		regSig:     ed25519.Sign(regPriv, digest[:]),
+	}
+}
+
+// pinTrust writes a trust-roots.yaml that pins srvURL with the registry
+// pubkey from f. The yamlExtra string lets a test inject additional
+// top-level fields (e.g. tenant_scope: kup-berlin).
+func (f *e2eFixture) pinTrust(t *testing.T, home, srvURL, yamlExtra string) {
+	t.Helper()
+	regKeyB64 := base64.StdEncoding.EncodeToString(f.regPub)
+	body := yamlExtra + `trust_roots:
+  - registry_url: ` + srvURL + `/api/skills
+    registry_keys:
+      - id: k1
+        pubkey: ` + regKeyB64 + `
+        issued: "2026-05-05"
+    identity_keys_authorized: from-registry
+    governance_minimum: green
+`
+	writeTrustRoots(t, home, body)
+}
+
+// happyMux returns a mux serving the canonical happy-path responses for
+// the fixture. Tests can override individual handlers with mux.Handle to
+// inject failure shapes.
+func (f *e2eFixture) happyMux(t *testing.T, manifest map[string]any, currentGovernance string, attestations []map[string]any) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/skills/by-name/", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "fetch-contract",
+			"versions": []map[string]any{
+				{"version": "1.0.0", "digest": f.digestStr, "status": "admitted"},
+			},
+		})
+	})
+	mux.HandleFunc("/api/skills/bundles/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("meta") == "1" {
+			payload := map[string]any{
+				"bundle":             map[string]any{"bundle_digest": f.digestStr, "status": "admitted"},
+				"signatures": []map[string]any{
+					{"role": "author", "identity_id": "id:author@m3c", "signature_b64": base64.StdEncoding.EncodeToString(f.authorSig), "status": "active"},
+					{"role": "registry", "identity_id": "id:registry@aims-core", "signature_b64": base64.StdEncoding.EncodeToString(f.regSig), "status": "active"},
+				},
+				"manifest":           manifest,
+				"current_governance": currentGovernance,
+			}
+			if attestations != nil {
+				payload["attestations"] = attestations
+			}
+			_ = json.NewEncoder(w).Encode(payload)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(f.blob)
+	})
+	mux.HandleFunc("/api/skills/identities/", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":          "id:author@m3c",
+			"pubkey_b64":  base64.StdEncoding.EncodeToString(f.authorPub),
+			"auth_source": "manual",
+		})
+	})
+	return mux
+}
+
+// ----- happy path -----
+
+func TestInstall_GoodBundle_Exit0(t *testing.T) {
+	home := t.TempDir()
+	f := newFixture(t)
+	mux := f.happyMux(t, map[string]any{"depends_on": []any{}}, "green", nil)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	f.pinTrust(t, home, srv.URL, "")
+
+	code, stdout, stderr := runSkillctl(t, home, "install", "--home", home, "fetch-contract@1.0.0")
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "installed:") {
+		t.Errorf("stdout missing 'installed:'; got: %s", stdout)
+	}
+}
+
+// ----- 10: digest mismatch -----
+
+func TestInstall_TamperedBundle_Exit10(t *testing.T) {
+	home := t.TempDir()
+	f := newFixture(t)
+	tampered := append([]byte(nil), f.blob...)
+	tampered[5] ^= 0x80
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/skills/by-name/", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "fetch-contract",
+			"versions": []map[string]any{
+				{"version": "1.0.0", "digest": f.digestStr, "status": "admitted"},
+			},
+		})
+	})
+	mux.HandleFunc("/api/skills/bundles/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("meta") == "1" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"bundle": map[string]any{"bundle_digest": f.digestStr, "status": "admitted"},
+				"signatures": []map[string]any{
+					{"role": "author", "identity_id": "id:a", "signature_b64": base64.StdEncoding.EncodeToString(f.authorSig), "status": "active"},
+					{"role": "registry", "identity_id": "id:r", "signature_b64": base64.StdEncoding.EncodeToString(f.regSig), "status": "active"},
+				},
+				"manifest":           map[string]any{},
+				"current_governance": "green",
+			})
+			return
+		}
+		_, _ = w.Write(tampered)
+	})
+	mux.HandleFunc("/api/skills/identities/", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":          "id:a",
+			"pubkey_b64":  base64.StdEncoding.EncodeToString(f.authorPub),
+			"auth_source": "manual",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	f.pinTrust(t, home, srv.URL, "")
+
+	code, _, stderr := runSkillctl(t, home, "install", "--home", home, "fetch-contract@1.0.0")
+	if code != verify.ExitDigestMismatch {
+		t.Errorf("exit = %d, want %d; stderr: %s", code, verify.ExitDigestMismatch, stderr)
+	}
+}
+
+// ----- 11: author signature invalid -----
+
+func TestInstall_BadAuthorSig_Exit11(t *testing.T) {
+	home := t.TempDir()
+	f := newFixture(t)
+
+	// Sign with a different key than the one the registry advertises.
+	_, badPriv, _ := ed25519.GenerateKey(rand.Reader)
+	badAuthorSig := ed25519.Sign(badPriv, f.digest[:])
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/skills/by-name/", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "fetch-contract",
+			"versions": []map[string]any{
+				{"version": "1.0.0", "digest": f.digestStr, "status": "admitted"},
+			},
+		})
+	})
+	mux.HandleFunc("/api/skills/bundles/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("meta") == "1" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"bundle": map[string]any{"bundle_digest": f.digestStr, "status": "admitted"},
+				"signatures": []map[string]any{
+					{"role": "author", "identity_id": "id:a", "signature_b64": base64.StdEncoding.EncodeToString(badAuthorSig), "status": "active"},
+					{"role": "registry", "identity_id": "id:r", "signature_b64": base64.StdEncoding.EncodeToString(f.regSig), "status": "active"},
+				},
+				"manifest":           map[string]any{},
+				"current_governance": "green",
+			})
+			return
+		}
+		_, _ = w.Write(f.blob)
+	})
+	mux.HandleFunc("/api/skills/identities/", func(w http.ResponseWriter, r *http.Request) {
+		// Identity advertises the GOOD authorPub; the signature is over
+		// digest by a DIFFERENT key — verify must reject.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":          "id:a",
+			"pubkey_b64":  base64.StdEncoding.EncodeToString(f.authorPub),
+			"auth_source": "manual",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	f.pinTrust(t, home, srv.URL, "")
+
+	code, _, stderr := runSkillctl(t, home, "install", "--home", home, "fetch-contract@1.0.0")
+	if code != verify.ExitAuthorSigInvalid {
+		t.Errorf("exit = %d, want %d; stderr: %s", code, verify.ExitAuthorSigInvalid, stderr)
+	}
+}
+
+// ----- 12: registry not in trust roots -----
+
+func TestInstall_UntrustedRegistry_Exit12(t *testing.T) {
+	home := t.TempDir()
+	f := newFixture(t)
+
+	// Sign the registry signature with a key NOT pinned in trust-roots.
+	_, otherRegPriv, _ := ed25519.GenerateKey(rand.Reader)
+	badRegSig := ed25519.Sign(otherRegPriv, f.digest[:])
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/skills/by-name/", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "fetch-contract",
+			"versions": []map[string]any{
+				{"version": "1.0.0", "digest": f.digestStr, "status": "admitted"},
+			},
+		})
+	})
+	mux.HandleFunc("/api/skills/bundles/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("meta") == "1" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"bundle": map[string]any{"bundle_digest": f.digestStr, "status": "admitted"},
+				"signatures": []map[string]any{
+					{"role": "author", "identity_id": "id:a", "signature_b64": base64.StdEncoding.EncodeToString(f.authorSig), "status": "active"},
+					{"role": "registry", "identity_id": "id:r", "signature_b64": base64.StdEncoding.EncodeToString(badRegSig), "status": "active"},
+				},
+				"manifest":           map[string]any{},
+				"current_governance": "green",
+			})
+			return
+		}
+		_, _ = w.Write(f.blob)
+	})
+	mux.HandleFunc("/api/skills/identities/", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":          "id:a",
+			"pubkey_b64":  base64.StdEncoding.EncodeToString(f.authorPub),
+			"auth_source": "manual",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	// Trust-roots pins f.regPub — the registry signed with otherRegPriv,
+	// so no active trust-root key matches → ErrRegistryNotTrusted (12).
+	f.pinTrust(t, home, srv.URL, "")
+
+	code, _, stderr := runSkillctl(t, home, "install", "--home", home, "fetch-contract@1.0.0")
+	if code != verify.ExitRegistryNotTrusted {
+		t.Errorf("exit = %d, want %d; stderr: %s", code, verify.ExitRegistryNotTrusted, stderr)
+	}
+}
+
+// ----- 13: governance below minimum -----
+
+func TestInstall_BelowGovMin_Exit13(t *testing.T) {
+	home := t.TempDir()
+	f := newFixture(t)
+	// Trust root requires green; bundle current_governance is yellow.
+	mux := f.happyMux(t, map[string]any{}, "yellow", nil)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	f.pinTrust(t, home, srv.URL, "")
+
+	code, _, stderr := runSkillctl(t, home, "install", "--home", home, "fetch-contract@1.0.0")
+	if code != verify.ExitGovernanceBelowMin {
+		t.Errorf("exit = %d, want %d; stderr: %s", code, verify.ExitGovernanceBelowMin, stderr)
+	}
+}
+
+// ----- 14: depends_on unsatisfied -----
+
+func TestInstall_DepsUnsatisfied_Exit14(t *testing.T) {
+	home := t.TempDir()
+	f := newFixture(t)
+	// Malformed depends_on entry (missing kind) → stepResolveDeps fails.
+	manifest := map[string]any{
+		"depends_on": []any{
+			map[string]any{"name": "click"}, // missing 'kind'
+		},
+	}
+	mux := f.happyMux(t, manifest, "green", nil)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	f.pinTrust(t, home, srv.URL, "")
+
+	code, _, stderr := runSkillctl(t, home, "install", "--home", home, "fetch-contract@1.0.0")
+	if code != verify.ExitDepsUnsatisfied {
+		t.Errorf("exit = %d, want %d; stderr: %s", code, verify.ExitDepsUnsatisfied, stderr)
+	}
+}
+
+// ----- 15: blob missing -----
+
+func TestInstall_BlobMissing_Exit15(t *testing.T) {
+	home := t.TempDir()
+	f := newFixture(t)
+
+	// by-name resolves cleanly, but the blob endpoint 404s. install.go
+	// translates that into verify.ErrBlobMissing → exit 15.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/skills/by-name/", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "fetch-contract",
+			"versions": []map[string]any{
+				{"version": "1.0.0", "digest": f.digestStr, "status": "admitted"},
+			},
+		})
+	})
+	mux.HandleFunc("/api/skills/bundles/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	f.pinTrust(t, home, srv.URL, "")
+
+	code, _, stderr := runSkillctl(t, home, "install", "--home", home, "fetch-contract@1.0.0")
+	if code != verify.ExitBlobMissing {
+		t.Errorf("exit = %d, want %d; stderr: %s", code, verify.ExitBlobMissing, stderr)
+	}
+}
+
+// ----- 16: tenant blocked (post-PR-#17 surface) -----
+
+func TestInstall_TenantBlocked_Exit16(t *testing.T) {
+	home := t.TempDir()
+	f := newFixture(t)
+	// Bundle is globally green AND has a tenant-scoped red attestation
+	// for tenant kup-berlin. With --tenant kup-berlin the verifier's
+	// step 5.5 fails closed.
+	attestations := []map[string]any{
+		{
+			"attestation_id": "att-block-001",
+			"reviewer_id":    "id:ciso@kup",
+			"attested_at":    "2026-05-06T12:00:00Z",
+			"tenant_scope":   "kup-berlin",
+			"level":          "red",
+			"status":         "active",
+		},
+	}
+	mux := f.happyMux(t, map[string]any{}, "green", attestations)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	f.pinTrust(t, home, srv.URL, "")
+
+	code, _, stderr := runSkillctl(t, home,
+		"install", "--home", home, "--tenant", "kup-berlin", "fetch-contract@1.0.0",
+	)
+	if code != verify.ExitTenantBlocked {
+		t.Errorf("exit = %d, want %d; stderr: %s", code, verify.ExitTenantBlocked, stderr)
+	}
+}

--- a/cmd/skillctl/main.go
+++ b/cmd/skillctl/main.go
@@ -42,10 +42,14 @@ func main() {
 		os.Exit(runAttest(os.Args[2:], os.Stdout, os.Stderr))
 	// === end SPEC-0188 S9-cli ===
 	// === SPEC-0188 S8: install/verify subcommands ===
+	//
+	// Both routed through runWithExit so the SPEC-0188 §11 numbered exit
+	// codes (10..16) surface verbatim to the parent process — see
+	// cmd/skillctl/exit.go for the single audit point.
 	case "install":
-		os.Exit(runInstall(os.Args[2:], os.Stdout, os.Stderr))
+		runWithExit(func() int { return runInstall(os.Args[2:], os.Stdout, os.Stderr) })
 	case "verify":
-		os.Exit(runVerify(os.Args[2:], os.Stdout, os.Stderr))
+		runWithExit(func() int { return runVerify(os.Args[2:], os.Stdout, os.Stderr) })
 	// === END SPEC-0188 S8 ===
 	// === SPEC-0189 S0a: scanner family dispatchers (imported from
 	// feature/thinking-engine-phase1; pre-SPEC-0189 behaviour preserved). ===

--- a/pkg/skillctl/verify/errors.go
+++ b/pkg/skillctl/verify/errors.go
@@ -26,30 +26,64 @@ import "errors"
 // in this package to avoid a duplicate-symbol drift across packages. (See
 // ExitCode for how nil and unknown errors map.)
 const (
-	// ExitDigestMismatch — recomputed bundle digest did not match the
-	// digest the registry signed.
+	// ExitDigestMismatch (10) — "Bundle modified after signing."
+	// (SPEC-0188 §11 row 1)
+	//
+	// Returned when the recomputed bundle digest does not match the
+	// digest the registry signed. UX: show expected vs actual digest;
+	// refuse install. User remediation: re-fetch the bundle; do not
+	// install a tampered artefact.
 	ExitDigestMismatch = 10
-	// ExitAuthorSigInvalid — the author's ed25519 signature did not
-	// verify against the identity's public key.
+	// ExitAuthorSigInvalid (11) — "Wrong public key, or modified after
+	// signing." (SPEC-0188 §11 row 2)
+	//
+	// Returned when the author's ed25519 signature did not verify
+	// against the identity's public key. UX: show author identity from
+	// manifest vs registry; refuse. User remediation: confirm with the
+	// author that their identity_id + pubkey on the registry are correct
+	// and current; refuse install.
 	ExitAuthorSigInvalid = 11
-	// ExitRegistryNotTrusted — the bundle came from a registry whose
-	// public key isn't in ~/.claude/skill-trust-roots.yaml (or the key
-	// that signed is retired).
+	// ExitRegistryNotTrusted (12) — "Bundle came from an unknown
+	// registry." (SPEC-0188 §11 row 3)
+	//
+	// Returned when the bundle came from a registry whose public key
+	// isn't in ~/.claude/skill-trust-roots.yaml (or the key that signed
+	// is retired). UX: show registry key fingerprint; suggest
+	// `skillctl trust add`.
 	ExitRegistryNotTrusted = 12
-	// ExitGovernanceBelowMin — the bundle's current governance level
-	// is below trust-roots.yaml's `governance_minimum`.
+	// ExitGovernanceBelowMin (13) — "Skill is 🟡 but trust-roots
+	// requires 🟢." (SPEC-0188 §11 row 4)
+	//
+	// Returned when the bundle's current governance level is below
+	// trust-roots.yaml's `governance_minimum`. UX: show current
+	// attestations; suggest `skillctl install --allow-yellow` for an
+	// explicit (audited) override.
 	ExitGovernanceBelowMin = 13
-	// ExitDepsUnsatisfied — depends_on resolution failed (missing
-	// Python wheel, system tool, or a depended-on skill version).
+	// ExitDepsUnsatisfied (14) — "Missing Python pkg or version
+	// mismatch." (SPEC-0188 §11 row 5)
+	//
+	// Returned when depends_on resolution failed (missing Python wheel,
+	// system tool, or a depended-on skill version). UX: show resolution
+	// failure; suggest `pip install` or `--ignore-deps` for an explicit
+	// (audited) override.
 	ExitDepsUnsatisfied = 14
-	// ExitBlobMissing — the registry has metadata for a digest but
-	// the actual blob is unreachable.
+	// ExitBlobMissing (15) — registry advertised metadata for a digest
+	// but the actual blob is unreachable, or the bundle's status is no
+	// longer "admitted". (SPEC-0188 §11 — extension of the §11 table
+	// for the §7 step-7 status check; covers blob 404, meta 404, and
+	// status=revoked.)
+	//
+	// User remediation: refresh the registry view; if the bundle was
+	// revoked the operator must contact the publisher.
 	ExitBlobMissing = 15
-	// ExitTenantBlocked — at least one tenant-scoped governance attestation
-	// (SPEC-0188 §7 step 5.5, G-18 closure 2026-05-06) carries
-	// governance_level=red for the consumer's pinned tenant. The bundle is
-	// admitted globally but the tenant CISO has blocked it; the verifier
-	// fails closed.
+	// ExitTenantBlocked (16) — at least one tenant-scoped governance
+	// attestation (SPEC-0188 §7 step 5.5, G-18 closure 2026-05-06)
+	// carries governance_level=red for the consumer's pinned tenant.
+	//
+	// The bundle is admitted globally but the tenant CISO has blocked
+	// it; the verifier fails closed. UX: surface attestation_id +
+	// reviewer_id so the operator can trace the block back to the
+	// SPEC-0192 CISO console verdict.
 	ExitTenantBlocked = 16
 )
 


### PR DESCRIPTION
Closes Sprint 1 / Stream M / S1.1.

## Summary
- Central `runWithExit()` helper bridges verifier errors → process exit codes
- 8 subprocess tests covering codes 0/10/11/12/13/14/15/16 — all PASS
- §11 doc-strings on every ExitX constant for spec↔code traceability
- 4 files, 614 insertions

## Sprint 1 verdict
**GREEN** per `PROJECTS/Skill-Manager/DELIVERY-PLAN/SPRINTS/S1-TEST-GATE.md` (in m3c-tools-maintenance).

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/skillctl/...` all PASS
- [x] `go test ./cmd/skillctl/...` all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)