### PR TITLE
SPEC-0196/0202 P2: declared data-scope + per-invocation signed runtime envelope

### DIFF
--- a/cmd/skillctl/compliance_cmds.go
+++ b/cmd/skillctl/compliance_cmds.go
@@ -43,7 +43,37 @@ type complianceReport struct {
 	Summary    map[string]int      `json:"summary"`
 	Skills     []complianceSkill   `json:"skills"`
 	ControlMap []complianceControl `json:"control_map"`
+	Trail      *trailVerification  `json:"invocation_trail,omitempty"`
 	Disclaimer string              `json:"disclaimer"`
+}
+
+// withTrailEvidence returns a copy of the control map in which the EU AI Act
+// Art.12 "Evidence" cell is replaced with the concrete, verified figures from
+// the signed invocation trail. Non-Art.12 rows and other frameworks are
+// untouched. Pure — never mutates the package-level complianceFrameworks map.
+func withTrailEvidence(controls []complianceControl, tv trailVerification) []complianceControl {
+	out := make([]complianceControl, len(controls))
+	copy(out, controls)
+	for i := range out {
+		if strings.HasPrefix(out[i].Control, "Art. 12") {
+			out[i].Evidence = trailEvidenceSentence(tv)
+		}
+	}
+	return out
+}
+
+// trailEvidenceSentence renders a one-line, auditor-readable summary of the
+// signed-trail state for the Art.12 evidence cell.
+func trailEvidenceSentence(tv trailVerification) string {
+	if !tv.Present {
+		return "Per-invocation signed events (SPEC-0202): no invocation-trail.jsonl yet on this host (no skill invocations recorded). Trail is created on first gated invocation."
+	}
+	key := tv.DeviceKeyID
+	if key == "" {
+		key = "(device key unavailable — cannot verify)"
+	}
+	return fmt.Sprintf("Per-invocation signed events (SPEC-0202): %d/%d invocation records device-signed & verified offline (%d unverified, %d replays) by device key %s. Append-only ~/.claude/skillctl/invocation-trail.jsonl.",
+		tv.Verified, tv.Total, tv.Unverified, tv.Replays, key)
 }
 
 const complianceDisclaimer = "Evidence aid for an auditor — NOT a certification or attestation of compliance. " +
@@ -105,17 +135,19 @@ func runCompliance(args []string, stdout, stderr io.Writer) int {
 		return exitUsage
 	}
 
+	// Resolve home first — needed both for the default skills dir AND for the
+	// signed invocation trail (the Art.12 evidence).
+	home := *homeOverride
+	if home == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Fprintf(stderr, "compliance: resolve home: %v\n", err)
+			return exitGeneric
+		}
+		home = h
+	}
 	dir := *skillsDir
 	if dir == "" {
-		home := *homeOverride
-		if home == "" {
-			h, err := os.UserHomeDir()
-			if err != nil {
-				fmt.Fprintf(stderr, "compliance: resolve home: %v\n", err)
-				return exitGeneric
-			}
-			home = h
-		}
 		dir = filepath.Join(home, ".claude", "skills")
 	}
 
@@ -125,12 +157,24 @@ func runCompliance(args []string, stdout, stderr io.Writer) int {
 		return exitGeneric
 	}
 
+	// SPEC-0202 §9 — read + verify the device-signed invocation trail. This is
+	// the concrete, offline-verifiable evidence for the EU AI Act Art.12
+	// record-keeping control: the report now reports HOW MANY invocation records
+	// are signed and verifiable, by which device key — not just a forward-ref.
+	tv := readAndVerifyTrail(home)
+
+	// For the EU AI Act framework, replace the static Art.12 "Evidence" cell
+	// with the concrete trail figures. Copy the slice so we don't mutate the
+	// package-level map.
+	controls = withTrailEvidence(controls, tv)
+
 	rep := complianceReport{
 		Framework:  strings.ToLower(strings.TrimSpace(*framework)),
 		SkillsDir:  dir,
 		Summary:    summarizeCompliance(skills),
 		Skills:     skills,
 		ControlMap: controls,
+		Trail:      &tv,
 		Disclaimer: complianceDisclaimer,
 	}
 
