### PR TITLE
fix(skillctl): publish --attest auto-resolves digest from packed .skb

### DIFF
--- a/cmd/skillctl/publish_attest_digest_test.go
+++ b/cmd/skillctl/publish_attest_digest_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveBundleDigest(t *testing.T) {
+	// 1) explicit --digest wins, verbatim
+	if got, err := resolveBundleDigest("sha256:abc", "", "x", "1"); err != nil || got != "sha256:abc" {
+		t.Fatalf("digest passthrough: got %q err %v", got, err)
+	}
+
+	// 2) --bundle <path> → sha256 of the file
+	dir := t.TempDir()
+	bp := filepath.Join(dir, "b.skb")
+	if err := os.WriteFile(bp, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveBundleDigest("", bp, "x", "1")
+	if err != nil || got == "" || got[:7] != "sha256:" {
+		t.Fatalf("bundle digest: got %q err %v", got, err)
+	}
+
+	// 3) default ./<name>@<version>.skb in CWD (the publish-admit output)
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir(dir)
+	if err := os.WriteFile("didactic-session@0.1.0.skb", []byte("bundle-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := resolveBundleDigest("", "", "didactic-session", "0.1.0")
+	if err != nil || d[:7] != "sha256:" {
+		t.Fatalf("default skb digest: got %q err %v", d, err)
+	}
+
+	// 4) nothing available → clear error
+	if _, err := resolveBundleDigest("", "", "nope", "9.9.9"); err == nil {
+		t.Fatal("expected error when no digest/bundle/skb")
+	}
+}

--- a/cmd/skillctl/publish_cmds.go
+++ b/cmd/skillctl/publish_cmds.go
@@ -342,6 +342,34 @@ func runPublishAdmit(stdout, stderr io.Writer, a publishAdmitArgs) int {
 	return 0
 }
 
+// resolveBundleDigest determines the sha256 digest for --attest / --revoke:
+//  1. --digest sha256:<hex> if given (verbatim)
+//  2. --bundle <path> → sha256 of that file
+//  3. the in-place bundle ./<name>@<version>.skb that `publish` (admit) writes —
+//     so `publish --attest <name>@<ver>` works right after `publish <name>@<ver>`
+//     with no repeated --digest/--bundle.
+func resolveBundleDigest(digestArg, bundlePath, name, version string) (string, error) {
+	if strings.TrimSpace(digestArg) != "" {
+		return digestArg, nil
+	}
+	if bundlePath == "" {
+		cand := fmt.Sprintf("%s@%s.skb", name, version)
+		if _, err := os.Stat(cand); err == nil {
+			bundlePath = cand
+		}
+	}
+	if bundlePath == "" {
+		return "", fmt.Errorf("need --digest sha256:<hex> or --bundle <path> "+
+			"(no ./%s@%s.skb here — run from where you published, or pass --digest)", name, version)
+	}
+	skb, err := os.ReadFile(bundlePath)
+	if err != nil {
+		return "", fmt.Errorf("read bundle %s: %w", bundlePath, err)
+	}
+	d, _ := sha256Hex(skb)
+	return "sha256:" + d, nil
+}
+
 // ─── attest mode ───────────────────────────────────────────────────────────
 
 type publishAttestArgs struct {
@@ -352,19 +380,10 @@ type publishAttestArgs struct {
 }
 
 func runPublishAttest(stdout, stderr io.Writer, a publishAttestArgs) int {
-	digest := a.digestArg
-	if digest == "" {
-		if a.bundlePath == "" {
-			fmt.Fprintln(stderr, "publish --attest: need --digest sha256:<hex> or --bundle <path>")
-			return 2
-		}
-		skb, err := os.ReadFile(a.bundlePath)
-		if err != nil {
-			fmt.Fprintf(stderr, "publish --attest: read bundle: %v\n", err)
-			return 1
-		}
-		d, _ := sha256Hex(skb)
-		digest = "sha256:" + d
+	digest, err := resolveBundleDigest(a.digestArg, a.bundlePath, a.name, a.version)
+	if err != nil {
+		fmt.Fprintf(stderr, "publish --attest: %v\n", err)
+		return 2
 	}
 
 	priv, err := signing.LoadPrivateKey(a.keyPath)
@@ -443,19 +462,10 @@ type publishRevokeArgs struct {
 }
 
 func runPublishRevoke(stdout, stderr io.Writer, a publishRevokeArgs) int {
-	digest := a.digestArg
-	if digest == "" {
-		if a.bundlePath == "" {
-			fmt.Fprintln(stderr, "publish --revoke: need --digest sha256:<hex> or --bundle <path>")
-			return 2
-		}
-		skb, err := os.ReadFile(a.bundlePath)
-		if err != nil {
-			fmt.Fprintf(stderr, "publish --revoke: read bundle: %v\n", err)
-			return 1
-		}
-		d, _ := sha256Hex(skb)
-		digest = "sha256:" + d
+	digest, err := resolveBundleDigest(a.digestArg, a.bundlePath, a.name, a.version)
+	if err != nil {
+		fmt.Fprintf(stderr, "publish --revoke: %v\n", err)
+		return 2
 	}
 	if a.reason == "" {
 		fmt.Fprintln(stderr, "publish --revoke: --reason required (short code, e.g. key-compromise, deprecated)")


### PR DESCRIPTION
`publish --attest <name>@<ver>` now finds the in-place `./<name>@<ver>.skb` that admit wrote (digest precedence: --digest > --bundle > ./<name>@<ver>.skb). Shared with --revoke; unit-tested. Fixes the 'need --digest or --bundle' error right after publishing. 🤖 Generated with [Claude Code](https://claude.com/claude-code)