### PR TITLE
feat(skillctl): SPEC-0275 P0 — skill-bundled runbooks

### DIFF
--- a/cmd/skillctl/publish_cmds.go
+++ b/cmd/skillctl/publish_cmds.go
@@ -101,6 +101,9 @@ func runPublish(args []string, stdout, stderr io.Writer) int {
 		// Session hook (P1.5)
 		noCheckpoint = fs.Bool("no-checkpoint", false, "Do not append a checkpoint to the open SPEC-0213 session (default: on if a session is open).")
 
+		// SPEC-0275: auto-register the skill's runbook.html into the THOH catalog.
+		noRunbookPublish = fs.Bool("no-runbook-publish", false, "Do not auto-register the skill's runbook.html/runbook.meta.json into the THOH catalog (SPEC-0275).")
+
 		// UX
 		yes    = fs.Bool("yes", false, "Skip the 🟡 confirm pause (scripted runs).")
 		dryRun = fs.Bool("dry-run", false, "Print the plan + the rendered item body; do not POST or pack.")
@@ -203,19 +206,20 @@ func runPublish(args []string, stdout, stderr io.Writer) int {
 		})
 	}
 	return runPublishAdmit(stdout, stderr, publishAdmitArgs{
-		name:         name,
-		version:      ver,
-		skillDir:     *skillDir,
-		bundlePath:   *bundle,
-		identity:     *identity,
-		keyPath:      *keyPath,
-		er1Target:    *er1Target,
-		er1Context:   *er1Context,
-		inlineMax:    *inlineMax,
-		yes:          *yes,
-		dryRun:       *dryRun,
-		noCheckpoint: *noCheckpoint,
-		shareRooms:   rooms,
+		name:             name,
+		version:          ver,
+		skillDir:         *skillDir,
+		bundlePath:       *bundle,
+		identity:         *identity,
+		keyPath:          *keyPath,
+		er1Target:        *er1Target,
+		er1Context:       *er1Context,
+		inlineMax:        *inlineMax,
+		yes:              *yes,
+		dryRun:           *dryRun,
+		noCheckpoint:     *noCheckpoint,
+		noRunbookPublish: *noRunbookPublish,
+		shareRooms:       rooms,
 	})
 }
 
@@ -225,7 +229,7 @@ type publishAdmitArgs struct {
 	name, version, skillDir, bundlePath, identity, keyPath string
 	er1Target, er1Context                                  string
 	inlineMax                                              int
-	yes, dryRun, noCheckpoint                              bool
+	yes, dryRun, noCheckpoint, noRunbookPublish            bool
 	shareRooms                                             []string
 }
 
@@ -331,6 +335,7 @@ func runPublishAdmit(stdout, stderr io.Writer, a publishAdmitArgs) int {
 	})
 	if errors.Is(err, registry.ErrAlreadyPublished) {
 		fmt.Fprintf(stdout, "==> already published: doc_id=%s (idempotent no-op)\n", res.DocID)
+		maybeRegisterRunbook(stdout, stderr, a, ver) // SPEC-0275 (best-effort)
 		return 0
 	}
 	if err != nil {
@@ -339,6 +344,7 @@ func runPublishAdmit(stdout, stderr io.Writer, a publishAdmitArgs) int {
 	}
 	fmt.Fprintf(stdout, "==> admitted: doc_id=%s  transport=%s  body_bytes=%d\n", res.DocID, res.Transport, res.ItemBodySize)
 	maybeCheckpoint(stdout, a.noCheckpoint, a.er1Target, a.er1Context, fmt.Sprintf("published (admit) %s@%s digest=%s doc=%s", a.name, ver, digest, res.DocID))
+	maybeRegisterRunbook(stdout, stderr, a, ver) // SPEC-0275 (best-effort)
 	return 0
 }
 

--- a/cmd/skillctl/runbook_cmds.go
+++ b/cmd/skillctl/runbook_cmds.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -78,7 +79,6 @@ func runRunbook(args []string, stdout, stderr io.Writer) int {
 		},
 		"html_url": fmt.Sprintf("https://github.com/kamir/m3c-tools/releases/download/%s/skillctl-publisher-runbook.html", *tag),
 	}
