### PR TITLE
SPEC-0276 Round A — trustless offline verification + compliance pack (P0+P1)

### DIFF
--- a/cmd/skillctl/compliance_cmds.go
+++ b/cmd/skillctl/compliance_cmds.go
@@ -1,0 +1,295 @@
+package main
+
+// SPEC-0276 R5 — `skillctl compliance report --framework <eu-ai-act|nist-ai-rmf|soc2>`.
+//
+// An offline evidence pack: it enumerates installed skills and their trust
+// posture (governance level, author, offline-verifiable, provenance) from the
+// metadata we already keep, and maps our controls to the named framework. It is
+// an EVIDENCE AID for an auditor — NOT a certification (that is precisely the
+// overreach we flagged in the hosted-CA rival's "we built it"). Closes the one
+// productised asset that rival ships and we did not (R5).
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/install"
+)
+
+type complianceSkill struct {
+	Name              string `json:"name"`
+	Version           string `json:"version,omitempty"`
+	Governance        string `json:"governance"` // green|yellow|red|unknown
+	Author            string `json:"author,omitempty"`
+	OfflineVerifiable bool   `json:"offline_verifiable"`
+	HasProvenance     bool   `json:"has_provenance"`
+}
+
+type complianceControl struct {
+	Control     string `json:"control"`
+	Requirement string `json:"requirement"`
+	Evidence    string `json:"evidence"`
+}
+
+type complianceReport struct {
+	Framework  string              `json:"framework"`
+	SkillsDir  string              `json:"skills_dir"`
+	Summary    map[string]int      `json:"summary"`
+	Skills     []complianceSkill   `json:"skills"`
+	ControlMap []complianceControl `json:"control_map"`
+	Disclaimer string              `json:"disclaimer"`
+}
+
+const complianceDisclaimer = "Evidence aid for an auditor — NOT a certification or attestation of compliance. " +
+	"It summarises technical controls and maps them to the named framework; it does not assert conformance."
+
+// complianceFrameworks embeds a concise, real control→evidence map per
+// framework. The CISO owns the authoritative mapping (m3c-tools-maintenance/
+// CISO-WORK/compliance-maps/); this is the machine-collected projection.
+var complianceFrameworks = map[string][]complianceControl{
+	"eu-ai-act": {
+		{"Art. 12 — Record-keeping", "Automatic logging over the lifetime", "Per-invocation signed events (SPEC-0202) + admit/attest/revoke audit trail"},
+		{"Art. 13 — Transparency", "Information to deployers", "Declared intent + data-scope per skill (SPEC-0196); provenance edges"},
+		{"Art. 14 — Human oversight", "Enable human oversight", "Governance Ampel 🟢🟡🔴 + human checkpoints; reviewer≠author (SPEC-0246)"},
+		{"Art. 15 — Accuracy/robustness/security", "Resilience to tampering", "ed25519 signed bundles + content-binding; offline verify + revocation (SPEC-0276)"},
+	},
+	"nist-ai-rmf": {
+		{"GOVERN", "Policies, accountability, roles", "Trust-roots policy + skill:author RBAC; governance handbook"},
+		{"MAP", "Context + provenance of components", "derived_from provenance; pinned authorship; skill inventory"},
+		{"MEASURE", "Assess trustworthiness", "bodyscan behavioural inspection; the §7 verify chain; governance levels"},
+		{"MANAGE", "Respond, recover, revoke", "Signed revocation list enforced offline (SPEC-0276 R4.4)"},
+	},
+	"soc2": {
+		{"CC6.x — Logical access", "Restrict access to assets", "Pinned trust-roots; capability/data-scope declarations"},
+		{"CC7.x — System operations", "Detect & respond to anomalies", "Audit trail of admit/attest/revoke + invocation events"},
+		{"CC8.1 — Change management", "Authorize & track changes", "Signed bundles, reviewer≠author, version/digest pinning"},
+	},
+}
+
+func runCompliance(args []string, stdout, stderr io.Writer) int {
+	// Optional leading "report" verb (the only mode in v1).
+	if len(args) > 0 && args[0] == "report" {
+		args = args[1:]
+	}
+	fs := flag.NewFlagSet("compliance", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	framework := fs.String("framework", "", "Compliance framework: eu-ai-act | nist-ai-rmf | soc2 (required).")
+	format := fs.String("format", "md", "Output format: md | json.")
+	skillsDir := fs.String("skills-dir", "", "Skills directory to inventory (default: <home>/.claude/skills).")
+	homeOverride := fs.String("home", "", "Home dir override used to locate the skills directory.")
+	outPath := fs.String("out", "", "Write the report to this file instead of stdout.")
+	_ = fs.Bool("offline", true, "Offline mode (default and only mode in v1).")
+
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl compliance report --framework <eu-ai-act|nist-ai-rmf|soc2> [--format md|json] [--out file]")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "Offline evidence aid (SPEC-0276 R5). NOT a certification.")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	controls, ok := complianceFrameworks[strings.ToLower(strings.TrimSpace(*framework))]
+	if !ok {
+		fmt.Fprintf(stderr, "compliance: unknown --framework %q (want eu-ai-act | nist-ai-rmf | soc2)\n", *framework)
+		return exitUsage
+	}
+	if *format != "md" && *format != "json" {
+		fmt.Fprintf(stderr, "compliance: unknown --format %q (want md | json)\n", *format)
+		return exitUsage
+	}
+
+	dir := *skillsDir
+	if dir == "" {
+		home := *homeOverride
+		if home == "" {
+			h, err := os.UserHomeDir()
+			if err != nil {
+				fmt.Fprintf(stderr, "compliance: resolve home: %v\n", err)
+				return exitGeneric
+			}
+			home = h
+		}
+		dir = filepath.Join(home, ".claude", "skills")
+	}
+
+	skills, err := collectComplianceSkills(dir)
+	if err != nil {
+		fmt.Fprintf(stderr, "compliance: inventory %s: %v\n", dir, err)
+		return exitGeneric
+	}
+
+	rep := complianceReport{
+		Framework:  strings.ToLower(strings.TrimSpace(*framework)),
+		SkillsDir:  dir,
+		Summary:    summarizeCompliance(skills),
+		Skills:     skills,
+		ControlMap: controls,
+		Disclaimer: complianceDisclaimer,
+	}
+
+	var rendered string
+	if *format == "json" {
+		b, _ := json.MarshalIndent(rep, "", "  ")
+		rendered = string(b) + "\n"
+	} else {
+		rendered = renderComplianceMD(rep)
+	}
+
+	if *outPath != "" {
+		if err := os.WriteFile(*outPath, []byte(rendered), 0o644); err != nil {
+			fmt.Fprintf(stderr, "compliance: write %s: %v\n", *outPath, err)
+			return exitGeneric
+		}
+		fmt.Fprintf(stdout, "wrote %s (%d skills, framework %s)\n", *outPath, len(skills), rep.Framework)
+		return exitOK
+	}
+	fmt.Fprint(stdout, rendered)
+	return exitOK
+}
+
+// collectComplianceSkills inventories <skillsDir>/*/ and reads each skill's
+// trust metadata best-effort. A directory without SKILL.md is skipped.
+func collectComplianceSkills(skillsDir string) ([]complianceSkill, error) {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return nil, err
+	}
+	var out []complianceSkill
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		d := filepath.Join(skillsDir, e.Name())
+		if _, err := os.Stat(filepath.Join(d, "SKILL.md")); err != nil {
+			continue
+		}
+		cs := complianceSkill{Name: e.Name(), Governance: "unknown"}
+
+		if om := readOfflineMetaForCompliance(d); om != nil && om.BundleMeta != nil {
+			cs.OfflineVerifiable = true
+			if g := strings.TrimSpace(om.BundleMeta.CurrentGovernance); g != "" {
+				cs.Governance = g
+			}
+			if v, ok := om.BundleMeta.Bundle["version"].(string); ok {
+				cs.Version = v
+			}
+			cs.Author = authorIDOf(om.BundleMeta)
+		}
+		if prov := readProvenanceForCompliance(d); prov != nil {
+			cs.HasProvenance = true
+			if cs.Governance == "unknown" {
+				if g, _ := prov["governance_level"].(string); g != "" {
+					cs.Governance = g
+				}
+			}
+			if cs.Version == "" {
+				if v, _ := prov["version"].(string); v != "" {
+					cs.Version = v
+				}
+			}
+			if cs.Author == "" {
+				if a, _ := prov["author"].(string); a != "" {
+					cs.Author = a
+				}
+			}
+		}
+		out = append(out, cs)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func readOfflineMetaForCompliance(dir string) *install.OfflineMeta {
+	b, err := os.ReadFile(filepath.Join(dir, ".skillctl-offline.json"))
+	if err != nil {
+		return nil
+	}
+	var om install.OfflineMeta
+	if err := json.Unmarshal(b, &om); err != nil {
+		return nil
+	}
+	return &om
+}
+
+func readProvenanceForCompliance(dir string) map[string]any {
+	b, err := os.ReadFile(filepath.Join(dir, ".m3c-provenance.json"))
+	if err != nil {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+func summarizeCompliance(skills []complianceSkill) map[string]int {
+	s := map[string]int{"total": len(skills), "green": 0, "yellow": 0, "red": 0, "unknown": 0, "offline_verifiable": 0, "with_provenance": 0}
+	for _, sk := range skills {
+		switch sk.Governance {
+		case "green", "yellow", "red":
+			s[sk.Governance]++
+		default:
+			s["unknown"]++
+		}
+		if sk.OfflineVerifiable {
+			s["offline_verifiable"]++
+		}
+		if sk.HasProvenance {
+			s["with_provenance"]++
+		}
+	}
+	return s
+}
+
+func renderComplianceMD(r complianceReport) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Compliance evidence — %s\n\n", strings.ToUpper(r.Framework))
+	fmt.Fprintf(&b, "> %s\n\n", r.Disclaimer)
+	fmt.Fprintf(&b, "Skills directory: `%s`\n\n", r.SkillsDir)
+
+	b.WriteString("## Posture summary\n\n")
+	fmt.Fprintf(&b, "- Total skills: %d\n", r.Summary["total"])
+	fmt.Fprintf(&b, "- Governance: %d green · %d yellow · %d red · %d unknown\n", r.Summary["green"], r.Summary["yellow"], r.Summary["red"], r.Summary["unknown"])
+	fmt.Fprintf(&b, "- Offline-verifiable (stashed metadata): %d\n", r.Summary["offline_verifiable"])
+	fmt.Fprintf(&b, "- With provenance: %d\n\n", r.Summary["with_provenance"])
+
+	b.WriteString("## Inventory\n\n")
+	b.WriteString("| Skill | Version | Governance | Author | Offline | Provenance |\n")
+	b.WriteString("|---|---|---|---|:-:|:-:|\n")
+	for _, s := range r.Skills {
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s |\n",
+			s.Name, dash(s.Version), s.Governance, dash(s.Author), yn(s.OfflineVerifiable), yn(s.HasProvenance))
+	}
+	if len(r.Skills) == 0 {
+		b.WriteString("| _(no skills found)_ | | | | | |\n")
+	}
+	b.WriteString("\n## Control map\n\n")
+	b.WriteString("| Control | Requirement | Evidence in this system |\n|---|---|---|\n")
+	for _, c := range r.ControlMap {
+		fmt.Fprintf(&b, "| %s | %s | %s |\n", c.Control, c.Requirement, c.Evidence)
+	}
+	b.WriteString("\n---\nGenerated by `skillctl compliance report` (SPEC-0276 R5).\n")
+	return b.String()
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+func yn(b bool) string {
+	if b {
+		return "✓"
+	}
+	return "—"
+}

--- a/cmd/skillctl/compliance_test.go
+++ b/cmd/skillctl/compliance_test.go
@@ -1,0 +1,114 @@
+package main
+
+// SPEC-0276 R5 — tests for `skillctl compliance report`.
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/install"
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+)
+
+// makeSkillDir creates <root>/<name>/ with a SKILL.md and, if govern != "", a
+// .skillctl-offline.json carrying a BundleMeta at that governance level.
+func makeSkillDir(t *testing.T, root, name, version, govern, author string) {
+	t.Helper()
+	d := filepath.Join(root, name)
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "SKILL.md"), []byte("# "+name+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if govern == "" {
+		return
+	}
+	om := install.OfflineMeta{
+		BundleMeta: &registry.BundleMeta{
+			Bundle:            map[string]any{"name": name, "version": version, "status": "admitted"},
+			Signatures:        []registry.SignatureRow{{Role: "author", IdentityID: author, Status: "active"}},
+			CurrentGovernance: govern,
+		},
+		Identities: map[string]*registry.Identity{},
+		StashedAt:  "2026-06-22T10:00:00Z",
+	}
+	b, _ := json.MarshalIndent(om, "", "  ")
+	if err := os.WriteFile(filepath.Join(d, ".skillctl-offline.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCompliance_JSONReport(t *testing.T) {
+	root := t.TempDir()
+	makeSkillDir(t, root, "alpha", "1.0.0", "green", "id:kamir@m3c")
+	makeSkillDir(t, root, "beta", "", "", "") // present but unverified
+
+	var out, errBuf bytes.Buffer
+	code := runCompliance([]string{"report", "--framework", "nist-ai-rmf", "--skills-dir", root, "--format", "json"}, &out, &errBuf)
+	if code != exitOK {
+		t.Fatalf("want 0, got %d; stderr=%s", code, errBuf.String())
+	}
+	var rep complianceReport
+	if err := json.Unmarshal(out.Bytes(), &rep); err != nil {
+		t.Fatalf("json: %v\n%s", err, out.String())
+	}
+	if rep.Framework != "nist-ai-rmf" {
+		t.Errorf("framework=%s", rep.Framework)
+	}
+	if rep.Summary["total"] != 2 || rep.Summary["green"] != 1 || rep.Summary["unknown"] != 1 || rep.Summary["offline_verifiable"] != 1 {
+		t.Errorf("summary wrong: %+v", rep.Summary)
+	}
+	if len(rep.ControlMap) == 0 {
+		t.Error("control map should not be empty")
+	}
+	// alpha sorts first; should be green + offline-verifiable + author present.
+	a := rep.Skills[0]
+	if a.Name != "alpha" || a.Governance != "green" || !a.OfflineVerifiable || a.Author != "id:kamir@m3c" {
+		t.Errorf("alpha row wrong: %+v", a)
+	}
+}
+
+func TestCompliance_MDHasDisclaimerAndControls(t *testing.T) {
+	root := t.TempDir()
+	makeSkillDir(t, root, "alpha", "1.0.0", "green", "id:kamir@m3c")
+
+	var out, errBuf bytes.Buffer
+	code := runCompliance([]string{"report", "--framework", "eu-ai-act", "--skills-dir", root}, &out, &errBuf)
+	if code != exitOK {
+		t.Fatalf("want 0, got %d", code)
+	}
+	s := out.String()
+	if !bytes.Contains(out.Bytes(), []byte("NOT a certification")) {
+		t.Errorf("missing disclaimer; got:\n%s", s)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("Art. 12")) {
+		t.Errorf("missing EU AI Act control rows; got:\n%s", s)
+	}
+}
+
+func TestCompliance_UnknownFramework(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runCompliance([]string{"report", "--framework", "iso-9001", "--skills-dir", t.TempDir()}, &out, &errBuf)
+	if code != exitUsage {
+		t.Fatalf("want exitUsage, got %d", code)
+	}
+}
+
+func TestCompliance_EmptyDir(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runCompliance([]string{"report", "--framework", "soc2", "--skills-dir", t.TempDir(), "--format", "json"}, &out, &errBuf)
+	if code != exitOK {
+		t.Fatalf("want 0, got %d", code)
+	}
+	var rep complianceReport
+	if err := json.Unmarshal(out.Bytes(), &rep); err != nil {
+		t.Fatal(err)
+	}
+	if rep.Summary["total"] != 0 {
+		t.Errorf("expected 0 skills, got %d", rep.Summary["total"])
+	}
+}

--- a/cmd/skillctl/export_kit_cmds.go
+++ b/cmd/skillctl/export_kit_cmds.go
@@ -315,7 +315,17 @@ var secretPatterns = []string{
 	"er1_api_key",
 	"device_token_secret",
 	"authorization: bearer",
-	"sk_live_", "sk_test_", "ghp_", "xoxb-", "aws_secret_access_key",
+	// Provider token prefixes (widened per the SPEC-0276 red-team review — modern
+	// 2025/26 formats the original list missed). Lower-cased substring match. We
+	// deliberately include ONLY patterns containing '-' or '_' (which StdEncoding
+	// base64 never produces) so they cannot false-positive on the kit's own base64
+	// pubkeys/signatures; bare-alnum prefixes (AKIA…, AIza…) are intentionally
+	// omitted to avoid collisions — their secret *values* carry distinct markers.
+	"sk_live_", "sk_test_", "sk-proj-", "sk-ant-",
+	"ghp_", "gho_", "ghs_", "github_pat_", "glpat-",
+	"xoxb-", "xoxp-", "xapp-",
+	"aws_secret_access_key",
+	"npm_", "hf_", "dop_v1_",
 }
 
 // scrubSecrets refuses a kit file whose bytes contain an obvious secret. The

--- a/cmd/skillctl/export_kit_cmds.go
+++ b/cmd/skillctl/export_kit_cmds.go
@@ -1,0 +1,371 @@
+package main
+
+// SPEC-0276 R4.3 — `skillctl export-verification-kit`.
+//
+// Packages a signed bundle into a portable, self-contained directory (and
+// optional .zip) that a third party can verify OFFLINE with no access to our
+// servers and no trust in us beyond a public key they confirm out-of-band:
+//
+//	kit/
+//	  <name>@<ver>.skb            the signed bundle blob
+//	  <name>@<ver>.skbmeta.json   BundleMeta envelope (author+registry+governance sigs)
+//	  trust-roots.pinned.yaml     ONLY the pinned author + registry pubkeys needed
+//	  revocations.json            signed revocation snapshot (optional)
+//	  VERIFY.md                   one-command instructions + expected verdict + fingerprint
+//	  verify.sh                   `skillctl verify --bundle … --trust-roots ./trust-roots.pinned.yaml`
+//
+// The export SELF-VALIDATES (runs the offline verify before writing) so we never
+// ship a broken kit, and runs a hard secret-scrub over every generated text file
+// so the kit is safe to email/publish.
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// runExportKit implements `skillctl export-verification-kit [flags]`.
+func runExportKit(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("export-verification-kit", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	bundlePath := fs.String("bundle", "", "Path to the signed .skb bundle to package (required).")
+	metaPath := fs.String("meta", "", "Path to the BundleMeta envelope JSON (default: the .skbmeta.json sidecar next to the .skb).")
+	trustRootsPath := fs.String("trust-roots", "", "Trust-roots YAML to source pinned keys from (default: ~/.claude/skill-trust-roots.yaml). Must be pinned mode.")
+	revocationsPath := fs.String("revocations", "", "Optional signed revocation list to include in the kit (validated against the pinned registry key before inclusion).")
+	registryURL := fs.String("registry", "", "Registry URL to disambiguate when trust-roots pins multiple registries.")
+	outDir := fs.String("out", "", "Output directory for the kit (required).")
+	makeZip := fs.Bool("zip", false, "Also produce <out>.zip.")
+
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl export-verification-kit --bundle <file.skb> --out <dir> [flags]")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "Builds a portable, offline, trust-nothing verification kit (SPEC-0276 R4.3).")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *bundlePath == "" || *outDir == "" {
+		fs.Usage()
+		return exitUsage
+	}
+	if st, err := os.Stat(*bundlePath); err != nil || st.IsDir() {
+		fmt.Fprintf(stderr, "export-verification-kit: cannot read bundle %s\n", *bundlePath)
+		return exitUsage
+	}
+
+	// Load the BundleMeta envelope (reuses the --bundle sidecar resolution).
+	mp := *metaPath
+	if mp == "" {
+		mp = defaultMetaSidecar(*bundlePath)
+	}
+	meta, err := loadBundleMetaSidecar(mp)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+
+	// Resolve the source trust-roots and pick the matching root. Must be pinned
+	// so the emitted kit is verifiable with no registry.
+	_, root, err := loadAndPickRootFromPath(*trustRootsPath, *registryURL)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	if root.IdentityKeysAuthorized != "pinned" {
+		fmt.Fprintf(stderr, "export-verification-kit: trust root %s must be identity_keys_authorized: pinned so the kit verifies offline (see SPEC-0276 R4.1).\n", root.RegistryURL)
+		return exitGeneric
+	}
+
+	// Identify the bundle's author and its pinned key.
+	authorID := authorIDOf(meta)
+	if authorID == "" {
+		fmt.Fprintln(stderr, "export-verification-kit: bundle has no author signature row; cannot build a kit.")
+		return exitGeneric
+	}
+	authorKey := root.FindAuthor(authorID)
+	if authorKey == nil {
+		fmt.Fprintf(stderr, "export-verification-kit: author %s is not pinned in trust root %s; pin it first.\n", authorID, root.RegistryURL)
+		return exitGeneric
+	}
+
+	// Self-validate: run the offline verify BEFORE writing anything, so we never
+	// emit a kit that doesn't verify.
+	res, verr := verify.Verify(verify.VerifyOpts{
+		BundlePath:      *bundlePath,
+		BundleMeta:      meta,
+		TrustRoot:       root,
+		IdentityFetcher: nil,
+		Ctx:             context.Background(),
+	})
+	if verr != nil {
+		fmt.Fprintf(stderr, "export-verification-kit: refusing to package a bundle that does not verify: %v\n", verr)
+		return verify.ExitCode(verr)
+	}
+
+	// If a revocation list is supplied, validate it (and that it does NOT already
+	// revoke this very bundle) before including it.
+	if *revocationsPath != "" {
+		revoked, rerr := checkBundleRevoked(*revocationsPath, root, res.Digest)
+		if rerr != nil {
+			fmt.Fprintf(stderr, "export-verification-kit: revocation list rejected: %v\n", rerr)
+			return verify.ExitCode(rerr)
+		}
+		if revoked {
+			fmt.Fprintf(stderr, "export-verification-kit: this bundle (%s) is already revoked by the supplied list; not packaging.\n", res.Digest)
+			return exitBundleRevoked
+		}
+	}
+
+	// Build the kit in a temp staging dir, scrub, then move into place — so a
+	// scrub failure never leaves a half-written kit.
+	if err := os.MkdirAll(*outDir, 0o755); err != nil {
+		fmt.Fprintf(stderr, "export-verification-kit: mkdir %s: %v\n", *outDir, err)
+		return exitGeneric
+	}
+
+	skbName := filepath.Base(*bundlePath)
+	metaName := filepath.Base(defaultMetaSidecar(skbName))
+	hasRevocations := *revocationsPath != ""
+
+	files := map[string][]byte{}
+
+	// .skb blob — copied verbatim; NOT scrubbed (it is the signed artifact, its
+	// integrity is cryptographically bound; an env-var NAME documented in a
+	// SKILL.md is not a secret leak).
+	skbBytes, err := os.ReadFile(*bundlePath)
+	if err != nil {
+		fmt.Fprintf(stderr, "export-verification-kit: read bundle: %v\n", err)
+		return exitGeneric
+	}
+
+	metaBytes, err := os.ReadFile(mp)
+	if err != nil {
+		fmt.Fprintf(stderr, "export-verification-kit: read meta: %v\n", err)
+		return exitGeneric
+	}
+	files[metaName] = metaBytes
+
+	trYAML, err := minimalPinnedTrustRootsYAML(root, authorID)
+	if err != nil {
+		fmt.Fprintf(stderr, "export-verification-kit: build trust-roots: %v\n", err)
+		return exitGeneric
+	}
+	files["trust-roots.pinned.yaml"] = trYAML
+
+	if hasRevocations {
+		revBytes, err := os.ReadFile(*revocationsPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "export-verification-kit: read revocations: %v\n", err)
+			return exitGeneric
+		}
+		files["revocations.json"] = revBytes
+	}
+
+	authorFP := pubkeyFingerprint(ed25519.PublicKey(authorKey.Pubkey))
+	files["VERIFY.md"] = []byte(renderVerifyMD(res, skbName, authorID, authorFP, hasRevocations))
+	verifyScript := renderVerifyScript(skbName, hasRevocations)
+	files["verify.sh"] = []byte(verifyScript)
+
+	// Hard secret-scrub over every generated text file.
+	for name, data := range files {
+		if err := scrubSecrets(name, data); err != nil {
+			fmt.Fprintf(stderr, "export-verification-kit: refusing to emit — %v\n", err)
+			return exitGeneric
+		}
+	}
+
+	// Write everything.
+	if err := os.WriteFile(filepath.Join(*outDir, skbName), skbBytes, 0o644); err != nil {
+		fmt.Fprintf(stderr, "export-verification-kit: write skb: %v\n", err)
+		return exitGeneric
+	}
+	for name, data := range files {
+		mode := os.FileMode(0o644)
+		if name == "verify.sh" {
+			mode = 0o755
+		}
+		if err := os.WriteFile(filepath.Join(*outDir, name), data, mode); err != nil {
+			fmt.Fprintf(stderr, "export-verification-kit: write %s: %v\n", name, err)
+			return exitGeneric
+		}
+	}
+
+	if *makeZip {
+		zipPath := strings.TrimRight(*outDir, "/") + ".zip"
+		if err := zipDir(*outDir, zipPath); err != nil {
+			fmt.Fprintf(stderr, "export-verification-kit: zip: %v\n", err)
+			return exitGeneric
+		}
+		fmt.Fprintf(stdout, "kit: %s\nzip: %s\n", *outDir, zipPath)
+	} else {
+		fmt.Fprintf(stdout, "kit: %s\n", *outDir)
+	}
+	fmt.Fprintf(stdout, "verify with: (cd %s && bash verify.sh)  → expect: %s\n", *outDir, res.ChainSummary)
+	return exitOK
+}
+
+// authorIDOf returns the author identity_id from a BundleMeta, or "".
+func authorIDOf(meta *registry.BundleMeta) string {
+	for _, s := range meta.Signatures {
+		if s.Role == "author" && s.Status != "revoked" && s.IdentityID != "" {
+			return s.IdentityID
+		}
+	}
+	return ""
+}
+
+// minimalPinnedTrustRootsYAML builds a trust-roots YAML containing ONLY the
+// matched registry's active keys and the single pinned author the bundle
+// references — the least the kit needs to verify, and no more. Reuses
+// verify.TrustRoots.Save so the YAML shape stays canonical.
+func minimalPinnedTrustRootsYAML(root *verify.TrustRoot, authorID string) ([]byte, error) {
+	ak := root.FindAuthor(authorID)
+	if ak == nil {
+		return nil, fmt.Errorf("author %s not pinned", authorID)
+	}
+	min := verify.TrustRoots{
+		Roots: []verify.TrustRoot{{
+			RegistryURL:            root.RegistryURL,
+			RegistryKeys:           root.ActiveKeys(),
+			IdentityKeysAuthorized: "pinned",
+			Authors:                []verify.AuthorKey{*ak},
+			GovernanceMinimum:      root.GovernanceMinimum,
+		}},
+	}
+	// Marshal by Save-ing to a temp file (Save validates + emits canonical YAML),
+	// then read it back. Keeps one source of truth for the on-disk format.
+	tmp, err := os.CreateTemp("", "trust-roots-*.yaml")
+	if err != nil {
+		return nil, err
+	}
+	tmpPath := tmp.Name()
+	_ = tmp.Close()
+	defer os.Remove(tmpPath)
+	min.Path = tmpPath
+	if err := min.Save(); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(tmpPath)
+}
+
+// renderVerifyMD produces the human VERIFY.md. It states the expected digest +
+// chain summary (so the verifier compares against a known-good string) and
+// instructs them to confirm the author fingerprint OUT-OF-BAND — the kit proves
+// integrity; the out-of-band fingerprint proves identity.
+func renderVerifyMD(res *verify.VerifyResult, skbName, authorID, authorFP string, hasRevocations bool) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Verification kit — %s\n\n", skbName)
+	b.WriteString("This kit lets ANYONE verify this skill bundle **offline** — no network, and no\n")
+	b.WriteString("trust in the publisher beyond a public key you confirm out-of-band.\n\n")
+	b.WriteString("## One command\n\n```\nbash verify.sh\n```\n\n")
+	fmt.Fprintf(&b, "Expected: exit code 0 and the line:\n\n    %s\n\n", res.ChainSummary)
+	b.WriteString("## What it proves\n\n")
+	fmt.Fprintf(&b, "- The bundle bytes match the signed digest: `%s`\n", res.Digest)
+	fmt.Fprintf(&b, "- The author signature is valid for identity: `%s`\n", authorID)
+	fmt.Fprintf(&b, "- A pinned registry key admitted it; governance level: `%s`\n\n", res.GovernanceLevel)
+	b.WriteString("## Confirm identity out-of-band (important)\n\n")
+	b.WriteString("The kit proves INTEGRITY. To also trust IDENTITY, confirm the author key\n")
+	b.WriteString("fingerprint below through a SEPARATE channel (a call, Signal, a known web\n")
+	b.WriteString("page) — NOT from this kit:\n\n")
+	fmt.Fprintf(&b, "    author %s fingerprint: %s\n\n", authorID, authorFP)
+	b.WriteString("If that fingerprint matches AND verify.sh exits 0, the bundle is authentic and unmodified.\n")
+	if hasRevocations {
+		b.WriteString("\n## Revocation\n\nThis kit includes a signed `revocations.json`; verify.sh enforces it offline.\n")
+		b.WriteString("A revoked bundle exits 17; a forged/untrusted revocation list exits 12.\n")
+	}
+	b.WriteString("\n---\nGenerated by `skillctl export-verification-kit` (SPEC-0276).\n")
+	return b.String()
+}
+
+// renderVerifyScript writes a POSIX verify.sh that resolves paths relative to
+// itself so the kit is location-independent.
+func renderVerifyScript(skbName string, hasRevocations bool) string {
+	var b strings.Builder
+	b.WriteString("#!/usr/bin/env sh\n")
+	b.WriteString("# Trustless offline verification — no network; trust only the pinned key.\n")
+	b.WriteString("set -eu\n")
+	b.WriteString("DIR=\"$(cd \"$(dirname \"$0\")\" && pwd)\"\n")
+	fmt.Fprintf(&b, "skillctl verify --bundle \"$DIR/%s\" --trust-roots \"$DIR/trust-roots.pinned.yaml\"", skbName)
+	if hasRevocations {
+		b.WriteString(" --revocations \"$DIR/revocations.json\"")
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// secretPatterns is a conservative, low-false-positive set. Substring matches
+// are case-insensitive; the goal is to catch a private key or live token that a
+// generated kit file should never contain.
+var secretPatterns = []string{
+	"-----begin", // any PEM key block
+	"private key",
+	"x-api-key",
+	"er1_api_key",
+	"device_token_secret",
+	"authorization: bearer",
+	"sk_live_", "sk_test_", "ghp_", "xoxb-", "aws_secret_access_key",
+}
+
+// scrubSecrets refuses a kit file whose bytes contain an obvious secret. The
+// .skb blob is exempt (see runExportKit) — this scans only the text artifacts
+// the kit GENERATES, which must be safe to email/publish (SPEC-0276 R4.3.2).
+func scrubSecrets(name string, data []byte) error {
+	lower := bytes.ToLower(data)
+	for _, pat := range secretPatterns {
+		if bytes.Contains(lower, []byte(pat)) {
+			return fmt.Errorf("secret-scrub: %s appears to contain a secret (matched %q); refusing to package", name, pat)
+		}
+	}
+	return nil
+}
+
+// zipDir writes every file in dir to zipPath, preserving verify.sh's exec bit.
+func zipDir(dir, zipPath string) error {
+	zf, err := os.Create(zipPath)
+	if err != nil {
+		return err
+	}
+	defer zf.Close()
+	zw := zip.NewWriter(zf)
+	defer zw.Close()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return err
+		}
+		hdr := &zip.FileHeader{Name: e.Name(), Method: zip.Deflate}
+		if e.Name() == "verify.sh" {
+			hdr.SetMode(0o755)
+		} else {
+			hdr.SetMode(0o644)
+		}
+		w, err := zw.CreateHeader(hdr)
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write(data); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/skillctl/export_kit_test.go
+++ b/cmd/skillctl/export_kit_test.go
@@ -85,7 +85,7 @@ func TestExportKit_WithRevocations(t *testing.T) {
 	// A valid list (signed by the pinned reg key) that does NOT revoke this
 	// bundle — should be included, and the kit still verifies.
 	other := sha256.Sum256([]byte("unrelated"))
-	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z",
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", 1,
 		[]string{"sha256:" + hex.EncodeToString(other[:])}, f.regPriv)
 	if err != nil {
 		t.Fatal(err)
@@ -117,7 +117,7 @@ func TestExportKit_RefusesAlreadyRevokedBundle(t *testing.T) {
 	f := buildBundleFixture(t)
 	// A list that DOES revoke this bundle → export refuses (don't ship a kit for
 	// a dead bundle).
-	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", []string{f.digest}, f.regPriv)
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", 1, []string{f.digest}, f.regPriv)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/skillctl/export_kit_test.go
+++ b/cmd/skillctl/export_kit_test.go
@@ -1,0 +1,162 @@
+package main
+
+// SPEC-0276 R4.3 — end-to-end tests for `skillctl export-verification-kit`.
+// The decisive test (TestExportKit_BuildsAndReverifies) proves the round trip:
+// export a kit, then verify it with ONLY the kit's own files — the trustless
+// third-party path, demonstrated.
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+func TestExportKit_BuildsAndReverifies(t *testing.T) {
+	f := buildBundleFixture(t)
+	kit := filepath.Join(t.TempDir(), "kit")
+
+	var out, errBuf bytes.Buffer
+	code := runExportKit([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath, "--out", kit}, &out, &errBuf)
+	if code != exitOK {
+		t.Fatalf("export want 0, got %d; stderr=%s", code, errBuf.String())
+	}
+
+	for _, want := range []string{"demo@1.0.0.skb", "demo@1.0.0.skbmeta.json", "trust-roots.pinned.yaml", "VERIFY.md", "verify.sh"} {
+		if _, err := os.Stat(filepath.Join(kit, want)); err != nil {
+			t.Errorf("kit missing %s", want)
+		}
+	}
+
+	// The decisive check: verify using ONLY the kit's files (no original paths).
+	var vout, verr bytes.Buffer
+	vc := runVerify([]string{
+		"--bundle", filepath.Join(kit, "demo@1.0.0.skb"),
+		"--trust-roots", filepath.Join(kit, "trust-roots.pinned.yaml"),
+	}, &vout, &verr)
+	if vc != exitOK {
+		t.Fatalf("re-verify from kit want 0, got %d; stderr=%s", vc, verr.String())
+	}
+
+	// VERIFY.md must carry the expected digest and an out-of-band fingerprint.
+	md, _ := os.ReadFile(filepath.Join(kit, "VERIFY.md"))
+	if !bytes.Contains(md, []byte(f.digest)) || !bytes.Contains(md, []byte("fingerprint:")) {
+		t.Errorf("VERIFY.md missing digest or fingerprint:\n%s", md)
+	}
+}
+
+func TestExportKit_SecretScrubRefuses(t *testing.T) {
+	f := buildBundleFixture(t)
+	// Inject a secret into a benign extra field of the sidecar: json.Unmarshal
+	// ignores it (so verify still passes) but its raw bytes trip the scrub.
+	raw, _ := os.ReadFile(f.metaPath)
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	m["note"] = "-----BEGIN PRIVATE KEY-----\nMIIBVgIBADANBg...\n-----END PRIVATE KEY-----"
+	patched, _ := json.MarshalIndent(m, "", "  ")
+	if err := os.WriteFile(f.metaPath, patched, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	kit := filepath.Join(t.TempDir(), "kit")
+	var out, errBuf bytes.Buffer
+	code := runExportKit([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath, "--out", kit}, &out, &errBuf)
+	if code != exitGeneric {
+		t.Fatalf("want exitGeneric on secret, got %d", code)
+	}
+	if !bytes.Contains(errBuf.Bytes(), []byte("secret-scrub")) {
+		t.Errorf("expected secret-scrub message; stderr=%s", errBuf.String())
+	}
+	// Nothing should have been written (scrub runs before any file write).
+	if _, err := os.Stat(filepath.Join(kit, "demo@1.0.0.skb")); err == nil {
+		t.Error("kit .skb should NOT have been written after scrub failure")
+	}
+}
+
+func TestExportKit_WithRevocations(t *testing.T) {
+	f := buildBundleFixture(t)
+	// A valid list (signed by the pinned reg key) that does NOT revoke this
+	// bundle — should be included, and the kit still verifies.
+	other := sha256.Sum256([]byte("unrelated"))
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z",
+		[]string{"sha256:" + hex.EncodeToString(other[:])}, f.regPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revPath := writeRevocations(t, f.dir, list)
+
+	kit := filepath.Join(t.TempDir(), "kit")
+	var out, errBuf bytes.Buffer
+	code := runExportKit([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath, "--revocations", revPath, "--out", kit}, &out, &errBuf)
+	if code != exitOK {
+		t.Fatalf("export with revocations want 0, got %d; stderr=%s", code, errBuf.String())
+	}
+	if _, err := os.Stat(filepath.Join(kit, "revocations.json")); err != nil {
+		t.Errorf("kit missing revocations.json")
+	}
+	// Re-verify from the kit WITH the revocation list → still 0.
+	var vout, verr bytes.Buffer
+	vc := runVerify([]string{
+		"--bundle", filepath.Join(kit, "demo@1.0.0.skb"),
+		"--trust-roots", filepath.Join(kit, "trust-roots.pinned.yaml"),
+		"--revocations", filepath.Join(kit, "revocations.json"),
+	}, &vout, &verr)
+	if vc != exitOK {
+		t.Fatalf("re-verify with revocations want 0, got %d; stderr=%s", vc, verr.String())
+	}
+}
+
+func TestExportKit_RefusesAlreadyRevokedBundle(t *testing.T) {
+	f := buildBundleFixture(t)
+	// A list that DOES revoke this bundle → export refuses (don't ship a kit for
+	// a dead bundle).
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", []string{f.digest}, f.regPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revPath := writeRevocations(t, f.dir, list)
+
+	kit := filepath.Join(t.TempDir(), "kit")
+	var out, errBuf bytes.Buffer
+	code := runExportKit([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath, "--revocations", revPath, "--out", kit}, &out, &errBuf)
+	if code != exitBundleRevoked {
+		t.Fatalf("want exit 17 for already-revoked bundle, got %d", code)
+	}
+}
+
+func TestExportKit_RefusesBrokenBundle(t *testing.T) {
+	f := buildBundleFixture(t)
+	// Tamper the .skb after the meta was signed → self-validate fails → no kit.
+	skb, _ := os.ReadFile(f.skbPath)
+	_ = os.WriteFile(f.skbPath, append(skb, 'Z'), 0o644)
+
+	kit := filepath.Join(t.TempDir(), "kit")
+	var out, errBuf bytes.Buffer
+	code := runExportKit([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath, "--out", kit}, &out, &errBuf)
+	if code != 10 {
+		t.Fatalf("want exit 10 (broken bundle), got %d; stderr=%s", code, errBuf.String())
+	}
+}
+
+func TestExportKit_ZipProduced(t *testing.T) {
+	f := buildBundleFixture(t)
+	kit := filepath.Join(t.TempDir(), "kit")
+	var out, errBuf bytes.Buffer
+	code := runExportKit([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath, "--out", kit, "--zip"}, &out, &errBuf)
+	if code != exitOK {
+		t.Fatalf("want 0, got %d; stderr=%s", code, errBuf.String())
+	}
+	if _, err := os.Stat(kit + ".zip"); err != nil {
+		t.Errorf("expected %s.zip", kit)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("zip:")) {
+		t.Errorf("stdout should mention the zip; got %s", out.String())
+	}
+}

--- a/cmd/skillctl/install_cmds.go
+++ b/cmd/skillctl/install_cmds.go
@@ -174,13 +174,22 @@ func runVerify(args []string, stdout, stderr io.Writer) int {
 	verboseFlag := fs.Bool("verbose", false, "Print structured per-step log lines to stderr.")
 	homeOverride := fs.String("home", "", "Override the install root.")
 	offline := fs.Bool("offline", false, "Network-free verify: use the stashed metadata + bind the extracted on-disk content to the signed .skb. No registry calls (revocations posted after install are not seen).")
+	bundlePath := fs.String("bundle", "", "Verify a standalone .skb FILE (not an installed skill), fully offline against pinned trust-roots (SPEC-0276 R4.2). Requires a sidecar <file>.skbmeta.json (or --meta).")
+	metaPath := fs.String("meta", "", "Path to the BundleMeta envelope JSON for --bundle (default: the .skbmeta.json sidecar next to the .skb).")
+	trustRootsPath := fs.String("trust-roots", "", "Path to a trust-roots YAML to use instead of the default (~/.claude/skill-trust-roots.yaml). Pair with --bundle for a portable verification kit.")
+	jsonOut := fs.Bool("json", false, "Emit the verification result as JSON (--bundle mode).")
 
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "Usage: skillctl verify <name> [flags]   (or: skillctl verify --all [--quarantine])")
+		fmt.Fprintln(stderr, "Usage: skillctl verify <name> [flags]")
+		fmt.Fprintln(stderr, "   or: skillctl verify --all [--quarantine]")
+		fmt.Fprintln(stderr, "   or: skillctl verify --bundle <file.skb> [--trust-roots <file>] [--json]")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Re-runs the SPEC-0188 §7 trust-chain check against an already-installed")
 		fmt.Fprintln(stderr, "skill (~/.claude/skills/<name>/). Useful for catching post-install registry")
 		fmt.Fprintln(stderr, "revocations or trust-root rotations. --offline skips the registry.")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "--bundle verifies a standalone .skb FILE with NO install state and NO network,")
+		fmt.Fprintln(stderr, "against locally pinned trust-roots — the trustless third-party path.")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Exit codes are the same as `install` (see SPEC-0188 §11).")
 		fs.PrintDefaults()
@@ -189,6 +198,28 @@ func runVerify(args []string, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
 	}
+
+	// --bundle: standalone, fully-offline verification of a .skb FILE against
+	// pinned trust-roots (SPEC-0276 R4.2). No install state, no network — the
+	// path a third party runs to reproduce our verdict without trusting us.
+	if *bundlePath != "" {
+		if fs.NArg() != 0 {
+			fmt.Fprintln(stderr, "skillctl verify --bundle <file.skb>: do not also pass a <name> positional arg.")
+			return exitUsage
+		}
+		return runVerifyBundle(verifyBundleParams{
+			bundlePath:     *bundlePath,
+			metaPath:       *metaPath,
+			trustRootsPath: *trustRootsPath,
+			registryURL:    *registryURL,
+			governanceMin:  *governanceMin,
+			allowYellow:    *allowYellow,
+			tenantFlag:     *tenantFlag,
+			jsonOut:        *jsonOut,
+			verbose:        *verboseFlag,
+		}, stdout, stderr)
+	}
+
 	if fs.NArg() != 1 {
 		fs.Usage()
 		return exitUsage
@@ -287,9 +318,22 @@ func parseNameAtVersion(s string) (string, string, error) {
 //     home-lab / single-tenant case).
 //   - Else, error: ambiguous, ask the user to pass --registry.
 func loadAndPickRoot(registryFlag string) (*verify.TrustRoots, *verify.TrustRoot, error) {
-	path, err := verify.DefaultPath()
-	if err != nil {
-		return nil, nil, err
+	return loadAndPickRootFromPath("", registryFlag)
+}
+
+// loadAndPickRootFromPath is loadAndPickRoot with an explicit trust-roots file
+// path. An empty path resolves to the default (~/.claude/skill-trust-roots.yaml).
+// The `--trust-roots <file>` override lets a portable verification kit
+// (SPEC-0276 R4.3) carry its own pinned-author trust-roots next to the .skb, so
+// a third party can verify with no access to our machine's config.
+func loadAndPickRootFromPath(trustRootsPath, registryFlag string) (*verify.TrustRoots, *verify.TrustRoot, error) {
+	path := trustRootsPath
+	if path == "" {
+		p, err := verify.DefaultPath()
+		if err != nil {
+			return nil, nil, err
+		}
+		path = p
 	}
 	tr, err := verify.Load(path)
 	if errors.Is(err, os.ErrNotExist) {

--- a/cmd/skillctl/install_cmds.go
+++ b/cmd/skillctl/install_cmds.go
@@ -177,6 +177,7 @@ func runVerify(args []string, stdout, stderr io.Writer) int {
 	bundlePath := fs.String("bundle", "", "Verify a standalone .skb FILE (not an installed skill), fully offline against pinned trust-roots (SPEC-0276 R4.2). Requires a sidecar <file>.skbmeta.json (or --meta).")
 	metaPath := fs.String("meta", "", "Path to the BundleMeta envelope JSON for --bundle (default: the .skbmeta.json sidecar next to the .skb).")
 	trustRootsPath := fs.String("trust-roots", "", "Path to a trust-roots YAML to use instead of the default (~/.claude/skill-trust-roots.yaml). Pair with --bundle for a portable verification kit.")
+	revocationsPath := fs.String("revocations", "", "Path to a signed revocation list (JSON) to enforce offline for --bundle. A revoked digest → exit 17; an untrusted/forged list → exit 12.")
 	jsonOut := fs.Bool("json", false, "Emit the verification result as JSON (--bundle mode).")
 
 	fs.Usage = func() {
@@ -208,15 +209,16 @@ func runVerify(args []string, stdout, stderr io.Writer) int {
 			return exitUsage
 		}
 		return runVerifyBundle(verifyBundleParams{
-			bundlePath:     *bundlePath,
-			metaPath:       *metaPath,
-			trustRootsPath: *trustRootsPath,
-			registryURL:    *registryURL,
-			governanceMin:  *governanceMin,
-			allowYellow:    *allowYellow,
-			tenantFlag:     *tenantFlag,
-			jsonOut:        *jsonOut,
-			verbose:        *verboseFlag,
+			bundlePath:      *bundlePath,
+			metaPath:        *metaPath,
+			trustRootsPath:  *trustRootsPath,
+			revocationsPath: *revocationsPath,
+			registryURL:     *registryURL,
+			governanceMin:   *governanceMin,
+			allowYellow:     *allowYellow,
+			tenantFlag:      *tenantFlag,
+			jsonOut:         *jsonOut,
+			verbose:         *verboseFlag,
 		}, stdout, stderr)
 	}
 

--- a/cmd/skillctl/main.go
+++ b/cmd/skillctl/main.go
@@ -79,6 +79,14 @@ func main() {
 	case "verify":
 		runWithExit(func() int { return runVerify(os.Args[2:], os.Stdout, os.Stderr) })
 	// === END SPEC-0188 S8 ===
+	// === SPEC-0276 R4.3: portable, offline, trust-nothing verification kit ===
+	case "export-verification-kit":
+		runWithExit(func() int { return runExportKit(os.Args[2:], os.Stdout, os.Stderr) })
+	// === END SPEC-0276 R4.3 ===
+	// === SPEC-0276 R5: offline compliance evidence pack ===
+	case "compliance":
+		os.Exit(runCompliance(os.Args[2:], os.Stdout, os.Stderr))
+	// === END SPEC-0276 R5 ===
 	// === SPEC-0247 P0.1: Claude Code PreToolUse(Skill) trust gate ===
 	// Reads the hook event on stdin, re-runs the §7 chain against the
 	// installed skill, and emits an allow/deny decision. Fail-closed:

--- a/cmd/skillctl/runbook_cmds.go
+++ b/cmd/skillctl/runbook_cmds.go
@@ -100,7 +100,7 @@ func runRunbook(args []string, stdout, stderr io.Writer) int {
 	if !*yes {
 		fmt.Fprintf(stdout, "\n🟡 About to publish into the THOH catalog at %s. Proceed? [y/N] ", *base)
 		var resp string
-		fmt.Fscanln(os.Stdin, &resp)
+		_, _ = fmt.Fscanln(os.Stdin, &resp)
 		if r := strings.ToLower(strings.TrimSpace(resp)); r != "y" && r != "yes" {
 			fmt.Fprintln(stdout, "aborted.")
 			return 0

--- a/cmd/skillctl/verify_bundle_cmds.go
+++ b/cmd/skillctl/verify_bundle_cmds.go
@@ -55,9 +55,13 @@ type bundleVerifyResult struct {
 	Author        string `json:"author_identity,omitempty"`
 	RegistryKeyID string `json:"registry_key_id,omitempty"`
 	Governance    string `json:"governance_level,omitempty"`
-	ChainSummary  string `json:"chain_summary,omitempty"`
-	Error         string `json:"error,omitempty"`
-	ExitCode      int    `json:"exit_code"`
+	// GovernanceVerified (SPEC-0281) lets machine consumers distinguish a
+	// cryptographically re-verified "attested" level from an unsigned advisory
+	// one — without scraping chain_summary free text.
+	GovernanceVerified bool   `json:"governance_verified"`
+	ChainSummary       string `json:"chain_summary,omitempty"`
+	Error              string `json:"error,omitempty"`
+	ExitCode           int    `json:"exit_code"`
 }
 
 // runVerifyBundle implements the --bundle path. Returns the SPEC-0188 §11
@@ -147,6 +151,7 @@ func runVerifyBundle(p verifyBundleParams, stdout, stderr io.Writer) int {
 			out.Author = res.AuthorIdentity
 			out.RegistryKeyID = res.RegistryKeyID
 			out.Governance = res.GovernanceLevel
+			out.GovernanceVerified = res.GovernanceVerified
 			out.ChainSummary = res.ChainSummary
 			out.ExitCode = exitOK
 		}

--- a/cmd/skillctl/verify_bundle_cmds.go
+++ b/cmd/skillctl/verify_bundle_cmds.go
@@ -184,7 +184,7 @@ func checkBundleRevoked(path string, root *verify.TrustRoot, digest string) (boo
 	if err := json.Unmarshal(data, &list); err != nil {
 		return false, fmt.Errorf("verify --bundle: parse revocations %s: %w", path, err)
 	}
-	set, err := verify.VerifyRevocationList(&list, root)
+	set, err := verify.VerifyRevocationList(&list, root, root.MinRevocationEpoch)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/skillctl/verify_bundle_cmds.go
+++ b/cmd/skillctl/verify_bundle_cmds.go
@@ -1,0 +1,177 @@
+package main
+
+// SPEC-0276 R4.2 — `skillctl verify --bundle <file.skb>`.
+//
+// The trustless third-party path: verify a standalone .skb FILE with NO
+// install state and NO network, against locally pinned trust-roots. This is
+// the property a hosted-CA rival markets ("anyone can verify, no trust
+// required") but cannot deliver — their verify is a call to their server; ours
+// runs on the verifier's machine against a key they pinned out-of-band.
+//
+// Inputs:
+//   - the .skb blob (digest recomputed from its bytes — repack → exit 10)
+//   - a BundleMeta envelope sidecar (<file>.skbmeta.json or --meta) carrying
+//     the author + registry signatures and the governance verdict
+//   - a pinned trust-roots file (default or --trust-roots) whose matched root
+//     MUST be identity_keys_authorized: pinned, so the author signature is
+//     verifiable with no registry call
+//
+// Everything routes through verify.Verify, so the §7 chain, the exit codes,
+// and the content-binding (digest recompute vs advertised) are identical to
+// the installed-skill path — only the inputs and the "no fetcher" wiring differ.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// verifyBundleParams is the resolved flag set for the --bundle path. Grouped
+// into a struct so runVerify's dispatch stays a single readable call.
+type verifyBundleParams struct {
+	bundlePath     string
+	metaPath       string
+	trustRootsPath string
+	registryURL    string
+	governanceMin  string
+	allowYellow    bool
+	tenantFlag     string
+	jsonOut        bool
+	verbose        bool
+}
+
+// bundleVerifyResult is the --json shape. Stable field names so CI scripts can
+// branch on `.ok` / `.exit_code` without parsing human text.
+type bundleVerifyResult struct {
+	OK            bool   `json:"ok"`
+	Digest        string `json:"digest,omitempty"`
+	Author        string `json:"author_identity,omitempty"`
+	RegistryKeyID string `json:"registry_key_id,omitempty"`
+	Governance    string `json:"governance_level,omitempty"`
+	ChainSummary  string `json:"chain_summary,omitempty"`
+	Error         string `json:"error,omitempty"`
+	ExitCode      int    `json:"exit_code"`
+}
+
+// runVerifyBundle implements the --bundle path. Returns the SPEC-0188 §11
+// numeric exit code.
+func runVerifyBundle(p verifyBundleParams, stdout, stderr io.Writer) int {
+	// The .skb file must exist and be a regular file.
+	if st, err := os.Stat(p.bundlePath); err != nil || st.IsDir() {
+		fmt.Fprintf(stderr, "skillctl verify --bundle: cannot read bundle file %s\n", p.bundlePath)
+		return exitUsage
+	}
+
+	// Load the BundleMeta envelope from the sidecar (or --meta override).
+	metaPath := p.metaPath
+	if metaPath == "" {
+		metaPath = defaultMetaSidecar(p.bundlePath)
+	}
+	meta, err := loadBundleMetaSidecar(metaPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+
+	// Resolve the pinned trust-roots and pick the matching root.
+	tr, root, err := loadAndPickRootFromPath(p.trustRootsPath, p.registryURL)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+
+	// --bundle is offline by construction: with no fetcher, the author
+	// signature can only be checked against a locally pinned key. Refuse a
+	// from-registry root up front with an actionable message rather than
+	// letting verify.Verify fail with the generic "IdentityFetcher required".
+	if root.IdentityKeysAuthorized != "pinned" {
+		fmt.Fprintf(stderr,
+			"skillctl verify --bundle is offline; trust root %s must use identity_keys_authorized: pinned "+
+				"(so the author key is verifiable with no registry call). See SPEC-0276 R4.1.\n",
+			root.RegistryURL)
+		return exitGeneric
+	}
+
+	tenant := resolveTenant(p.tenantFlag, tr)
+
+	var logger io.Writer
+	if p.verbose {
+		logger = stderr
+	}
+
+	res, verr := verify.Verify(verify.VerifyOpts{
+		BundlePath:      p.bundlePath,
+		BundleMeta:      meta,
+		TrustRoot:       root,
+		IdentityFetcher: nil, // pinned mode: no fetcher, no network
+		GovernanceMin:   p.governanceMin,
+		AllowYellow:     p.allowYellow,
+		Tenant:          tenant,
+		Logger:          logger,
+		Ctx:             context.Background(),
+	})
+
+	if p.jsonOut {
+		out := bundleVerifyResult{}
+		if verr != nil {
+			out.Error = verr.Error()
+			out.ExitCode = verify.ExitCode(verr)
+		} else {
+			out.OK = true
+			out.Digest = res.Digest
+			out.Author = res.AuthorIdentity
+			out.RegistryKeyID = res.RegistryKeyID
+			out.Governance = res.GovernanceLevel
+			out.ChainSummary = res.ChainSummary
+			out.ExitCode = exitOK
+		}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(out)
+		return out.ExitCode
+	}
+
+	if verr != nil {
+		fmt.Fprintln(stderr, verr)
+		return verify.ExitCode(verr)
+	}
+	fmt.Fprintln(stdout, res.ChainSummary+" (offline, bundle)")
+	return exitOK
+}
+
+// defaultMetaSidecar derives the sidecar BundleMeta path from a .skb path:
+// "foo@1.0.0.skb" -> "foo@1.0.0.skbmeta.json". A non-.skb path just gets
+// ".skbmeta.json" appended.
+func defaultMetaSidecar(bundlePath string) string {
+	if strings.HasSuffix(bundlePath, ".skb") {
+		return strings.TrimSuffix(bundlePath, ".skb") + ".skbmeta.json"
+	}
+	return bundlePath + ".skbmeta.json"
+}
+
+// loadBundleMetaSidecar reads and JSON-decodes the BundleMeta envelope. Lenient
+// on unknown fields (a registry may attach extras we don't model) — the
+// security-relevant fields are validated cryptographically downstream by
+// verify.Verify, not by the JSON shape here.
+func loadBundleMetaSidecar(path string) (*registry.BundleMeta, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf(
+				"verify --bundle: BundleMeta sidecar not found at %s "+
+					"(produce one with `skillctl export-verification-kit`, or pass --meta <file>)", path)
+		}
+		return nil, fmt.Errorf("verify --bundle: read sidecar %s: %w", path, err)
+	}
+	var meta registry.BundleMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("verify --bundle: parse sidecar %s: %w", path, err)
+	}
+	return &meta, nil
+}

--- a/cmd/skillctl/verify_bundle_cmds.go
+++ b/cmd/skillctl/verify_bundle_cmds.go
@@ -35,15 +35,16 @@ import (
 // verifyBundleParams is the resolved flag set for the --bundle path. Grouped
 // into a struct so runVerify's dispatch stays a single readable call.
 type verifyBundleParams struct {
-	bundlePath     string
-	metaPath       string
-	trustRootsPath string
-	registryURL    string
-	governanceMin  string
-	allowYellow    bool
-	tenantFlag     string
-	jsonOut        bool
-	verbose        bool
+	bundlePath      string
+	metaPath        string
+	trustRootsPath  string
+	revocationsPath string
+	registryURL     string
+	governanceMin   string
+	allowYellow     bool
+	tenantFlag      string
+	jsonOut         bool
+	verbose         bool
 }
 
 // bundleVerifyResult is the --json shape. Stable field names so CI scripts can
@@ -117,12 +118,30 @@ func runVerifyBundle(p verifyBundleParams, stdout, stderr io.Writer) int {
 		Ctx:             context.Background(),
 	})
 
+	// Offline revocation enforcement (SPEC-0276 R4.4): only meaningful once the
+	// chain otherwise passed (a chain failure already returns its own code). A
+	// forged/untrusted list is fail-closed (revErr → exit 12); a revoked digest
+	// → exit 17.
+	var revoked bool
+	var revErr error
+	if verr == nil && p.revocationsPath != "" {
+		revoked, revErr = checkBundleRevoked(p.revocationsPath, root, res.Digest)
+	}
+
 	if p.jsonOut {
 		out := bundleVerifyResult{}
-		if verr != nil {
+		switch {
+		case verr != nil:
 			out.Error = verr.Error()
 			out.ExitCode = verify.ExitCode(verr)
-		} else {
+		case revErr != nil:
+			out.Error = revErr.Error()
+			out.ExitCode = verify.ExitCode(revErr)
+		case revoked:
+			out.Digest = res.Digest
+			out.Error = "bundle digest is in the signed revocation list"
+			out.ExitCode = exitBundleRevoked
+		default:
 			out.OK = true
 			out.Digest = res.Digest
 			out.Author = res.AuthorIdentity
@@ -137,12 +156,40 @@ func runVerifyBundle(p verifyBundleParams, stdout, stderr io.Writer) int {
 		return out.ExitCode
 	}
 
-	if verr != nil {
+	switch {
+	case verr != nil:
 		fmt.Fprintln(stderr, verr)
 		return verify.ExitCode(verr)
+	case revErr != nil:
+		fmt.Fprintln(stderr, revErr)
+		return verify.ExitCode(revErr)
+	case revoked:
+		fmt.Fprintf(stderr, "REVOKED: %s is in the signed revocation list (%s)\n", res.Digest, p.revocationsPath)
+		return exitBundleRevoked
 	}
 	fmt.Fprintln(stdout, res.ChainSummary+" (offline, bundle)")
 	return exitOK
+}
+
+// checkBundleRevoked loads a signed revocation list, verifies its signature
+// against the pinned root, and reports whether digest is revoked. A signature
+// that matches no active registry key is an error (fail-closed), not a silent
+// "not revoked".
+func checkBundleRevoked(path string, root *verify.TrustRoot, digest string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("verify --bundle: read revocations %s: %w", path, err)
+	}
+	var list verify.RevocationList
+	if err := json.Unmarshal(data, &list); err != nil {
+		return false, fmt.Errorf("verify --bundle: parse revocations %s: %w", path, err)
+	}
+	set, err := verify.VerifyRevocationList(&list, root)
+	if err != nil {
+		return false, err
+	}
+	_, revoked := set[strings.ToLower(strings.TrimSpace(digest))]
+	return revoked, nil
 }
 
 // defaultMetaSidecar derives the sidecar BundleMeta path from a .skb path:

--- a/cmd/skillctl/verify_bundle_test.go
+++ b/cmd/skillctl/verify_bundle_test.go
@@ -236,7 +236,7 @@ func TestVerifyBundle_RevokedDigest(t *testing.T) {
 	f := buildBundleFixture(t)
 	// A revocation list, signed by the PINNED registry key, that contains this
 	// bundle's digest → exit 17.
-	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", []string{f.digest}, f.regPriv)
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", 1, []string{f.digest}, f.regPriv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,7 +254,7 @@ func TestVerifyBundle_NotRevoked(t *testing.T) {
 	// Properly signed list that does NOT contain this digest → still exit 0.
 	other := sha256.Sum256([]byte("a different bundle"))
 	otherDigest := "sha256:" + hex.EncodeToString(other[:])
-	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", []string{otherDigest}, f.regPriv)
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", 1, []string{otherDigest}, f.regPriv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -272,7 +272,7 @@ func TestVerifyBundle_ForgedRevocationListRefused(t *testing.T) {
 	// A list signed by an attacker key (not the pinned registry key). Must be
 	// fail-closed: exit 12, NOT silently ignored.
 	_, attackerPriv, _ := ed25519.GenerateKey(rand.Reader)
-	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", []string{f.digest}, attackerPriv)
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", 1, []string{f.digest}, attackerPriv)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/skillctl/verify_bundle_test.go
+++ b/cmd/skillctl/verify_bundle_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
 )
 
 // bundleFixture is a fully-wired, self-consistent --bundle scenario on disk.
@@ -26,9 +27,11 @@ type bundleFixture struct {
 	skbPath  string
 	metaPath string
 	trPath   string
+	dir      string
 	digest   string // "sha256:<hex>"
 	authorID string
 	regURL   string
+	regPriv  ed25519.PrivateKey // pins this; used to sign a revocation list
 }
 
 // buildBundleFixture writes a .skb blob, its signed BundleMeta sidecar, and a
@@ -87,8 +90,8 @@ func buildBundleFixture(t *testing.T) bundleFixture {
 		authorID, base64.StdEncoding.EncodeToString(authorPub))
 
 	return bundleFixture{
-		skbPath: skbPath, metaPath: metaPath, trPath: trPath,
-		digest: digestStr, authorID: authorID, regURL: regURL,
+		skbPath: skbPath, metaPath: metaPath, trPath: trPath, dir: dir,
+		digest: digestStr, authorID: authorID, regURL: regURL, regPriv: regPriv,
 	}
 }
 
@@ -212,6 +215,73 @@ func TestVerifyBundle_JSONOutput(t *testing.T) {
 	}
 	if !res.OK || res.ExitCode != 0 || res.Digest != f.digest {
 		t.Errorf("unexpected json result: %+v", res)
+	}
+}
+
+// writeRevocations marshals a (possibly forged) revocation list to a path.
+func writeRevocations(t *testing.T, dir string, list *verify.RevocationList) string {
+	t.Helper()
+	b, err := json.MarshalIndent(list, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal revocations: %v", err)
+	}
+	p := filepath.Join(dir, "revocations.json")
+	if err := os.WriteFile(p, b, 0o644); err != nil {
+		t.Fatalf("write revocations: %v", err)
+	}
+	return p
+}
+
+func TestVerifyBundle_RevokedDigest(t *testing.T) {
+	f := buildBundleFixture(t)
+	// A revocation list, signed by the PINNED registry key, that contains this
+	// bundle's digest → exit 17.
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", []string{f.digest}, f.regPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revPath := writeRevocations(t, f.dir, list)
+
+	var out, errBuf bytes.Buffer
+	code := runVerify([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath, "--revocations", revPath}, &out, &errBuf)
+	if code != 17 {
+		t.Fatalf("want exit 17 (revoked), got %d; stderr=%s", code, errBuf.String())
+	}
+}
+
+func TestVerifyBundle_NotRevoked(t *testing.T) {
+	f := buildBundleFixture(t)
+	// Properly signed list that does NOT contain this digest → still exit 0.
+	other := sha256.Sum256([]byte("a different bundle"))
+	otherDigest := "sha256:" + hex.EncodeToString(other[:])
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", []string{otherDigest}, f.regPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revPath := writeRevocations(t, f.dir, list)
+
+	var out, errBuf bytes.Buffer
+	code := runVerify([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath, "--revocations", revPath}, &out, &errBuf)
+	if code != exitOK {
+		t.Fatalf("want exit 0 (not revoked), got %d; stderr=%s", code, errBuf.String())
+	}
+}
+
+func TestVerifyBundle_ForgedRevocationListRefused(t *testing.T) {
+	f := buildBundleFixture(t)
+	// A list signed by an attacker key (not the pinned registry key). Must be
+	// fail-closed: exit 12, NOT silently ignored.
+	_, attackerPriv, _ := ed25519.GenerateKey(rand.Reader)
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-06-22T10:00:00Z", []string{f.digest}, attackerPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revPath := writeRevocations(t, f.dir, list)
+
+	var out, errBuf bytes.Buffer
+	code := runVerify([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath, "--revocations", revPath}, &out, &errBuf)
+	if code != 12 {
+		t.Fatalf("want exit 12 (untrusted revocation list), got %d; stderr=%s", code, errBuf.String())
 	}
 }
 

--- a/cmd/skillctl/verify_bundle_test.go
+++ b/cmd/skillctl/verify_bundle_test.go
@@ -1,0 +1,236 @@
+package main
+
+// SPEC-0276 R4.2 — end-to-end tests for `skillctl verify --bundle`. These
+// drive the real CLI runner with on-disk crypto material and assert the
+// canonical exit codes, proving the trustless third-party path works with no
+// install state and no network (the trust-roots file is a temp pinned file; no
+// HTTP server is ever started).
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+)
+
+// bundleFixture is a fully-wired, self-consistent --bundle scenario on disk.
+type bundleFixture struct {
+	skbPath  string
+	metaPath string
+	trPath   string
+	digest   string // "sha256:<hex>"
+	authorID string
+	regURL   string
+}
+
+// buildBundleFixture writes a .skb blob, its signed BundleMeta sidecar, and a
+// pinned trust-roots file into a temp dir. mutate lets a test perturb the YAML
+// (e.g. flip to from-registry) before it is written.
+func buildBundleFixture(t *testing.T) bundleFixture {
+	t.Helper()
+	dir := t.TempDir()
+
+	authorPub, authorPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("author keygen: %v", err)
+	}
+	regPub, regPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("reg keygen: %v", err)
+	}
+
+	// The .skb blob — arbitrary bytes; the verifier only sees them via sha256.
+	skbPath := filepath.Join(dir, "demo@1.0.0.skb")
+	content := []byte("a perfectly ordinary signed skill bundle blob")
+	if err := os.WriteFile(skbPath, content, 0o644); err != nil {
+		t.Fatalf("write skb: %v", err)
+	}
+	dRaw := sha256.Sum256(content)
+	digestStr := "sha256:" + hex.EncodeToString(dRaw[:])
+
+	authorID := "id:kamir@m3c"
+	regURL := "https://reg.example/api/skills"
+
+	meta := registry.BundleMeta{
+		Bundle: map[string]any{
+			"bundle_digest": digestStr,
+			"name":          "demo",
+			"version":       "1.0.0",
+			"status":        "admitted",
+		},
+		Signatures: []registry.SignatureRow{
+			{Role: "author", IdentityID: authorID, SignatureB64: signB64(authorPriv, dRaw), Status: "active"},
+			{Role: "registry", IdentityID: "id:registry@aims-core", SignatureB64: signB64(regPriv, dRaw), Status: "active"},
+		},
+		CurrentGovernance: "green",
+	}
+	metaJSON, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	metaPath := filepath.Join(dir, "demo@1.0.0.skbmeta.json")
+	if err := os.WriteFile(metaPath, metaJSON, 0o644); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+
+	trPath := filepath.Join(dir, "trust-roots.pinned.yaml")
+	writePinnedTrustRoots(t, trPath, regURL,
+		base64.StdEncoding.EncodeToString(regPub),
+		authorID, base64.StdEncoding.EncodeToString(authorPub))
+
+	return bundleFixture{
+		skbPath: skbPath, metaPath: metaPath, trPath: trPath,
+		digest: digestStr, authorID: authorID, regURL: regURL,
+	}
+}
+
+func signB64(priv ed25519.PrivateKey, digest [32]byte) string {
+	return base64.StdEncoding.EncodeToString(ed25519.Sign(priv, digest[:]))
+}
+
+func writePinnedTrustRoots(t *testing.T, path, regURL, regPubB64, authorID, authorPubB64 string) {
+	t.Helper()
+	body := "" +
+		"trust_roots:\n" +
+		"  - registry_url: " + regURL + "\n" +
+		"    registry_keys:\n" +
+		"      - id: reg-key-1\n" +
+		"        pubkey: " + regPubB64 + "\n" +
+		"    identity_keys_authorized: pinned\n" +
+		"    governance_minimum: green\n" +
+		"    authors:\n" +
+		"      - id: " + authorID + "\n" +
+		"        pubkey: " + authorPubB64 + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write trust-roots: %v", err)
+	}
+}
+
+func TestVerifyBundle_HappyPath(t *testing.T) {
+	f := buildBundleFixture(t)
+	var out, errBuf bytes.Buffer
+	code := runVerify([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath}, &out, &errBuf)
+	if code != exitOK {
+		t.Fatalf("want exit 0, got %d; stderr=%s", code, errBuf.String())
+	}
+	if !bytes.Contains(out.Bytes(), []byte("offline, bundle")) {
+		t.Errorf("missing offline marker; stdout=%s", out.String())
+	}
+	if !bytes.Contains(out.Bytes(), []byte(f.authorID)) {
+		t.Errorf("chain summary should name the author; stdout=%s", out.String())
+	}
+}
+
+func TestVerifyBundle_RepackDetected(t *testing.T) {
+	f := buildBundleFixture(t)
+	// Append a byte to the .skb AFTER the meta was signed → digest mismatch.
+	skb, _ := os.ReadFile(f.skbPath)
+	if err := os.WriteFile(f.skbPath, append(skb, 'X'), 0o644); err != nil {
+		t.Fatalf("repack: %v", err)
+	}
+	var out, errBuf bytes.Buffer
+	code := runVerify([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath}, &out, &errBuf)
+	if code != 10 {
+		t.Fatalf("want exit 10 (digest mismatch), got %d; stderr=%s", code, errBuf.String())
+	}
+}
+
+func TestVerifyBundle_WrongPinnedAuthor(t *testing.T) {
+	f := buildBundleFixture(t)
+	// Rewrite trust-roots to pin a DIFFERENT author key under the same id.
+	otherPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	regPubB64 := readRegPubB64(t, f.trPath)
+	writePinnedTrustRoots(t, f.trPath, f.regURL, regPubB64, f.authorID,
+		base64.StdEncoding.EncodeToString(otherPub))
+
+	var out, errBuf bytes.Buffer
+	code := runVerify([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath}, &out, &errBuf)
+	if code != 11 {
+		t.Fatalf("want exit 11 (author sig invalid), got %d; stderr=%s", code, errBuf.String())
+	}
+}
+
+func TestVerifyBundle_FromRegistryRootRefused(t *testing.T) {
+	f := buildBundleFixture(t)
+	regPubB64 := readRegPubB64(t, f.trPath)
+	// A from-registry root has no pinned authors → --bundle can't verify
+	// offline → actionable refusal (exitGeneric), not a crypto exit code.
+	body := "" +
+		"trust_roots:\n" +
+		"  - registry_url: " + f.regURL + "\n" +
+		"    registry_keys:\n" +
+		"      - id: reg-key-1\n" +
+		"        pubkey: " + regPubB64 + "\n" +
+		"    identity_keys_authorized: from-registry\n" +
+		"    governance_minimum: green\n"
+	if err := os.WriteFile(f.trPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("rewrite tr: %v", err)
+	}
+	var out, errBuf bytes.Buffer
+	code := runVerify([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath}, &out, &errBuf)
+	if code != exitGeneric {
+		t.Fatalf("want exitGeneric, got %d", code)
+	}
+	if !bytes.Contains(errBuf.Bytes(), []byte("identity_keys_authorized: pinned")) {
+		t.Errorf("expected actionable message; stderr=%s", errBuf.String())
+	}
+}
+
+func TestVerifyBundle_MissingSidecar(t *testing.T) {
+	f := buildBundleFixture(t)
+	if err := os.Remove(f.metaPath); err != nil {
+		t.Fatalf("rm meta: %v", err)
+	}
+	var out, errBuf bytes.Buffer
+	code := runVerify([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath}, &out, &errBuf)
+	if code != exitGeneric {
+		t.Fatalf("want exitGeneric for missing sidecar, got %d", code)
+	}
+	if !bytes.Contains(errBuf.Bytes(), []byte("sidecar not found")) {
+		t.Errorf("expected sidecar-not-found message; stderr=%s", errBuf.String())
+	}
+}
+
+func TestVerifyBundle_JSONOutput(t *testing.T) {
+	f := buildBundleFixture(t)
+	var out, errBuf bytes.Buffer
+	code := runVerify([]string{"--bundle", f.skbPath, "--trust-roots", f.trPath, "--json"}, &out, &errBuf)
+	if code != exitOK {
+		t.Fatalf("want exit 0, got %d; stderr=%s", code, errBuf.String())
+	}
+	var res bundleVerifyResult
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatalf("json parse: %v; out=%s", err, out.String())
+	}
+	if !res.OK || res.ExitCode != 0 || res.Digest != f.digest {
+		t.Errorf("unexpected json result: %+v", res)
+	}
+}
+
+// readRegPubB64 extracts the pinned registry pubkey b64 from a trust-roots file
+// so a rewrite can keep the same registry key while changing the author pin.
+func readRegPubB64(t *testing.T, trPath string) string {
+	t.Helper()
+	data, err := os.ReadFile(trPath)
+	if err != nil {
+		t.Fatalf("read tr: %v", err)
+	}
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		s := bytes.TrimSpace(line)
+		// The registry key line is the first "pubkey:" under registry_keys;
+		// the author pubkey appears later. Take the first match.
+		if bytes.HasPrefix(s, []byte("pubkey:")) {
+			return string(bytes.TrimSpace(bytes.TrimPrefix(s, []byte("pubkey:"))))
+		}
+	}
+	t.Fatal("no pubkey line in trust-roots")
+	return ""
+}

--- a/pkg/skillctl/verify/governance_signed_test.go
+++ b/pkg/skillctl/verify/governance_signed_test.go
@@ -1,0 +1,137 @@
+package verify
+
+// SPEC-0281 — signed governance attestation re-verification (closes the
+// red-team's red→green sidecar-downgrade exploit) + SPEC-0279 revocation epoch
+// rollback protection.
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
+)
+
+type govCase struct {
+	currentGov    string // what the (attacker-editable) sidecar claims
+	attLevel      string // the attestation row's Level
+	attSignDigest string // "" = sign over the bundle's own digest; else a replay
+	pinReviewer   bool
+	requireSigned bool
+	governanceMin string
+}
+
+func runGovCase(t *testing.T, c govCase) (*VerifyResult, error) {
+	t.Helper()
+	authorKey := mustKeypair(t)
+	regKey := mustKeypair(t)
+	revKey := mustKeypair(t)
+	bundlePath, digestRaw, digestStr := writeBundle(t, []byte("gov-test bundle bytes"))
+	authorID := "id:author@m3c"
+	reviewerID := "id:rev@m3c"
+	attestedAt := "2026-06-22T09:00:00Z"
+
+	signDigest := digestStr
+	if c.attSignDigest != "" {
+		signDigest = c.attSignDigest
+	}
+	attMsg, err := signing.CanonicalizeAttestationMessage(signDigest, c.attLevel, attestedAt, reviewerID)
+	if err != nil {
+		t.Fatalf("canon attestation: %v", err)
+	}
+	attSig := base64.StdEncoding.EncodeToString(ed25519.Sign(revKey.priv, attMsg))
+
+	meta := &registry.BundleMeta{
+		Bundle: map[string]any{"bundle_digest": digestStr, "name": "demo", "version": "1.0.0", "status": "admitted"},
+		Signatures: []registry.SignatureRow{
+			{Role: "author", IdentityID: authorID, SignatureB64: signOver(t, authorKey.priv, digestRaw), Status: "active"},
+			{Role: "registry", IdentityID: "id:reg@m3c", SignatureB64: signOver(t, regKey.priv, digestRaw), Status: "active"},
+		},
+		CurrentGovernance: c.currentGov,
+		Attestations: []registry.AttestationRow{
+			{Level: c.attLevel, ReviewerID: reviewerID, AttestedAt: attestedAt, SignatureB64: attSig, Status: "active"},
+		},
+	}
+	root := pinnedTrustRoot(authorID, authorKey.pub, regKey.pub, c.governanceMin)
+	root.RequireSignedGovernance = c.requireSigned
+	if c.pinReviewer {
+		root.Reviewers = []AuthorKey{{ID: reviewerID, Pubkey: []byte(revKey.pub), PubkeyB64: revKey.b64}}
+	}
+	return Verify(VerifyOpts{BundlePath: bundlePath, BundleMeta: meta, TrustRoot: root, IdentityFetcher: nil})
+}
+
+func TestGovernance_SignedAttestation_Verified(t *testing.T) {
+	res, err := runGovCase(t, govCase{currentGov: "green", attLevel: "green", pinReviewer: true, requireSigned: true, governanceMin: "green"})
+	if err != nil {
+		t.Fatalf("valid signed green should verify: %v", err)
+	}
+	if !res.GovernanceVerified {
+		t.Error("GovernanceVerified should be true")
+	}
+	if !bytes.Contains([]byte(res.ChainSummary), []byte("attested green")) {
+		t.Errorf("summary should say attested green: %q", res.ChainSummary)
+	}
+}
+
+// AC1 — the red-team exploit: a genuinely-RED bundle with its sidecar flipped to
+// green is REFUSED under require_signed_governance (no signed green attestation).
+func TestGovernance_DowngradeRefused(t *testing.T) {
+	_, err := runGovCase(t, govCase{currentGov: "green", attLevel: "red", pinReviewer: true, requireSigned: true, governanceMin: "green"})
+	if !errors.Is(err, ErrGovernanceBelowMin) {
+		t.Fatalf("red→green downgrade must be refused, got: %v", err)
+	}
+}
+
+// AC2 — a valid signed green attestation by a NON-pinned reviewer is not trusted.
+func TestGovernance_NonPinnedReviewerRefused(t *testing.T) {
+	_, err := runGovCase(t, govCase{currentGov: "green", attLevel: "green", pinReviewer: false, requireSigned: true, governanceMin: "green"})
+	if !errors.Is(err, ErrGovernanceBelowMin) {
+		t.Fatalf("non-pinned reviewer must be refused, got: %v", err)
+	}
+}
+
+// AC3 — a green attestation signed over a DIFFERENT bundle's digest (replay) fails.
+func TestGovernance_ReplayedAttestationRefused(t *testing.T) {
+	other := digestOf("some other bundle entirely")
+	_, err := runGovCase(t, govCase{currentGov: "green", attLevel: "green", attSignDigest: other, pinReviewer: true, requireSigned: true, governanceMin: "green"})
+	if !errors.Is(err, ErrGovernanceBelowMin) {
+		t.Fatalf("replayed attestation must be refused, got: %v", err)
+	}
+}
+
+// AC4 — backward compatible: with no reviewers pinned and require off, the level
+// is ADVISORY (passes the floor) and the summary does not claim "attested".
+func TestGovernance_AdvisoryWhenNoReviewers(t *testing.T) {
+	res, err := runGovCase(t, govCase{currentGov: "green", attLevel: "green", pinReviewer: false, requireSigned: false, governanceMin: "green"})
+	if err != nil {
+		t.Fatalf("advisory mode should pass: %v", err)
+	}
+	if res.GovernanceVerified {
+		t.Error("GovernanceVerified should be false in advisory mode")
+	}
+	if !bytes.Contains([]byte(res.ChainSummary), []byte("governance(advisory) green")) {
+		t.Errorf("summary should mark advisory: %q", res.ChainSummary)
+	}
+}
+
+// SPEC-0279 R1 — a signed list with epoch below the pinned floor is refused (rollback).
+func TestRevocation_EpochRollbackRefused(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	root := revocationRoot(t, pub)
+	list, err := NewSignedRevocationList(root.RegistryURL, "2026-06-22T10:00:00Z", 1, []string{digestOf("x")}, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := VerifyRevocationList(list, root, 2); !errors.Is(err, ErrRegistryNotTrusted) {
+		t.Fatalf("epoch 1 below floor 2 must be refused, got: %v", err)
+	}
+	// epoch at/above the floor verifies.
+	list2, _ := NewSignedRevocationList(root.RegistryURL, "2026-06-22T10:00:00Z", 3, []string{digestOf("x")}, priv)
+	if _, err := VerifyRevocationList(list2, root, 2); err != nil {
+		t.Fatalf("epoch 3 >= floor 2 should verify, got: %v", err)
+	}
+}

--- a/pkg/skillctl/verify/revocation.go
+++ b/pkg/skillctl/verify/revocation.go
@@ -1,0 +1,157 @@
+package verify
+
+// SPEC-0276 R4.4 — signed, offline-distributable revocation list.
+//
+// A hosted CA enforces revocation by making every verifier call its OCSP/CRL
+// endpoint. That re-introduces the network dependency we removed: "verify"
+// becomes "ask the issuer". Instead we distribute a SIGNED list of revoked
+// bundle digests that a third party can pin and check entirely offline — the
+// signature is ed25519 over a canonical payload, verifiable against the same
+// pinned registry keys that admit bundles. A forged or unsigned list cannot
+// block (or silently fail-open) a bundle: it must verify against an active
+// registry key or it is refused.
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// RevocationList is the on-disk, signed revocation snapshot.
+type RevocationList struct {
+	// RegistryURL is the registry this list speaks for. Part of the signed
+	// canonical payload, so it cannot be retargeted without re-signing.
+	RegistryURL string `json:"registry_url"`
+
+	// RevokedDigests is the set of revoked bundle digests, each "sha256:<hex>".
+	RevokedDigests []string `json:"revoked_digests"`
+
+	// IssuedAt is the RFC3339 timestamp the list was signed. Advisory for
+	// humans (freshness); the security property is the signature, not the time.
+	IssuedAt string `json:"issued_at"`
+
+	// SignatureB64 is base64 of the raw 64-byte ed25519 signature over
+	// CanonicalRevocationBytes(RegistryURL, IssuedAt, RevokedDigests).
+	SignatureB64 string `json:"signature_b64"`
+}
+
+// revocationCanonicalV1 is the deterministic, signed payload. A struct (not a
+// map) so json.Marshal field order is fixed; digests are sorted+normalized
+// before marshalling so the same logical list always yields the same bytes.
+type revocationCanonicalV1 struct {
+	Type           string   `json:"type"`
+	Version        int      `json:"version"`
+	RegistryURL    string   `json:"registry_url"`
+	IssuedAt       string   `json:"issued_at"`
+	RevokedDigests []string `json:"revoked_digests"`
+}
+
+// CanonicalRevocationBytes returns the exact bytes that are signed/verified.
+// Digests are validated (must be sha256:<64hex>), lowercased, de-duplicated and
+// sorted, so signer and verifier agree regardless of input order or case.
+func CanonicalRevocationBytes(registryURL, issuedAt string, digests []string) ([]byte, error) {
+	norm, err := normalizeDigests(digests)
+	if err != nil {
+		return nil, err
+	}
+	payload := revocationCanonicalV1{
+		Type:           "skillctl-revocation-list",
+		Version:        1,
+		RegistryURL:    strings.TrimRight(strings.TrimSpace(registryURL), "/"),
+		IssuedAt:       strings.TrimSpace(issuedAt),
+		RevokedDigests: norm,
+	}
+	return json.Marshal(payload)
+}
+
+// normalizeDigests validates, lowercases, de-dups and sorts a digest list.
+func normalizeDigests(digests []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(digests))
+	out := make([]string, 0, len(digests))
+	for _, d := range digests {
+		d = strings.ToLower(strings.TrimSpace(d))
+		if d == "" {
+			continue
+		}
+		if _, err := decodeShaHexDigest(d); err != nil {
+			return nil, fmt.Errorf("revocation list: invalid digest %q: %w", d, err)
+		}
+		if _, dup := seen[d]; dup {
+			continue
+		}
+		seen[d] = struct{}{}
+		out = append(out, d)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// NewSignedRevocationList builds and signs a RevocationList with a registry
+// private key. Used by tooling/tests; the production signer is the registry,
+// but the format is symmetric so we can produce one locally for a kit.
+func NewSignedRevocationList(registryURL, issuedAt string, digests []string, priv ed25519.PrivateKey) (*RevocationList, error) {
+	canon, err := CanonicalRevocationBytes(registryURL, issuedAt, digests)
+	if err != nil {
+		return nil, err
+	}
+	norm, _ := normalizeDigests(digests) // already validated by CanonicalRevocationBytes
+	sig := ed25519.Sign(priv, canon)
+	return &RevocationList{
+		RegistryURL:    strings.TrimRight(strings.TrimSpace(registryURL), "/"),
+		RevokedDigests: norm,
+		IssuedAt:       strings.TrimSpace(issuedAt),
+		SignatureB64:   base64.StdEncoding.EncodeToString(sig),
+	}, nil
+}
+
+// VerifyRevocationList checks the list's signature against an active registry
+// key in root and returns the set of revoked digests (lowercased). Fail-closed:
+// a list whose signature matches no active key returns ErrRegistryNotTrusted —
+// an attacker cannot drop a revocation by stripping its signature, nor forge
+// one to block a healthy bundle.
+func VerifyRevocationList(list *RevocationList, root *TrustRoot) (map[string]struct{}, error) {
+	if list == nil {
+		return nil, fmt.Errorf("revocation list: nil: %w", ErrRegistryNotTrusted)
+	}
+	if root == nil {
+		return nil, errors.New("revocation list: nil trust root")
+	}
+	canon, err := CanonicalRevocationBytes(list.RegistryURL, list.IssuedAt, list.RevokedDigests)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := decodeSignatureB64(list.SignatureB64)
+	if err != nil {
+		return nil, fmt.Errorf("revocation list: decode signature: %w", errors.Join(ErrRegistryNotTrusted, err))
+	}
+	active := root.ActiveKeys()
+	if len(active) == 0 {
+		return nil, fmt.Errorf("revocation list: trust root %s has no active registry keys: %w", root.RegistryURL, ErrRegistryNotTrusted)
+	}
+	matched := false
+	for _, k := range active {
+		if len(k.Pubkey) != ed25519.PublicKeySize {
+			continue
+		}
+		if ed25519.Verify(ed25519.PublicKey(k.Pubkey), canon, sig) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return nil, fmt.Errorf("revocation list: signature did not match any active registry key in %s: %w", root.RegistryURL, ErrRegistryNotTrusted)
+	}
+	norm, err := normalizeDigests(list.RevokedDigests)
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]struct{}, len(norm))
+	for _, d := range norm {
+		set[d] = struct{}{}
+	}
+	return set, nil
+}

--- a/pkg/skillctl/verify/revocation.go
+++ b/pkg/skillctl/verify/revocation.go
@@ -31,11 +31,17 @@ type RevocationList struct {
 	RevokedDigests []string `json:"revoked_digests"`
 
 	// IssuedAt is the RFC3339 timestamp the list was signed. Advisory for
-	// humans (freshness); the security property is the signature, not the time.
+	// humans (freshness); rollback protection is the signed Epoch, not the time.
 	IssuedAt string `json:"issued_at"`
 
+	// Epoch is a monotonic revocation generation (SPEC-0279 R1). It is part of
+	// the signed canonical payload; a verifier refuses a list whose epoch is
+	// below its pinned floor, so an attacker cannot substitute an older signed
+	// list to defeat a revocation. 0 = unversioned.
+	Epoch int `json:"epoch,omitempty"`
+
 	// SignatureB64 is base64 of the raw 64-byte ed25519 signature over
-	// CanonicalRevocationBytes(RegistryURL, IssuedAt, RevokedDigests).
+	// CanonicalRevocationBytes(RegistryURL, IssuedAt, Epoch, RevokedDigests).
 	SignatureB64 string `json:"signature_b64"`
 }
 
@@ -47,13 +53,15 @@ type revocationCanonicalV1 struct {
 	Version        int      `json:"version"`
 	RegistryURL    string   `json:"registry_url"`
 	IssuedAt       string   `json:"issued_at"`
+	Epoch          int      `json:"epoch"`
 	RevokedDigests []string `json:"revoked_digests"`
 }
 
 // CanonicalRevocationBytes returns the exact bytes that are signed/verified.
 // Digests are validated (must be sha256:<64hex>), lowercased, de-duplicated and
-// sorted, so signer and verifier agree regardless of input order or case.
-func CanonicalRevocationBytes(registryURL, issuedAt string, digests []string) ([]byte, error) {
+// sorted, so signer and verifier agree regardless of input order or case. The
+// epoch is signed so it cannot be forged upward on an old list (SPEC-0279 R1).
+func CanonicalRevocationBytes(registryURL, issuedAt string, epoch int, digests []string) ([]byte, error) {
 	norm, err := normalizeDigests(digests)
 	if err != nil {
 		return nil, err
@@ -63,6 +71,7 @@ func CanonicalRevocationBytes(registryURL, issuedAt string, digests []string) ([
 		Version:        1,
 		RegistryURL:    strings.TrimRight(strings.TrimSpace(registryURL), "/"),
 		IssuedAt:       strings.TrimSpace(issuedAt),
+		Epoch:          epoch,
 		RevokedDigests: norm,
 	}
 	return json.Marshal(payload)
@@ -93,8 +102,8 @@ func normalizeDigests(digests []string) ([]string, error) {
 // NewSignedRevocationList builds and signs a RevocationList with a registry
 // private key. Used by tooling/tests; the production signer is the registry,
 // but the format is symmetric so we can produce one locally for a kit.
-func NewSignedRevocationList(registryURL, issuedAt string, digests []string, priv ed25519.PrivateKey) (*RevocationList, error) {
-	canon, err := CanonicalRevocationBytes(registryURL, issuedAt, digests)
+func NewSignedRevocationList(registryURL, issuedAt string, epoch int, digests []string, priv ed25519.PrivateKey) (*RevocationList, error) {
+	canon, err := CanonicalRevocationBytes(registryURL, issuedAt, epoch, digests)
 	if err != nil {
 		return nil, err
 	}
@@ -104,6 +113,7 @@ func NewSignedRevocationList(registryURL, issuedAt string, digests []string, pri
 		RegistryURL:    strings.TrimRight(strings.TrimSpace(registryURL), "/"),
 		RevokedDigests: norm,
 		IssuedAt:       strings.TrimSpace(issuedAt),
+		Epoch:          epoch,
 		SignatureB64:   base64.StdEncoding.EncodeToString(sig),
 	}, nil
 }
@@ -113,14 +123,17 @@ func NewSignedRevocationList(registryURL, issuedAt string, digests []string, pri
 // a list whose signature matches no active key returns ErrRegistryNotTrusted —
 // an attacker cannot drop a revocation by stripping its signature, nor forge
 // one to block a healthy bundle.
-func VerifyRevocationList(list *RevocationList, root *TrustRoot) (map[string]struct{}, error) {
+// minEpoch (SPEC-0279 R1) is the rollback floor: a list whose signed Epoch is
+// below minEpoch is refused even if its signature is valid, so an attacker
+// cannot substitute an older genuinely-signed list to defeat a revocation.
+func VerifyRevocationList(list *RevocationList, root *TrustRoot, minEpoch int) (map[string]struct{}, error) {
 	if list == nil {
 		return nil, fmt.Errorf("revocation list: nil: %w", ErrRegistryNotTrusted)
 	}
 	if root == nil {
 		return nil, errors.New("revocation list: nil trust root")
 	}
-	canon, err := CanonicalRevocationBytes(list.RegistryURL, list.IssuedAt, list.RevokedDigests)
+	canon, err := CanonicalRevocationBytes(list.RegistryURL, list.IssuedAt, list.Epoch, list.RevokedDigests)
 	if err != nil {
 		return nil, err
 	}
@@ -144,6 +157,10 @@ func VerifyRevocationList(list *RevocationList, root *TrustRoot) (map[string]str
 	}
 	if !matched {
 		return nil, fmt.Errorf("revocation list: signature did not match any active registry key in %s: %w", root.RegistryURL, ErrRegistryNotTrusted)
+	}
+	// SPEC-0279 R1 — rollback protection: refuse a signed-but-stale list.
+	if list.Epoch < minEpoch {
+		return nil, fmt.Errorf("revocation list: epoch %d is below the pinned floor %d (rollback): %w", list.Epoch, minEpoch, ErrRegistryNotTrusted)
 	}
 	norm, err := normalizeDigests(list.RevokedDigests)
 	if err != nil {

--- a/pkg/skillctl/verify/revocation_test.go
+++ b/pkg/skillctl/verify/revocation_test.go
@@ -36,12 +36,12 @@ func revocationRoot(t *testing.T, regPub ed25519.PublicKey) *TrustRoot {
 func TestCanonicalRevocation_DeterministicAcrossOrderAndCase(t *testing.T) {
 	a := digestOf("one")
 	b := digestOf("two")
-	c1, err := CanonicalRevocationBytes("https://reg.example/api/skills/", "2026-06-22T10:00:00Z", []string{a, b})
+	c1, err := CanonicalRevocationBytes("https://reg.example/api/skills/", "2026-06-22T10:00:00Z", 1, []string{a, b})
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Reversed order + uppercased hex + a duplicate → identical canonical bytes.
-	c2, err := CanonicalRevocationBytes("https://reg.example/api/skills", "2026-06-22T10:00:00Z", []string{bytesUpper(b), a, a})
+	c2, err := CanonicalRevocationBytes("https://reg.example/api/skills", "2026-06-22T10:00:00Z", 1, []string{bytesUpper(b), a, a})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,11 +56,11 @@ func TestRevocationList_SignVerifyRoundTrip(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
 	root := revocationRoot(t, pub)
 	target := digestOf("revoke-me")
-	list, err := NewSignedRevocationList(root.RegistryURL, "2026-06-22T10:00:00Z", []string{target, digestOf("other")}, priv)
+	list, err := NewSignedRevocationList(root.RegistryURL, "2026-06-22T10:00:00Z", 1, []string{target, digestOf("other")}, priv)
 	if err != nil {
 		t.Fatal(err)
 	}
-	set, err := VerifyRevocationList(list, root)
+	set, err := VerifyRevocationList(list, root, 0)
 	if err != nil {
 		t.Fatalf("verify: %v", err)
 	}
@@ -74,11 +74,11 @@ func TestRevocationList_ForgedSignatureRejected(t *testing.T) {
 	pinnedPub, _, _ := ed25519.GenerateKey(rand.Reader) // a DIFFERENT key is pinned
 	root := revocationRoot(t, pinnedPub)
 	// Signed by the attacker, not by the pinned registry key.
-	list, err := NewSignedRevocationList(root.RegistryURL, "2026-06-22T10:00:00Z", []string{digestOf("x")}, attackerPriv)
+	list, err := NewSignedRevocationList(root.RegistryURL, "2026-06-22T10:00:00Z", 1, []string{digestOf("x")}, attackerPriv)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := VerifyRevocationList(list, root); !errors.Is(err, ErrRegistryNotTrusted) {
+	if _, err := VerifyRevocationList(list, root, 0); !errors.Is(err, ErrRegistryNotTrusted) {
 		t.Fatalf("forged list must be ErrRegistryNotTrusted, got: %v", err)
 	}
 }
@@ -86,19 +86,19 @@ func TestRevocationList_ForgedSignatureRejected(t *testing.T) {
 func TestRevocationList_TamperedDigestSetBreaksSignature(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
 	root := revocationRoot(t, pub)
-	list, err := NewSignedRevocationList(root.RegistryURL, "2026-06-22T10:00:00Z", []string{digestOf("a")}, priv)
+	list, err := NewSignedRevocationList(root.RegistryURL, "2026-06-22T10:00:00Z", 1, []string{digestOf("a")}, priv)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Attacker adds a digest after signing → canonical bytes change → sig fails.
 	list.RevokedDigests = append(list.RevokedDigests, digestOf("sneaky"))
-	if _, err := VerifyRevocationList(list, root); !errors.Is(err, ErrRegistryNotTrusted) {
+	if _, err := VerifyRevocationList(list, root, 0); !errors.Is(err, ErrRegistryNotTrusted) {
 		t.Fatalf("tampered digest set must be rejected, got: %v", err)
 	}
 }
 
 func TestRevocationList_InvalidDigestRefused(t *testing.T) {
-	if _, err := CanonicalRevocationBytes("https://reg.example/api/skills", "now", []string{"not-a-digest"}); err == nil {
+	if _, err := CanonicalRevocationBytes("https://reg.example/api/skills", "now", 1, []string{"not-a-digest"}); err == nil {
 		t.Fatal("expected error for malformed digest")
 	}
 }

--- a/pkg/skillctl/verify/revocation_test.go
+++ b/pkg/skillctl/verify/revocation_test.go
@@ -1,0 +1,104 @@
+package verify
+
+// SPEC-0276 R4.4 — signed offline revocation list.
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"testing"
+)
+
+func digestOf(s string) string {
+	d := sha256.Sum256([]byte(s))
+	return "sha256:" + hex.EncodeToString(d[:])
+}
+
+func revocationRoot(t *testing.T, regPub ed25519.PublicKey) *TrustRoot {
+	t.Helper()
+	return &TrustRoot{
+		RegistryURL: "https://reg.example/api/skills",
+		RegistryKeys: []RegistryKey{{
+			ID:        "reg-key-1",
+			Pubkey:    []byte(regPub),
+			PubkeyB64: base64.StdEncoding.EncodeToString(regPub),
+		}},
+		IdentityKeysAuthorized: "pinned",
+		Authors:                []AuthorKey{{ID: "id:a@m3c", Pubkey: []byte(regPub), PubkeyB64: base64.StdEncoding.EncodeToString(regPub)}},
+		GovernanceMinimum:      "green",
+	}
+}
+
+func TestCanonicalRevocation_DeterministicAcrossOrderAndCase(t *testing.T) {
+	a := digestOf("one")
+	b := digestOf("two")
+	c1, err := CanonicalRevocationBytes("https://reg.example/api/skills/", "2026-06-22T10:00:00Z", []string{a, b})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Reversed order + uppercased hex + a duplicate → identical canonical bytes.
+	c2, err := CanonicalRevocationBytes("https://reg.example/api/skills", "2026-06-22T10:00:00Z", []string{bytesUpper(b), a, a})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(c1, c2) {
+		t.Fatalf("canonical bytes not order/case invariant:\n%s\n%s", c1, c2)
+	}
+}
+
+func bytesUpper(s string) string { return string(bytes.ToUpper([]byte(s))) }
+
+func TestRevocationList_SignVerifyRoundTrip(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	root := revocationRoot(t, pub)
+	target := digestOf("revoke-me")
+	list, err := NewSignedRevocationList(root.RegistryURL, "2026-06-22T10:00:00Z", []string{target, digestOf("other")}, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	set, err := VerifyRevocationList(list, root)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if _, ok := set[target]; !ok {
+		t.Errorf("target digest not in verified set")
+	}
+}
+
+func TestRevocationList_ForgedSignatureRejected(t *testing.T) {
+	_, attackerPriv, _ := ed25519.GenerateKey(rand.Reader)
+	pinnedPub, _, _ := ed25519.GenerateKey(rand.Reader) // a DIFFERENT key is pinned
+	root := revocationRoot(t, pinnedPub)
+	// Signed by the attacker, not by the pinned registry key.
+	list, err := NewSignedRevocationList(root.RegistryURL, "2026-06-22T10:00:00Z", []string{digestOf("x")}, attackerPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := VerifyRevocationList(list, root); !errors.Is(err, ErrRegistryNotTrusted) {
+		t.Fatalf("forged list must be ErrRegistryNotTrusted, got: %v", err)
+	}
+}
+
+func TestRevocationList_TamperedDigestSetBreaksSignature(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	root := revocationRoot(t, pub)
+	list, err := NewSignedRevocationList(root.RegistryURL, "2026-06-22T10:00:00Z", []string{digestOf("a")}, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Attacker adds a digest after signing → canonical bytes change → sig fails.
+	list.RevokedDigests = append(list.RevokedDigests, digestOf("sneaky"))
+	if _, err := VerifyRevocationList(list, root); !errors.Is(err, ErrRegistryNotTrusted) {
+		t.Fatalf("tampered digest set must be rejected, got: %v", err)
+	}
+}
+
+func TestRevocationList_InvalidDigestRefused(t *testing.T) {
+	if _, err := CanonicalRevocationBytes("https://reg.example/api/skills", "now", []string{"not-a-digest"}); err == nil {
+		t.Fatal("expected error for malformed digest")
+	}
+}

--- a/pkg/skillctl/verify/trustroots.go
+++ b/pkg/skillctl/verify/trustroots.go
@@ -170,6 +170,24 @@ type TrustRoot struct {
 	// current attestation is below this level is rejected with exit
 	// code 13 (ErrGovernanceBelowMin).
 	GovernanceMinimum string `yaml:"governance_minimum"`
+
+	// Reviewers are pinned reviewer identities (SPEC-0281). When present, the
+	// verifier re-verifies the SIGNED governance attestation against the
+	// pinned reviewer key instead of trusting the registry's unsigned
+	// CurrentGovernance string. Same shape/validation as Authors.
+	Reviewers []AuthorKey `yaml:"reviewers,omitempty"`
+
+	// RequireSignedGovernance (SPEC-0281): when true, the governance level
+	// MUST be backed by a signed attestation that verifies against a pinned
+	// reviewer key, or verification is refused (exit 13). When false (default)
+	// governance is advisory in offline mode — the chain summary reports
+	// "governance(advisory)" rather than "attested".
+	RequireSignedGovernance bool `yaml:"require_signed_governance,omitempty"`
+
+	// MinRevocationEpoch (SPEC-0279 R1): the verifier refuses a signed
+	// revocation list whose epoch is below this floor — rollback protection
+	// against substituting an older signed list. 0 = no floor.
+	MinRevocationEpoch int `yaml:"min_revocation_epoch,omitempty"`
 }
 
 // ActiveKeys returns the subset of RegistryKeys that are not retired. It
@@ -195,6 +213,20 @@ func (t *TrustRoot) FindAuthor(identityID string) *AuthorKey {
 	for i := range t.Authors {
 		if t.Authors[i].ID == identityID && t.Authors[i].IsActive() {
 			return &t.Authors[i]
+		}
+	}
+	return nil
+}
+
+// FindReviewer returns the active pinned reviewer key for identityID, or nil
+// (SPEC-0281). Retired pins are skipped. Mirrors FindAuthor.
+func (t *TrustRoot) FindReviewer(identityID string) *AuthorKey {
+	if t == nil {
+		return nil
+	}
+	for i := range t.Reviewers {
+		if t.Reviewers[i].ID == identityID && t.Reviewers[i].IsActive() {
+			return &t.Reviewers[i]
 		}
 	}
 	return nil
@@ -588,6 +620,45 @@ func (t *TrustRoots) validate() error {
 			// Hydrate raw bytes so the verifier doesn't redo the decode.
 			t.Roots[i].Authors[j].Pubkey = raw
 		}
+
+		// Pinned reviewers (SPEC-0281): same validation as authors. If
+		// require_signed_governance is set there must be at least one reviewer
+		// to verify against. Entries present without the flag are still
+		// validated (so a typo can't lie dormant).
+		if root.RequireSignedGovernance && len(root.Reviewers) == 0 {
+			return fmt.Errorf("trust_roots[%d] %s: require_signed_governance needs a non-empty reviewers list", i, root.RegistryURL)
+		}
+		seenReviewerIDs := make(map[string]struct{}, len(root.Reviewers))
+		for j, r := range root.Reviewers {
+			if r.ID == "" {
+				return fmt.Errorf("trust_roots[%d].reviewers[%d]: id is required", i, j)
+			}
+			if _, dup := seenReviewerIDs[r.ID]; dup {
+				return fmt.Errorf("trust_roots[%d] %s: duplicate reviewer id %q", i, root.RegistryURL, r.ID)
+			}
+			seenReviewerIDs[r.ID] = struct{}{}
+			if r.PubkeyB64 == "" {
+				return fmt.Errorf("trust_roots[%d].reviewers[%d] (%s): pubkey is required", i, j, r.ID)
+			}
+			raw, err := base64.StdEncoding.DecodeString(r.PubkeyB64)
+			if err != nil {
+				return fmt.Errorf("trust_roots[%d].reviewers[%d] (%s): pubkey is not valid base64: %w", i, j, r.ID, err)
+			}
+			if len(raw) != pubkeyRawSize {
+				return fmt.Errorf("trust_roots[%d].reviewers[%d] (%s): pubkey decodes to %d bytes, want %d", i, j, r.ID, len(raw), pubkeyRawSize)
+			}
+			if r.Fingerprint != "" {
+				want := authorFingerprint(raw)
+				if !strings.EqualFold(strings.TrimSpace(r.Fingerprint), want) {
+					return fmt.Errorf("trust_roots[%d].reviewers[%d] (%s): fingerprint %q does not match pubkey (derived %s)", i, j, r.ID, r.Fingerprint, want)
+				}
+			}
+			t.Roots[i].Reviewers[j].Pubkey = raw
+		}
+		if root.MinRevocationEpoch < 0 {
+			return fmt.Errorf("trust_roots[%d] %s: min_revocation_epoch must be >= 0", i, root.RegistryURL)
+		}
+
 		if root.GovernanceMinimum == "" {
 			return fmt.Errorf("trust_roots[%d] %s: governance_minimum is required", i, root.RegistryURL)
 		}

--- a/pkg/skillctl/verify/trustroots.go
+++ b/pkg/skillctl/verify/trustroots.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"crypto/ed25519"
+	"crypto/sha256"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/govlevel"
 	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
@@ -44,11 +45,18 @@ const DefaultTrustRootsPath = ".claude/skill-trust-roots.yaml"
 const pubkeyRawSize = ed25519.PublicKeySize // 32
 
 // validIdentityModes is the closed set of accepted values for
-// `identity_keys_authorized`. Today only "from-registry" is meaningful;
-// future modes (e.g. "manual-pin") will be added here once their semantics
-// are speced.
+// `identity_keys_authorized`.
+//
+//   - "from-registry" — author pubkeys are resolved from the registry's
+//     identity table at verify time (the v1 default; requires a network call
+//     or a stashed identity).
+//   - "pinned" — author pubkeys are pinned LOCALLY in this trust root's
+//     `authors:` list, so the author signature is verified with NO registry
+//     call. This is the primitive that makes third-party, offline, "no trust
+//     in the registry" verification possible (SPEC-0276 R4.1).
 var validIdentityModes = map[string]struct{}{
 	"from-registry": {},
+	"pinned":        {},
 }
 
 // RegistryKey is one pinned ed25519 public key for a registry. A registry
@@ -94,6 +102,41 @@ func (rk RegistryKey) IsActive() bool {
 	return rk.Retired == ""
 }
 
+// AuthorKey is one pinned ed25519 public key for a skill-author identity.
+// Consulted ONLY when its TrustRoot sets identity_keys_authorized: pinned.
+// Pinning the author key locally lets the verifier check the author signature
+// without calling the registry's identity table — the property that makes
+// fully offline, third-party verification possible (SPEC-0276 R4.1): a party
+// who pins this key out-of-band can reproduce our verdict with no trust in,
+// and no call to, our servers.
+type AuthorKey struct {
+	// ID is the author identity_id exactly as it appears in the bundle's
+	// author signature row (e.g. "id:kamir@m3c"). Matched verbatim.
+	ID string `yaml:"id"`
+
+	// Pubkey is the raw 32-byte ed25519 public key. Hydrated once by Load
+	// from PubkeyB64 so callers don't re-decode per verification.
+	Pubkey []byte `yaml:"-"`
+
+	// PubkeyB64 is the base64 form preserved verbatim for lossless round-trip.
+	PubkeyB64 string `yaml:"pubkey"`
+
+	// Fingerprint, if set, is the advisory "sha256:<hex>" over the raw pubkey
+	// bytes. When present it MUST match the key (a typo'd fingerprint is
+	// refused at Load) so a human who cross-checks the fingerprint out-of-band
+	// can rely on it. Verification uses the key bytes, never this string.
+	Fingerprint string `yaml:"fingerprint,omitempty"`
+
+	// Retired, if non-empty, marks the pin inert — same binary-toggle
+	// semantics as RegistryKey.Retired (the date is metadata, not a schedule).
+	Retired string `yaml:"retired,omitempty"`
+}
+
+// IsActive reports whether the pinned author key is eligible today (not retired).
+func (ak AuthorKey) IsActive() bool {
+	return ak.Retired == ""
+}
+
 // TrustRoot is one pinned registry. It carries 1..N keys (overlap-window
 // rotation) plus the policy knobs that bound what the verifier will admit
 // from this registry.
@@ -111,10 +154,17 @@ type TrustRoot struct {
 	RegistryKeys []RegistryKey `yaml:"registry_keys"`
 
 	// IdentityKeysAuthorized governs how the verifier looks up author
-	// public keys. v1 only accepts "from-registry" — the verifier
-	// trusts the registry's identity table. Future values (e.g.
-	// "manual-pin") would let admins pin authoring identities locally.
+	// public keys. "from-registry" (default) trusts the registry's identity
+	// table; "pinned" verifies the author signature against the local
+	// Authors list below, with no registry call (SPEC-0276 R4.1).
 	IdentityKeysAuthorized string `yaml:"identity_keys_authorized"`
+
+	// Authors are pinned author identities, consulted ONLY when
+	// IdentityKeysAuthorized == "pinned". Each entry binds one author
+	// identity_id to its ed25519 pubkey so the author signature verifies
+	// locally and offline. Ignored (and normally absent) in from-registry
+	// mode. Additive: an empty list in from-registry mode is fine.
+	Authors []AuthorKey `yaml:"authors,omitempty"`
 
 	// GovernanceMinimum is one of "green" or "yellow". A bundle whose
 	// current attestation is below this level is rejected with exit
@@ -132,6 +182,22 @@ func (t TrustRoot) ActiveKeys() []RegistryKey {
 		}
 	}
 	return out
+}
+
+// FindAuthor returns a pointer to the active pinned AuthorKey for identityID,
+// or nil if this root has no active pin for it. Retired pins are skipped so a
+// rotated-out author key cannot verify. The returned pointer aliases the
+// backing array — callers must not mutate it.
+func (t *TrustRoot) FindAuthor(identityID string) *AuthorKey {
+	if t == nil {
+		return nil
+	}
+	for i := range t.Authors {
+		if t.Authors[i].ID == identityID && t.Authors[i].IsActive() {
+			return &t.Authors[i]
+		}
+	}
+	return nil
 }
 
 // TrustRoots is the in-memory representation of the YAML file plus a
@@ -483,7 +549,44 @@ func (t *TrustRoots) validate() error {
 			return fmt.Errorf("trust_roots[%d] %s: identity_keys_authorized is required", i, root.RegistryURL)
 		}
 		if _, ok := validIdentityModes[root.IdentityKeysAuthorized]; !ok {
-			return fmt.Errorf("trust_roots[%d] %s: identity_keys_authorized %q is not one of [from-registry]", i, root.RegistryURL, root.IdentityKeysAuthorized)
+			return fmt.Errorf("trust_roots[%d] %s: identity_keys_authorized %q is not one of [from-registry, pinned]", i, root.RegistryURL, root.IdentityKeysAuthorized)
+		}
+
+		// Pinned-author mode (SPEC-0276 R4.1): the authors list is the local
+		// authority for author pubkeys, so it must be non-empty and every
+		// entry must decode to a valid ed25519 key. In from-registry mode the
+		// list is ignored, but we still validate any entries present so a typo
+		// can't lie dormant until the operator flips the mode.
+		if root.IdentityKeysAuthorized == "pinned" && len(root.Authors) == 0 {
+			return fmt.Errorf("trust_roots[%d] %s: identity_keys_authorized: pinned requires a non-empty authors list", i, root.RegistryURL)
+		}
+		seenAuthorIDs := make(map[string]struct{}, len(root.Authors))
+		for j, a := range root.Authors {
+			if a.ID == "" {
+				return fmt.Errorf("trust_roots[%d].authors[%d]: id is required", i, j)
+			}
+			if _, dup := seenAuthorIDs[a.ID]; dup {
+				return fmt.Errorf("trust_roots[%d] %s: duplicate author id %q", i, root.RegistryURL, a.ID)
+			}
+			seenAuthorIDs[a.ID] = struct{}{}
+			if a.PubkeyB64 == "" {
+				return fmt.Errorf("trust_roots[%d].authors[%d] (%s): pubkey is required", i, j, a.ID)
+			}
+			raw, err := base64.StdEncoding.DecodeString(a.PubkeyB64)
+			if err != nil {
+				return fmt.Errorf("trust_roots[%d].authors[%d] (%s): pubkey is not valid base64: %w", i, j, a.ID, err)
+			}
+			if len(raw) != pubkeyRawSize {
+				return fmt.Errorf("trust_roots[%d].authors[%d] (%s): pubkey decodes to %d bytes, want %d", i, j, a.ID, len(raw), pubkeyRawSize)
+			}
+			if a.Fingerprint != "" {
+				want := authorFingerprint(raw)
+				if !strings.EqualFold(strings.TrimSpace(a.Fingerprint), want) {
+					return fmt.Errorf("trust_roots[%d].authors[%d] (%s): fingerprint %q does not match pubkey (derived %s)", i, j, a.ID, a.Fingerprint, want)
+				}
+			}
+			// Hydrate raw bytes so the verifier doesn't redo the decode.
+			t.Roots[i].Authors[j].Pubkey = raw
 		}
 		if root.GovernanceMinimum == "" {
 			return fmt.Errorf("trust_roots[%d] %s: governance_minimum is required", i, root.RegistryURL)
@@ -608,6 +711,16 @@ func resolveAndValidatePath(path string) (string, error) {
 	// CLI defaulted to ~/.claude/...; that guard lives at the CLI
 	// boundary, not in Load.
 	return abs, nil
+}
+
+// authorFingerprint returns the canonical "sha256:<hex>" fingerprint over the
+// raw ed25519 pubkey bytes. This MUST match the derivation used everywhere
+// else in the trust stack (registry.selfFingerprint, cmd pubkeyFingerprint) so
+// a fingerprint an operator reads from one tool can be pinned in another and
+// cross-checked out-of-band. hexLower lives in verify.go (same package).
+func authorFingerprint(rawPub []byte) string {
+	sum := sha256.Sum256(rawPub)
+	return "sha256:" + hexLower(sum[:])
 }
 
 // deriveKeyID returns a short, deterministic id of the form "key-<hex8>"

--- a/pkg/skillctl/verify/verify.go
+++ b/pkg/skillctl/verify/verify.go
@@ -128,6 +128,12 @@ type VerifyResult struct {
 	// otherwise).
 	GovernanceLevel string
 
+	// GovernanceVerified (SPEC-0281) reports whether GovernanceLevel was
+	// backed by a signed attestation re-verified against a pinned reviewer
+	// key. When false the level is ADVISORY (the registry's unsigned word);
+	// the chain summary reflects this so the tool never overclaims.
+	GovernanceVerified bool
+
 	// ChainSummary is a human-readable one-liner suitable for stdout.
 	ChainSummary string
 }
@@ -207,12 +213,13 @@ func Verify(opts VerifyOpts) (*VerifyResult, error) {
 		logStep(opts.Logger, "tenant_block_ok", "tenant=%s", opts.Tenant)
 	}
 
-	// Step 5 — governance gate.
-	govLevel, err := stepCheckGovernance(opts.BundleMeta, opts.TrustRoot, opts.GovernanceMin, opts.AllowYellow)
+	// Step 5 — governance gate (SPEC-0281: re-verify the signed attestation
+	// against a pinned reviewer key; advisory if no reviewers pinned).
+	govLevel, govVerified, err := stepCheckGovernance(digestStr, opts.BundleMeta, opts.TrustRoot, opts.GovernanceMin, opts.AllowYellow)
 	if err != nil {
 		return nil, err
 	}
-	logStep(opts.Logger, "governance_ok", "level=%s", govLevel)
+	logStep(opts.Logger, "governance_ok", "level=%s verified=%v", govLevel, govVerified)
 
 	// Step 6 — depends_on resolution. v1 is a no-op (bundles in tree
 	// shape rather than DAG; Python-wheel resolution lives behind a
@@ -225,14 +232,22 @@ func Verify(opts VerifyOpts) (*VerifyResult, error) {
 	}
 	logStep(opts.Logger, "deps_ok", "ignore_deps=%v", opts.IgnoreDeps)
 
+	// SPEC-0281: only claim "attested <level>" when the governance attestation
+	// was cryptographically re-verified against a pinned reviewer key; otherwise
+	// report it as advisory so the tool never overclaims governance.
+	govDesc := "attested " + govLevel
+	if !govVerified {
+		govDesc = "governance(advisory) " + govLevel
+	}
 	res := &VerifyResult{
-		Digest:          digestStr,
-		AuthorIdentity:  authorID,
-		RegistryKeyID:   regKeyID,
-		GovernanceLevel: govLevel,
+		Digest:             digestStr,
+		AuthorIdentity:     authorID,
+		RegistryKeyID:      regKeyID,
+		GovernanceLevel:    govLevel,
+		GovernanceVerified: govVerified,
 		ChainSummary: fmt.Sprintf(
-			"%s: signed by %s, admitted by %s, attested %s",
-			digestStr, authorID, regKeyID, govLevel,
+			"%s: signed by %s, admitted by %s, %s",
+			digestStr, authorID, regKeyID, govDesc,
 		),
 	}
 	return res, nil
@@ -457,12 +472,20 @@ func stepVerifyRegistry(digest [sha256.Size]byte, meta *registry.BundleMeta, roo
 // `--allow-yellow` lowers the effective minimum from green to yellow when
 // the trust-root says green. Red bundles are NEVER admitted, regardless
 // of override.
-func stepCheckGovernance(meta *registry.BundleMeta, root *TrustRoot, override string, allowYellow bool) (string, error) {
+//
+// SPEC-0281: the level is taken from BundleMeta.CurrentGovernance, but that field
+// is the registry's UNSIGNED word in the (attacker-editable) sidecar. So the
+// verifier additionally re-verifies the SIGNED governance attestation against a
+// pinned reviewer key. Returns (level, verified). When the trust root sets
+// require_signed_governance, an unverifiable level is REFUSED (defeats the
+// red→green sidecar downgrade); otherwise the level is advisory and `verified`
+// is reported so the caller can avoid claiming "attested".
+func stepCheckGovernance(digestStr string, meta *registry.BundleMeta, root *TrustRoot, override string, allowYellow bool) (string, bool, error) {
 	level := govlevel.Normalize(meta.CurrentGovernance)
 	if level == "" {
 		// Fail-closed: a registry that didn't compute a verdict is
 		// treated as red.
-		return "", fmt.Errorf("verify: bundle has no current_governance (treated as red): %w", ErrGovernanceBelowMin)
+		return "", false, fmt.Errorf("verify: bundle has no current_governance (treated as red): %w", ErrGovernanceBelowMin)
 	}
 
 	min := override
@@ -473,7 +496,7 @@ func stepCheckGovernance(meta *registry.BundleMeta, root *TrustRoot, override st
 	if min == "" {
 		// Defensive — Load already enforces this; surface clearly
 		// rather than panic.
-		return "", fmt.Errorf("verify: trust root %s has no governance_minimum: %w", root.RegistryURL, ErrGovernanceBelowMin)
+		return "", false, fmt.Errorf("verify: trust root %s has no governance_minimum: %w", root.RegistryURL, ErrGovernanceBelowMin)
 	}
 
 	if allowYellow && min == "green" {
@@ -482,17 +505,65 @@ func stepCheckGovernance(meta *registry.BundleMeta, root *TrustRoot, override st
 
 	bundleRank := governanceRank(level)
 	if bundleRank < 0 {
-		return "", fmt.Errorf("verify: unknown governance level %q: %w", level, ErrGovernanceBelowMin)
+		return "", false, fmt.Errorf("verify: unknown governance level %q: %w", level, ErrGovernanceBelowMin)
 	}
 	minRank := governanceRank(min)
 	if minRank < 0 {
-		return "", fmt.Errorf("verify: invalid governance_minimum %q: %w", min, ErrGovernanceBelowMin)
+		return "", false, fmt.Errorf("verify: invalid governance_minimum %q: %w", min, ErrGovernanceBelowMin)
 	}
 
 	if bundleRank < minRank {
-		return "", fmt.Errorf("verify: bundle governance %q below minimum %q: %w", level, min, ErrGovernanceBelowMin)
+		return "", false, fmt.Errorf("verify: bundle governance %q below minimum %q: %w", level, min, ErrGovernanceBelowMin)
 	}
-	return level, nil
+
+	// SPEC-0281: re-verify the signed attestation that backs this level.
+	verified := verifyGovernanceAttestation(digestStr, level, meta, root)
+	if root.RequireSignedGovernance && !verified {
+		return "", false, fmt.Errorf("verify: governance %q is not backed by a signed attestation from a pinned reviewer (require_signed_governance): %w", level, ErrGovernanceBelowMin)
+	}
+	return level, verified, nil
+}
+
+// verifyGovernanceAttestation reports whether `level` is backed by a GLOBAL,
+// active governance attestation whose ed25519 signature verifies against a
+// PINNED reviewer key, over the canonical attestation message bound to this
+// bundle's digest (SPEC-0281 R2/R3). The digest binding defeats cross-bundle
+// replay; the level being part of the signed message defeats the red→green
+// sidecar edit (an attacker has no pinned reviewer's signature over "green").
+func verifyGovernanceAttestation(digestStr, level string, meta *registry.BundleMeta, root *TrustRoot) bool {
+	if len(root.Reviewers) == 0 {
+		return false
+	}
+	for _, att := range meta.Attestations {
+		if att.Status == "revoked" {
+			continue
+		}
+		if strings.TrimSpace(att.TenantScope) != "" {
+			continue // only global rows establish CurrentGovernance
+		}
+		if !strings.EqualFold(strings.TrimSpace(att.Level), level) {
+			continue
+		}
+		if att.SignatureB64 == "" || att.ReviewerID == "" || att.AttestedAt == "" {
+			continue
+		}
+		rk := root.FindReviewer(att.ReviewerID)
+		if rk == nil || len(rk.Pubkey) != ed25519.PublicKeySize {
+			continue
+		}
+		msg, err := signing.CanonicalizeAttestationMessage(digestStr, level, att.AttestedAt, att.ReviewerID)
+		if err != nil {
+			continue
+		}
+		sig, err := decodeSignatureB64(att.SignatureB64)
+		if err != nil {
+			continue
+		}
+		if ed25519.Verify(ed25519.PublicKey(rk.Pubkey), msg, sig) {
+			return true
+		}
+	}
+	return false
 }
 
 // stepTenantBlockCheck implements SPEC-0188 §7 step 5.5: when the consumer

--- a/pkg/skillctl/verify/verify.go
+++ b/pkg/skillctl/verify/verify.go
@@ -535,7 +535,10 @@ func verifyGovernanceAttestation(digestStr, level string, meta *registry.BundleM
 		return false
 	}
 	for _, att := range meta.Attestations {
-		if att.Status == "revoked" {
+		// Status allowlist (defense-in-depth): only "active" (or empty for
+		// forward-compat) rows establish governance; "revoked" and any unknown
+		// future status are skipped in the protective direction.
+		if att.Status != "" && att.Status != "active" {
 			continue
 		}
 		if strings.TrimSpace(att.TenantScope) != "" {

--- a/pkg/skillctl/verify/verify.go
+++ b/pkg/skillctl/verify/verify.go
@@ -174,7 +174,7 @@ func Verify(opts VerifyOpts) (*VerifyResult, error) {
 	logStep(opts.Logger, "bundle_admitted_ok", "")
 
 	// Step 2/3 — verify author signature against identity pubkey.
-	authorID, err := stepVerifyAuthor(ctx, digestRaw, opts.BundleMeta, opts.IdentityFetcher, opts.Logger)
+	authorID, err := stepVerifyAuthor(ctx, digestRaw, opts.BundleMeta, opts.TrustRoot, opts.IdentityFetcher, opts.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -250,8 +250,11 @@ func validateOpts(opts VerifyOpts) error {
 	if opts.TrustRoot == nil {
 		return errors.New("verify: TrustRoot is required")
 	}
-	if opts.IdentityFetcher == nil {
-		return errors.New("verify: IdentityFetcher is required")
+	// In pinned-author mode the author signature is checked against a locally
+	// pinned key (SPEC-0276 R4.1), so no identity fetcher is needed — this is
+	// the fully-offline path. Every other mode requires a fetcher.
+	if opts.TrustRoot.IdentityKeysAuthorized != "pinned" && opts.IdentityFetcher == nil {
+		return errors.New("verify: IdentityFetcher is required (or pin authors via identity_keys_authorized: pinned)")
 	}
 	return nil
 }
@@ -324,7 +327,7 @@ func stepCheckBundleStatus(meta *registry.BundleMeta) error {
 //   - identity not found / revoked
 //   - pubkey malformed (length, base64)
 //   - ed25519.Verify says no
-func stepVerifyAuthor(ctx context.Context, digest [sha256.Size]byte, meta *registry.BundleMeta, fetcher identityFetcher, logger io.Writer) (string, error) {
+func stepVerifyAuthor(ctx context.Context, digest [sha256.Size]byte, meta *registry.BundleMeta, root *TrustRoot, fetcher identityFetcher, logger io.Writer) (string, error) {
 	row, err := pickSingleSignature(meta.Signatures, "author")
 	if err != nil {
 		return "", fmt.Errorf("verify: %w: %w", ErrAuthorSigInvalid, err)
@@ -334,6 +337,40 @@ func stepVerifyAuthor(ctx context.Context, digest [sha256.Size]byte, meta *regis
 		return "", fmt.Errorf("verify: author signature has empty identity_id: %w", ErrAuthorSigInvalid)
 	}
 
+	sig, err := decodeSignatureB64(row.SignatureB64)
+	if err != nil {
+		return "", fmt.Errorf("verify: decode author signature: %w", errors.Join(ErrAuthorSigInvalid, err))
+	}
+
+	// Pinned-author mode (SPEC-0276 R4.1): verify the author signature against
+	// a key pinned LOCALLY in trust-roots, with NO registry call. This is what
+	// makes third-party, fully-offline verification real — the verifier trusts
+	// a key it pinned out-of-band, not the registry's identity table.
+	//
+	// Trade-off: offline mode cannot see a registry-side identity revocation
+	// (the author identity is implicitly frozen at pin time). Post-issuance
+	// revocation is covered separately by the signed revocation list
+	// (SPEC-0276 R4.2.4), not by an identity-table lookup here.
+	if root != nil && root.IdentityKeysAuthorized == "pinned" {
+		ak := root.FindAuthor(row.IdentityID)
+		if ak == nil {
+			return "", fmt.Errorf("verify: author identity %s is not pinned in trust root %s: %w", row.IdentityID, root.RegistryURL, ErrAuthorSigInvalid)
+		}
+		if len(ak.Pubkey) != ed25519.PublicKeySize {
+			return "", fmt.Errorf("verify: pinned author key for %s is malformed (%d bytes): %w", row.IdentityID, len(ak.Pubkey), ErrAuthorSigInvalid)
+		}
+		if !ed25519.Verify(ed25519.PublicKey(ak.Pubkey), digest[:], sig) {
+			return "", fmt.Errorf("verify: ed25519 author signature failed for pinned identity %s: %w", row.IdentityID, ErrAuthorSigInvalid)
+		}
+		logStep(logger, "author_identity", "id=%s source=pinned", row.IdentityID)
+		return row.IdentityID, nil
+	}
+
+	// from-registry mode (default): resolve the author pubkey from the
+	// registry's identity table.
+	if fetcher == nil {
+		return "", fmt.Errorf("verify: no identity fetcher and author %s not pinned: %w", row.IdentityID, ErrAuthorSigInvalid)
+	}
 	ident, err := fetcher.GetIdentity(ctx, row.IdentityID)
 	if err != nil {
 		return "", fmt.Errorf("verify: fetch identity %s: %w", row.IdentityID, errors.Join(ErrAuthorSigInvalid, err))
@@ -360,11 +397,7 @@ func stepVerifyAuthor(ctx context.Context, digest [sha256.Size]byte, meta *regis
 		return "", fmt.Errorf("verify: decode pubkey for %s: %w", ident.ID, errors.Join(ErrAuthorSigInvalid, err))
 	}
 
-	sig, err := decodeSignatureB64(row.SignatureB64)
-	if err != nil {
-		return "", fmt.Errorf("verify: decode author signature: %w", errors.Join(ErrAuthorSigInvalid, err))
-	}
-
+	// sig was decoded once up front (shared with the pinned path).
 	// ed25519.Verify is constant-time on the signature comparison per
 	// stdlib docs. Don't roll our own.
 	if !ed25519.Verify(pub, digest[:], sig) {

--- a/pkg/skillctl/verify/verify_pinned_test.go
+++ b/pkg/skillctl/verify/verify_pinned_test.go
@@ -1,0 +1,225 @@
+package verify
+
+// Tests for SPEC-0276 R4.1 — pinned author identities. The point of the
+// feature is fully-offline, third-party verification: the author signature is
+// checked against a key pinned LOCALLY in trust-roots, with NO registry call.
+// These tests therefore pass a nil IdentityFetcher on the happy path — if the
+// verifier reached for the registry it would nil-panic, which is the strongest
+// possible proof that pinned mode is network-free.
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+)
+
+// pinnedTrustRoot builds a TrustRoot in pinned mode that pins authorID to
+// authorPub and trusts regPub as the registry key. Pubkey raw bytes are set
+// directly (Load hydrates them; a hand-built fixture must do it itself).
+func pinnedTrustRoot(authorID string, authorPub, regPub ed25519.PublicKey, govMin string) *TrustRoot {
+	if govMin == "" {
+		govMin = "green"
+	}
+	return &TrustRoot{
+		RegistryURL: "https://reg.example/api/skills",
+		RegistryKeys: []RegistryKey{{
+			ID:        "reg-key-1",
+			Pubkey:    []byte(regPub),
+			PubkeyB64: base64.StdEncoding.EncodeToString(regPub),
+			Issued:    "2026-05-05",
+		}},
+		IdentityKeysAuthorized: "pinned",
+		Authors: []AuthorKey{{
+			ID:        authorID,
+			Pubkey:    []byte(authorPub),
+			PubkeyB64: base64.StdEncoding.EncodeToString(authorPub),
+		}},
+		GovernanceMinimum: govMin,
+	}
+}
+
+// pinnedOpts wires a complete VerifyOpts in pinned mode with NO fetcher.
+func pinnedOpts(t *testing.T) (VerifyOpts, keyMaterial) {
+	t.Helper()
+	authorKey := mustKeypair(t)
+	regKey := mustKeypair(t)
+	bundlePath, digestRaw, digestStr := writeBundle(t, []byte("pinned-mode bundle bytes"))
+	authorSig := signOver(t, authorKey.priv, digestRaw)
+	regSig := signOver(t, regKey.priv, digestRaw)
+	authorID := "id:kamir@m3c"
+
+	opts := VerifyOpts{
+		BundlePath:      bundlePath,
+		BundleMeta:      goodMeta(digestStr, authorID, authorSig, regSig, "green"),
+		TrustRoot:       pinnedTrustRoot(authorID, authorKey.pub, regKey.pub, "green"),
+		IdentityFetcher: nil, // pinned mode must not need it
+	}
+	return opts, authorKey
+}
+
+func TestVerify_Pinned_HappyPath_NoFetcher(t *testing.T) {
+	opts, _ := pinnedOpts(t)
+	var log bytes.Buffer
+	opts.Logger = &log
+
+	res, err := Verify(opts)
+	if err != nil {
+		t.Fatalf("pinned verify should pass with no fetcher, got: %v", err)
+	}
+	if res.AuthorIdentity != "id:kamir@m3c" {
+		t.Errorf("author identity = %q, want id:kamir@m3c", res.AuthorIdentity)
+	}
+	if !bytes.Contains(log.Bytes(), []byte("source=pinned")) {
+		t.Errorf("verbose log should record source=pinned; got:\n%s", log.String())
+	}
+}
+
+func TestVerify_Pinned_DoesNotCallFetcher(t *testing.T) {
+	opts, _ := pinnedOpts(t)
+	called := false
+	opts.IdentityFetcher = &spyFetcher{onCall: func() { called = true }}
+
+	if _, err := Verify(opts); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if called {
+		t.Fatal("pinned mode must NOT call the identity fetcher")
+	}
+}
+
+// spyFetcher records whether GetIdentity was invoked.
+type spyFetcher struct{ onCall func() }
+
+func (s *spyFetcher) GetIdentity(_ context.Context, id string) (*registry.Identity, error) {
+	s.onCall()
+	return &registry.Identity{ID: id, AuthSource: "manual"}, nil
+}
+
+func TestVerify_Pinned_AuthorNotPinned(t *testing.T) {
+	opts, _ := pinnedOpts(t)
+	// Remove the pin so the author id is unknown locally.
+	opts.TrustRoot.Authors = []AuthorKey{{
+		ID:        "id:someone-else@m3c",
+		Pubkey:    opts.TrustRoot.Authors[0].Pubkey,
+		PubkeyB64: opts.TrustRoot.Authors[0].PubkeyB64,
+	}}
+
+	_, err := Verify(opts)
+	if !errors.Is(err, ErrAuthorSigInvalid) {
+		t.Fatalf("unpinned author should yield ErrAuthorSigInvalid, got: %v", err)
+	}
+}
+
+func TestVerify_Pinned_WrongKey(t *testing.T) {
+	opts, _ := pinnedOpts(t)
+	// Pin a DIFFERENT key under the right id — signature won't verify.
+	other := mustKeypair(t)
+	opts.TrustRoot.Authors[0].Pubkey = []byte(other.pub)
+	opts.TrustRoot.Authors[0].PubkeyB64 = other.b64
+
+	_, err := Verify(opts)
+	if !errors.Is(err, ErrAuthorSigInvalid) {
+		t.Fatalf("wrong pinned key should yield ErrAuthorSigInvalid, got: %v", err)
+	}
+}
+
+func TestVerify_Pinned_RetiredKeyRejected(t *testing.T) {
+	opts, _ := pinnedOpts(t)
+	opts.TrustRoot.Authors[0].Retired = "2026-06-01"
+
+	_, err := Verify(opts)
+	if !errors.Is(err, ErrAuthorSigInvalid) {
+		t.Fatalf("retired pin should be inert → ErrAuthorSigInvalid, got: %v", err)
+	}
+}
+
+// ----- trust-roots Load/validate tests for the pinned schema -----
+
+func writeTrustRootsYAML(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "skill-trust-roots.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	return p
+}
+
+func TestTrustRoots_Pinned_RequiresAuthors(t *testing.T) {
+	regKey := mustKeypair(t)
+	body := "" +
+		"trust_roots:\n" +
+		"  - registry_url: https://reg.example/api/skills\n" +
+		"    registry_keys:\n" +
+		"      - id: reg-key-1\n" +
+		"        pubkey: " + regKey.b64 + "\n" +
+		"    identity_keys_authorized: pinned\n" +
+		"    governance_minimum: green\n"
+	_, err := Load(writeTrustRootsYAML(t, body))
+	if err == nil {
+		t.Fatal("pinned mode with no authors should fail validation")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("requires a non-empty authors")) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestTrustRoots_Pinned_FingerprintMatch_Hydrates(t *testing.T) {
+	regKey := mustKeypair(t)
+	authorKey := mustKeypair(t)
+	fp := authorFingerprint(authorKey.pub)
+	body := "" +
+		"trust_roots:\n" +
+		"  - registry_url: https://reg.example/api/skills\n" +
+		"    registry_keys:\n" +
+		"      - id: reg-key-1\n" +
+		"        pubkey: " + regKey.b64 + "\n" +
+		"    identity_keys_authorized: pinned\n" +
+		"    governance_minimum: green\n" +
+		"    authors:\n" +
+		"      - id: id:kamir@m3c\n" +
+		"        pubkey: " + authorKey.b64 + "\n" +
+		"        fingerprint: " + fp + "\n"
+	tr, err := Load(writeTrustRootsYAML(t, body))
+	if err != nil {
+		t.Fatalf("valid pinned config should load, got: %v", err)
+	}
+	ak := tr.Roots[0].FindAuthor("id:kamir@m3c")
+	if ak == nil {
+		t.Fatal("FindAuthor should locate the pinned author")
+	}
+	if len(ak.Pubkey) != ed25519.PublicKeySize {
+		t.Errorf("Pubkey not hydrated: %d bytes", len(ak.Pubkey))
+	}
+}
+
+func TestTrustRoots_Pinned_FingerprintMismatch_Refuses(t *testing.T) {
+	regKey := mustKeypair(t)
+	authorKey := mustKeypair(t)
+	wrong := authorFingerprint(mustKeypair(t).pub) // a real-looking but wrong fp
+	body := "" +
+		"trust_roots:\n" +
+		"  - registry_url: https://reg.example/api/skills\n" +
+		"    registry_keys:\n" +
+		"      - id: reg-key-1\n" +
+		"        pubkey: " + regKey.b64 + "\n" +
+		"    identity_keys_authorized: pinned\n" +
+		"    governance_minimum: green\n" +
+		"    authors:\n" +
+		"      - id: id:kamir@m3c\n" +
+		"        pubkey: " + authorKey.b64 + "\n" +
+		"        fingerprint: " + wrong + "\n"
+	_, err := Load(writeTrustRootsYAML(t, body))
+	if err == nil {
+		t.Fatal("mismatched fingerprint must be refused")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("does not match pubkey")) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## What & why

Round A of the response to the ComputeID/AgentPassport competitive signal (SPEC-0276 in `m3c-tools-maintenance`). A hosted-CA rival markets *"anyone can verify, no trust required"* — a property its centralized architecture cannot deliver. This PR makes that property **real and demonstrable**: a third party verifies a bundle on an air-gapped box, against a key they pinned out-of-band, with no call to us.

`skillctl verify --offline` already existed for installed skills; the gaps were (a) author keys were registry-fetched, (b) no standalone file verifier, (c) no portable kit, (d) no offline revocation, (e) no compliance artifact. All closed here.

## Steps (5 commits)

1. **Pinned author identities** — `identity_keys_authorized: pinned` + `Authors` in trust-roots; `stepVerifyAuthor` verifies against a locally pinned ed25519 key, **no fetcher, no network**.
2. **`verify --bundle <file.skb>`** — standalone offline verifier (`--meta`/`--trust-roots`/`--json`); content-binding + §11 exit codes inherited from `verify.Verify`.
3. **Signed offline revocation list** — `verify --bundle --revocations`: revoked digest → exit 17; **fail-closed** on a forged/unsigned list → exit 12.
4. **`export-verification-kit`** — packages `{.skb, .skbmeta.json, minimal pinned trust-roots, optional revocations, VERIFY.md, verify.sh}` (+ `--zip`); self-validates before writing; hard secret-scrub gate; refuses already-revoked bundles. **The decisive test exports a kit then verifies from the kit's files alone → exit 0.**
5. **`compliance report --framework eu-ai-act|nist-ai-rmf|soc2`** (P1) — offline evidence pack from existing metadata + an embedded control→evidence map; md/json; explicitly an **evidence aid, not a certification**.

## Tests & gates
- **29 new tests** across `pkg/skillctl/verify` and `cmd/skillctl` (pinned verify, bundle e2e, revocation crypto + e2e, kit round-trip/scrub/zip, compliance).
- `go build ./... && go vet ./...` clean; new files gofmt-clean; `cmd/skillctl` + `verify` + `install` suites green. Real-binary smoke confirmed.
- Backward compatible: `from-registry` stays the default; existing tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)