### PR TITLE
chore(workflow): Stage 3 long-term branch hygiene

### DIFF
--- a/.github/workflows/archive-merged-branches.yml
+++ b/.github/workflows/archive-merged-branches.yml
@@ -1,0 +1,103 @@
+name: Archive merged branches
+
+# Weekly cleanup: any branch (other than reserved ones) whose linked PR is
+# merged gets:
+#   1. an immutable tag `archive/<branch>` pointing at the branch tip
+#   2. the branch deleted from origin
+# Local checkouts can be cleaned up afterwards with `git fetch --prune` plus
+# `git branch --merged origin/master | xargs git branch -D`.
+#
+# Stage 3 deliverable from incident 2026-05-07 (m3c-tools master-drift).
+# Runs Sundays 04:00 UTC; manual run via workflow_dispatch.
+
+on:
+  schedule:
+    - cron: "0 4 * * 0"   # Sunday 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print actions without executing (true/false)"
+        required: false
+        default: "false"
+
+permissions:
+  contents: write   # to push tags + delete branches
+  pull-requests: read
+
+jobs:
+  archive:
+    name: Archive merged branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history needed to tag any commit
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Find merged branches
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          # Reserved refs that are NEVER deleted, even if a PR mentions them.
+          reserved='^(master|main|gh-pages|pre-release-.*|archive/.*|HEAD)$'
+
+          to_archive=()
+          # All remote branches except reserved ones
+          while read -r branch; do
+            branch="${branch#origin/}"
+            [ -z "$branch" ] && continue
+            if [[ "$branch" =~ $reserved ]]; then
+              continue
+            fi
+            # Find the most recent PR for this branch (any state)
+            pr_state=$(gh pr list --head "$branch" --state all --json state \
+                       --jq '.[0].state // ""' 2>/dev/null || echo "")
+            if [ "$pr_state" = "MERGED" ]; then
+              to_archive+=("$branch")
+            fi
+          done < <(git for-each-ref --format='%(refname:short)' refs/remotes/origin/ \
+                   | grep -v '^origin/HEAD$')
+
+          echo "Found ${#to_archive[@]} branch(es) to archive:"
+          printf '  - %s\n' "${to_archive[@]}"
+
+          if [ "${#to_archive[@]}" -eq 0 ]; then
+            echo "Nothing to do."
+            exit 0
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN — no tags pushed, no branches deleted."
+            exit 0
+          fi
+
+          for branch in "${to_archive[@]}"; do
+            tag="archive/$branch"
+            echo "::group::archive $branch"
+            sha=$(git rev-parse "origin/$branch")
+            # Skip if tag already exists (idempotent)
+            if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
+              echo "  tag $tag already exists, skipping tag step"
+            else
+              git tag -a "$tag" "$sha" \
+                -m "Archived merged branch $branch on $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              git push origin "refs/tags/$tag"
+              echo "  ✓ tagged $sha as $tag"
+            fi
+            git push origin --delete "$branch" || \
+              echo "  warning: delete of $branch failed (already deleted?)"
+            echo "  ✓ deleted origin/$branch"
+            echo "::endgroup::"
+          done
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "Archive run complete on $(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -1,0 +1,48 @@
+name: Branch name check
+
+# Enforces the branch-naming convention from README §"Branch & worktree workflow".
+# Runs on PR open/reopen/edit; fails the check if the head ref doesn't match the regex.
+# Stage 3 deliverable from incident 2026-05-07 (m3c-tools master-drift).
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  check-branch-name:
+    name: Validate branch name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check head ref matches convention
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          # Allowed prefixes — keep in sync with README.md and Makefile.
+          # Any addition here must come with a README update in the same PR.
+          regex='^(feat|feature|fix|chore|docs|test|refactor|spec-[0-9]+|s[0-9]+-m[0-9]+|r-[0-9]+|archive|rescue)\/[A-Za-z0-9._-]+$'
+          if [[ "$HEAD_REF" =~ $regex ]]; then
+            echo "✓ branch name '$HEAD_REF' matches convention"
+            exit 0
+          fi
+          cat <<EOF >&2
+          ✗ branch name '$HEAD_REF' does not match convention
+
+          Required pattern: $regex
+
+          Examples that pass:
+            feat/spec-0188-bundle-pack
+            fix/bug-0124-time-tracking-auth
+            s2-m1/awareness-sync
+            r-01/tenant-aware-verifier
+            chore/branch-hygiene-stage3
+            docs/updated-readme-clarification
+
+          Rename your branch:
+            git branch -m <new-name>
+            git push origin :<old-name> && git push -u origin <new-name>
+            (then update the PR head ref via the GitHub UI or `gh pr edit`)
+
+          Reasoning + full convention: README.md §"Branch & worktree workflow".
+          EOF
+          exit 1

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,47 @@ menubar: build
 clean:
 	rm -rf $(BUILD_DIR)
 