-	body, _ := json.Marshal(map[string]any{"descriptor": descriptor, "html": string(html)})
 
 	fmt.Fprintf(stdout, "Runbook : %s@%s — %q\n", *rbID, version, *title)
 	fmt.Fprintf(stdout, "HTML    : %s (%d bytes)\n", htmlPath, len(html))
@@ -107,20 +107,14 @@ func runRunbook(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
-	req, _ := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: 30 * time.Second}
-	res, err := client.Do(req)
+	code, out, err := postRunbookToCatalog(*base, token, descriptor, html)
 	if err != nil {
 		fmt.Fprintf(stderr, "runbook publish: POST failed: %v\n", err)
 		return 1
 	}
-	defer res.Body.Close()
-	out, _ := io.ReadAll(res.Body)
-	fmt.Fprintf(stdout, "HTTP %d %s\n", res.StatusCode, strings.TrimSpace(string(out)))
+	fmt.Fprintf(stdout, "HTTP %d %s\n", code, out)
 
-	switch res.StatusCode {
+	switch code {
 	case 200, 201:
 		fmt.Fprintf(stdout, "✓ runbook in catalog — assign it from the THOH board (%s/thoh).\n", strings.TrimRight(*base, "/"))
 		return 0
@@ -131,4 +125,114 @@ func runRunbook(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "publish failed.")
 		return 1
 	}
+}
+
+// postRunbookToCatalog POSTs {descriptor, html} to <base>/api/thoh/runbooks with
+// the device token. The one wire path shared by `skillctl runbook publish` and the
+// SPEC-0275 `skillctl publish` auto-register hook (no descriptor duplication).
+func postRunbookToCatalog(base, token string, descriptor map[string]any, html []byte) (int, string, error) {
+	endpoint := strings.TrimRight(base, "/") + "/api/thoh/runbooks"
+	body, _ := json.Marshal(map[string]any{"descriptor": descriptor, "html": string(html)})
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return 0, "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+	defer res.Body.Close()
+	out, _ := io.ReadAll(res.Body)
+	return res.StatusCode, strings.TrimSpace(string(out)), nil
+}
+
+// maybeRegisterRunbook is the SPEC-0275 auto-register hook. After a successful
+// `skillctl publish` admit, if the skill dir carries BOTH runbook.html and the
+// sidecar runbook.meta.json (and --no-runbook-publish wasn't passed), it posts
+// them to the THOH catalog. Best-effort: every failure warns but NEVER fails the
+// publish — the admit is already done and the runbook bytes are in the signed
+// .skb regardless. The descriptor is the sidecar; version is overridden by the
+// authoritative skill version (single source of truth).
+//
+//	publish admit OK ──▶ runbook.html + runbook.meta.json present?
+//	                       ├─ neither      → silent (skill ships no runbook)
+//	                       ├─ only one     → WARN, skip
+//	                       └─ both         → validate(runbook_id,title) → POST (best-effort)
+func maybeRegisterRunbook(stdout, stderr io.Writer, a publishAdmitArgs, ver string) {
+	if a.noRunbookPublish {
+		return
+	}
+	dir := a.skillDir
+	if dir == "" {
+		home, _ := os.UserHomeDir()
+		dir = filepath.Join(home, ".claude", "skills", a.name)
+	}
+	htmlPath := filepath.Join(dir, "runbook.html")
+	metaPath := filepath.Join(dir, "runbook.meta.json")
+	_, htmlErr := os.Stat(htmlPath)
+	_, metaErr := os.Stat(metaPath)
+	if htmlErr != nil && metaErr != nil {
+		return // skill ships no runbook — nothing to do
+	}
+	if htmlErr != nil || metaErr != nil {
+		fmt.Fprintln(stderr, "    [runbook] runbook.html / runbook.meta.json present without its pair — not registered.")
+		return
+	}
+
+	html, err := os.ReadFile(htmlPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "    [runbook] read %s: %v — not registered.\n", htmlPath, err)
+		return
+	}
+	descriptor, err := loadRunbookDescriptor(metaPath, ver)
+	if err != nil {
+		fmt.Fprintf(stderr, "    [runbook] %v — not registered.\n", err)
+		return
+	}
+
+	token := os.Getenv("ER1_DEVICE_TOKEN")
+	if token == "" {
+		fmt.Fprintln(stderr, "    [runbook] no device token — skipping catalog register (run 'skillctl login').")
+		return
+	}
+	base, _ := er1Endpoint(a.er1Target)
+	code, out, err := postRunbookToCatalog(base, token, descriptor, html)
+	if err != nil {
+		fmt.Fprintf(stderr, "    [runbook] catalog register failed (non-fatal): %v\n", err)
+		return
+	}
+	if code == 200 || code == 201 {
+		rbID, _ := descriptor["runbook_id"].(string)
+		fmt.Fprintf(stdout, "    [runbook] ✓ registered %s in THOH catalog (%s/thoh)\n", rbID, strings.TrimRight(base, "/"))
+		return
+	}
+	fmt.Fprintf(stderr, "    [runbook] catalog register HTTP %d (non-fatal): %s\n", code, out)
+}
+
+// loadRunbookDescriptor reads + validates the sidecar runbook.meta.json. Required:
+// runbook_id, title. version is always overridden by the skill version (ver) so the
+// skill stays the single source of truth. Pure (no I/O beyond the file read) → unit-tested.
+func loadRunbookDescriptor(metaPath, ver string) (map[string]any, error) {
+	raw, err := os.ReadFile(metaPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", metaPath, err)
+	}
+	return parseRunbookDescriptor(raw, ver)
+}
+
+func parseRunbookDescriptor(raw []byte, ver string) (map[string]any, error) {
+	var d map[string]any
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil, fmt.Errorf("runbook.meta.json is not valid JSON: %w", err)
+	}
+	if s, _ := d["runbook_id"].(string); strings.TrimSpace(s) == "" {
+		return nil, fmt.Errorf(`runbook.meta.json missing required "runbook_id"`)
+	}
+	if s, _ := d["title"].(string); strings.TrimSpace(s) == "" {
+		return nil, fmt.Errorf(`runbook.meta.json missing required "title"`)
+	}
+	d["version"] = ver // skill is the single source of truth for version
+	return d, nil
 }

