### PR TITLE
feat(skillctl): login + device-token autoload (FR-0043)

### DIFF
--- a/cmd/skillctl/login_cmds.go
+++ b/cmd/skillctl/login_cmds.go
@@ -1,0 +1,158 @@
+package main
+
+// `skillctl login` + the device-token autoload bootstrap — FR-0043.
+//
+// Problem (the reported bug): `m3c-tools login` persisted a device token, but
+// skillctl only ever read ER1_DEVICE_TOKEN from the environment, so a user who
+// had logged in still got 401s unless they manually `export ER1_DEVICE_TOKEN`.
+//
+// Fix, two halves:
+//   - login:    `skillctl login` runs the browser device-pairing flow itself
+//               (so a box with only the skillctl binary — e.g. Eric's — is
+//               self-sufficient) and persists the token via pkg/auth.
+//   - autoload: before any ER1-bound command, if ER1_DEVICE_TOKEN is unset, load
+//               the persisted token and export it for the process — mirroring
+//               what cmd/m3c-tools/main.go already does for the product binary.
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/auth"
+	"github.com/kamir/m3c-tools/pkg/er1login"
+)
+
+// networkCommands are the subcommands that talk to ER1 and therefore need a
+// device token. Only these trigger autoloadDeviceToken — so offline commands
+// (version, keygen, sign, verify-sig, trust, …) never touch the OS keychain.
+var networkCommands = map[string]bool{
+	"publish":   true,
+	"pull":      true,
+	"registry":  true,
+	"attest":    true,
+	"revoke":    true,
+	"awareness": true,
+	"session":   true,
+	"room":      true,
+	"install":   true,
+}
+
+// autoloadDeviceToken implements the read-back half of FR-0043. If
+// ER1_DEVICE_TOKEN is already set it is left untouched (explicit wins). The
+// keychain backend ignores the userID; the encrypted-file backend derives its
+// key from it, so we pass ER1_USER_ID — or the sub parsed from ER1_CONTEXT_ID —
+// as a best-effort hint for headless/file-backed hosts.
+func autoloadDeviceToken(stderr io.Writer) {
+	if os.Getenv("ER1_DEVICE_TOKEN") != "" {
+		return
+	}
+	uid := strings.TrimSpace(os.Getenv("ER1_USER_ID"))
+	if uid == "" {
+		if ctx := os.Getenv("ER1_CONTEXT_ID"); ctx != "" {
+			uid = strings.SplitN(ctx, "___", 2)[0]
+		}
+	}
+	token, expired := auth.PersistedBearer(uid)
+	switch {
+	case token != "":
+		_ = os.Setenv("ER1_DEVICE_TOKEN", token)
+	case expired:
+		fmt.Fprintln(stderr, "[skillctl] your saved device token has expired — run 'skillctl login' to refresh.")
+	}
+}
+
+func runLogin(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("login", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	noBrowser := fs.Bool("no-browser", false, "Print the login URL but do not open a browser (headless/SSH).")
+	timeout := fs.Duration("timeout", 5*time.Minute, "How long to wait for the browser callback.")
+	baseFlag := fs.String("base-url", "", "ER1 server base URL. Default: derived from ER1_API_URL.")
+	logout := fs.Bool("logout", false, "Remove the stored device token and exit.")
+	status := fs.Bool("status", false, "Report whether a (non-expired) device token is stored, and exit.")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl login [--no-browser] [--timeout 5m] [--base-url URL]")
+		fmt.Fprintln(stderr, "       skillctl login --status | --logout")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if *status {
+		if auth.HasStoredToken() {
+			tok, expired := auth.PersistedBearer(strings.SplitN(os.Getenv("ER1_CONTEXT_ID"), "___", 2)[0])
+			if tok != "" {
+				fmt.Fprintf(stdout, "Logged in — device token stored (%s).\n", auth.ActiveStoreName())
+				return 0
+			}
+			if expired {
+				fmt.Fprintln(stdout, "A device token is stored but has expired — run 'skillctl login'.")
+				return 0
+			}
+		}
+		fmt.Fprintln(stdout, "Not logged in — run 'skillctl login'.")
+		return 0
+	}
+
+	if *logout {
+		if err := auth.Clear(); err != nil {
+			fmt.Fprintf(stderr, "logout: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, "Logged out — device token removed.")
+		return 0
+	}
+
+	base := strings.TrimSpace(*baseFlag)
+	if base == "" {
+		apiURL := os.Getenv("ER1_API_URL")
+		if apiURL == "" {
+			apiURL = "https://127.0.0.1:8081/upload_2"
+		}
+		base = er1login.BaseURL(apiURL)
+	}
+	if base == "" {
+		fmt.Fprintln(stderr, "login: cannot determine ER1 base URL — set ER1_API_URL or pass --base-url.")
+		return 1
+	}
+
+	res, err := er1login.DeviceLogin(base, !*noBrowser, stdout, *timeout)
+	if err != nil {
+		fmt.Fprintf(stderr, "login failed: %v\n", err)
+		return 1
+	}
+	if res.DeviceToken == "" {
+		fmt.Fprintln(stderr, "login failed: the server returned no device token (is device-token issuance enabled on this ER1?).")
+		return 1
+	}
+
+	dt := &auth.DeviceToken{
+		Token:     res.DeviceToken,
+		UserID:    res.UserID,
+		ContextID: res.ContextID,
+		UserName:  res.UserName,
+		UserEmail: res.UserEmail,
+		DeviceID:  auth.DeviceID(),
+		SavedAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := auth.Save(dt); err != nil {
+		fmt.Fprintf(stderr, "login: token received but could not be saved: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "✓ Logged in as %s — device token saved (%s). skillctl will use it automatically.\n",
+		firstNonEmpty(res.UserEmail, res.UserID, res.ContextID, "unknown"), auth.ActiveStoreName())
+	return 0
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/cmd/skillctl/login_cmds_test.go
+++ b/cmd/skillctl/login_cmds_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/auth"
+)
+
+// FR-0043: ER1-bound commands autoload the persisted token into the env.
+
+func TestAutoloadDeviceToken_FromStore(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("M3C_TOKEN_STORE", "file")
+	t.Setenv("ER1_DEVICE_TOKEN", "")
+	t.Setenv("ER1_USER_ID", "")
+	t.Setenv("ER1_CONTEXT_ID", "testsub___mft") // → userID hint "testsub"
+
+	dt := &auth.DeviceToken{
+		Token:    "auto-tok",
+		UserID:   "testsub",
+		DeviceID: auth.DeviceID(),
+		SavedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := auth.Save(dt); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	var errb bytes.Buffer
+	autoloadDeviceToken(&errb)
+	if got := os.Getenv("ER1_DEVICE_TOKEN"); got != "auto-tok" {
+		t.Fatalf("ER1_DEVICE_TOKEN = %q, want auto-tok (stderr=%q)", got, errb.String())
+	}
+}
+
+func TestAutoloadDeviceToken_RespectsExplicitEnv(t *testing.T) {
+	t.Setenv("ER1_DEVICE_TOKEN", "explicit")
+	autoloadDeviceToken(&bytes.Buffer{})
+	if got := os.Getenv("ER1_DEVICE_TOKEN"); got != "explicit" {
+		t.Fatalf("autoload overwrote an explicit token: %q", got)
+	}
+}
+
+func TestAutoloadDeviceToken_ExpiredWarns(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("M3C_TOKEN_STORE", "file")
+	t.Setenv("ER1_DEVICE_TOKEN", "")
+	t.Setenv("ER1_USER_ID", "testsub")
+
+	dt := &auth.DeviceToken{
+		Token:     "stale",
+		UserID:    "testsub",
+		DeviceID:  auth.DeviceID(),
+		ExpiresAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+	}
+	if err := auth.Save(dt); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	var errb bytes.Buffer
+	autoloadDeviceToken(&errb)
+	if got := os.Getenv("ER1_DEVICE_TOKEN"); got != "" {
+		t.Fatalf("expired token must not be exported, got %q", got)
+	}
+	if !bytes.Contains(errb.Bytes(), []byte("expired")) {
+		t.Fatalf("expected an 'expired' warning, got %q", errb.String())
+	}
+}
+
+func TestNetworkCommandsGating(t *testing.T) {
+	if !networkCommands["pull"] || !networkCommands["publish"] {
+		t.Fatal("pull/publish must be gated as network commands")
+	}
+	if networkCommands["keygen"] || networkCommands["version"] || networkCommands["sign"] {
+		t.Fatal("offline commands must NOT trigger the keychain autoload")
+	}
+}

--- a/cmd/skillctl/main.go
+++ b/cmd/skillctl/main.go
@@ -25,7 +25,17 @@ func main() {
 		printUsage(os.Stderr)
 		os.Exit(2)
 	}
+	// FR-0043: for ER1-bound commands, auto-load the device token persisted by
+	// `skillctl login` / `m3c-tools login` so users need not export it by hand.
+	// Gated to networkCommands so offline commands never touch the OS keychain.
+	if networkCommands[os.Args[1]] {
+		autoloadDeviceToken(os.Stderr)
+	}
 	switch os.Args[1] {
+	// === FR-0043: device login (browser pairing) + token autoload ===
+	case "login":
+		os.Exit(runLogin(os.Args[2:], os.Stdout, os.Stderr))
+	// === END FR-0043 ===
 	case "version", "--version", "-v":
 		fmt.Println(version)
 		os.Exit(0)
@@ -163,6 +173,10 @@ func printUsage(w *os.File) {
 	fmt.Fprintln(w, "  sign         Sign a .skb bundle with an ed25519 private key.")
 	fmt.Fprintln(w, "  verify-sig   Verify a detached author signature locally.")
 	fmt.Fprintln(w, "  attest       POST a signed governance attestation to the registry.")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Commands (FR-0043 / device login):")
+	fmt.Fprintln(w, "  login        Browser device-pairing against ER1; saves a token skillctl uses automatically.")
+	fmt.Fprintln(w, "               Flags: --no-browser, --timeout 5m, --base-url URL, --status, --logout.")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Commands (Stream S7 / SPEC-0188 Phase 4):")
 	fmt.Fprintln(w, "  trust        Manage ~/.claude/skill-trust-roots.yaml (list/add/remove).")

--- a/pkg/auth/headers.go
+++ b/pkg/auth/headers.go
@@ -32,3 +32,25 @@ func AuthMethod() string {
 	}
 	return "none"
 }
+
+// PersistedBearer resolves a device token from the at-rest store (OS keychain or
+// the encrypted-file fallback) for use as an Authorization: Bearer credential,
+// WITHOUT requiring the caller to export ER1_DEVICE_TOKEN. It is the read-back
+// half of FR-0043: `m3c-tools login` / `skillctl login` persist the token; this
+// reads it so skillctl can authenticate after a login alone.
+//
+// userIDHint is only consulted by the encrypted-file backend's key derivation
+// (the keychain backend ignores it). Pass the caller's own Google sub, or "".
+//
+// Returns ("", false) when no token is stored, and ("", true) when a token
+// exists but has expired (caller should prompt a re-login).
+func PersistedBearer(userIDHint string) (token string, expired bool) {
+	dt, err := Load(DeviceID(), userIDHint)
+	if err != nil || dt == nil {
+		return "", false
+	}
+	if dt.IsExpired() {
+		return "", true
+	}
+	return dt.Token, false
+}

--- a/pkg/auth/persisted_test.go
+++ b/pkg/auth/persisted_test.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+// FR-0043: PersistedBearer reads a stored token back so skillctl can authenticate
+// after a login alone, without an exported ER1_DEVICE_TOKEN.
+
+func TestPersistedBearer_FileBackend(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("M3C_TOKEN_STORE", "file")
+
+	tok := &DeviceToken{
+		Token:    "tok-abc-123",
+		UserID:   "testsub",
+		DeviceID: DeviceID(),
+		SavedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := (fileStore{}).Save(tok); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, expired := PersistedBearer("testsub")
+	if expired {
+		t.Fatalf("unexpected expired=true")
+	}
+	if got != "tok-abc-123" {
+		t.Fatalf("PersistedBearer = %q, want tok-abc-123", got)
+	}
+}
+
+func TestPersistedBearer_Expired(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("M3C_TOKEN_STORE", "file")
+
+	tok := &DeviceToken{
+		Token:     "tok-old",
+		UserID:    "testsub",
+		DeviceID:  DeviceID(),
+		ExpiresAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+	}
+	if err := (fileStore{}).Save(tok); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, expired := PersistedBearer("testsub")
+	if got != "" || !expired {
+		t.Fatalf("PersistedBearer = (%q, %v), want (\"\", true)", got, expired)
+	}
+}
+
+func TestPersistedBearer_None(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("M3C_TOKEN_STORE", "file")
+
+	got, expired := PersistedBearer("nobody")
+	if got != "" || expired {
+		t.Fatalf("PersistedBearer = (%q, %v), want (\"\", false)", got, expired)
+	}
+}

--- a/pkg/er1login/login.go
+++ b/pkg/er1login/login.go
@@ -1,0 +1,143 @@
+// Package er1login runs the aims-core browser device-pairing flow and returns
+// the issued device token. It is the reusable core behind `m3c-tools login` and
+// `skillctl login` (FR-0043): a localhost callback server receives the OAuth
+// redirect from <baseURL>/v2/signin?next=<callback>, which carries the
+// device_token + context_id as query parameters.
+package er1login
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	neturl "net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Result is the data delivered by the aims-core login redirect.
+type Result struct {
+	ContextID   string
+	DeviceToken string
+	UserID      string
+	UserName    string
+	UserEmail   string
+}
+
+// BaseURL derives the ER1 server root from an ER1 API (upload) URL by stripping
+// a trailing /upload* path segment, e.g.
+//
+//	https://host:8081/upload_2  ->  https://host:8081
+func BaseURL(apiURL string) string {
+	u := strings.TrimSpace(apiURL)
+	if idx := strings.LastIndex(u, "/upload"); idx > 0 {
+		u = u[:idx]
+	}
+	return strings.TrimRight(u, "/")
+}
+
+// DeviceLogin runs the browser device-pairing flow: it starts a localhost
+// callback server, points the browser at <baseURL>/v2/signin?next=<callback>,
+// and blocks until the redirect delivers the device token (or the timeout
+// elapses). Progress is written to out. When openBrowser is false the URL is
+// only printed (for headless / SSH sessions).
+func DeviceLogin(baseURL string, openBrowser bool, out io.Writer, timeout time.Duration) (*Result, error) {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return nil, fmt.Errorf("empty ER1 base URL (set ER1_API_URL or pass --base-url)")
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("start callback server: %w", err)
+	}
+	nonce := make([]byte, 16)
+	if _, err := rand.Read(nonce); err != nil {
+		_ = ln.Close()
+		return nil, fmt.Errorf("generate callback nonce: %w", err)
+	}
+	path := "/skillctl-login-" + hex.EncodeToString(nonce)
+	addr := ln.Addr().String()
+	callbackURL := "http://" + addr + path
+	resultCh := make(chan Result, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		ctxID := strings.TrimSpace(q.Get("context_id"))
+		if ctxID == "" {
+			ctxID = strings.TrimSpace(q.Get("user_id"))
+		}
+		select {
+		case resultCh <- Result{
+			ContextID:   ctxID,
+			DeviceToken: strings.TrimSpace(q.Get("device_token")),
+			UserID:      strings.TrimSpace(q.Get("user_id")),
+			UserName:    strings.TrimSpace(q.Get("user_name")),
+			UserEmail:   strings.TrimSpace(q.Get("user_email")),
+		}:
+		default:
+		}
+		// SEC: lock the throwaway page down — no scripts, no remote fetches.
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		_, _ = io.WriteString(w, successHTML)
+	})
+
+	srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}()
+
+	loginURL := fmt.Sprintf("%s/v2/signin?next=%s", baseURL, neturl.QueryEscape(callbackURL))
+	fmt.Fprintf(out, "Opening browser for login…\nIf it does not open, visit:\n  %s\n\n", loginURL)
+	if openBrowser {
+		if err := openURL(loginURL); err != nil {
+			fmt.Fprintf(out, "(could not open a browser automatically: %v — open the URL above)\n", err)
+		}
+	}
+	fmt.Fprintf(out, "Waiting for login to complete (timeout %s)…\n", timeout)
+
+	select {
+	case res := <-resultCh:
+		if res.DeviceToken == "" && res.ContextID == "" {
+			return nil, fmt.Errorf("login callback carried neither a device token nor a context id")
+		}
+		return &res, nil
+	case <-time.After(timeout):
+		return nil, fmt.Errorf("login timed out after %s waiting for the browser callback", timeout)
+	}
+}
+
+const successHTML = `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+	`<title>skillctl — logged in</title>` +
+	`<style>body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;` +
+	`background:#0b0d11;color:#e8eaed;display:grid;place-items:center;height:100vh;margin:0}` +
+	`.c{text-align:center}.c h1{color:#16c79a;margin:0 0 8px}.c p{color:#9aa3b2}</style></head>` +
+	`<body><div class="c"><h1>✓ Logged in</h1><p>You can close this tab and return to the terminal.</p></div></body></html>`
+
+// openURL best-effort launches the platform browser. Failure is non-fatal —
+// the caller has already printed the URL for manual navigation.
+func openURL(u string) error {
+	var name string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		name, args = "open", []string{u}
+	case "windows":
+		name, args = "rundll32", []string{"url.dll,FileProtocolHandler", u}
+	default:
+		name, args = "xdg-open", []string{u}
+	}
+	return exec.Command(name, args...).Start()
+}

--- a/pkg/er1login/login_test.go
+++ b/pkg/er1login/login_test.go
@@ -1,0 +1,37 @@
+package er1login
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+func TestBaseURL(t *testing.T) {
+	cases := map[string]string{
+		"https://h:8081/upload_2":     "https://h:8081",
+		"https://h:8081/upload":       "https://h:8081",
+		"https://h/api/upload_2":      "https://h/api",
+		"https://h:8081/":             "https://h:8081",
+		"https://h:8081":              "https://h:8081",
+		"  https://h:8081/upload_2  ": "https://h:8081",
+	}
+	for in, want := range cases {
+		if got := BaseURL(in); got != want {
+			t.Errorf("BaseURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDeviceLogin_Timeout(t *testing.T) {
+	// openBrowser=false → no exec; no one hits the callback → it must time out.
+	_, err := DeviceLogin("https://127.0.0.1:65535", false, io.Discard, 80*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+}
+
+func TestDeviceLogin_EmptyBase(t *testing.T) {
+	if _, err := DeviceLogin("   ", false, io.Discard, time.Second); err == nil {
+		t.Fatal("expected error for empty base URL")
+	}
+}


### PR DESCRIPTION
## Summary
Fixes the reported bug: `m3c-tools login` persisted a device token, but `skillctl` only read `ER1_DEVICE_TOKEN` from the environment — so a login-only setup still returned **401**. skillctl now logs in and uses the token.

## What changed
- **`skillctl login`** — browser device-pairing via a new reusable **`pkg/er1login`** package (localhost callback + `/v2/signin?next=<cb>`), so a box with only the skillctl binary is self-sufficient. Flags: `--status`, `--logout`, `--no-browser`, `--timeout`, `--base-url`.
- **Token autoload** — ER1-bound subcommands load the persisted token via new **`pkg/auth.PersistedBearer`** and export it for the process. Gated to `networkCommands`, so offline commands (`version`, `keygen`, …) never touch the OS keychain.
- Caller-sub wrinkle: keychain ignores the userID; the encrypted-file backend resolves it from `ER1_USER_ID` → the sub parsed from `ER1_CONTEXT_ID`.

## Tests
`pkg/auth` (PersistedBearer: ok/expired/none), `pkg/er1login` (BaseURL/timeout/empty-base), `cmd/skillctl` (autoload from store, respects explicit env, expired-warns, network-gating). `go build ./...`, `go vet`, gofmt all clean.

Closes FR-0043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)