+# Create a new git worktree under wt/ following the project convention.
+# Usage: make worktree SPEC=spec-0195 STEP=awareness-S2.1 BRANCH=s2-m1/awareness-sync [BASE=origin/master]
+#
+# Convention enforced:
+#   - directory:  ../wt/<SPEC>/<STEP>
+#   - branch:     <BRANCH> (created from BASE if it doesn't exist)
+#   - one branch per worktree, one worktree per active branch
+#
+# After creation, run `git wta` from any worktree to see the full inventory.
+.PHONY: worktree
+worktree:
+	@if [ -z "$(SPEC)" ] || [ -z "$(STEP)" ] || [ -z "$(BRANCH)" ]; then \
+		echo "Usage: make worktree SPEC=spec-XXXX STEP=name BRANCH=feat/name [BASE=origin/master]"; \
+		exit 2; \
+	fi
+	@base=$${BASE:-origin/master}; \
+	wtpath="../wt/$(SPEC)/$(STEP)"; \
+	if [ -e "$$wtpath" ]; then echo "$$wtpath already exists"; exit 2; fi; \
+	if git show-ref --verify --quiet "refs/heads/$(BRANCH)"; then \
+		echo "Branch $(BRANCH) exists — attaching worktree to it"; \
+		git worktree add "$$wtpath" "$(BRANCH)"; \
+	else \
+		echo "Creating branch $(BRANCH) from $$base"; \
+		git worktree add -b "$(BRANCH)" "$$wtpath" "$$base"; \
+	fi
+	@echo "✓ worktree created at $$wtpath on branch $(BRANCH)"
+
+# Audit all worktrees: which branch, how old, how dirty.
+# Mirrors the `git wta` global alias for users who haven't installed it.
+.PHONY: branches-audit
+branches-audit:
+	@printf "%-50s %-30s %-15s %s\n" "PATH" "BRANCH" "AGE" "DIRTY"
+	@git worktree list --porcelain | awk '/^worktree/{print $$2}' | while read -r wt; do \
+		cd "$$wt" 2>/dev/null || continue; \
+		branch=$$(git branch --show-current 2>/dev/null); \
+		age=$$(git log -1 --format='%cr' HEAD 2>/dev/null); \
+		dirty=$$(git status --porcelain 2>/dev/null | wc -l | tr -d ' '); \
+		flag=""; [ "$$dirty" -gt 0 ] && flag=" ⚠"; \
+		printf "%-50s %-30s %-15s %s%s\n" "$$wt" "$$branch" "$$age" "$$dirty" "$$flag"; \
+	done
+
 # Check all packages compile
 .PHONY: vet
 vet:

--- a/README.md
+++ b/README.md
@@ -177,6 +177,76 @@ make uninstall
 
 Data at `~/.m3c-tools/` is preserved — remove manually if desired.
 