--- a/cmd/skillctl/runbook_publish_test.go
+++ b/cmd/skillctl/runbook_publish_test.go
@@ -1,0 +1,142 @@
+package main
+
+// SPEC-0275 — skill-bundled runbooks: pack inclusion, descriptor parsing, and
+// the best-effort auto-register hook.
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillbundle"
+)
+
+// T2/T5 — the sidecar descriptor: required fields + version override (pure).
+func TestParseRunbookDescriptor(t *testing.T) {
+	// happy path: version overridden by the skill version
+	d, err := parseRunbookDescriptor([]byte(`{"runbook_id":"rb-x","title":"X","version":"9.9.9"}`), "1.2.3")
+	if err != nil {
+		t.Fatalf("valid meta: %v", err)
+	}
+	if d["version"] != "1.2.3" {
+		t.Fatalf("version must be overridden by skill version, got %v", d["version"])
+	}
+	if d["runbook_id"] != "rb-x" {
+		t.Fatalf("runbook_id lost: %v", d["runbook_id"])
+	}
+
+	// missing runbook_id → error
+	if _, err := parseRunbookDescriptor([]byte(`{"title":"X"}`), "1.0.0"); err == nil {
+		t.Fatal("expected error for missing runbook_id")
+	}
+	// missing title → error
+	if _, err := parseRunbookDescriptor([]byte(`{"runbook_id":"rb-x"}`), "1.0.0"); err == nil {
+		t.Fatal("expected error for missing title")
+	}
+	// invalid JSON → error
+	if _, err := parseRunbookDescriptor([]byte(`{not json`), "1.0.0"); err == nil {
+		t.Fatal("expected error for bad JSON")
+	}
+}
+
+// T1 — pack includes runbook.html + runbook.meta.json (WalkDir packs the whole dir).
+func TestPackIncludesRunbook(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("SKILL.md", "---\nname: demo\nversion: 0.1.0\n---\n")
+	write("runbook.html", "<!doctype html><title>demo</title>")
+	write("runbook.meta.json", `{"runbook_id":"rb-demo","title":"Demo"}`)
+
+	out := filepath.Join(t.TempDir(), "demo@0.1.0.skb")
+	if _, err := skillbundle.Pack(dir, out, skillbundle.PackOptions{}); err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+
+	names := tarEntryNames(t, out)
+	for _, want := range []string{"runbook.html", "runbook.meta.json", "SKILL.md"} {
+		if !names[want] {
+			t.Errorf("packed .skb missing %q (entries: %v)", want, names)
+		}
+	}
+}
+
+// T4 + pairing — the auto-register hook is always best-effort: it never panics
+// and never blocks the caller, whatever the catalog / filesystem state.
+func TestMaybeRegisterRunbook_BestEffort(t *testing.T) {
+	// flag off → immediate no-op even with files present
+	t.Run("disabled", func(t *testing.T) {
+		dir := skillDirWithRunbook(t)
+		maybeRegisterRunbook(io_discard(), io_discard(), publishAdmitArgs{name: "demo", skillDir: dir, noRunbookPublish: true}, "0.1.0")
+	})
+	// no runbook files → silent no-op
+	t.Run("no-runbook", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("x"), 0o644)
+		maybeRegisterRunbook(io_discard(), io_discard(), publishAdmitArgs{name: "demo", skillDir: dir}, "0.1.0")
+	})
+	// only one of the pair → skip (warn), no crash
+	t.Run("orphan-html", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "runbook.html"), []byte("<html>"), 0o644)
+		maybeRegisterRunbook(io_discard(), io_discard(), publishAdmitArgs{name: "demo", skillDir: dir}, "0.1.0")
+	})
+	// catalog returns 500 → warn, but the function returns normally (non-fatal)
+	t.Run("catalog-5xx-non-fatal", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+		t.Setenv("ER1_DEVICE_TOKEN", "test-token")
+		dir := skillDirWithRunbook(t)
+		// er1Endpoint passes through an http:// target verbatim.
+		maybeRegisterRunbook(io_discard(), io_discard(), publishAdmitArgs{name: "demo", skillDir: dir, er1Target: srv.URL}, "0.1.0")
+		// no assertion needed: a panic or os.Exit would fail the test; reaching here = non-fatal.
+	})
+}
+
+func skillDirWithRunbook(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("x"), 0o644)
+	os.WriteFile(filepath.Join(dir, "runbook.html"), []byte("<!doctype html>"), 0o644)
+	os.WriteFile(filepath.Join(dir, "runbook.meta.json"), []byte(`{"runbook_id":"rb-demo","title":"Demo"}`), 0o644)
+	return dir
+}
+
+func tarEntryNames(t *testing.T, skb string) map[string]bool {
+	t.Helper()
+	f, err := os.Open(skb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := tar.NewReader(gz)
+	names := map[string]bool{}
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			break
+		}
+		names[strings.TrimPrefix(hdr.Name, "./")] = true
+	}
+	return names
+}
+
+func io_discard() *os.File {
+	// /dev/null sink for stdout/stderr in tests that only check non-fatality.
+	f, _ := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	return f
+}


### PR DESCRIPTION
A skill ships `runbook.html` + `runbook.meta.json`; they ride in the **signed .skb** (pack WalkDir, free) and `skillctl publish` auto-registers them in the THOH catalog — **best-effort/non-fatal**, `--no-runbook-publish` to skip. Sidecar = descriptor; version from the skill. DRY: shared `postRunbookToCatalog()`. Tests T1/T2/T4/T5. SPEC-0275. 🤖 Generated with [Claude Code](https://claude.com/claude-code)