### PR TITLE
fix(skillctl): login defaults to public SaaS (not localhost)

### DIFF
--- a/cmd/skillctl/login_cmds.go
+++ b/cmd/skillctl/login_cmds.go
@@ -65,12 +65,29 @@ func autoloadDeviceToken(stderr io.Writer) {
 	}
 }
 
+// publicER1Base is the default login target. `skillctl login` is the publisher
+// pairing flow against the public SaaS — NOT the local dev server. A local
+// developer overrides via --base-url or by setting ER1_API_URL.
+const publicER1Base = "https://onboarding.guide"
+
+// resolveLoginBase picks the /v2/signin host: explicit --base-url wins, then a
+// set ER1_API_URL (upload URL → stripped to its root), else the public SaaS.
+func resolveLoginBase(baseFlag, apiURLEnv string) string {
+	if b := strings.TrimSpace(baseFlag); b != "" {
+		return strings.TrimRight(b, "/")
+	}
+	if a := strings.TrimSpace(apiURLEnv); a != "" {
+		return er1login.BaseURL(a)
+	}
+	return publicER1Base
+}
+
 func runLogin(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("login", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	noBrowser := fs.Bool("no-browser", false, "Print the login URL but do not open a browser (headless/SSH).")
 	timeout := fs.Duration("timeout", 5*time.Minute, "How long to wait for the browser callback.")
-	baseFlag := fs.String("base-url", "", "ER1 server base URL. Default: derived from ER1_API_URL.")
+	baseFlag := fs.String("base-url", "", "ER1 server base URL. Default: public SaaS (https://onboarding.guide), or ER1_API_URL if set.")
 	logout := fs.Bool("logout", false, "Remove the stored device token and exit.")
 	status := fs.Bool("status", false, "Report whether a (non-expired) device token is stored, and exit.")
 	fs.Usage = func() {
@@ -107,14 +124,7 @@ func runLogin(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	base := strings.TrimSpace(*baseFlag)
-	if base == "" {
-		apiURL := os.Getenv("ER1_API_URL")
-		if apiURL == "" {
-			apiURL = "https://127.0.0.1:8081/upload_2"
-		}
-		base = er1login.BaseURL(apiURL)
-	}
+	base := resolveLoginBase(*baseFlag, os.Getenv("ER1_API_URL"))
 	if base == "" {
 		fmt.Fprintln(stderr, "login: cannot determine ER1 base URL — set ER1_API_URL or pass --base-url.")
 		return 1

--- a/cmd/skillctl/login_cmds_test.go
+++ b/cmd/skillctl/login_cmds_test.go
@@ -77,3 +77,22 @@ func TestNetworkCommandsGating(t *testing.T) {
 		t.Fatal("offline commands must NOT trigger the keychain autoload")
 	}
 }
+
+func TestResolveLoginBase(t *testing.T) {
+	// default → public SaaS (the Eric bug: was localhost)
+	if got := resolveLoginBase("", ""); got != "https://onboarding.guide" {
+		t.Fatalf("default base = %q, want https://onboarding.guide", got)
+	}
+	// explicit --base-url wins (trailing slash trimmed)
+	if got := resolveLoginBase("https://stage.example/", ""); got != "https://stage.example" {
+		t.Fatalf("flag base = %q, want https://stage.example", got)
+	}
+	// ER1_API_URL (upload URL) → stripped to root
+	if got := resolveLoginBase("", "https://127.0.0.1:8081/upload_2"); got != "https://127.0.0.1:8081" {
+		t.Fatalf("env base = %q, want https://127.0.0.1:8081", got)
+	}
+	// flag beats env
+	if got := resolveLoginBase("https://onboarding.guide", "https://127.0.0.1:8081/upload_2"); got != "https://onboarding.guide" {
+		t.Fatalf("flag should beat env, got %q", got)
+	}
+}

--- a/tools/release-templates/skillctl-publisher-runbook.template.html
+++ b/tools/release-templates/skillctl-publisher-runbook.template.html
@@ -256,10 +256,11 @@ bash ~/.claude/skills/{{skill}}/tests/smoke.sh</code></pre>
       <p class="why">From __SKILLCTL_VERSION__, skillctl logs in via the browser and uses the device token automatically (FR-0043) — no manual export, no minted token.</p></div>
       <span class="req r">REQUIRED</span></div>
     <div class="body">
-      <pre><code>skillctl login            # opens a browser; saves the device token
-skillctl login --status   # should print: Logged in</code></pre>
-      <div class="chk">No token to copy by hand. Headless/SSH? run <code>skillctl login --no-browser</code> and open the printed URL.
-      Fallback if login is unavailable: <code>export ER1_DEVICE_TOKEN=&lt;token from Kamir&gt;</code>.</div>
+      <pre><code>skillctl login --base-url https://onboarding.guide   # browser -> public SaaS; saves the device token
+skillctl login --status                              # should print: Logged in</code></pre>
+      <div class="chk">⚠ Use <code>--base-url https://onboarding.guide</code> (the public SaaS) — without it, older builds default to the local
+      server and login fails. Headless/SSH? add <code>--no-browser</code> and open the printed URL. Last-resort fallback:
+      <code>export ER1_DEVICE_TOKEN=&lt;token from Kamir&gt;</code>.</div>
       <div class="donerow"><input type="checkbox" id="c6" data-step="s6" data-field="done"><label for="c6">Logged in (status shows "Logged in")</label></div>
     </div>
   </section>


### PR DESCRIPTION
`skillctl login` defaulted to `https://127.0.0.1:8081` — so a publisher pairing against the SaaS got a localhost signin URL and login failed. Now: `--base-url` > `ER1_API_URL` > **https://onboarding.guide**. Unit-tested. Runbook Step 6 pins `--base-url https://onboarding.guide` (works on rc2 today). Immediate unblock: `skillctl login --base-url https://onboarding.guide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)