@@ -159,6 +203,11 @@ func runCompliance(args []string, stdout, stderr io.Writer) int {
 func collectComplianceSkills(skillsDir string) ([]complianceSkill, error) {
 	entries, err := os.ReadDir(skillsDir)
 	if err != nil {
+		// A missing skills dir is a valid empty inventory (a host that has not
+		// installed any skill yet) — not an error. Other read errors propagate.
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	var out []complianceSkill
@@ -259,7 +308,21 @@ func renderComplianceMD(r complianceReport) string {
 	fmt.Fprintf(&b, "- Total skills: %d\n", r.Summary["total"])
 	fmt.Fprintf(&b, "- Governance: %d green · %d yellow · %d red · %d unknown\n", r.Summary["green"], r.Summary["yellow"], r.Summary["red"], r.Summary["unknown"])
 	fmt.Fprintf(&b, "- Offline-verifiable (stashed metadata): %d\n", r.Summary["offline_verifiable"])
-	fmt.Fprintf(&b, "- With provenance: %d\n\n", r.Summary["with_provenance"])
+	fmt.Fprintf(&b, "- With provenance: %d\n", r.Summary["with_provenance"])
+	if r.Trail != nil {
+		t := r.Trail
+		if !t.Present {
+			fmt.Fprintf(&b, "- Signed invocation trail (SPEC-0202): none yet (no recorded invocations)\n")
+		} else {
+			key := t.DeviceKeyID
+			if key == "" {
+				key = "(unavailable)"
+			}
+			fmt.Fprintf(&b, "- Signed invocation trail (SPEC-0202): %d/%d records verified · %d unverified · %d replays · device key %s\n",
+				t.Verified, t.Total, t.Unverified, t.Replays, key)
+		}
+	}
+	b.WriteString("\n")
 
 	b.WriteString("## Inventory\n\n")
 	b.WriteString("| Skill | Version | Governance | Author | Offline | Provenance |\n")

--- a/cmd/skillctl/compliance_cmds.go
+++ b/cmd/skillctl/compliance_cmds.go
@@ -72,7 +72,12 @@ func trailEvidenceSentence(tv trailVerification) string {
 	if key == "" {
 		key = "(device key unavailable — cannot verify)"
 	}
-	return fmt.Sprintf("Per-invocation signed events (SPEC-0202): %d/%d invocation records device-signed & verified offline (%d unverified, %d replays) by device key %s. Append-only ~/.claude/skillctl/invocation-trail.jsonl.",
+	// Honest framing (P2 challenge-gate F-5.1): the device key is LOCALLY ANCHORED
+	// — verification proves integrity-since-signing on THIS host, not authenticity
+	// against an external root (registry attestation of the device key is a
+	// follow-up). Do not let an auditor read self-referential verification as
+	// external attestation.
+	return fmt.Sprintf("Per-invocation signed events (SPEC-0202): %d/%d invocation records pass local device-key integrity verification (%d unverified, %d replays). Device key %s is locally anchored (integrity-since-signing on this host; not yet registry-attested). Append-only ~/.claude/skillctl/invocation-trail.jsonl.",
 		tv.Verified, tv.Total, tv.Unverified, tv.Replays, key)
 }
 

--- a/cmd/skillctl/compliance_test.go
+++ b/cmd/skillctl/compliance_test.go
@@ -127,11 +127,15 @@ func TestCompliance_Art12PointsAtSignedTrail(t *testing.T) {
 	if art12 == "" {
 		t.Fatalf("Art.12 control row missing")
 	}
-	if !bytes.Contains([]byte(art12), []byte("2/2 invocation records device-signed & verified")) {
+	if !bytes.Contains([]byte(art12), []byte("2/2 invocation records pass local device-key integrity verification")) {
 		t.Errorf("Art.12 evidence does not reflect the signed trail; got %q", art12)
 	}
 	if !bytes.Contains([]byte(art12), []byte("device:")) {
 		t.Errorf("Art.12 evidence missing device key id; got %q", art12)
+	}
+	// Honesty (P2 F-5.1): the sentence must NOT overclaim external attestation.
+	if !bytes.Contains([]byte(art12), []byte("locally anchored")) {
+		t.Errorf("Art.12 evidence must state the local-anchor trust boundary; got %q", art12)
 	}
 }
 

--- a/cmd/skillctl/compliance_test.go
+++ b/cmd/skillctl/compliance_test.go
@@ -90,6 +90,67 @@ func TestCompliance_MDHasDisclaimerAndControls(t *testing.T) {
 	}
 }
 
+func TestCompliance_Art12PointsAtSignedTrail(t *testing.T) {
+	home := t.TempDir()
+	skillsDir := filepath.Join(home, ".claude", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Emit two device-signed invocation records into this home's trail.
+	appendSignedInvocation(home, sampleInvocation())
+	r2 := sampleInvocation()
+	r2.EventID = "01HZTRAILEVENT00000000099"
+	appendSignedInvocation(home, r2)
+
+	var out, errBuf bytes.Buffer
+	code := runCompliance([]string{"report", "--framework", "eu-ai-act", "--home", home, "--format", "json"}, &out, &errBuf)
+	if code != exitOK {
+		t.Fatalf("want 0, got %d; stderr=%s", code, errBuf.String())
+	}
+	var rep complianceReport
+	if err := json.Unmarshal(out.Bytes(), &rep); err != nil {
+		t.Fatalf("json: %v\n%s", err, out.String())
+	}
+	if rep.Trail == nil {
+		t.Fatalf("report missing invocation_trail block")
+	}
+	if rep.Trail.Total != 2 || rep.Trail.Verified != 2 {
+		t.Errorf("trail figures wrong: %+v", *rep.Trail)
+	}
+	// The Art.12 control row must carry the concrete signed-trail figures.
+	var art12 string
+	for _, c := range rep.ControlMap {
+		if bytes.Contains([]byte(c.Control), []byte("Art. 12")) {
+			art12 = c.Evidence
+		}
+	}
+	if art12 == "" {
+		t.Fatalf("Art.12 control row missing")
+	}
+	if !bytes.Contains([]byte(art12), []byte("2/2 invocation records device-signed & verified")) {
+		t.Errorf("Art.12 evidence does not reflect the signed trail; got %q", art12)
+	}
+	if !bytes.Contains([]byte(art12), []byte("device:")) {
+		t.Errorf("Art.12 evidence missing device key id; got %q", art12)
+	}
+}
+
+func TestCompliance_Art12NoTrailYet(t *testing.T) {
+	home := t.TempDir()
+	var out, errBuf bytes.Buffer
+	code := runCompliance([]string{"report", "--framework", "eu-ai-act", "--home", home, "--format", "json"}, &out, &errBuf)
+	if code != exitOK {
+		t.Fatalf("want 0, got %d", code)
+	}
+	var rep complianceReport
+	if err := json.Unmarshal(out.Bytes(), &rep); err != nil {
+		t.Fatal(err)
+	}
+	if rep.Trail == nil || rep.Trail.Present {
+		t.Errorf("expected an absent trail on a fresh home: %+v", rep.Trail)
+	}
+}
+
 func TestCompliance_UnknownFramework(t *testing.T) {
 	var out, errBuf bytes.Buffer
 	code := runCompliance([]string{"report", "--framework", "iso-9001", "--skills-dir", t.TempDir()}, &out, &errBuf)

--- a/cmd/skillctl/intent_cmds.go
+++ b/cmd/skillctl/intent_cmds.go
@@ -50,6 +50,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kamir/m3c-tools/pkg/skillctl/datascope"
 	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
 	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
 	"gopkg.in/yaml.v3"
@@ -60,9 +61,9 @@ import (
 // caller can declare multiple dependencies on one command line.
 type stringSliceFlag []string
 
-func (s *stringSliceFlag) String() string         { return strings.Join(*s, ",") }
-func (s *stringSliceFlag) Set(v string) error     { *s = append(*s, v); return nil }
-func (s *stringSliceFlag) Get() any               { return []string(*s) }
+func (s *stringSliceFlag) String() string     { return strings.Join(*s, ",") }
+func (s *stringSliceFlag) Set(v string) error { *s = append(*s, v); return nil }
+func (s *stringSliceFlag) Get() any           { return []string(*s) }
 
 // intentDeclareReq is the wire shape of `PATCH /api/skills/bundles/<digest>/intent`.
 // The endpoint expects the new (proposed) `intent` block plus an explicit
@@ -94,15 +95,16 @@ type intentYAMLFile struct {
 // intentDeclareOpts captures everything runIntentDeclareWithClient needs.
 // Built by the flag-parser; tests can construct it directly.
 type intentDeclareOpts struct {
-	skill          string
-	registryURL    string
-	dryRun         bool
-	confirm        bool
-	timeout        time.Duration
-	httpClient     *http.Client // injected by tests
-	intent         map[string]any
-	dataDeps       []map[string]any
-	resolveDigest  func(ctx context.Context, c *registry.Client, name string) (string, error) // injected
+	skill         string
+	registryURL   string
+	dryRun        bool
+	confirm       bool
+	timeout       time.Duration
+	httpClient    *http.Client // injected by tests
+	intent        map[string]any
+	dataDeps      []map[string]any
+	governance    string                                                                     // governance_intent for the §3.3 destructive_green client check
+	resolveDigest func(ctx context.Context, c *registry.Client, name string) (string, error) // injected
 }
 
 // runIntent is the dispatcher for `skillctl intent <subcommand>`. Today only
@@ -116,6 +118,8 @@ func runIntent(args []string, stdout, stderr io.Writer) int {
 	switch args[0] {
 	case "declare":
 		return runIntentDeclare(args[1:], stdout, stderr)
+	case "show":
+		return runIntentShow(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
 		printIntentUsage(stdout)
 		return exitOK
@@ -139,8 +143,11 @@ func runIntentDeclare(args []string, stdout, stderr io.Writer) int {
 	hrFlag := fs.String("human-review-required", "", "Author claim: skill requires human review beyond governance attestation. true|false.")
 	subprocessFlag := fs.String("subprocess", "", "Comma-separated subprocess allowlist (e.g. pandoc,git).")
 	summaryFlag := fs.String("summary", "", "One-line plain-English summary of the skill's intent.")
+	governanceFlag := fs.String("governance-intent", "", "Bundle governance intent (green|yellow|red) — checked against the §3.3 destructive_green cross-rule.")
+	var dataScopeFlag stringSliceFlag
+	fs.Var(&dataScopeFlag, "data-scopes", "Typed SPEC-0196 data-scope JSON declaration; repeatable. Validated client-side through pkg/skillctl/datascope before the PATCH.")
 	var dataDepFlag stringSliceFlag
-	fs.Var(&dataDepFlag, "data-dep", "Per-dependency JSON declaration; repeatable.")
+	fs.Var(&dataDepFlag, "data-dep", "DEPRECATED alias for --data-scopes (same JSON shape, same validation). Prefer --data-scopes.")
 	fromYAML := fs.String("from-yaml", "", "Read the entire intent + data_dependencies block from a YAML file (alternative to per-flag declaration).")
 	dryRun := fs.Bool("dry-run", false, "Print the proposed PATCH payload and exit 0; no HTTP call.")
 	confirm := fs.Bool("confirm", false, "Required to actually issue the PATCH (footgun-resistance).")
@@ -183,6 +190,16 @@ func runIntentDeclare(args []string, stdout, stderr io.Writer) int {
 		return exitUsage
 	}
 
+	// --data-scopes is the typed first-class flag; --data-dep is the
+	// deprecated alias. They share the exact JSON shape and the exact
+	// validator, so we concatenate them (scopes first) and warn once if the
+	// alias was used.
+	depStrings := append([]string(nil), dataScopeFlag...)
+	if len(dataDepFlag) > 0 {
+		fmt.Fprintln(stderr, "skillctl intent declare: NOTE --data-dep is deprecated; use --data-scopes (same JSON shape, same validation).")
+		depStrings = append(depStrings, dataDepFlag...)
+	}
+
 	// Build the intent block from flags or --from-yaml. The two are
 	// mutually exclusive only by convention — if both are passed, the
 	// per-flag values win on a key-by-key basis (so a YAML file can
@@ -195,7 +212,7 @@ func runIntentDeclare(args []string, stdout, stderr io.Writer) int {
 		*hrFlag,
 		*subprocessFlag,
 		*summaryFlag,
-		dataDepFlag,
+		depStrings,
 	)
 	if err != nil {
 		fmt.Fprintf(stderr, "skillctl intent declare: %v\n", err)
@@ -226,6 +243,7 @@ func runIntentDeclare(args []string, stdout, stderr io.Writer) int {
 		timeout:     *timeout,
 		intent:      intentBlock,
 		dataDeps:    dataDeps,
+		governance:  strings.TrimSpace(*governanceFlag),
 	}
 	return runIntentDeclareWithClient(opts, stdout, stderr)
 }
@@ -234,6 +252,17 @@ func runIntentDeclare(args []string, stdout, stderr io.Writer) int {
 // struct carries everything (flag values + injected http.Client + injected
 // digest resolver) so tests can stub the network entirely.
 func runIntentDeclareWithClient(opts intentDeclareOpts, stdout, stderr io.Writer) int {
+	// CLIENT-SIDE data-scope validation (SPEC-0196 §3 + §3.3), fail-closed.
+	// This runs BEFORE the dry-run print and BEFORE any network access, so an
+	// inconsistent declaration is rejected locally — without ever leaking a
+	// half-baked PATCH to the registry. A §3.3 cross-rule failure maps to the
+	// SAME exit 18 the server returns, so CI cannot tell client refusal from
+	// server refusal (the red-team relies on this: the binding cannot be
+	// bypassed by declaring offline).
+	if code, ok := validateDeclarationLocally(opts, stderr); !ok {
+		return code
+	}
+
 	// --dry-run prints the payload + exits 0 BEFORE any network access,
 	// even before digest resolution. This keeps `--dry-run` strictly
 	// non-side-effecting (no scan, no HTTP) — useful for fixture tests
@@ -336,6 +365,167 @@ func runIntentDeclareWithClient(opts intentDeclareOpts, stdout, stderr io.Writer
 		}
 		return exitGeneric
 	}
+}
+
+// runIntentShow implements `skillctl intent show <skill-name|@digest>`. It
+// resolves the bundle, fetches its registry meta, and prints the declared
+// intent + data_dependencies (the SPEC-0196 §3 fields). Read-only — no PATCH,
+// no --confirm. Useful for the CISO to read what a skill says it does before
+// authorizing a data dependency (SPEC-0196 §8).
+func runIntentShow(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("intent show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	registryURL := fs.String("registry", "", "Registry base URL (required).")
+	asJSON := fs.Bool("json", false, "Emit the declared intent + data_dependencies as JSON.")
+	timeout := fs.Duration("timeout", registry.DefaultTimeout, "HTTP timeout.")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl intent show <skill-name|@digest> --registry URL [--json]")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "Prints the declared SPEC-0196 intent + data_dependencies for a bundle.")
+		fs.PrintDefaults()
+	}
+
+	skillArg, flagArgs := extractSkillPositional(args)
+	if err := fs.Parse(flagArgs); err != nil {
+		return exitUsage
+	}
+	skill := skillArg
+	if skill == "" && fs.NArg() == 1 {
+		skill = strings.TrimSpace(fs.Arg(0))
+	}
+	if skill == "" {
+		fs.Usage()
+		return exitUsage
+	}
+	if *registryURL == "" {
+		fmt.Fprintln(stderr, "skillctl intent show: --registry is required.")
+		return exitUsage
+	}
+	if err := validateRegistryURL(*registryURL); err != nil {
+		fmt.Fprintf(stderr, "skillctl intent show: %v\n", err)
+		return exitUsage
+	}
+
+	httpClient := &http.Client{Timeout: *timeout}
+	c := registry.New(*registryURL, httpClient)
+	ctx := context.Background()
+	digest, err := resolveSkillDigest(ctx, c, skill, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillctl intent show: %v\n", err)
+		return exitGeneric
+	}
+	meta, err := c.GetBundleMeta(ctx, digest)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillctl intent show: fetch meta for %s: %v\n", digest, err)
+		return exitGeneric
+	}
+
+	intentBlock, dataDeps := extractDeclaredIntent(meta)
+
+	if *asJSON {
+		out := map[string]any{
+			"digest":            digest,
+			"governance":        meta.CurrentGovernance,
+			"intent":            intentBlock,
+			"data_dependencies": dataDeps,
+		}
+		b, _ := json.MarshalIndent(out, "", "  ")
+		fmt.Fprintln(stdout, string(b))
+		return exitOK
+	}
+
+	fmt.Fprintf(stdout, "digest:     %s\n", digest)
+	fmt.Fprintf(stdout, "governance: %s\n", dashOrValue(meta.CurrentGovernance))
+	if intentBlock == nil {
+		fmt.Fprintln(stdout, "intent:     (none declared)")
+	} else {
+		fmt.Fprintln(stdout, "intent:")
+		if b, err := json.MarshalIndent(intentBlock, "  ", "  "); err == nil {
+			fmt.Fprintf(stdout, "  %s\n", string(b))
+		}
+	}
+	if len(dataDeps) == 0 {
+		fmt.Fprintln(stdout, "data_dependencies: (none declared)")
+	} else {
+		fmt.Fprintf(stdout, "data_dependencies (%d):\n", len(dataDeps))
+		for _, d := range dataDeps {
+			if b, err := json.Marshal(d); err == nil {
+				fmt.Fprintf(stdout, "  - %s\n", string(b))
+			}
+		}
+	}
+	return exitOK
+}
+
+// extractDeclaredIntent pulls the declared intent + data_dependencies out of a
+// BundleMeta. The post-hoc `intent declare` PATCH writes them onto the registry
+// row (BundleMeta.Bundle); a pack-time binding writes them into bundle.json
+// (BundleMeta.Manifest). We prefer the row (it is the post-admission source of
+// truth) and fall back to the manifest.
+func extractDeclaredIntent(meta *registry.BundleMeta) (map[string]any, []map[string]any) {
+	pick := func(src map[string]any) (map[string]any, []map[string]any, bool) {
+		if src == nil {
+			return nil, nil, false
+		}
+		in, _ := src["intent"].(map[string]any)
+		var deps []map[string]any
+		if raw, ok := src["data_dependencies"].([]any); ok {
+			for _, item := range raw {
+				if m, ok := item.(map[string]any); ok {
+					deps = append(deps, m)
+				}
+			}
+		}
+		if in != nil || len(deps) > 0 {
+			return in, deps, true
+		}
+		return nil, nil, false
+	}
+	if in, deps, ok := pick(meta.Bundle); ok {
+		return in, deps
+	}
+	in, deps, _ := pick(meta.Manifest)
+	return in, deps
+}
+
+func dashOrValue(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "(unknown)"
+	}
+	return s
+}
+
+// validateDeclarationLocally runs the typed SPEC-0196 validator over the
+// proposed declaration. It returns (exitCode, ok): on ok=true the caller
+// proceeds; on ok=false the caller returns exitCode.
+//
+//   - A §3.3 cross-rule failure → exit 18 (verify.ExitIntentInconsistent),
+//     matching the server PATCH's 422→18 mapping (the failed_rule is printed).
+//   - A structural failure (bad kind/scope/id, out-of-vocabulary side effect)
+//     → exit 2 (usage): the declaration is malformed, not merely inconsistent.
+//
+// The dependency maps the CLI carries are decoded into typed datascope.DataScope
+// values first; a decode error is a usage error.
+func validateDeclarationLocally(opts intentDeclareOpts, stderr io.Writer) (int, bool) {
+	scopes, err := datascope.FromMaps(opts.dataDeps)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillctl intent declare: %v\n", err)
+		return exitUsage, false
+	}
+	in := datascope.IntentFromMap(opts.intent)
+	if verr := datascope.Validate(in, scopes, opts.governance); verr != nil {
+		var ve *datascope.ValidationError
+		if errors.As(verr, &ve) && ve.FailedRule != "" {
+			// A real §3.3 cross-rule fired → exit 18, same as the server.
+			fmt.Fprintf(stderr, "skillctl intent declare: rejected locally — failed_rule=%s\n", ve.FailedRule)
+			fmt.Fprintf(stderr, "detail: %s\n", ve.Detail)
+			return verify.ExitCode(fmt.Errorf("rule=%s: %w", ve.FailedRule, verify.ErrIntentInconsistent)), false
+		}
+		// Structural / vocabulary failure → usage error.
+		fmt.Fprintf(stderr, "skillctl intent declare: invalid declaration: %v\n", verr)
+		return exitUsage, false
+	}
+	return exitOK, true
 }
 
 // buildIntentFromInputs assembles the (intent, data_dependencies) tuple
@@ -552,6 +742,8 @@ func printIntentUsage(w io.Writer) {
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Subcommands:")
 	fmt.Fprintln(w, "  declare    Patch a previously-admitted bundle's intent block.")
+	fmt.Fprintln(w, "             Typed data-scope via --data-scopes (repeatable JSON, SPEC-0196).")
+	fmt.Fprintln(w, "  show       Print the declared intent + data_dependencies for a bundle.")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Run any subcommand with --help for its flags.")
 }

--- a/cmd/skillctl/intent_cmds_test.go
+++ b/cmd/skillctl/intent_cmds_test.go
@@ -84,13 +84,17 @@ func TestIntentDeclare_BuildsPatchPayload(t *testing.T) {
 		registryURL: srv.URL,
 		confirm:     true,
 		intent: map[string]any{
-			"summary":     "test skill",
-			"destructive": false,
-			"network":     true,
+			"summary":      "test skill",
+			"destructive":  false,
+			"network":      true,
 			"side_effects": []string{"fs:write", "llm:call"},
 		},
 		dataDeps: []map[string]any{
+			// read dep needs no scope; network=true requires an http dep, so
+			// include one (valid client-side declaration — the server still
+			// gets the PATCH).
 			{"id": "ds:filesystem/cwd", "kind": "local_fs", "access": "read"},
+			{"id": "ds:http/anthropic", "kind": "http_endpoint", "access": "passthrough", "scope": "https://api.anthropic.com/*"},
 		},
 		httpClient: srv.Client(),
 	}
@@ -105,8 +109,8 @@ func TestIntentDeclare_BuildsPatchPayload(t *testing.T) {
 	if got := captured.Intent["network"]; got != true {
 		t.Errorf("captured.Intent.network = %v, want true", got)
 	}
-	if got := len(captured.DataDependencies); got != 1 {
-		t.Fatalf("captured.DataDependencies len = %d, want 1", got)
+	if got := len(captured.DataDependencies); got != 2 {
+		t.Fatalf("captured.DataDependencies len = %d, want 2", got)
 	}
 	if got := captured.DataDependencies[0]["kind"]; got != "local_fs" {
 		t.Errorf("captured DataDeps[0].kind = %v, want local_fs", got)
@@ -206,8 +210,12 @@ func TestIntentDeclare_CrossRuleViolationExits18(t *testing.T) {
 		intent: map[string]any{
 			"network": false,
 		},
+		// Client-valid (http dep carries a scope), but the SERVER rejects the
+		// network=false ↔ http-dep contradiction → 400 → exit 18. This keeps
+		// the test exercising the server-side cross-rule path, not the client
+		// one (the client only fires on network=true without an http dep).
 		dataDeps: []map[string]any{
-			{"id": "ds:http/api", "kind": "http_endpoint", "access": "passthrough"},
+			{"id": "ds:http/api", "kind": "http_endpoint", "access": "passthrough", "scope": "https://api.example.com/*"},
 		},
 		httpClient: srv.Client(),
 	}
@@ -218,6 +226,122 @@ func TestIntentDeclare_CrossRuleViolationExits18(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "network_false_http_dep") {
 		t.Errorf("stderr missing failed_rule; got: %q", stderr.String())
+	}
+}
+
+func TestIntentDeclare_LocalCrossRuleExits18(t *testing.T) {
+	// A §3.3 cross-rule that the CLIENT catches (destructive=true + green)
+	// must exit 18 WITHOUT touching the network — the binding can't be
+	// bypassed by declaring offline.
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.Error(w, "should not be reached", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	opts := intentDeclareOpts{
+		skill:       "@sha256:" + strings.Repeat("d", 64),
+		registryURL: srv.URL,
+		confirm:     true,
+		governance:  "green",
+		intent: map[string]any{
+			"destructive":  true,
+			"side_effects": []string{"fs:delete"},
+		},
+		httpClient: srv.Client(),
+	}
+	var stdout, stderr bytes.Buffer
+	code := runIntentDeclareWithClient(opts, &stdout, &stderr)
+	if code != 18 {
+		t.Fatalf("exit = %d, want 18 (local destructive_green); stderr=%q", code, stderr.String())
+	}
+	if hits != 0 {
+		t.Errorf("client-side cross-rule hit the server %d times, want 0", hits)
+	}
+	if !strings.Contains(stderr.String(), "destructive_green") {
+		t.Errorf("stderr missing failed_rule destructive_green; got %q", stderr.String())
+	}
+}
+
+func TestIntentDeclare_InvalidScopeIsUsageError(t *testing.T) {
+	// A structurally-invalid data-scope (write to local_fs without a scope) is
+	// a usage error (exit 2), not an inconsistency (18) — and never reaches
+	// the server, even in --dry-run.
+	opts := intentDeclareOpts{
+		skill:       "@sha256:" + strings.Repeat("e", 64),
+		registryURL: "http://127.0.0.1:1",
+		dryRun:      true,
+		intent: map[string]any{
+			"destructive": true,
+		},
+		dataDeps: []map[string]any{
+			{"id": "ds:fs", "kind": "local_fs", "access": "write"}, // no scope → invalid
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	code := runIntentDeclareWithClient(opts, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("exit = %d, want %d (usage); stderr=%q", code, exitUsage, stderr.String())
+	}
+}
+
+func TestIntentDeclare_DataScopesFlagParsed(t *testing.T) {
+	// The typed --data-scopes flag flows through the flag-parser into the
+	// PATCH body. Drive runIntent end-to-end with a captured server.
+	var captured intentDeclareReq
+	srv := newIntentTestServer(t, "ok", &captured)
+	defer srv.Close()
+
+	args := []string{
+		"declare",
+		"@sha256:" + strings.Repeat("f", 64),
+		"--registry", srv.URL,
+		"--summary", "typed scope test",
+		"--destructive", "true",
+		"--side-effects", "fs:write",
+		"--data-scopes", `{"id":"ds:fs/out","kind":"local_fs","access":"write","scope":"<cwd>/out/**"}`,
+		"--confirm",
+	}
+	var stdout, stderr bytes.Buffer
+	code := runIntent(args, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if len(captured.DataDependencies) != 1 {
+		t.Fatalf("data deps len = %d, want 1", len(captured.DataDependencies))
+	}
+	if captured.DataDependencies[0]["scope"] != "<cwd>/out/**" {
+		t.Errorf("scope not carried through: %v", captured.DataDependencies[0])
+	}
+}
+
+func TestIntentDeclare_DataDepAliasStillWorks(t *testing.T) {
+	// The deprecated --data-dep alias routes through the SAME validator and
+	// reaches the PATCH; a deprecation note is printed to stderr.
+	var captured intentDeclareReq
+	srv := newIntentTestServer(t, "ok", &captured)
+	defer srv.Close()
+
+	args := []string{
+		"declare",
+		"@sha256:" + strings.Repeat("1", 64),
+		"--registry", srv.URL,
+		"--summary", "alias test",
+		"--side-effects", "fs:read",
+		"--data-dep", `{"id":"ds:er1/plm","kind":"er1_collection","access":"read"}`,
+		"--confirm",
+	}
+	var stdout, stderr bytes.Buffer
+	code := runIntent(args, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if len(captured.DataDependencies) != 1 {
+		t.Fatalf("data deps len = %d, want 1", len(captured.DataDependencies))
+	}
+	if !strings.Contains(stderr.String(), "deprecated") {
+		t.Errorf("expected deprecation note for --data-dep; got %q", stderr.String())
 	}
 }
 

--- a/cmd/skillctl/invocation_hook_test.go
+++ b/cmd/skillctl/invocation_hook_test.go
@@ -1,0 +1,71 @@
+package main
+
+// Tests for SPEC-0202 §9 — the verify-hook deferred block emits ONE
+// device-signed invocation record per gated skill, for BOTH allow AND deny,
+// into the separate signed trail. Asserts the record is written AND verifies.
+
+import (
+	"testing"
+)
+
+func TestHook_EmitsSignedTrailRecord_OnAllow(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	mkManagedSkill(t, home, "good")
+	orig := verifyManagedOfflineFn
+	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return exitOK, "ok", true }
+	t.Cleanup(func() { verifyManagedOfflineFn = orig })
+
+	if c, _, _ := feed(t, `{"tool_name":"Skill","tool_input":{"skill":"good"},"session_id":"sess-allow"}`); c != exitOK {
+		t.Fatalf("expected allow, got exit %d", c)
+	}
+
+	tv := readAndVerifyTrail(home)
+	if tv.Total != 1 || tv.Verified != 1 {
+		t.Fatalf("signed trail = %+v, want 1 verified record on allow", tv)
+	}
+}
+
+func TestHook_EmitsSignedTrailRecord_OnDeny(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	mkManagedSkill(t, home, "bad")
+	orig := verifyManagedOfflineFn
+	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) {
+		return 11, "author signature invalid", true
+	}
+	t.Cleanup(func() { verifyManagedOfflineFn = orig })
+
+	c, _, _ := feed(t, `{"tool_name":"Skill","tool_input":{"skill":"bad"},"session_id":"sess-deny"}`)
+	if c != exitHookBlock {
+		t.Fatalf("expected deny (exit %d), got %d", exitHookBlock, c)
+	}
+
+	tv := readAndVerifyTrail(home)
+	if tv.Total != 1 || tv.Verified != 1 {
+		t.Fatalf("signed trail = %+v, want 1 verified record on deny", tv)
+	}
+}
+
+func TestHook_SignedTrailIsSeparateFromGateAudit(t *testing.T) {
+	// The two logs are distinct files (unambiguous trust posture).
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	mkManagedSkill(t, home, "good")
+	orig := verifyManagedOfflineFn
+	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return exitOK, "ok", true }
+	t.Cleanup(func() { verifyManagedOfflineFn = orig })
+
+	_, _, _ = feed(t, `{"tool_name":"Skill","tool_input":{"skill":"good"},"session_id":"s"}`)
+
+	if gateAuditPath(home) == invocationTrailPath(home) {
+		t.Fatalf("advisory and signed logs share a path")
+	}
+	// Both exist; the gate-audit is unsigned, the trail is signed.
+	if evs := readGateAudit(t, home); len(evs) != 1 {
+		t.Errorf("gate-audit advisory log missing")
+	}
+	if tv := readAndVerifyTrail(home); tv.Total != 1 {
+		t.Errorf("signed trail missing")
+	}
+}

--- a/cmd/skillctl/invocation_trail.go
+++ b/cmd/skillctl/invocation_trail.go
@@ -205,13 +205,16 @@ func readAndVerifyTrail(home string) trailVerification {
 			tv.Unverified++
 			continue
 		}
-		// Replay: a second occurrence of an event_id we've already counted.
+		// Replay: a second occurrence of an event_id we've already counted is a
+		// REPLAY, not new evidence — it must NOT inflate the verified-evidence
+		// count (P2 challenge-gate finding). Count it as a replay and move on, so
+		// `Verified` reflects DISTINCT verified events only.
 		if rec.EventID != "" {
 			if _, dup := seen[rec.EventID]; dup {
 				tv.Replays++
-			} else {
-				seen[rec.EventID] = struct{}{}
+				continue
 			}
+			seen[rec.EventID] = struct{}{}
 		}
 		if havePub && skillgate.VerifyInvocationRecord(&rec, pubKey, base64.StdEncoding.DecodeString) {
 			tv.Verified++

--- a/cmd/skillctl/invocation_trail.go
+++ b/cmd/skillctl/invocation_trail.go
@@ -1,0 +1,223 @@
+package main
+
+// invocation_trail.go — SPEC-0202 §9 signed invocation trail.
+//
+// This is the DURABLE, append-only, DEVICE-SIGNED evidence log: one JSON line
+// per skill invocation in ~/.claude/skillctl/invocation-trail.jsonl. It is kept
+// STRICTLY SEPARATE from the unsigned advisory gate-audit.jsonl (SPEC-0255) so
+// the trust posture is unambiguous:
+//
+//   - gate-audit.jsonl  — advisory telemetry, NOT a trust input, unsigned.
+//   - invocation-trail.jsonl — SIGNED evidence, the EU AI Act Art.12 record.
+//
+// Don't retrofit signatures onto the advisory log; don't read this trail back
+// into a gate decision. The two never mix (ADR §4.3).
+//
+// CONTRACT — panic-safe, fire-and-forget, ALWAYS-ON:
+// appendSignedInvocation swallows EVERY error and recovers from any panic. It
+// sits next to the gate/run hot path; a logging failure (read-only home, full
+// disk, a key it cannot create, a marshal panic) must NEVER alter the decision
+// or the exit code. The caller invokes it as a bare statement and never branches
+// on a result. Emission is unconditional (every invocation → one signed record);
+// enforcement (capability tokens) stays a separate, opt-in concern.
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/device"
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+)
+
+// newInvocationEventID returns a sortable-by-time, replay-resistant event id:
+// a millisecond Unix timestamp prefix + a 10-byte random tail (the SPEC-0202
+// §4.3 nonce shape). This is the dedup key of the trail — the device signature
+// binds it, so a replayed signature can't be re-pointed at a fresh id.
+func newInvocationEventID() string {
+	var tail [10]byte
+	_, _ = rand.Read(tail[:])
+	return fmt.Sprintf("inv:%013d:%s", time.Now().UTC().UnixMilli(), hex.EncodeToString(tail[:]))
+}
+
+// invocationTrailMaxBytes bounds the live trail; beyond it the file rotates to
+// invocation-trail.jsonl.1 (single generation). A var (not const) so tests can
+// exercise rotation without writing megabytes. Distinct from gateAuditMaxBytes
+// so the two logs rotate independently.
+var invocationTrailMaxBytes int64 = 5 << 20 // 5 MiB
+
+// invocationTrailPath reuses verdictDir so the ~/.claude/skillctl 0700
+// convention matches the verdict cache and the gate-audit log.
+func invocationTrailPath(home string) string {
+	return filepath.Join(verdictDir(home), "invocation-trail.jsonl")
+}
+
+// invocationTrailSink is the write seam — tests inject a failing sink to prove
+// the gate decision is unchanged when the trail write fails.
+var invocationTrailSink = defaultInvocationTrailSink
+
+// invocationDeviceKey is the device-key seam. Production points it at
+// device.EnsureKey (lazy-create on first use); tests can stub it to force a
+// key-acquisition failure and assert fail-safety.
+var invocationDeviceKey = device.EnsureKey
+
+func defaultInvocationTrailSink(home string, line []byte) error {
+	dir := verdictDir(home)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	path := invocationTrailPath(home)
+	// Best-effort size rotation BEFORE the append. A lost rotation race just
+	// means one extra line in the old generation — bounded, never load-bearing.
+	if fi, err := os.Stat(path); err == nil && fi.Size() >= invocationTrailMaxBytes {
+		_ = os.Rename(path, path+".1")
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(append(line, '\n'))
+	return err
+}
+
+// appendSignedInvocation builds, device-signs, and appends one InvocationRecord
+// to the signed trail. Fire-and-forget: any error or panic is swallowed so it
+// can NEVER reach the caller's decision path.
+//
+// The record's transient fields are filled here: Schema, OccurredAt (if empty),
+// and DeviceKeyID (from the resolved device key). The agent_identity /
+// owner_identity P3 placeholders are left empty (v1). The signature covers the
+// canonical bytes; the line written is the full JSON including the signature.
+func appendSignedInvocation(home string, rec skillgate.InvocationRecord) {
+	defer func() { _ = recover() }()
+	if home == "" {
+		return // nowhere to write (e.g. a pre-home input-validation deny)
+	}
+
+	// Resolve (lazily create) the per-machine device key. A failure here is NOT
+	// fatal to the caller — we just skip the signed record. Fail-safe for the
+	// hot path; the absence of a record is itself observable if the key store
+	// is broken.
+	key, err := invocationDeviceKey(home)
+	if err != nil || key == nil {
+		return
+	}
+
+	if rec.Schema == "" {
+		rec.Schema = skillgate.InvocationSchema
+	}
+	if rec.EventID == "" {
+		rec.EventID = newInvocationEventID()
+	}
+	if rec.OccurredAt == "" {
+		rec.OccurredAt = time.Now().UTC().Format("2006-01-02T15:04:05Z")
+	}
+	rec.DeviceKeyID = key.KeyID()
+	// P3 placeholders stay empty in v1 (SPEC-0277 forward-compat).
+	rec.AgentIdentity = ""
+	rec.OwnerIdentity = ""
+
+	if err := skillgate.SignInvocationRecord(&rec, key.Sign, base64.StdEncoding.EncodeToString); err != nil {
+		return // refused to sign ambiguous bytes (e.g. newline-smuggled field)
+	}
+
+	line, err := json.Marshal(rec)
+	if err != nil {
+		return
+	}
+	_ = invocationTrailSink(home, line)
+}
+
+// trailVerification is the result of reading + verifying the signed trail. It is
+// the offline-verifiable evidence summary the compliance report surfaces for the
+// EU AI Act Art.12 control.
+type trailVerification struct {
+	// Path is the trail file path (for the operator).
+	Path string
+	// Present is true when the trail file exists (even if empty).
+	Present bool
+	// Total is the number of JSON lines read (parseable records).
+	Total int
+	// Verified is the number whose device signature verified against the local
+	// device key.
+	Verified int
+	// Unverified is Total - Verified (tampered / wrong-key / unsigned lines).
+	Unverified int
+	// Replays is the count of records sharing an already-seen event_id —
+	// duplicate event ids are the replay signal.
+	Replays int
+	// DeviceKeyID is the local device key's id ("" if the key is unavailable).
+	DeviceKeyID string
+}
+
+// readAndVerifyTrail reads the signed invocation trail at home, verifies each
+// record's device signature against the LOCAL device key, and counts
+// verified / unverified / replayed records. Read-only; never creates the key
+// (it Loads an existing one — a machine that never emitted a record has no key
+// and no trail, which is a legitimate empty-evidence state, not an error).
+//
+// Fail-closed counting: any line that does not parse, or whose signature does
+// not verify, is counted as Unverified — never silently dropped from the total
+// in a way that would inflate the verified ratio.
+func readAndVerifyTrail(home string) trailVerification {
+	tv := trailVerification{Path: invocationTrailPath(home)}
+	if home == "" {
+		return tv
+	}
+
+	// Load (do not create) the device key. Without it we cannot verify — report
+	// the records as present-but-unverified rather than claiming verification.
+	var (
+		havePub bool
+		pubKey  []byte
+	)
+	if key, err := device.Load(home); err == nil && key != nil {
+		tv.DeviceKeyID = key.KeyID()
+		pubKey = key.PublicKey()
+		havePub = true
+	}
+
+	data, err := os.ReadFile(tv.Path)
+	if err != nil {
+		return tv // absent trail → present=false, zero counts (empty evidence)
+	}
+	tv.Present = true
+
+	seen := make(map[string]struct{})
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
+	for sc.Scan() {
+		raw := bytes.TrimSpace(sc.Bytes())
+		if len(raw) == 0 {
+			continue
+		}
+		tv.Total++
+		var rec skillgate.InvocationRecord
+		if err := json.Unmarshal(raw, &rec); err != nil {
+			tv.Unverified++
+			continue
+		}
+		// Replay: a second occurrence of an event_id we've already counted.
+		if rec.EventID != "" {
+			if _, dup := seen[rec.EventID]; dup {
+				tv.Replays++
+			} else {
+				seen[rec.EventID] = struct{}{}
+			}
+		}
+		if havePub && skillgate.VerifyInvocationRecord(&rec, pubKey, base64.StdEncoding.DecodeString) {
+			tv.Verified++
+		} else {
+			tv.Unverified++
+		}
+	}
+	return tv
+}

--- a/cmd/skillctl/invocation_trail_test.go
+++ b/cmd/skillctl/invocation_trail_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/device"
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+)
+
+func sampleInvocation() skillgate.InvocationRecord {
+	return skillgate.InvocationRecord{
+		EventID:      "01HZTRAILEVENT00000000000",
+		EventType:    "skill.invocation",
+		SkillName:    "didactic-session",
+		SkillVersion: "1.0.0",
+		Action:       "invoke",
+		Tool:         "skill",
+		SessionID:    "sess:abc",
+		ExitCode:     0,
+	}
+}
+
+func TestAppendSignedInvocation_WritesVerifiableLine(t *testing.T) {
+	home := t.TempDir()
+	rec := sampleInvocation()
+	appendSignedInvocation(home, rec)
+
+	path := invocationTrailPath(home)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("trail not written: %v", err)
+	}
+	if !strings.Contains(string(data), "device_signature_b64") {
+		t.Errorf("trail line missing signature; got %q", string(data))
+	}
+	// 0600 file, 0700 dir (POSIX).
+	if runtime.GOOS != "windows" {
+		fi, _ := os.Stat(path)
+		if fi.Mode().Perm() != 0o600 {
+			t.Errorf("trail file mode = %#o, want 0600", fi.Mode().Perm())
+		}
+		di, _ := os.Stat(filepath.Dir(path))
+		if di.Mode().Perm() != 0o700 {
+			t.Errorf("trail dir mode = %#o, want 0700", di.Mode().Perm())
+		}
+	}
+
+	// The record verifies under the lazily-created device key.
+	tv := readAndVerifyTrail(home)
+	if !tv.Present || tv.Total != 1 || tv.Verified != 1 || tv.Unverified != 0 {
+		t.Fatalf("verification = %+v, want 1 verified", tv)
+	}
+	if !strings.HasPrefix(tv.DeviceKeyID, "device:") {
+		t.Errorf("device key id %q lacks prefix", tv.DeviceKeyID)
+	}
+}
+
+func TestAppendSignedInvocation_AppendOnly(t *testing.T) {
+	home := t.TempDir()
+	appendSignedInvocation(home, sampleInvocation())
+	r2 := sampleInvocation()
+	r2.EventID = "01HZTRAILEVENT00000000002"
+	appendSignedInvocation(home, r2)
+
+	tv := readAndVerifyTrail(home)
+	if tv.Total != 2 || tv.Verified != 2 {
+		t.Fatalf("expected 2 verified records, got %+v", tv)
+	}
+}
+
+func TestReadAndVerifyTrail_DetectsTamper(t *testing.T) {
+	home := t.TempDir()
+	appendSignedInvocation(home, sampleInvocation())
+	// Tamper: append a hand-rolled line claiming a verified invocation but with
+	// a bogus signature.
+	path := invocationTrailPath(home)
+	f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	_, _ = f.WriteString(`{"schema":"m3c-skill-invocation/v1","event_id":"forged","event_type":"skill.invocation","skill_name":"evil","skill_version":"9","action":"invoke","tool":"x","session_id":"s","occurred_at":"2026-06-23T00:00:00Z","device_key_id":"device:dead","exit_code":0,"refusal_code":"","device_signature_b64":"AAAA"}` + "\n")
+	_ = f.Close()
+
+	tv := readAndVerifyTrail(home)
+	if tv.Total != 2 {
+		t.Fatalf("total = %d, want 2", tv.Total)
+	}
+	if tv.Verified != 1 || tv.Unverified != 1 {
+		t.Errorf("tampered line not flagged: %+v", tv)
+	}
+}
+
+func TestReadAndVerifyTrail_DetectsReplay(t *testing.T) {
+	home := t.TempDir()
+	rec := sampleInvocation()
+	appendSignedInvocation(home, rec)
+	appendSignedInvocation(home, rec) // SAME event_id → replay
+
+	tv := readAndVerifyTrail(home)
+	if tv.Total != 2 {
+		t.Fatalf("total = %d, want 2", tv.Total)
+	}
+	if tv.Replays != 1 {
+		t.Errorf("duplicate event_id not flagged as replay: %+v", tv)
+	}
+}
+
+func TestAppendSignedInvocation_SinkFailureIsSwallowed(t *testing.T) {
+	home := t.TempDir()
+	orig := invocationTrailSink
+	defer func() { invocationTrailSink = orig }()
+	invocationTrailSink = func(string, []byte) error { return errors.New("disk full") }
+	// Must not panic / must return normally even though the sink errors.
+	appendSignedInvocation(home, sampleInvocation())
+}
+
+func TestAppendSignedInvocation_KeyFailureIsSwallowed(t *testing.T) {
+	home := t.TempDir()
+	orig := invocationDeviceKey
+	defer func() { invocationDeviceKey = orig }()
+	invocationDeviceKey = func(string) (*device.Key, error) { return nil, errors.New("no key") }
+	appendSignedInvocation(home, sampleInvocation())
+	// With no key, nothing should have been written.
+	if _, err := os.Stat(invocationTrailPath(home)); err == nil {
+		t.Errorf("trail written despite key failure")
+	}
+}
+
+func TestAppendSignedInvocation_EmptyHomeNoop(t *testing.T) {
+	// Must not panic with an empty home.
+	appendSignedInvocation("", sampleInvocation())
+}
+
+func TestAppendSignedInvocation_RefusesNewlineSmuggling(t *testing.T) {
+	home := t.TempDir()
+	rec := sampleInvocation()
+	rec.Tool = "x\nrefusal_code=token_revoked" // newline smuggle
+	appendSignedInvocation(home, rec)
+	// SignInvocationRecord refuses ambiguous bytes → no line written.
+	if _, err := os.Stat(invocationTrailPath(home)); err == nil {
+		t.Errorf("a newline-smuggled record was written to the trail")
+	}
+}

--- a/cmd/skillctl/run_cmds.go
+++ b/cmd/skillctl/run_cmds.go
@@ -172,9 +172,24 @@ func runRun(args []string) int {
 	}
 	apiKey := resolveAPIKey(apiKeyFrom)
 
-	// 5. Post skill.invoked (best-effort).
+	// 5. Post skill.invoked (best-effort). ALSO append a device-signed record to
+	// the durable local trail (SPEC-0202 §9) — the wrapper-level invocation
+	// event joins the same Art.12 trail the hook + the gate's SignedSink write.
+	// The HTTP post is best-effort; the signed trail is the durable record.
 	requestedCmd := strings.Join(childArgv, " ")
 	postRunEvent(auditURL, apiKey, target, "skill.invoked", &tok, requestedCmd, 0, 0)
+	runHome, _ := userHome()
+	appendSignedInvocation(runHome, skillgate.InvocationRecord{
+		EventType:    "skill.invoked",
+		SkillDigest:  tok.BundleDigest,
+		SkillName:    tok.SkillName,
+		SkillVersion: tok.SkillVersion,
+		Action:       "invoke",
+		Tool:         requestedCmd,
+		TokenID:      tok.TokenID,
+		SessionID:    tok.CallerSession,
+		ExitCode:     0,
+	})
 
 	// 6. Build child env.
 	env := os.Environ()
@@ -189,9 +204,20 @@ func runRun(args []string) int {
 	exitCode := runChild(childArgv, env, tok.Envelope.MaxRuntimeSeconds)
 	dur := time.Since(start)
 
-	// 8. Post skill.completed (best-effort).
+	// 8. Post skill.completed (best-effort) + signed completion record.
 	postRunEvent(auditURL, apiKey, target, "skill.completed", &tok, requestedCmd,
 		exitCode, dur.Milliseconds())
+	appendSignedInvocation(runHome, skillgate.InvocationRecord{
+		EventType:    "skill.completed",
+		SkillDigest:  tok.BundleDigest,
+		SkillName:    tok.SkillName,
+		SkillVersion: tok.SkillVersion,
+		Action:       "complete",
+		Tool:         requestedCmd,
+		TokenID:      tok.TokenID,
+		SessionID:    tok.CallerSession,
+		ExitCode:     exitCode,
+	})
 
 	return exitCode
 }

--- a/cmd/skillctl/verify_hook_cmds.go
+++ b/cmd/skillctl/verify_hook_cmds.go
@@ -41,8 +41,32 @@ import (
 	"github.com/kamir/m3c-tools/pkg/skillctl/install"
 	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
 	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+	"github.com/kamir/m3c-tools/pkg/skillgate"
 	"gopkg.in/yaml.v3"
 )
+
+// refusalCodeForHook maps the hook's (exitCode, reason) into a stable
+// refusal_code token for the signed invocation record. An allow (exit 0) has
+// no refusal. A deny carries "deny" by default, refined to a more specific
+// token when the reason text reveals one (revoked / suspicious-name / etc.) so
+// the Art.12 trail is queryable without parsing free-form reason strings.
+func refusalCodeForHook(exitCode int, reason string) string {
+	if exitCode == exitOK {
+		return ""
+	}
+	switch {
+	case strings.Contains(reason, "revoked"):
+		return "bundle_revoked"
+	case strings.Contains(reason, "suspicious skill name"):
+		return "unsafe_skill_name"
+	case strings.Contains(reason, "policy deny"), strings.Contains(reason, "unmanaged"):
+		return "unmanaged_policy_deny"
+	case strings.Contains(reason, "internal error"):
+		return "internal_error"
+	default:
+		return "deny"
+	}
+}
 
 // exitHookBlock is the process exit code Claude Code interprets as "block this
 // tool call" for a PreToolUse hook. It happens to equal exitUsage (2); that is
@@ -137,6 +161,22 @@ func runVerifyHook(stdin io.Reader, stdout, stderr io.Writer) (code int) {
 				Source: "hook", Skill: audSkill, Decision: decisionForExit(code),
 				Reason: audReason, ExitCode: code,
 				Online: audOnline, CacheHit: audCache, SessionID: audSession,
+			})
+			// SPEC-0202 §9 — emit ONE device-signed invocation record per gated
+			// skill, for BOTH allow AND deny, into the SEPARATE signed trail.
+			// ALWAYS-ON evidence (Art.12), distinct from the advisory gate-audit
+			// above. Best-effort + panic-safe inside appendSignedInvocation;
+			// never alters `code`. The decision is encoded in exit_code (0=allow)
+			// and refusal_code (the deny reason as a stable token).
+			appendSignedInvocation(audHome, skillgate.InvocationRecord{
+				EventType:   "skill.invocation",
+				SkillDigest: installedSkillDigest(audHome, audSkill),
+				SkillName:   audSkill,
+				Action:      "skill_invocation",
+				Tool:        "Skill",
+				SessionID:   audSession,
+				ExitCode:    code,
+				RefusalCode: refusalCodeForHook(code, audReason),
 			})
 		}
 	}()

--- a/pkg/skillctl/datascope/datascope.go
+++ b/pkg/skillctl/datascope/datascope.go
@@ -1,0 +1,382 @@
+// Package datascope is the typed, client-side contract for SPEC-0196
+// declared data-scope (the `data_dependencies` + `intent` blocks in a
+// signed bundle).
+//
+// It is a LEAF package: stdlib-only, no imports from the rest of m3c-tools.
+// That is deliberate — both the `intent declare` CLI path (post-hoc PATCH)
+// and any future pack-time binding share ONE validator, and the package is
+// safe for bodyscan (P1) to import later without a cycle. It does NOT import
+// bodyscan; bodyscan does NOT import it today (no collision — see ADR §4.5).
+//
+// What this package adds over the server-side validation that already existed
+// (which only ran on PATCH/admit and surfaced as exit 18) is the missing
+// Go-side enforcement:
+//
+//   - per-`kind` scope validators (SPEC-0196 §12 Q2: the glob/URL/collection
+//     specifier depends on the dependency's kind);
+//   - the §3.3 cross-rules (destructive↔green, network→needs http dep,
+//     write→destructive), runnable offline before any byte is signed;
+//   - the §5 side-effect vocabulary as a closed set.
+//
+// SPEC reference: SPEC-0196 §3 (fields), §3.3 (cross-rules), §5 (side-effect
+// vocabulary), §12 Q2 (per-kind scope syntax).
+package datascope
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// Access is one of the four declared access modes a skill may have over a
+// data source (SPEC-0196 §3.2 + §6.2 edge mapping). Closed set.
+type Access string
+
+const (
+	// AccessRead — the skill reads from the source (reads_from edge).
+	AccessRead Access = "read"
+	// AccessWrite — the skill writes to the source (writes_to edge).
+	AccessWrite Access = "write"
+	// AccessTransform — reads + writes; mapped to writes_to (SPEC-0196 §6.2).
+	AccessTransform Access = "transform"
+	// AccessPassthrough — relays data without retention; mapped to reads_from.
+	AccessPassthrough Access = "passthrough"
+)
+
+// validAccess is the closed access set. A declaration outside it is rejected
+// before anything is signed.
+var validAccess = map[Access]struct{}{
+	AccessRead:        {},
+	AccessWrite:       {},
+	AccessTransform:   {},
+	AccessPassthrough: {},
+}
+
+// isWriteAccess reports whether an access mode mutates the source. Used by the
+// §3.3 write→destructive cross-rule and the writes_to edge mapping.
+func (a Access) isWriteAccess() bool {
+	return a == AccessWrite || a == AccessTransform
+}
+
+// Kind is the data-source kind. Each kind selects a scope validator
+// (SPEC-0196 §12 Q2). Closed set; an unknown kind fails validation rather
+// than being waved through (fail-closed — an attacker can't smuggle a scope
+// past the per-kind validator by inventing a kind).
+type Kind string
+
+const (
+	// KindLocalFS — local filesystem; scope is a path glob (** allowed).
+	KindLocalFS Kind = "local_fs"
+	// KindHTTPEndpoint — an outbound HTTP endpoint; scope is a URL pattern.
+	KindHTTPEndpoint Kind = "http_endpoint"
+	// KindER1Collection — an ER1 / Firestore collection path.
+	KindER1Collection Kind = "er1_collection"
+	// KindFirestore — a raw Firestore collection (alias kind kept distinct
+	// so the CISO console can facet ER1 vs general Firestore).
+	KindFirestore Kind = "firestore_collection"
+	// KindGCSBucket — a Google Cloud Storage bucket / object prefix.
+	KindGCSBucket Kind = "gcs_bucket"
+	// KindSecretsStore — a secrets store reference (e.g. macOS Keychain item).
+	KindSecretsStore Kind = "secrets_store"
+)
+
+// validKinds is the closed kind set.
+var validKinds = map[Kind]struct{}{
+	KindLocalFS:       {},
+	KindHTTPEndpoint:  {},
+	KindER1Collection: {},
+	KindFirestore:     {},
+	KindGCSBucket:     {},
+	KindSecretsStore:  {},
+}
+
+// SideEffectVocabulary is the FIXED §5 side-effect token set (v1). Additive
+// evolution is allowed; no token may be repurposed. A declaration containing a
+// token outside this set fails validation (SPEC-0196 §5: "Skills declaring
+// side-effects outside the vocabulary fail bundle-pack validation").
+//
+// The sentinel "UNKNOWN" (SPEC-0196 §7 awareness backfill) is permitted: a
+// legacy awareness-only bundle carries side_effects=["UNKNOWN"] and must not be
+// rejected by the validator before the operator has had a chance to declare.
+var SideEffectVocabulary = map[string]struct{}{
+	"fs:read":          {},
+	"fs:write":         {},
+	"fs:delete":        {},
+	"git:read":         {},
+	"git:write":        {},
+	"network:outbound": {},
+	"network:inbound":  {},
+	"subprocess":       {},
+	"secrets:read":     {},
+	"llm:call":         {},
+	"UNKNOWN":          {}, // §7 awareness sentinel — tolerated, not first-class.
+}
+
+// DataScope is one declared (skill → data source) dependency. It is the typed
+// projection of one `data_dependencies[]` entry (SPEC-0196 §3.2). The JSON
+// tags match the bundle.json wire shape exactly so a DataScope round-trips
+// through the signed bundle / the PATCH body without a translation layer.
+type DataScope struct {
+	// ID is the data-source identifier, e.g. "ds:er1/plm/skill-creations".
+	// Must be a "ds:"-prefixed, non-empty token (§3.2: "Each entry MUST have
+	// id"). It resolves to a DataSource record at admit time server-side.
+	ID string `json:"id"`
+	// Kind selects the scope validator (§12 Q2).
+	Kind Kind `json:"kind"`
+	// Access is read|write|transform|passthrough (§3.2).
+	Access Access `json:"access"`
+	// Scope is the narrow specifier — path glob / URL pattern / collection
+	// path — interpreted per Kind. Optional for some kinds (e.g. a whole ER1
+	// collection); required for others (local_fs, http_endpoint) so a write
+	// dependency can never be unbounded.
+	Scope string `json:"scope,omitempty"`
+	// Reason is the human rationale (§3.2: "Each entry MUST have ... reason").
+	Reason string `json:"reason,omitempty"`
+	// PayloadClass is optional metadata (PII / non-PII / config).
+	PayloadClass string `json:"payload_class,omitempty"`
+	// Retention is optional metadata (none / session / persistent).
+	Retention string `json:"retention,omitempty"`
+}
+
+// Intent is the typed projection of the `intent` block (SPEC-0196 §3.1). Only
+// the fields the §3.3 cross-rules read are first-class here; the free-form rest
+// (summary, claims, subprocess) stay advisory and are carried verbatim by the
+// caller's map. The pointer fields distinguish "declared false" from "absent",
+// which the cross-rules need (a missing `destructive` is not the same as
+// `destructive:false`).
+type Intent struct {
+	SideEffects []string `json:"side_effects,omitempty"`
+	Destructive *bool    `json:"destructive,omitempty"`
+	Network     *bool    `json:"network,omitempty"`
+}
+
+// ValidationError is a structured validation failure. FailedRule carries the
+// stable §3.3 rule name (destructive_green, network_false_http_dep,
+// write_access_non_destructive) so the CLI can map it to exit 18 exactly the
+// way the server-side PATCH path does, and the red-team can assert on it.
+type ValidationError struct {
+	// FailedRule is the stable rule identifier, or "" for a structural error.
+	FailedRule string
+	// Detail is the human message.
+	Detail string
+}
+
+func (e *ValidationError) Error() string {
+	if e.FailedRule != "" {
+		return fmt.Sprintf("data-scope rule %s: %s", e.FailedRule, e.Detail)
+	}
+	return "data-scope: " + e.Detail
+}
+
+// Stable §3.3 cross-rule identifiers. These MUST match the server-side
+// `failed_rule` values (SPEC-0196 §7.1) so a client-side refusal and a
+// server-side 422 are indistinguishable to CI.
+const (
+	RuleDestructiveGreen    = "destructive_green"
+	RuleNetworkFalseHTTPDep = "network_false_http_dep"
+	RuleWriteAccessNonDestr = "write_access_non_destructive"
+)
+
+// ValidateScope validates a single DataScope: the id shape, the kind, the
+// access mode, and the per-kind scope specifier. Pure; no I/O.
+func (d DataScope) Validate() error {
+	if strings.TrimSpace(d.ID) == "" {
+		return &ValidationError{Detail: "data_dependencies[].id must not be empty"}
+	}
+	if !strings.HasPrefix(d.ID, "ds:") {
+		return &ValidationError{Detail: fmt.Sprintf("data_dependencies[].id %q must be a ds:-prefixed identifier", d.ID)}
+	}
+	if _, ok := validKinds[d.Kind]; !ok {
+		return &ValidationError{Detail: fmt.Sprintf("data_dependencies[].kind %q is not a known kind (%s)", d.Kind, kindList())}
+	}
+	if _, ok := validAccess[d.Access]; !ok {
+		return &ValidationError{Detail: fmt.Sprintf("data_dependencies[].access %q is not read|write|transform|passthrough", d.Access)}
+	}
+	if err := validateScopeForKind(d.Kind, d.Access, d.Scope); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateScopeForKind runs the per-kind scope validator (SPEC-0196 §12 Q2).
+//
+// The load-bearing invariant: a WRITE/TRANSFORM dependency on a bounded-scope
+// kind (filesystem, http, gcs) MUST carry a non-empty scope, so a skill can
+// never declare an *unbounded* write. A read may omit the scope (read the whole
+// collection) but a write must say where.
+func validateScopeForKind(kind Kind, access Access, scope string) error {
+	scope = strings.TrimSpace(scope)
+	switch kind {
+	case KindLocalFS:
+		// A WRITE/TRANSFORM to the filesystem MUST be bounded — a skill may not
+		// declare an unbounded write. A READ may omit the scope (read broadly).
+		if access.isWriteAccess() && scope == "" {
+			return &ValidationError{Detail: "local_fs write dependency requires a path-glob scope (e.g. <cwd>/decks/**)"}
+		}
+		// When a scope IS given (any access), it must not be a bare wildcard
+		// that escapes any anchor — "**" or "/**" alone is unbounded.
+		if scope == "**" || scope == "/**" || scope == "/" {
+			return &ValidationError{Detail: fmt.Sprintf("local_fs scope %q is unbounded; anchor it (e.g. <cwd>/path/**)", scope)}
+		}
+	case KindHTTPEndpoint:
+		if scope == "" {
+			return &ValidationError{Detail: "http_endpoint dependency requires a URL-pattern scope (e.g. https://api.anthropic.com/*)"}
+		}
+		if err := validateHTTPScope(scope); err != nil {
+			return err
+		}
+	case KindGCSBucket:
+		if access.isWriteAccess() && scope == "" {
+			return &ValidationError{Detail: "gcs_bucket write dependency requires a bucket/prefix scope"}
+		}
+	case KindER1Collection, KindFirestore:
+		// Collection scope is optional (a read of the whole collection is a
+		// legitimate, common case). When present it must look like a
+		// collection path, not a glob or URL.
+		if scope != "" && (strings.Contains(scope, "://") || strings.HasPrefix(scope, "/")) {
+			return &ValidationError{Detail: fmt.Sprintf("%s scope %q should be a collection path (no scheme, no leading slash)", kind, scope)}
+		}
+	case KindSecretsStore:
+		// Secrets are read-only by contract; a write to a secrets store is a
+		// declaration error.
+		if access.isWriteAccess() {
+			return &ValidationError{Detail: "secrets_store dependency cannot declare write/transform access"}
+		}
+	}
+	return nil
+}
+
+// validateHTTPScope checks an http_endpoint scope is an https URL pattern. A
+// trailing "/*" or "*" is allowed (prefix match per §12 Q2). http:// (non-TLS)
+// is rejected — a declared cleartext egress is a smell, and the gate's
+// egress_allowlist is host-based anyway.
+func validateHTTPScope(scope string) error {
+	bare := strings.TrimSuffix(strings.TrimSuffix(scope, "*"), "/")
+	if bare == "" {
+		return &ValidationError{Detail: fmt.Sprintf("http_endpoint scope %q has no host", scope)}
+	}
+	u, err := url.Parse(bare)
+	if err != nil {
+		return &ValidationError{Detail: fmt.Sprintf("http_endpoint scope %q is not a URL pattern: %v", scope, err)}
+	}
+	if u.Scheme != "https" {
+		return &ValidationError{Detail: fmt.Sprintf("http_endpoint scope %q must use https (got scheme %q)", scope, u.Scheme)}
+	}
+	if u.Host == "" {
+		return &ValidationError{Detail: fmt.Sprintf("http_endpoint scope %q has no host", scope)}
+	}
+	return nil
+}
+
+// ValidateSideEffects checks every side-effect token is in the §5 vocabulary.
+func ValidateSideEffects(sideEffects []string) error {
+	for _, s := range sideEffects {
+		if _, ok := SideEffectVocabulary[s]; !ok {
+			return &ValidationError{Detail: fmt.Sprintf("side_effect %q is not in the SPEC-0196 §5 vocabulary (%s)", s, sideEffectList())}
+		}
+	}
+	return nil
+}
+
+// Validate runs the FULL SPEC-0196 declaration check: per-scope validation, the
+// §5 side-effect vocabulary, and the §3.3 cross-rules. It takes the typed
+// Intent plus the governance level (green|yellow|red|"") because two of the
+// three cross-rules straddle intent and governance.
+//
+// On the FIRST failure it returns a *ValidationError whose FailedRule (when a
+// cross-rule fired) matches the server-side `failed_rule` exactly. Pure.
+func Validate(intent Intent, scopes []DataScope, governanceLevel string) error {
+	// (a) every scope is individually well-formed.
+	for i, d := range scopes {
+		if err := d.Validate(); err != nil {
+			if ve, ok := err.(*ValidationError); ok {
+				return &ValidationError{FailedRule: ve.FailedRule, Detail: fmt.Sprintf("data_dependencies[%d]: %s", i, ve.Detail)}
+			}
+			return err
+		}
+	}
+	// (b) side-effect vocabulary.
+	if err := ValidateSideEffects(intent.SideEffects); err != nil {
+		return err
+	}
+	// (c) the three §3.3 cross-rules.
+	return crossRules(intent, scopes, governanceLevel)
+}
+
+// crossRules enforces SPEC-0196 §3.3:
+//
+//  1. destructive=true paired with governance "green" is incompatible.
+//  2. network=true requires at least one HTTP-shaped data dependency.
+//  3. data_dependencies[].access=write paired with destructive=false is
+//     inconsistent (a write IS a destructive-ish effect; declaring otherwise is
+//     the cross-check the spec wants to catch).
+//
+// "Spec divergence between fields is itself a security signal" (§3.3) — a skill
+// that lies in `intent` but tells the truth in `data_dependencies` is caught
+// here. Fail-closed ordering: the cheapest, most-specific rule first.
+func crossRules(intent Intent, scopes []DataScope, governanceLevel string) error {
+	destructive := intent.Destructive != nil && *intent.Destructive
+	network := intent.Network != nil && *intent.Network
+
+	// Rule 1: destructive ⇒ NOT green.
+	if destructive && strings.EqualFold(strings.TrimSpace(governanceLevel), "green") {
+		return &ValidationError{
+			FailedRule: RuleDestructiveGreen,
+			Detail:     "intent.destructive=true is incompatible with governance_intent=green (a destructive skill cannot be 🟢)",
+		}
+	}
+
+	// Rule 2: network ⇒ at least one HTTP-shaped dependency.
+	if network {
+		hasHTTP := false
+		for _, d := range scopes {
+			if d.Kind == KindHTTPEndpoint {
+				hasHTTP = true
+				break
+			}
+		}
+		if !hasHTTP {
+			return &ValidationError{
+				FailedRule: RuleNetworkFalseHTTPDep,
+				Detail:     "intent.network=true but no http_endpoint data dependency is declared",
+			}
+		}
+	}
+
+	// Rule 3: any write/transform dependency ⇒ destructive=true.
+	// Only fires when destructive was explicitly declared false (a missing
+	// destructive is handled by the pack-time requirement, not here) — this
+	// mirrors the server rule `write_access_non_destructive`.
+	if intent.Destructive != nil && !*intent.Destructive {
+		for i, d := range scopes {
+			if d.Access.isWriteAccess() {
+				return &ValidationError{
+					FailedRule: RuleWriteAccessNonDestr,
+					Detail:     fmt.Sprintf("data_dependencies[%d] declares access=%q but intent.destructive=false", i, d.Access),
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// kindList renders the closed kind set sorted, for error messages.
+func kindList() string {
+	out := make([]string, 0, len(validKinds))
+	for k := range validKinds {
+		out = append(out, string(k))
+	}
+	sort.Strings(out)
+	return strings.Join(out, "|")
+}
+
+// sideEffectList renders the §5 vocabulary sorted, for error messages.
+func sideEffectList() string {
+	out := make([]string, 0, len(SideEffectVocabulary))
+	for s := range SideEffectVocabulary {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ", ")
+}

--- a/pkg/skillctl/datascope/datascope_test.go
+++ b/pkg/skillctl/datascope/datascope_test.go
@@ -1,0 +1,189 @@
+package datascope
+
+import (
+	"errors"
+	"testing"
+)
+
+func ptrBool(b bool) *bool { return &b }
+
+// failedRule extracts the §3.3 rule name from an error, "" if not a
+// ValidationError or no rule fired.
+func failedRule(err error) string {
+	var ve *ValidationError
+	if errors.As(err, &ve) {
+		return ve.FailedRule
+	}
+	return ""
+}
+
+func TestDataScope_Validate_OK(t *testing.T) {
+	cases := []DataScope{
+		{ID: "ds:er1/plm/skill-creations", Kind: KindER1Collection, Access: AccessRead, Reason: "seed"},
+		{ID: "ds:filesystem/cwd", Kind: KindLocalFS, Access: AccessWrite, Scope: "<cwd>/decks/**", Reason: "write decks"},
+		{ID: "ds:http/anthropic", Kind: KindHTTPEndpoint, Access: AccessPassthrough, Scope: "https://api.anthropic.com/*", Reason: "llm"},
+		{ID: "ds:gcs/bucket", Kind: KindGCSBucket, Access: AccessRead, Reason: "read blobs"},
+		{ID: "ds:secret/keychain", Kind: KindSecretsStore, Access: AccessRead, Reason: "read api key"},
+		{ID: "ds:fs/transform", Kind: KindLocalFS, Access: AccessTransform, Scope: "<cwd>/out/**", Reason: "transform"},
+		{ID: "ds:fs/readall", Kind: KindLocalFS, Access: AccessRead, Reason: "read broadly (no scope ok for read)"},
+	}
+	for _, c := range cases {
+		if err := c.Validate(); err != nil {
+			t.Errorf("Validate(%+v) = %v, want nil", c, err)
+		}
+	}
+}
+
+func TestDataScope_Validate_Rejects(t *testing.T) {
+	cases := []struct {
+		name string
+		d    DataScope
+	}{
+		{"empty id", DataScope{Kind: KindLocalFS, Access: AccessRead, Scope: "x/**"}},
+		{"id not ds-prefixed", DataScope{ID: "er1/x", Kind: KindER1Collection, Access: AccessRead}},
+		{"unknown kind", DataScope{ID: "ds:x", Kind: "kafka_topic", Access: AccessRead}},
+		{"unknown access", DataScope{ID: "ds:x", Kind: KindLocalFS, Access: "delete", Scope: "a/**"}},
+		{"local_fs without scope", DataScope{ID: "ds:x", Kind: KindLocalFS, Access: AccessWrite}},
+		{"local_fs unbounded scope", DataScope{ID: "ds:x", Kind: KindLocalFS, Access: AccessWrite, Scope: "**"}},
+		{"http without scope", DataScope{ID: "ds:x", Kind: KindHTTPEndpoint, Access: AccessRead}},
+		{"http non-https", DataScope{ID: "ds:x", Kind: KindHTTPEndpoint, Access: AccessRead, Scope: "http://api.example.com/*"}},
+		{"http no host", DataScope{ID: "ds:x", Kind: KindHTTPEndpoint, Access: AccessRead, Scope: "https://*"}},
+		{"gcs write without scope", DataScope{ID: "ds:x", Kind: KindGCSBucket, Access: AccessWrite}},
+		{"er1 scope with scheme", DataScope{ID: "ds:x", Kind: KindER1Collection, Access: AccessRead, Scope: "https://x"}},
+		{"secrets write", DataScope{ID: "ds:x", Kind: KindSecretsStore, Access: AccessWrite}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.d.Validate(); err == nil {
+				t.Errorf("Validate(%+v) = nil, want error", c.d)
+			}
+		})
+	}
+}
+
+func TestValidateSideEffects(t *testing.T) {
+	if err := ValidateSideEffects([]string{"fs:write", "llm:call", "secrets:read"}); err != nil {
+		t.Errorf("valid side effects rejected: %v", err)
+	}
+	if err := ValidateSideEffects([]string{"UNKNOWN"}); err != nil {
+		t.Errorf("awareness sentinel UNKNOWN must be tolerated: %v", err)
+	}
+	if err := ValidateSideEffects([]string{"fs:write", "fs:nuke"}); err == nil {
+		t.Errorf("out-of-vocabulary side effect accepted, want error")
+	}
+}
+
+func TestCrossRule_DestructiveGreen(t *testing.T) {
+	in := Intent{Destructive: ptrBool(true), SideEffects: []string{"fs:delete"}}
+	err := Validate(in, nil, "green")
+	if got := failedRule(err); got != RuleDestructiveGreen {
+		t.Fatalf("failed_rule = %q, want %q (err=%v)", got, RuleDestructiveGreen, err)
+	}
+	// destructive + yellow is fine.
+	if err := Validate(in, nil, "yellow"); err != nil {
+		t.Errorf("destructive+yellow rejected: %v", err)
+	}
+}
+
+func TestCrossRule_NetworkFalseHTTPDep(t *testing.T) {
+	in := Intent{Network: ptrBool(true), SideEffects: []string{"network:outbound"}}
+	// network=true but no http dep.
+	err := Validate(in, []DataScope{{ID: "ds:fs", Kind: KindLocalFS, Access: AccessRead, Scope: "a/**"}}, "yellow")
+	if got := failedRule(err); got != RuleNetworkFalseHTTPDep {
+		t.Fatalf("failed_rule = %q, want %q (err=%v)", got, RuleNetworkFalseHTTPDep, err)
+	}
+	// network=true WITH an http dep is fine.
+	ok := []DataScope{{ID: "ds:http", Kind: KindHTTPEndpoint, Access: AccessPassthrough, Scope: "https://api.anthropic.com/*"}}
+	if err := Validate(in, ok, "yellow"); err != nil {
+		t.Errorf("network+http dep rejected: %v", err)
+	}
+}
+
+func TestCrossRule_WriteAccessNonDestructive(t *testing.T) {
+	in := Intent{Destructive: ptrBool(false), SideEffects: []string{"fs:write"}}
+	scopes := []DataScope{{ID: "ds:fs", Kind: KindLocalFS, Access: AccessWrite, Scope: "<cwd>/out/**"}}
+	err := Validate(in, scopes, "yellow")
+	if got := failedRule(err); got != RuleWriteAccessNonDestr {
+		t.Fatalf("failed_rule = %q, want %q (err=%v)", got, RuleWriteAccessNonDestr, err)
+	}
+	// transform also trips it.
+	scopes[0].Access = AccessTransform
+	if got := failedRule(Validate(in, scopes, "yellow")); got != RuleWriteAccessNonDestr {
+		t.Errorf("transform did not trip write rule")
+	}
+	// write + destructive=true is consistent.
+	in.Destructive = ptrBool(true)
+	scopes[0].Access = AccessWrite
+	if err := Validate(in, scopes, "yellow"); err != nil {
+		t.Errorf("write+destructive=true rejected: %v", err)
+	}
+}
+
+func TestCrossRule_MissingDestructiveDoesNotTripWriteRule(t *testing.T) {
+	// destructive absent (nil) + a write dep: rule 3 must NOT fire (only fires
+	// on an explicit false). pack-time requires destructive, not this validator.
+	in := Intent{SideEffects: []string{"fs:write"}}
+	scopes := []DataScope{{ID: "ds:fs", Kind: KindLocalFS, Access: AccessWrite, Scope: "<cwd>/out/**"}}
+	if err := Validate(in, scopes, "yellow"); err != nil {
+		t.Errorf("absent destructive + write tripped a rule: %v", err)
+	}
+}
+
+func TestValidate_HappyPath(t *testing.T) {
+	in := Intent{
+		SideEffects: []string{"fs:write", "llm:call"},
+		Destructive: ptrBool(false),
+		Network:     ptrBool(true),
+	}
+	scopes := []DataScope{
+		{ID: "ds:er1/plm", Kind: KindER1Collection, Access: AccessRead, Reason: "seed"},
+		{ID: "ds:http/anthropic", Kind: KindHTTPEndpoint, Access: AccessPassthrough, Scope: "https://api.anthropic.com/*", Reason: "llm"},
+	}
+	if err := Validate(in, scopes, "yellow"); err != nil {
+		t.Fatalf("happy path rejected: %v", err)
+	}
+}
+
+func TestFromMap_RoundTrip(t *testing.T) {
+	raw := map[string]any{
+		"id":     "ds:filesystem/cwd",
+		"kind":   "local_fs",
+		"access": "write",
+		"scope":  "<cwd>/decks/**",
+		"reason": "write decks",
+		"extra":  "ignored", // forward-compat unknown key
+	}
+	d, err := FromMap(raw)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	if d.ID != "ds:filesystem/cwd" || d.Kind != KindLocalFS || d.Access != AccessWrite || d.Scope != "<cwd>/decks/**" {
+		t.Fatalf("decoded wrong: %+v", d)
+	}
+	if err := d.Validate(); err != nil {
+		t.Errorf("decoded scope failed validation: %v", err)
+	}
+}
+
+func TestIntentFromMap(t *testing.T) {
+	m := map[string]any{
+		"side_effects": []any{"fs:write", "llm:call"},
+		"destructive":  false,
+		"network":      true,
+	}
+	in := IntentFromMap(m)
+	if len(in.SideEffects) != 2 {
+		t.Fatalf("side_effects len = %d", len(in.SideEffects))
+	}
+	if in.Destructive == nil || *in.Destructive {
+		t.Errorf("destructive not decoded as false")
+	}
+	if in.Network == nil || !*in.Network {
+		t.Errorf("network not decoded as true")
+	}
+	// absent fields stay nil
+	in2 := IntentFromMap(map[string]any{})
+	if in2.Destructive != nil || in2.Network != nil {
+		t.Errorf("absent fields should be nil pointers")
+	}
+}

--- a/pkg/skillctl/datascope/parse.go
+++ b/pkg/skillctl/datascope/parse.go
@@ -1,0 +1,82 @@
+package datascope
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// FromMap decodes one raw `data_dependencies[]` entry (the `map[string]any`
+// shape the `intent declare` CLI and the bundle.json both carry) into a typed
+// DataScope. It does NOT validate — the caller runs Validate()/Validate(...)
+// after decoding so the structural decode error and the semantic validation
+// error stay distinguishable.
+//
+// Unknown keys are tolerated (forward-compat): a future field on the wire must
+// not break decoding on an older binary. Only the typed fields are pulled out.
+func FromMap(m map[string]any) (DataScope, error) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return DataScope{}, fmt.Errorf("datascope: re-marshal raw dep: %w", err)
+	}
+	var d DataScope
+	if err := json.Unmarshal(b, &d); err != nil {
+		return DataScope{}, fmt.Errorf("datascope: decode dep: %w", err)
+	}
+	return d, nil
+}
+
+// FromMaps decodes a slice of raw deps. The first decode error short-circuits.
+func FromMaps(ms []map[string]any) ([]DataScope, error) {
+	out := make([]DataScope, 0, len(ms))
+	for i, m := range ms {
+		d, err := FromMap(m)
+		if err != nil {
+			return nil, fmt.Errorf("data_dependencies[%d]: %w", i, err)
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+// IntentFromMap pulls the typed cross-rule fields out of the free-form `intent`
+// map. It is lenient: a missing/absent key leaves the corresponding pointer
+// nil (so the cross-rules can tell "absent" from "false"). Non-bool values for
+// destructive/network are treated as absent rather than an error — the field
+// validators in the CLI already reject malformed flag input upstream; here we
+// only extract what is cleanly typed.
+func IntentFromMap(m map[string]any) Intent {
+	var in Intent
+	if se, ok := m["side_effects"]; ok {
+		in.SideEffects = toStringSlice(se)
+	}
+	if d, ok := m["destructive"]; ok {
+		if b, isBool := d.(bool); isBool {
+			in.Destructive = &b
+		}
+	}
+	if n, ok := m["network"]; ok {
+		if b, isBool := n.(bool); isBool {
+			in.Network = &b
+		}
+	}
+	return in
+}
+
+// toStringSlice coerces an `any` (typically []any from JSON or []string from
+// in-code construction) into []string, dropping non-string members.
+func toStringSlice(v any) []string {
+	switch s := v.(type) {
+	case []string:
+		return s
+	case []any:
+		out := make([]string, 0, len(s))
+		for _, item := range s {
+			if str, ok := item.(string); ok {
+				out = append(out, str)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/pkg/skillctl/device/device.go
+++ b/pkg/skillctl/device/device.go
@@ -1,0 +1,196 @@
+// Package device manages the per-machine DEVICE KEY that signs SPEC-0202
+// per-invocation runtime envelopes (the InvocationRecord in pkg/skillgate).
+//
+// Why a dedicated key (SPEC-0202 D1 — blast radius): the device key is
+// SEPARATE from the author key (SPEC-0188) and the registry capability-token
+// key. Compromise of the device key only lets an attacker forge LOCAL
+// invocation records on THIS machine — it cannot admit fake bundles or issue
+// capability tokens. Different blast radius → different key.
+//
+// The key is created LAZILY on first use (EnsureKey), stored at
+// ~/.claude/skillctl/device-key.priv (+ .pub), PEM/PKCS#8, mode 0600 — exactly
+// the format `signing.Generate` already writes, so there is NO new crypto here:
+// we reuse Generate/LoadPrivateKey/LoadPublicKey verbatim and add only the
+// lazy-create + KeyID derivation + a thin Sign wrapper.
+//
+// Signing is fully local and offline. Registry registration of the device
+// public key is a follow-up (ADR §4.1) — P2 ships offline-complete.
+//
+// SPEC reference: SPEC-0202 §9 ("signed by the local skillgate's per-host
+// key"), §15 D1 (separate keys / blast radius).
+package device
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
+)
+
+// keyBasename is the on-disk base path (without the .priv/.pub suffix that
+// signing.Generate appends). The directory mirrors the 0700 ~/.claude/skillctl
+// convention used by the verdict cache and the gate-audit log.
+const keyBasename = "device-key"
+
+// keyIDPrefix tags a device-key fingerprint so a KeyID is self-describing and
+// can never be confused with a registry key id (which uses other prefixes).
+const keyIDPrefix = "device:"
+
+// keyIDHexLen is how many hex chars of the SHA-256(pubkey) fingerprint we keep.
+// 16 hex chars = 64 bits of the digest — ample to identify the local key in an
+// audit line without bloating every record. The full pubkey is what actually
+// verifies; the KeyID is only a human/index handle.
+const keyIDHexLen = 16
+
+// Key is a loaded device keypair plus its derived KeyID. The private key never
+// leaves this struct; callers Sign through it rather than handling raw bytes.
+type Key struct {
+	priv  ed25519.PrivateKey
+	pub   ed25519.PublicKey
+	keyID string
+}
+
+// dirFor returns the ~/.claude/skillctl directory for the given home. Centralised
+// so the path convention is defined once.
+func dirFor(home string) string {
+	return filepath.Join(home, ".claude", "skillctl")
+}
+
+// privPath / pubPath return the on-disk key file paths for a home.
+func privPath(home string) string { return filepath.Join(dirFor(home), keyBasename+".priv") }
+func pubPath(home string) string  { return filepath.Join(dirFor(home), keyBasename+".pub") }
+
+// PrivPath exposes the private-key path (for diagnostics / tests). Not a secret.
+func PrivPath(home string) string { return privPath(home) }
+
+// PubPath exposes the public-key path.
+func PubPath(home string) string { return pubPath(home) }
+
+// EnsureKey loads the device key, lazily generating it on first use.
+//
+// Behaviour:
+//   - if both .priv and .pub exist → Load and return them;
+//   - if NEITHER exists → generate via signing.Generate (which refuses to
+//     overwrite, writes 0600 priv / 0644 pub, 0700 parent dir) then Load;
+//   - if EXACTLY ONE exists → refuse (a half-keypair is corruption; generating
+//     over it would risk clobbering a real private key, and signing.Generate
+//     refuses to overwrite anyway). The operator must resolve it explicitly.
+//
+// home must be a real directory (the caller resolves it via the same userHome
+// path the rest of skillctl uses). Returns a *Key ready to Sign.
+func EnsureKey(home string) (*Key, error) {
+	if home == "" {
+		return nil, fmt.Errorf("device: empty home dir")
+	}
+	pp := privPath(home)
+	pub := pubPath(home)
+	privExists := fileExists(pp)
+	pubExists := fileExists(pub)
+
+	switch {
+	case privExists && pubExists:
+		return Load(home)
+	case !privExists && !pubExists:
+		// Lazy create. signing.Generate appends .priv/.pub to the base path.
+		base := filepath.Join(dirFor(home), keyBasename)
+		if err := signing.Generate(base); err != nil {
+			return nil, fmt.Errorf("device: generate key: %w", err)
+		}
+		return Load(home)
+	default:
+		// Exactly one half present — corruption / partial rotation. Fail
+		// closed rather than silently regenerate (which signing.Generate
+		// would refuse anyway, but the error here is clearer).
+		return nil, fmt.Errorf("device: half-keypair at %s — exactly one of {.priv,.pub} exists; remove both to regenerate", dirFor(home))
+	}
+}
+
+// Load reads an EXISTING device key. Returns an error if it is absent — Load
+// never creates (use EnsureKey for lazy creation). Reuses the strict
+// signing.LoadPrivateKey / LoadPublicKey (mode + PEM-type validation).
+func Load(home string) (*Key, error) {
+	if home == "" {
+		return nil, fmt.Errorf("device: empty home dir")
+	}
+	priv, err := signing.LoadPrivateKey(privPath(home))
+	if err != nil {
+		return nil, fmt.Errorf("device: load private key: %w", err)
+	}
+	pub, err := signing.LoadPublicKey(pubPath(home))
+	if err != nil {
+		return nil, fmt.Errorf("device: load public key: %w", err)
+	}
+	// Defence-in-depth: the .pub on disk MUST be the public half of the .priv.
+	// If a tampered .pub were paired with a real .priv, an audit reader pinning
+	// the .pub would reject signatures the .priv produced (fail-closed), but we
+	// catch the mismatch here so the key is never returned in a confused state.
+	derived := priv.Public().(ed25519.PublicKey)
+	if !pubEqual(derived, pub) {
+		return nil, fmt.Errorf("device: key mismatch — %s is not the public half of %s", pubPath(home), privPath(home))
+	}
+	return &Key{priv: priv, pub: derived, keyID: deriveKeyID(derived)}, nil
+}
+
+// KeyID returns the device key's fingerprint id ("device:<16-hex>"). Stable for
+// the life of the key; recorded in every InvocationRecord so an auditor can
+// correlate a trail to the machine that produced it.
+func (k *Key) KeyID() string { return k.keyID }
+
+// PublicKey returns a copy of the raw 32-byte ed25519 public key — the value an
+// auditor pins to verify the trail. Public, not a secret.
+func (k *Key) PublicKey() ed25519.PublicKey {
+	out := make(ed25519.PublicKey, len(k.pub))
+	copy(out, k.pub)
+	return out
+}
+
+// Sign produces a 64-byte ed25519 detached signature over msg with the device
+// private key. The caller is responsible for passing CANONICAL, domain-separated
+// bytes (see pkg/skillgate CanonicalizeInvocationRecord) — Sign does not add a
+// domain separator itself, mirroring signing.SignAttestation.
+func (k *Key) Sign(msg []byte) []byte {
+	sig := ed25519.Sign(k.priv, msg)
+	if len(sig) != ed25519.SignatureSize {
+		// stdlib invariant; a wrong-length signature would corrupt the trail.
+		panic(fmt.Sprintf("device: ed25519.Sign returned %d bytes (want %d)", len(sig), ed25519.SignatureSize))
+	}
+	return sig
+}
+
+// Verify checks a detached signature against this key's public half. Provided
+// for symmetry / local round-trip tests; the durable verification path pins the
+// public key independently.
+func (k *Key) Verify(msg, sig []byte) bool {
+	return ed25519.Verify(k.pub, msg, sig)
+}
+
+// deriveKeyID computes "device:<first 16 hex of sha256(pubkey)>".
+func deriveKeyID(pub ed25519.PublicKey) string {
+	sum := sha256.Sum256(pub)
+	return keyIDPrefix + hex.EncodeToString(sum[:])[:keyIDHexLen]
+}
+
+// fileExists reports whether path exists as a regular file (or any file). A
+// stat error other than not-exist is treated as "exists" so EnsureKey refuses
+// to generate over an unreadable file rather than masking the problem.
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// pubEqual is a length-checked byte equality for two public keys.
+func pubEqual(a, b ed25519.PublicKey) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/skillctl/device/device_test.go
+++ b/pkg/skillctl/device/device_test.go
@@ -1,0 +1,135 @@
+package device
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestEnsureKey_LazyCreate(t *testing.T) {
+	home := t.TempDir()
+	// First call creates.
+	k, err := EnsureKey(home)
+	if err != nil {
+		t.Fatalf("EnsureKey (create): %v", err)
+	}
+	if !strings.HasPrefix(k.KeyID(), "device:") {
+		t.Errorf("KeyID %q lacks device: prefix", k.KeyID())
+	}
+	if !fileExists(privPath(home)) || !fileExists(pubPath(home)) {
+		t.Fatalf("key files not written")
+	}
+	// Private key file must be 0600 (POSIX only — Windows synthesizes modes).
+	if runtime.GOOS != "windows" {
+		fi, _ := os.Stat(privPath(home))
+		if perm := fi.Mode().Perm(); perm&0o077 != 0 {
+			t.Errorf("priv key mode = %#o, want 0600", perm)
+		}
+	}
+	// Second call is idempotent: same KeyID, no regeneration.
+	k2, err := EnsureKey(home)
+	if err != nil {
+		t.Fatalf("EnsureKey (reload): %v", err)
+	}
+	if k.KeyID() != k2.KeyID() {
+		t.Errorf("KeyID changed on reload: %q != %q", k.KeyID(), k2.KeyID())
+	}
+}
+
+func TestEnsureKey_RefuseHalfKeypair(t *testing.T) {
+	home := t.TempDir()
+	if _, err := EnsureKey(home); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Remove the .pub, leaving a half-keypair.
+	if err := os.Remove(pubPath(home)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EnsureKey(home); err == nil {
+		t.Fatalf("EnsureKey should refuse a half-keypair (only .priv present)")
+	}
+}
+
+func TestLoad_AbsentIsError(t *testing.T) {
+	home := t.TempDir()
+	if _, err := Load(home); err == nil {
+		t.Fatalf("Load on absent key should error")
+	}
+}
+
+func TestSignVerify_RoundTrip(t *testing.T) {
+	home := t.TempDir()
+	k, err := EnsureKey(home)
+	if err != nil {
+		t.Fatalf("EnsureKey: %v", err)
+	}
+	msg := []byte("invocation_event_v1\nschema=x\n")
+	sig := k.Sign(msg)
+	if len(sig) != 64 {
+		t.Fatalf("signature len = %d, want 64", len(sig))
+	}
+	if !k.Verify(msg, sig) {
+		t.Errorf("Verify failed on freshly-signed message")
+	}
+	// Tampered message must not verify.
+	if k.Verify([]byte("tampered"), sig) {
+		t.Errorf("Verify accepted a tampered message")
+	}
+	// A second loaded handle (same key) verifies the same signature.
+	k2, err := Load(home)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !k2.Verify(msg, sig) {
+		t.Errorf("reloaded key did not verify a signature from the original handle")
+	}
+}
+
+func TestKeyID_StableAcrossMachines_DependsOnPubKey(t *testing.T) {
+	// Two distinct homes get distinct keys → distinct KeyIDs (no accidental
+	// collision; the id is a function of the public key, not the path).
+	a, err := EnsureKey(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := EnsureKey(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.KeyID() == b.KeyID() {
+		t.Errorf("two independently-generated keys share a KeyID: %q", a.KeyID())
+	}
+}
+
+func TestLoad_DetectsTamperedPub(t *testing.T) {
+	// Pair a real .priv with a foreign .pub → Load must refuse (key-confusion
+	// guard), not return a confused handle.
+	homeA := t.TempDir()
+	homeB := t.TempDir()
+	if _, err := EnsureKey(homeA); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EnsureKey(homeB); err != nil {
+		t.Fatal(err)
+	}
+	// Overwrite A's .pub with B's .pub.
+	bPub, err := os.ReadFile(pubPath(homeB))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pubPath(homeA), bPub, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(homeA); err == nil {
+		t.Fatalf("Load accepted a mismatched .pub; want key-mismatch error")
+	}
+}
+
+func TestPaths(t *testing.T) {
+	home := "/tmp/h"
+	if got, want := PrivPath(home), filepath.Join("/tmp/h", ".claude", "skillctl", "device-key.priv"); got != want {
+		t.Errorf("PrivPath = %q, want %q", got, want)
+	}
+}

--- a/pkg/skillgate/event.go
+++ b/pkg/skillgate/event.go
@@ -1,0 +1,218 @@
+package skillgate
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"strings"
+)
+
+// InvocationDomainSeparator is the first line of the canonical message for a
+// SPEC-0202 per-invocation runtime envelope. It is DISTINCT from
+// CanonicalDomainSeparator ("capability_v1") and from the SPEC-0188
+// attestation domain ("attestation"), so a signature captured under one family
+// can never replay as a signature under another — even with the same key.
+//
+// SPEC reference: SPEC-0202 §9 (per-host-signed invocation events).
+const InvocationDomainSeparator = "invocation_event_v1"
+
+// InvocationSchema is the schema tag carried in the record and the canonical
+// bytes. Versioned so a future format change is a value change at a fixed line,
+// not a silent reinterpretation.
+const InvocationSchema = "m3c-skill-invocation/v1"
+
+// InvocationRecord is one per-invocation runtime-envelope event: the durable,
+// device-signed evidence that a specific skill invocation happened, what it
+// did, and how it ended. It is the SPEC-0202 §9 "signed invocation event",
+// recorded LOCALLY in the append-only invocation trail (the durable system of
+// record; any HTTP upload is best-effort on top).
+//
+// IMPORTANT — emission is ALWAYS-ON: every invocation produces one of these,
+// regardless of whether enforcement (capability tokens) is active. That is what
+// makes the EU AI Act Art.12 trail complete by construction.
+//
+// The struct fields below split into TWO groups:
+//   - the SIGNED fields, which feed CanonicalizeInvocationRecord in a fixed
+//     order (see that function for the exact line schema);
+//   - DeviceSignatureB64, the detached device signature, which is EXCLUDED from
+//     the canonical input (a signature can't sign itself).
+type InvocationRecord struct {
+	// --- signed fields (fixed canonical order) ---
+
+	Schema    string `json:"schema"`     // InvocationSchema
+	EventID   string `json:"event_id"`   // ULID / random nonce — the replay key
+	EventType string `json:"event_type"` // e.g. "skill.invocation", "gate.allowed", "gate.refused"
+
+	SkillDigest  string `json:"skill_digest"`  // sha256:<hex> of the invoked bundle ("" if unknown)
+	SkillName    string `json:"skill_name"`    //
+	SkillVersion string `json:"skill_version"` //
+
+	Action    string `json:"action"`     // the action surface (e.g. "subprocess", "egress", "invoke")
+	Tool      string `json:"tool"`       // the tool/binary/host the action targeted
+	TokenID   string `json:"token_id"`   // capability token id if enforcement was active ("" otherwise)
+	SessionID string `json:"session_id"` // Claude Code session id — the P3 join key
+
+	OccurredAt string `json:"occurred_at"` // RFC3339 UTC seconds, e.g. 2026-06-23T14:03:11Z
+
+	// AgentIdentity and OwnerIdentity are SPEC-0277 (P3) forward-compat
+	// PLACEHOLDERS. In v1 they are ALWAYS the empty string, but the canonical
+	// message ALWAYS emits their lines (present-but-empty). This is the
+	// load-bearing forward-compat property: when P3 populates them, the change
+	// is a VALUE change at a fixed line — NOT a format break. Omitting the
+	// lines now would force a domain/version bump later. DO NOT remove them.
+	AgentIdentity string `json:"agent_identity"` // SPEC-0277 P3 — present-but-empty in v1
+	OwnerIdentity string `json:"owner_identity"` // SPEC-0277 P3 — present-but-empty in v1
+
+	DeviceKeyID string `json:"device_key_id"` // the signing device key's fingerprint
+	ExitCode    int    `json:"exit_code"`     // child / action exit code (0 on allow)
+	RefusalCode string `json:"refusal_code"`  // gate refusal_code on a refused event ("" otherwise)
+
+	// --- NOT part of the canonical signed message ---
+
+	DeviceSignatureB64 string `json:"device_signature_b64,omitempty"` // detached ed25519 over the canonical bytes
+}
+
+// CanonicalizeInvocationRecord produces the byte-identical signature payload
+// for an InvocationRecord. Modeled on CanonicalizeToken / the SPEC-0188
+// attestation canonical: domain-separated first line, LF-terminated lines
+// (including the last), fixed field order, no JSON, no escaping ambiguity.
+//
+// Field order — line by line — is FIXED. Changing it (reorder, add, drop,
+// alter a separator) is a breaking change and MUST come with a domain/version
+// bump. The golden-bytes test pins this exact output.
+//
+//	invocation_event_v1
+//	schema=<...>
+//	event_id=<...>
+//	event_type=<...>
+//	skill_digest=<...>
+//	skill_name=<...>
+//	skill_version=<...>
+//	action=<...>
+//	tool=<...>
+//	token_id=<...>
+//	session_id=<...>
+//	occurred_at=<...>
+//	agent_identity=<empty-in-v1>
+//	owner_identity=<empty-in-v1>
+//	device_key_id=<...>
+//	exit_code=<int>
+//	refusal_code=<...>
+//
+// Every value is written verbatim after the "<key>=" prefix. Callers MUST reject
+// any field containing a newline BEFORE signing (see validateNoNewlines) so the
+// LF-delimited framing is unambiguous — a smuggled "\n" could otherwise forge a
+// field boundary. The detached device_signature_b64 is excluded.
+func CanonicalizeInvocationRecord(r *InvocationRecord) ([]byte, error) {
+	if r == nil {
+		return nil, fmt.Errorf("skillgate: nil invocation record")
+	}
+	if err := validateNoNewlines(r); err != nil {
+		return nil, err
+	}
+	var b strings.Builder
+	w := func(line string) { b.WriteString(line); b.WriteByte('\n') }
+
+	w(InvocationDomainSeparator)
+	w("schema=" + r.Schema)
+	w("event_id=" + r.EventID)
+	w("event_type=" + r.EventType)
+	w("skill_digest=" + r.SkillDigest)
+	w("skill_name=" + r.SkillName)
+	w("skill_version=" + r.SkillVersion)
+	w("action=" + r.Action)
+	w("tool=" + r.Tool)
+	w("token_id=" + r.TokenID)
+	w("session_id=" + r.SessionID)
+	w("occurred_at=" + r.OccurredAt)
+	// SPEC-0277 P3 placeholders — ALWAYS emitted, empty in v1. See struct doc.
+	w("agent_identity=" + r.AgentIdentity)
+	w("owner_identity=" + r.OwnerIdentity)
+	w("device_key_id=" + r.DeviceKeyID)
+	w(fmt.Sprintf("exit_code=%d", r.ExitCode))
+	w("refusal_code=" + r.RefusalCode)
+
+	return []byte(b.String()), nil
+}
+
+// validateNoNewlines refuses any signed string field that contains a CR or LF.
+// The canonical format is LF-delimited; a value with an embedded newline would
+// let an attacker forge field boundaries inside the signed bytes. Fail-closed:
+// we never sign over ambiguous bytes. (exit_code is an int — no check needed.)
+func validateNoNewlines(r *InvocationRecord) error {
+	fields := map[string]string{
+		"schema":         r.Schema,
+		"event_id":       r.EventID,
+		"event_type":     r.EventType,
+		"skill_digest":   r.SkillDigest,
+		"skill_name":     r.SkillName,
+		"skill_version":  r.SkillVersion,
+		"action":         r.Action,
+		"tool":           r.Tool,
+		"token_id":       r.TokenID,
+		"session_id":     r.SessionID,
+		"occurred_at":    r.OccurredAt,
+		"agent_identity": r.AgentIdentity,
+		"owner_identity": r.OwnerIdentity,
+		"device_key_id":  r.DeviceKeyID,
+		"refusal_code":   r.RefusalCode,
+	}
+	for name, v := range fields {
+		if strings.ContainsAny(v, "\n\r") {
+			return fmt.Errorf("skillgate: invocation field %q contains a newline; refusing to sign ambiguous bytes", name)
+		}
+	}
+	return nil
+}
+
+// SignInvocationRecord canonicalizes the record, signs it with the device
+// private key, and stamps the detached signature into r.DeviceSignatureB64
+// (base64 std). The record's DeviceKeyID should already be set to the signing
+// key's id so a verifier can look up the right public key.
+//
+// signFn is the device key's Sign method (k.Sign) — taking it as a closure keeps
+// this package free of an import on pkg/skillctl/device (device imports skillgate
+// indirectly via the record type at the call site, not vice-versa) and lets the
+// gate use whatever signer it holds. b64 is injected too so the caller controls
+// the exact encoding (std, no padding stripping).
+func SignInvocationRecord(r *InvocationRecord, signFn func([]byte) []byte, b64 func([]byte) string) error {
+	if r == nil {
+		return fmt.Errorf("skillgate: nil record")
+	}
+	if signFn == nil || b64 == nil {
+		return fmt.Errorf("skillgate: nil sign/encode func")
+	}
+	msg, err := CanonicalizeInvocationRecord(r)
+	if err != nil {
+		return err
+	}
+	sig := signFn(msg)
+	if len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("skillgate: device signature wrong length %d (want %d)", len(sig), ed25519.SignatureSize)
+	}
+	r.DeviceSignatureB64 = b64(sig)
+	return nil
+}
+
+// VerifyInvocationRecord re-canonicalizes the record and verifies its detached
+// device signature against pub. Fail-closed: any decode/length/parse problem
+// returns false, never a partial accept.
+//
+// decode is injected (the inverse of the b64 used to sign) so this package
+// stays encoding-agnostic and the caller pins the exact alphabet.
+func VerifyInvocationRecord(r *InvocationRecord, pub ed25519.PublicKey, decode func(string) ([]byte, error)) bool {
+	if r == nil || decode == nil || len(pub) != ed25519.PublicKeySize {
+		return false
+	}
+	if r.DeviceSignatureB64 == "" {
+		return false
+	}
+	sig, err := decode(r.DeviceSignatureB64)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return false
+	}
+	msg, err := CanonicalizeInvocationRecord(r)
+	if err != nil {
+		return false
+	}
+	return ed25519.Verify(pub, msg, sig)
+}

--- a/pkg/skillgate/event_test.go
+++ b/pkg/skillgate/event_test.go
@@ -1,0 +1,209 @@
+package skillgate
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// sampleRecord is a fully-populated v1 record with the P3 identity fields left
+// empty (as v1 requires).
+func sampleRecord() *InvocationRecord {
+	return &InvocationRecord{
+		Schema:        InvocationSchema,
+		EventID:       "01HZZZEVENTID0000000000000",
+		EventType:     "skill.invocation",
+		SkillDigest:   "sha256:" + strings.Repeat("a", 64),
+		SkillName:     "didactic-session",
+		SkillVersion:  "1.0.0",
+		Action:        "invoke",
+		Tool:          "skill",
+		TokenID:       "ct:01HZZZTOKEN0000000000000",
+		SessionID:     "sess:01HZZZSESSION00000000000",
+		OccurredAt:    "2026-06-23T14:03:11Z",
+		AgentIdentity: "", // v1: empty placeholder
+		OwnerIdentity: "", // v1: empty placeholder
+		DeviceKeyID:   "device:0123456789abcdef",
+		ExitCode:      0,
+		RefusalCode:   "",
+	}
+}
+
+func TestCanonicalize_GoldenBytes(t *testing.T) {
+	got, err := CanonicalizeInvocationRecord(sampleRecord())
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	want := strings.Join([]string{
+		"invocation_event_v1",
+		"schema=m3c-skill-invocation/v1",
+		"event_id=01HZZZEVENTID0000000000000",
+		"event_type=skill.invocation",
+		"skill_digest=sha256:" + strings.Repeat("a", 64),
+		"skill_name=didactic-session",
+		"skill_version=1.0.0",
+		"action=invoke",
+		"tool=skill",
+		"token_id=ct:01HZZZTOKEN0000000000000",
+		"session_id=sess:01HZZZSESSION00000000000",
+		"occurred_at=2026-06-23T14:03:11Z",
+		"agent_identity=",
+		"owner_identity=",
+		"device_key_id=device:0123456789abcdef",
+		"exit_code=0",
+		"refusal_code=",
+		"", // trailing LF after the last line
+	}, "\n")
+	if string(got) != want {
+		t.Fatalf("canonical bytes mismatch:\n--- got ---\n%q\n--- want ---\n%q", string(got), want)
+	}
+	// Last byte MUST be LF (every line LF-terminated, including the last).
+	if got[len(got)-1] != '\n' {
+		t.Errorf("canonical bytes do not end with LF")
+	}
+}
+
+func TestCanonicalize_EmptyPlaceholderLinesAlwaysPresent(t *testing.T) {
+	// Forward-compat proof: the agent_identity / owner_identity lines are
+	// emitted EVEN when empty. This is what lets SPEC-0277 P3 populate them as a
+	// value change rather than a format break.
+	got, _ := CanonicalizeInvocationRecord(sampleRecord())
+	s := string(got)
+	if !strings.Contains(s, "\nagent_identity=\n") {
+		t.Errorf("agent_identity placeholder line missing/non-empty framing")
+	}
+	if !strings.Contains(s, "\nowner_identity=\n") {
+		t.Errorf("owner_identity placeholder line missing/non-empty framing")
+	}
+
+	// And the proof that populating them is a pure VALUE change: set them and
+	// confirm ONLY those two lines differ (line count identical, same order).
+	r2 := sampleRecord()
+	r2.AgentIdentity = "agent:inst-01"
+	r2.OwnerIdentity = "id:kamir@m3c"
+	got2, _ := CanonicalizeInvocationRecord(r2)
+	l1 := strings.Split(string(got), "\n")
+	l2 := strings.Split(string(got2), "\n")
+	if len(l1) != len(l2) {
+		t.Fatalf("line count changed when populating P3 fields: %d vs %d", len(l1), len(l2))
+	}
+	diffs := 0
+	for i := range l1 {
+		if l1[i] != l2[i] {
+			diffs++
+		}
+	}
+	if diffs != 2 {
+		t.Errorf("populating agent+owner changed %d lines, want exactly 2", diffs)
+	}
+}
+
+func TestSignVerify_RoundTrip(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	r := sampleRecord()
+	err := SignInvocationRecord(r, func(m []byte) []byte { return ed25519.Sign(priv, m) }, base64.StdEncoding.EncodeToString)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if r.DeviceSignatureB64 == "" {
+		t.Fatalf("signature not stamped")
+	}
+	if !VerifyInvocationRecord(r, pub, base64.StdEncoding.DecodeString) {
+		t.Errorf("round-trip verify failed")
+	}
+}
+
+func TestVerify_TamperRejected(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	r := sampleRecord()
+	_ = SignInvocationRecord(r, func(m []byte) []byte { return ed25519.Sign(priv, m) }, base64.StdEncoding.EncodeToString)
+
+	// Tamper with a signed field — verification MUST fail (the signature no
+	// longer covers the canonical bytes).
+	tampered := *r
+	tampered.Tool = "attacker.example"
+	if VerifyInvocationRecord(&tampered, pub, base64.StdEncoding.DecodeString) {
+		t.Errorf("verify accepted a tampered tool field")
+	}
+
+	// Tamper with exit_code.
+	tampered2 := *r
+	tampered2.ExitCode = 1
+	if VerifyInvocationRecord(&tampered2, pub, base64.StdEncoding.DecodeString) {
+		t.Errorf("verify accepted a tampered exit_code")
+	}
+
+	// Wrong key rejects.
+	otherPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	if VerifyInvocationRecord(r, otherPub, base64.StdEncoding.DecodeString) {
+		t.Errorf("verify accepted under the wrong public key")
+	}
+}
+
+func TestVerify_FailClosed_OnBadInputs(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	if VerifyInvocationRecord(nil, pub, base64.StdEncoding.DecodeString) {
+		t.Errorf("nil record verified")
+	}
+	r := sampleRecord()
+	if VerifyInvocationRecord(r, pub, base64.StdEncoding.DecodeString) {
+		t.Errorf("record with empty signature verified")
+	}
+	r.DeviceSignatureB64 = "!!!not-base64!!!"
+	if VerifyInvocationRecord(r, pub, base64.StdEncoding.DecodeString) {
+		t.Errorf("record with garbage signature verified")
+	}
+	// short pubkey
+	r2 := sampleRecord()
+	_ = SignInvocationRecord(r2, func(m []byte) []byte { return make([]byte, 64) }, base64.StdEncoding.EncodeToString)
+	if VerifyInvocationRecord(r2, ed25519.PublicKey{1, 2, 3}, base64.StdEncoding.DecodeString) {
+		t.Errorf("verify accepted a malformed public key")
+	}
+}
+
+func TestCanonicalize_RejectsNewlineSmuggling(t *testing.T) {
+	// A field carrying an embedded newline could forge a field boundary inside
+	// the signed bytes. Canonicalize MUST refuse to produce bytes for it.
+	r := sampleRecord()
+	r.Tool = "skill\nrefusal_code=token_revoked"
+	if _, err := CanonicalizeInvocationRecord(r); err == nil {
+		t.Fatalf("canonicalize accepted a newline-smuggled field; want refusal")
+	}
+}
+
+func TestReplay_DuplicateEventIDDetectable(t *testing.T) {
+	// Replay defence lives at the trail level (dedup by event_id), but it is
+	// only sound if event_id is BOUND into the signed bytes — so a replayed
+	// signature can't be re-pointed at a fresh event_id without breaking the
+	// signature. Prove: changing event_id changes the canonical bytes.
+	a := sampleRecord()
+	b := sampleRecord()
+	b.EventID = "01HZZZDIFFERENT0000000000000"
+	ca, _ := CanonicalizeInvocationRecord(a)
+	cb, _ := CanonicalizeInvocationRecord(b)
+	if string(ca) == string(cb) {
+		t.Fatalf("event_id is not bound into the canonical bytes — replay protection unsound")
+	}
+
+	// And a naive replay tracker dedups by event_id.
+	seen := map[string]bool{}
+	record := func(r *InvocationRecord) bool {
+		if seen[r.EventID] {
+			return false // duplicate → replay
+		}
+		seen[r.EventID] = true
+		return true
+	}
+	if !record(a) {
+		t.Fatalf("first record should be accepted")
+	}
+	dup := sampleRecord() // same EventID as a
+	if record(dup) {
+		t.Errorf("duplicate event_id should be rejected as a replay")
+	}
+	if !record(b) {
+		t.Errorf("distinct event_id should be accepted")
+	}
+}

--- a/pkg/skillgate/gate.go
+++ b/pkg/skillgate/gate.go
@@ -9,16 +9,16 @@ import (
 
 // SPEC-0202 §8.2 refusal exit codes. Mirrors the Python SkillEnvelopeViolation.
 const (
-	ExitCapabilityMissing  = 30
-	ExitDataSourceMissing  = 31
-	ExitEgressNotAllowed   = 32
-	ExitSubprocessDenied   = 33
-	ExitFileOutsideEnv     = 34
-	ExitTokenExpired       = 35
-	ExitTokenRevoked       = 36
-	ExitInvalidSignature   = 37
-	ExitRuntimeQuota       = 38
-	ExitEgressByteQuota    = 39
+	ExitCapabilityMissing = 30
+	ExitDataSourceMissing = 31
+	ExitEgressNotAllowed  = 32
+	ExitSubprocessDenied  = 33
+	ExitFileOutsideEnv    = 34
+	ExitTokenExpired      = 35
+	ExitTokenRevoked      = 36
+	ExitInvalidSignature  = 37
+	ExitRuntimeQuota      = 38
+	ExitEgressByteQuota   = 39
 )
 
 // Stable refusal codes paired with the InvocationEvent emitted on refuse.
@@ -92,12 +92,28 @@ type InvocationEvent struct {
 	RequestedCmd string `json:"requested_cmd,omitempty"`
 }
 
+// SignedSink records ONE device-signed, action-level InvocationRecord into the
+// durable signed trail (SPEC-0202 §9). It is OPTIONAL on a Gate: when nil, the
+// gate only posts the legacy unsigned InvocationEvent to AuditPoster. When set,
+// every allow/refuse ALSO produces a signed record — so action-level events
+// (subprocess / egress / capability checks inside a running skill) join the same
+// Art.12 trail the hook writes. The sink owns signing + appending and MUST be
+// fire-and-forget (the cooperative model never lets a logging failure block
+// enforcement); the gate calls it as a bare statement.
+type SignedSink func(InvocationRecord)
+
 // Gate enforces a verified token's envelope. It is COOPERATIVE — see the
 // package doc.
 type Gate struct {
 	Token       *Token
 	AuditPoster InvocationPoster
-	Now         func() time.Time // injectable clock; defaults to time.Now().UTC()
+	// SignedSink, when non-nil, receives one signed action-level record per
+	// allow/refuse. Optional — see SignedSink.
+	SignedSink SignedSink
+	// SessionID is stamped into signed records so action events join the same
+	// session join-key the hook uses (SPEC-0277 P3 forward-compat). Optional.
+	SessionID string
+	Now       func() time.Time // injectable clock; defaults to time.Now().UTC()
 }
 
 // GateError is returned by Allow() on refuse. ExitCode maps to SPEC-0202 §8.2.
@@ -260,23 +276,47 @@ func (g *Gate) refuse(code string, exitCode int, msg, requestedCmd string) error
 	return &GateError{Code: code, ExitCode: exitCode, Message: msg}
 }
 
-// audit fires-and-forgets to the AuditPoster. A nil poster is allowed (e.g.
-// in tests where audit is irrelevant); failures are silently swallowed
-// because the cooperative model never lets audit failure block enforcement.
+// audit fires-and-forgets to the AuditPoster AND (when set) the SignedSink. A
+// nil poster/sink is allowed (e.g. in tests where audit is irrelevant); failures
+// are silently swallowed because the cooperative model never lets audit failure
+// block enforcement.
 func (g *Gate) audit(eventType, refusalCode, requestedCmd string) {
-	if g.AuditPoster == nil {
-		return
+	now := g.nowFn().Format("2006-01-02T15:04:05Z")
+	if g.AuditPoster != nil {
+		ev := InvocationEvent{
+			Type:         eventType,
+			TokenID:      g.Token.TokenID,
+			SkillName:    g.Token.SkillName,
+			Tenant:       g.Token.TenantScope,
+			Timestamp:    now,
+			RefusalCode:  refusalCode,
+			RequestedCmd: requestedCmd,
+		}
+		_ = g.AuditPoster.PostInvocation(ev) // best-effort
 	}
-	ev := InvocationEvent{
-		Type:         eventType,
-		TokenID:      g.Token.TokenID,
-		SkillName:    g.Token.SkillName,
-		Tenant:       g.Token.TenantScope,
-		Timestamp:    g.nowFn().Format("2006-01-02T15:04:05Z"),
-		RefusalCode:  refusalCode,
-		RequestedCmd: requestedCmd,
+	if g.SignedSink != nil {
+		// Action-level signed record — the durable Art.12 evidence for what the
+		// running skill actually did. exit_code carries the gate verdict: 0 on
+		// allow, the refusal exit (30..39 — not known here) is left to the sink's
+		// caller; we encode allow/refuse via refusal_code (empty = allowed).
+		exit := 0
+		if refusalCode != "" {
+			exit = 1
+		}
+		g.SignedSink(InvocationRecord{
+			EventType:    eventType, // "gate.allowed" | "gate.refused"
+			SkillName:    g.Token.SkillName,
+			SkillVersion: g.Token.SkillVersion,
+			SkillDigest:  g.Token.BundleDigest,
+			Action:       requestedCmd,
+			Tool:         g.Token.SkillName,
+			TokenID:      g.Token.TokenID,
+			SessionID:    g.SessionID,
+			OccurredAt:   now,
+			ExitCode:     exit,
+			RefusalCode:  refusalCode,
+		})
 	}
-	_ = g.AuditPoster.PostInvocation(ev) // best-effort
 }
 
 // splitHostPort parses "host" or "host:port" allowlist entries. Returns

--- a/pkg/skillgate/signed_sink_test.go
+++ b/pkg/skillgate/signed_sink_test.go
@@ -1,0 +1,64 @@
+package skillgate
+
+import "testing"
+
+func gateWithEnvelope(sink SignedSink) *Gate {
+	return &Gate{
+		Token: &Token{
+			TokenID:      "ct:test",
+			SkillName:    "didactic-session",
+			SkillVersion: "1.0.0",
+			BundleDigest: "sha256:abc",
+			TenantScope:  "kup-berlin",
+			ExpiresAt:    "2999-01-01T00:00:00Z",
+			Envelope: TokenEnvelope{
+				Capabilities:        []string{"subprocess_run:bash"},
+				SubprocessAllowlist: []string{"bash"},
+			},
+		},
+		SessionID:  "sess:123",
+		SignedSink: sink,
+	}
+}
+
+func TestSignedSink_FiresOnAllow(t *testing.T) {
+	var got []InvocationRecord
+	g := gateWithEnvelope(func(r InvocationRecord) { got = append(got, r) })
+	if err := g.Allow(Subprocess{Name: "bash"}); err != nil {
+		t.Fatalf("expected allow, got %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("SignedSink fired %d times, want 1", len(got))
+	}
+	r := got[0]
+	if r.EventType != "gate.allowed" || r.RefusalCode != "" || r.ExitCode != 0 {
+		t.Errorf("allow record wrong: %+v", r)
+	}
+	if r.SkillName != "didactic-session" || r.TokenID != "ct:test" || r.SessionID != "sess:123" {
+		t.Errorf("record metadata not stamped: %+v", r)
+	}
+}
+
+func TestSignedSink_FiresOnRefuse(t *testing.T) {
+	var got []InvocationRecord
+	g := gateWithEnvelope(func(r InvocationRecord) { got = append(got, r) })
+	// curl is not in the allowlist and subprocess_run:curl is not a capability.
+	if err := g.Allow(Subprocess{Name: "curl"}); err == nil {
+		t.Fatalf("expected refusal")
+	}
+	if len(got) != 1 {
+		t.Fatalf("SignedSink fired %d times, want 1", len(got))
+	}
+	r := got[0]
+	if r.EventType != "gate.refused" || r.RefusalCode == "" || r.ExitCode == 0 {
+		t.Errorf("refuse record wrong: %+v", r)
+	}
+}
+
+func TestSignedSink_NilIsSafe(t *testing.T) {
+	// A nil SignedSink must not panic and must not alter the decision.
+	g := gateWithEnvelope(nil)
+	if err := g.Allow(Subprocess{Name: "bash"}); err != nil {
+		t.Fatalf("nil sink changed the allow decision: %v", err)
+	}
+}


### PR DESCRIPTION
Implements ROADMAP P2 (ADR-P2-datascope-and-runtime-envelope) — SPEC-0196 declared data-scope + SPEC-0202 per-invocation signed runtime envelope. CORE LOGIC STDLIB-ONLY; reuses the existing ed25519 signing primitives (NO new crypto). Does NOT touch `pkg/skillctl/bodyscan`.

## What lands (the ADR's 9-step build order)

1. **`pkg/skillctl/datascope/`** (new leaf pkg, stdlib-only) — `DataScope{id,kind,access,scope,reason}`, per-kind scope validators, the §3.3 cross-rules (`destructive_green` / `network_false_http_dep` / `write_access_non_destructive`), the §5 side-effect vocabulary. Pure + tested.
2. **`intent declare`** gains a typed `--data-scopes` flag routed through `datascope.Validate` (client-side, fail-closed before any PATCH); `--data-dep` kept as a validated **deprecated alias**; added **`intent show`**. A client-caught §3.3 cross-rule exits **18** without touching the network — same code the server returns.
3. **`pkg/skillctl/device/`** (new) — per-machine device key at `~/.claude/skillctl/device-key.priv`, lazily generated via `signing.Generate`. `EnsureKey`/`Load`/`KeyID`/`Sign` + key-confusion guard. Separate key (SPEC-0202 D1 blast-radius).
4. **`pkg/skillgate/event.go`** (new) — `InvocationRecord` + `CanonicalizeInvocationRecord` modeled byte-for-byte on `canonical.go` (domain `invocation_event_v1`, LF-terminated, fixed order). `agent_identity`/`owner_identity` are **present-but-empty P3 placeholders** (SPEC-0277). Golden-bytes, sign/verify round-trip, tamper, replay-binding, newline-smuggle refusal, forward-compat proof.
5. **`cmd/skillctl/invocation_trail.go`** (new) — `appendSignedInvocation`: append-only, 0700 dir / 0600 file, size rotation, panic-safe fire-and-forget, **ALWAYS-ON**, writes `~/.claude/skillctl/invocation-trail.jsonl` (**SEPARATE** from the unsigned advisory `gate-audit.jsonl`).
6. **Hook emission** — the SPEC-0247 `verify-hook` deferred block emits one signed record per gated skill on **both allow and deny**, best-effort, never altering the decision/exit.
7. **`SignedSink` on `skillgate.Gate`** — optional; every allow/refuse also produces a signed action-level record. Wired from `skillctl run` (signed `skill.invoked`/`skill.completed`).
8. **`compliance report`** reads + verifies the trail; surfaces signed-event count / device key / verification status in the posture summary and points the **EU AI Act Art.12** row at concrete, offline-verified figures.
9. Full `go build/vet/test ./...` green, 0 golangci-lint issues, `GOOS=windows` build+vet clean.

## Key invariants
- **Emission ALWAYS-ON, enforcement opt-in.** Every invocation → a signed record (Art.12 trail complete by construction); enforcement stays via capability tokens (`skillctl run`).
- **Two trails, two purposes.** `gate-audit.jsonl` stays unsigned/advisory; `invocation-trail.jsonl` is signed evidence. They never mix; the trail is never a gate trust input.
- **Durable record = the LOCAL signed trail.** Any HTTP upload stays best-effort.
- **Fail-closed crypto.** Domain-separated ed25519; every signed string field is newline-guarded so the canonical bytes are unambiguous; verification fail-closed on any decode/length/key error.
- bodyscan untouched; `datascope` is a leaf so bodyscan may import it later with no cycle.

## Tests
New/expanded coverage in `datascope`, `device`, `pkg/skillgate` (event + SignedSink), and `cmd/skillctl` (trail, hook allow+deny signed emission, compliance Art.12). `-race` clean on the signed-evidence packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)