### PR TITLE
fix(runbook): pre-flight skill check uses ~/.claude/skills

### DIFF
--- a/tools/release-templates/skillctl-publisher-runbook.template.html
+++ b/tools/release-templates/skillctl-publisher-runbook.template.html
@@ -159,7 +159,7 @@
       <div class="field"><label>Response</label><textarea data-step="pf" data-field="pf_token" placeholder="paste what it printed"></textarea></div>
     </div>
     <div class="pf-check">
-      <pre><code>ls {{skill}}/SKILL.md 2&gt;/dev/null &amp;&amp; echo "have {{skill}}" || echo "{{skill}} folder not received yet"</code></pre>
+      <pre><code>ls ~/.claude/skills/{{skill}}/SKILL.md 2&gt;/dev/null &amp;&amp; echo "have {{skill}}" || echo "{{skill}} not in ~/.claude/skills/ yet"</code></pre>
       <div class="field"><label>Response</label><textarea data-step="pf" data-field="pf_skill" placeholder="paste what it printed"></textarea></div>
     </div>
     <div class="pf-check">


### PR DESCRIPTION
Pre-flight check ran `ls {{skill}}/SKILL.md` (CWD-relative) and falsely reported "not received" for an installed skill. Now checks `~/.claude/skills/{{skill}}/SKILL.md` — the real location. Surfaced during Eric's rc2 pre-flight (didactic-session showed as missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)