+## Branch & worktree workflow
+
+The repo uses a strict feature-branch + worktree workflow. Following these
+rules prevents the "uncommitted overnight work disappears in branch chaos"
+class of incident (post-mortem: `m3c-tools-maintenance/PLAN/incident-2026-05-07-m3c-tools-master-drift.md`).
+
+### Naming
+
+Branch names match `^(feat|feature|fix|chore|docs|test|refactor|spec-\d+|s\d+-m\d+|r-\d+|archive|rescue)/.+$`.
+This is enforced on PR open by the `branch-name-check` GH Action.
+
+Examples:
+- `feat/spec-0188-bundle-pack` — feature for a SPEC.
+- `fix/bug-0124-time-tracking-auth` — bug fix.
+- `s2-m1/awareness-sync` — sprint 2, milestone 1.
+- `r-01/tenant-aware-verifier` — release-blocker R-01.
+- `archive/<name>` — historical refs preserved as branches (typically also tagged).
+
+`master`, `main`, `gh-pages`, and `pre-release-*` are reserved.
+
+### Worktrees
+
+Each active branch gets one worktree under `../wt/<spec>/<short-name>`.
+Create with the canonical entry-point:
+
+```bash
+make worktree SPEC=spec-0195 STEP=awareness-S2.1 BRANCH=s2-m1/awareness-sync
+# creates ../wt/spec-0195/awareness-S2.1, attaches to (or creates) the branch
+```
+
+Optional `BASE=<ref>` (default `origin/master`) controls where new branches start.
+
+### Audit
+
+```bash
+git wta              # global alias — works from any repo
+make branches-audit  # in-repo equivalent
+```
+
+Both print path / branch / age / dirty-file count. Use them at session start
+and end. A nightly launchd job runs `~/.config/m3c/end-of-day-audit.sh` at
+23:30 and posts a macOS notification if any worktree is dirty.
+
+### Don't
+
+- **Don't `git checkout master`** to "clean up" — local `master` is a tracking
+  ref that follows `origin/master`; only update it via `git land` (alias)
+  or by going through PR merge. Direct work on master is an anti-pattern.
+- **Don't leave merged feature branches around.** A weekly GH Action
+  (`archive-merged-branches.yml`) auto-tags merged PR branches as
+  `archive/<branch>` and deletes them on origin; pull + prune to keep your
+  local view tidy:
+  ```bash
+  git fetch origin --prune
+  git branch --merged origin/master | grep -v master | xargs -n1 git branch -D
+  ```
+- **Don't share a worktree across two branches.** One branch, one worktree.
+  Switch by creating a second worktree, not by `git checkout` inside the
+  existing one.
+
+### Recovery
+
+If you lose track:
+- `git reflog --date=iso` — every HEAD movement, with timestamps. Reflog
+  entries live 90 days. If a branch tip got lost, it's recoverable here.
+- `archive/<name>` tags on origin — every merged-and-deleted branch lives
+  on as a tag.
+- `m3c-tools-maintenance/PLAN/incident-2026-05-07-m3c-tools-master-drift.md`
+  — full recovery worked example (master → wrong line → fix).
+
 ## License
 
 See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Closes the hygiene gap surfaced by the **master-drift incident** on 2026-05-07 (post-mortem: `m3c-tools-maintenance/PLAN/incident-2026-05-07-m3c-tools-master-drift.md`). Stage 0 (immediate save) and Stage 1+2 (cleanup + nightly audit) shipped already; this PR is **Stage 3** — the long-term workflow guardrails that prevent the next "yesterday-night work feels lost" panic from happening at all.

- 🔧 **`make worktree`** + **`make branches-audit`** — canonical entry-points; one branch per worktree under `../wt/<spec>/<step>`.
- 📖 **README §Branch & worktree workflow** — naming convention (regex), do/don't, recovery guide.
- 🤖 **`branch-name-check.yml`** — PR-time gate: rejects head refs that don't match the regex.
- 🤖 **`archive-merged-branches.yml`** — Sundays 04:00 UTC: tags merged-PR branches as `archive/<branch>`, deletes them on origin (`dry_run` input for review).

## Why now

This week we lost ~2h on:
1. A March-10 binary rebuilt because local `master` had drifted two months behind `origin/master`.
2. ~3,575 lines of overnight code sitting uncommitted in three worktrees.
3. A 25-hour-old cherry-pick conflict that never got `--continue`-d.
4. A live ER1 API key inline in a demo HTML, caught only because we re-ran the gitleaks pre-commit on the salvage path.

Each of those traces back to "branch sprawl + no enforced convention". This PR is the cheapest, most reversible fix for that root cause.

## Test plan

- [x] `make branches-audit` prints worktree path / branch / age / dirty
- [x] `make worktree` (no args) prints usage + exits 2
- [x] `make worktree SPEC=… STEP=… BRANCH=…` with all 3 args creates the worktree (manually verified locally)
- [x] Regex accepts: `feat/`, `feature/`, `fix/`, `chore/`, `docs/`, `test/`, `refactor/`, `spec-NNNN/…`, `sN-mM/…`, `r-NN/…`, `archive/…`, `rescue/…`
- [x] Regex rejects: `master`, `gh-pages`, `pre-release-*`, `WIP, integration target` (the actual offender from the incident)
- [x] `branch-name-check.yml` will run on this PR — should pass on `chore/branch-hygiene-stage3`
- [ ] `archive-merged-branches.yml` — dry-run via `workflow_dispatch` after merge, before letting the cron fire

## Linked

- Incident memo: `m3c-tools-maintenance/PLAN/incident-2026-05-07-m3c-tools-master-drift.md`
- Audit doc: `m3c-tools-maintenance/PLAN/m3c-tools-branch-audit-2026-05-07.md`
- Stage 1+2 already shipped (no PR; pure local + global git config + launchd job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)