### PR TITLE
SPEC-0246 P1c: bodyscan/floor hardening (key-confusion guard, case-norm, audit NotScanned)

### DIFF
--- a/cmd/skillctl/audit_security_cmds.go
+++ b/cmd/skillctl/audit_security_cmds.go
@@ -124,6 +124,7 @@ func runAuditSecurity(args []string, stdout, stderr io.Writer) int {
 			Skill        string                  `json:"skill"`
 			SkillMD      string                  `json:"skill_md"`
 			BodyScan     bodyscan.BodyScanReport `json:"bodyscan"`
+			NotScanned   bool                    `json:"not_scanned"`
 			SelfAttested *bool                   `json:"self_attested"`
 			ReviewerID   string                  `json:"reviewer_id,omitempty"`
 			AuthorID     string                  `json:"author_id,omitempty"`
@@ -131,6 +132,7 @@ func runAuditSecurity(args []string, stdout, stderr io.Writer) int {
 			Skill:      name,
 			SkillMD:    skillMD,
 			BodyScan:   rep,
+			NotScanned: bodyscan.NotScanned(rep),
 			ReviewerID: reviewer,
 			AuthorID:   author,
 		}
@@ -156,6 +158,9 @@ func runAuditSecurity(args []string, stdout, stderr io.Writer) int {
 	if reviewer != "" || author != "" {
 		fmt.Fprintf(stdout, "  reviewer_id: %s\n", emptyDash(reviewer))
 		fmt.Fprintf(stdout, "  author_id:   %s\n", emptyDash(author))
+	}
+	if bodyscan.NotScanned(rep) {
+		fmt.Fprintln(stdout, "note:          body NOT scanned (oversized) — verdict is advisory, not a clean signal")
 	}
 	fmt.Fprintln(stdout, "")
 	renderBodyScanTable(stdout, skillMD, rep)

--- a/pkg/skillctl/verify/p1c_hardening_test.go
+++ b/pkg/skillctl/verify/p1c_hardening_test.go
@@ -1,0 +1,70 @@
+package verify
+
+// P1c hardening (SPEC-0246/0281 follow-ups): the key-confusion guard and
+// case-normalized reviewer/author lookup.
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// A key pinned as BOTH an author and a reviewer in one root must be refused at
+// Load — otherwise the author could sign an "independent" attestation under a
+// reviewer id and launder reviewer≠author.
+func TestTrustRoots_KeyConfusion_Refused(t *testing.T) {
+	regKey := mustKeypair(t)
+	shared := mustKeypair(t) // same key pinned as author AND reviewer
+	body := "" +
+		"trust_roots:\n" +
+		"  - registry_url: https://reg.example/api/skills\n" +
+		"    registry_keys:\n      - id: reg-key-1\n        pubkey: " + regKey.b64 + "\n" +
+		"    identity_keys_authorized: pinned\n    governance_minimum: green\n" +
+		"    require_independent_review: true\n" +
+		"    authors:\n      - id: id:author@m3c\n        pubkey: " + shared.b64 + "\n" +
+		"    reviewers:\n      - id: id:reviewer@m3c\n        pubkey: " + shared.b64 + "\n"
+	_, err := Load(writeTrustRootsYAML(t, body))
+	if err == nil {
+		t.Fatal("a key pinned as both author and reviewer must be refused")
+	}
+	if !strings.Contains(err.Error(), "key-confusion") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Distinct keys for author vs reviewer load fine (the common, correct config).
+func TestTrustRoots_DistinctAuthorReviewer_OK(t *testing.T) {
+	regKey := mustKeypair(t)
+	a := mustKeypair(t)
+	r := mustKeypair(t)
+	body := "" +
+		"trust_roots:\n" +
+		"  - registry_url: https://reg.example/api/skills\n" +
+		"    registry_keys:\n      - id: reg-key-1\n        pubkey: " + regKey.b64 + "\n" +
+		"    identity_keys_authorized: pinned\n    governance_minimum: green\n" +
+		"    require_independent_review: true\n" +
+		"    authors:\n      - id: id:author@m3c\n        pubkey: " + a.b64 + "\n" +
+		"    reviewers:\n      - id: id:reviewer@m3c\n        pubkey: " + r.b64 + "\n"
+	if _, err := Load(writeTrustRootsYAML(t, body)); err != nil {
+		t.Fatalf("distinct author/reviewer keys should load: %v", err)
+	}
+}
+
+// FindReviewer / FindAuthor match ids case-insensitively (no lookup vs equality
+// asymmetry).
+func TestFindReviewerAuthor_CaseNormalized(t *testing.T) {
+	k := mustKeypair(t)
+	root := &TrustRoot{
+		Reviewers: []AuthorKey{{ID: "id:bob@m3c", Pubkey: []byte(k.pub), PubkeyB64: base64.StdEncoding.EncodeToString(k.pub)}},
+		Authors:   []AuthorKey{{ID: "id:dana@m3c", Pubkey: []byte(k.pub), PubkeyB64: base64.StdEncoding.EncodeToString(k.pub)}},
+	}
+	if root.FindReviewer("  id:BOB@M3C ") == nil {
+		t.Error("FindReviewer should match case/whitespace-variant id")
+	}
+	if root.FindAuthor("ID:Dana@m3c") == nil {
+		t.Error("FindAuthor should match case-variant id")
+	}
+	if root.FindReviewer("id:someone-else@m3c") != nil {
+		t.Error("FindReviewer must not match a different id")
+	}
+}

--- a/pkg/skillctl/verify/trustroots.go
+++ b/pkg/skillctl/verify/trustroots.go
@@ -222,8 +222,9 @@ func (t *TrustRoot) FindAuthor(identityID string) *AuthorKey {
 	if t == nil {
 		return nil
 	}
+	want := normalizeIdentityID(identityID)
 	for i := range t.Authors {
-		if t.Authors[i].ID == identityID && t.Authors[i].IsActive() {
+		if normalizeIdentityID(t.Authors[i].ID) == want && t.Authors[i].IsActive() {
 			return &t.Authors[i]
 		}
 	}
@@ -231,13 +232,16 @@ func (t *TrustRoot) FindAuthor(identityID string) *AuthorKey {
 }
 
 // FindReviewer returns the active pinned reviewer key for identityID, or nil
-// (SPEC-0281). Retired pins are skipped. Mirrors FindAuthor.
+// (SPEC-0281). Retired pins are skipped. Mirrors FindAuthor. ID matching is
+// case-normalized (P1c) so it agrees with the reviewer≠author comparison in
+// verify.go — no case-twin asymmetry between lookup and equality.
 func (t *TrustRoot) FindReviewer(identityID string) *AuthorKey {
 	if t == nil {
 		return nil
 	}
+	want := normalizeIdentityID(identityID)
 	for i := range t.Reviewers {
-		if t.Reviewers[i].ID == identityID && t.Reviewers[i].IsActive() {
+		if normalizeIdentityID(t.Reviewers[i].ID) == want && t.Reviewers[i].IsActive() {
 			return &t.Reviewers[i]
 		}
 	}
@@ -676,6 +680,20 @@ func (t *TrustRoots) validate() error {
 			}
 			t.Roots[i].Reviewers[j].Pubkey = raw
 		}
+
+		// P1c key-confusion guard: the SAME key must not be pinned as BOTH an
+		// author and a reviewer in one root. Otherwise the author could sign an
+		// "independent" governance attestation under a reviewer id and launder
+		// reviewer≠author (the floor compares ids, not key bytes). Compare raw
+		// pubkey bytes — ids may differ while the key is the same.
+		for ai := range t.Roots[i].Authors {
+			for ri := range t.Roots[i].Reviewers {
+				if string(t.Roots[i].Authors[ai].Pubkey) == string(t.Roots[i].Reviewers[ri].Pubkey) {
+					return fmt.Errorf("trust_roots[%d] %s: key pinned as both author %q and reviewer %q — a key cannot be both (key-confusion)", i, root.RegistryURL, t.Roots[i].Authors[ai].ID, t.Roots[i].Reviewers[ri].ID)
+				}
+			}
+		}
+
 		if root.MinRevocationEpoch < 0 {
 			return fmt.Errorf("trust_roots[%d] %s: min_revocation_epoch must be >= 0", i, root.RegistryURL)
 		}


### PR DESCRIPTION
LOW non-blocking follow-ups from the P1b challenge re-review (all stricter-only):
- **Key-confusion guard** — `trustroots.validate()` refuses a key pinned as both author and reviewer in one root (closes the N1 relying-party self-misconfiguration the red-team flagged).
- **Case-normalized lookup** — `FindAuthor`/`FindReviewer` match ids via `normalizeIdentityID`, removing the lookup-vs-equality asymmetry (safe: still needs the pinned private key).
- **`audit security` NotScanned** — surfaces oversized/not-scanned in JSON + text so it isn't read as a benign yellow.

Tests added; build/vet/gofmt/golangci-lint(0)/test green. No new exit codes; no behavior change to the merged P1b enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)