### PR TITLE
fix(release): install.sh self-pins to its release tag (+ runbook RELEASE_BASE)

### DIFF
--- a/tools/release-templates/skillctl-publisher-runbook.template.html
+++ b/tools/release-templates/skillctl-publisher-runbook.template.html
@@ -187,10 +187,11 @@
       <p class="why">Your first build is v0.2.2; the secure sign/verify path only exists in __SKILLCTL_VERSION__.</p></div>
       <span class="req r">REQUIRED</span></div>
     <div class="body">
-      <pre><code>curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/__SKILLCTL_VERSION__/install.sh | bash
-skillctl version
+      <pre><code>curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/__SKILLCTL_VERSION__/install.sh | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/__SKILLCTL_VERSION__ bash
+skillctl version    # must print __SKILLCTL_VERSION__
 which skillctl</code></pre>
-      <div class="chk">Expected: <b>skillctl __SKILLCTL_VERSION__</b>. Installer verifies the release signature (fp <code>5f8f39cb…</code>) first.</div>
+      <div class="chk">Expected: <b>skillctl __SKILLCTL_VERSION__</b> (installer verifies the release signature, fp <code>5f8f39cb…</code>).
+      ⚠ If <code>skillctl version</code> shows an OLDER version, the <code>RELEASE_BASE=…</code> override above is what pins this release — keep it on the command.</div>
       <div class="donerow"><input type="checkbox" id="c1" data-step="s1" data-field="done"><label for="c1">__SKILLCTL_VERSION__ confirmed</label></div>
     </div>
   </section>
@@ -216,7 +217,8 @@ which skillctl</code></pre>
       <span class="req r">REQUIRED</span></div>
     <div class="body">
       <pre><code>skillctl keygen --out {{keystem}}</code></pre>
-      <div class="chk">Produces <code>{{keystem}}.priv</code> (0600) and <code>{{keystem}}.pub</code>.</div>
+      <div class="chk">Produces <code>{{keystem}}.priv</code> (0600) and <code>{{keystem}}.pub</code>.
+      Already have a key? <code>keygen</code> refuses to overwrite — that's expected: <b>reuse your existing key, skip to step 4</b> (don't rotate unless you mean to).</div>
       <div class="donerow"><input type="checkbox" id="c3" data-step="s3" data-field="done"><label for="c3">Key created</label></div>
     </div>
   </section>

--- a/tools/skillctl-release.sh
+++ b/tools/skillctl-release.sh
@@ -61,6 +61,13 @@ openssl pkeyutl -verify -pubin -inkey "${OUT}/skillctl-release.pub" -rawin \
   || { echo "SIGNATURE VERIFY FAILED" >&2; exit 1; }
 
 cp "${REPO_ROOT}/tools/skillctl-install.sh" "${OUT}/install.sh"
+# Stamp the installer's default RELEASE_BASE to THIS release, so
+# `curl …/${TAG}/install.sh | bash` (no env override) installs THIS version.
+# Without this the copied default points at whatever tag was committed, and a
+# no-override install silently fetches the wrong (older) binary.
+sed "s#download/skillctl/[^\"}]*#download/${TAG}#" "${OUT}/install.sh" > "${OUT}/install.sh.tmp" && mv "${OUT}/install.sh.tmp" "${OUT}/install.sh"
+echo "==> install.sh RELEASE_BASE default → ${TAG}"
+grep 'RELEASE_BASE:-' "${OUT}/install.sh" | head -1
 FP="sha256:$(openssl pkey -in "${RELEASE_KEY}" -pubout -outform DER 2>/dev/null | tail -c 32 | sha256 | awk '{print $1}')"
 
 cat > "${OUT}/RELEASE_NOTES.md" <<EOF


### PR DESCRIPTION
Field bug: `curl .../skillctl/v0.2.11-rc2/install.sh | bash` installed **v0.2.10** because the packaged installer's default `RELEASE_BASE` was the committed (old) tag. Now the release script stamps install.sh's default `RELEASE_BASE` to the release tag, the runbook Step 1 passes it explicitly + checks the version, and Step 3 notes that reusing an existing key is fine. rc2's published install.sh + runbook assets were re-uploaded with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)