### PR TITLE
SPEC-0196 P2b: bind declared data-scope into the signed bundle (author-signature-covered)

### DIFF
--- a/cmd/skillctl/intent_cmds.go
+++ b/cmd/skillctl/intent_cmds.go
@@ -420,14 +420,29 @@ func runIntentShow(args []string, stdout, stderr io.Writer) int {
 		return exitGeneric
 	}
 
-	intentBlock, dataDeps := extractDeclaredIntent(meta)
+	view := extractDeclaredView(meta)
+	authIntent, authDeps, authProv := view.authoritativeIntent()
 
 	if *asJSON {
+		// Emit the authoritative declaration flat (back-compat with existing
+		// consumers) PLUS a provenance-tagged breakdown so a CISO tool can tell
+		// signed-manifest from bundle-row without scraping text.
 		out := map[string]any{
-			"digest":            digest,
-			"governance":        meta.CurrentGovernance,
-			"intent":            intentBlock,
-			"data_dependencies": dataDeps,
+			"digest":                 digest,
+			"governance":             meta.CurrentGovernance,
+			"intent":                 authIntent,
+			"data_dependencies":      authDeps,
+			"declaration_provenance": authProv,
+			"sources": map[string]any{
+				provSignedManifest: map[string]any{
+					"intent":            view.signedIntent,
+					"data_dependencies": view.signedDeps,
+				},
+				provBundleRow: map[string]any{
+					"intent":            view.rowIntent,
+					"data_dependencies": view.rowDeps,
+				},
+			},
 		}
 		b, _ := json.MarshalIndent(out, "", "  ")
 		fmt.Fprintln(stdout, string(b))
@@ -436,36 +451,105 @@ func runIntentShow(args []string, stdout, stderr io.Writer) int {
 
 	fmt.Fprintf(stdout, "digest:     %s\n", digest)
 	fmt.Fprintf(stdout, "governance: %s\n", dashOrValue(meta.CurrentGovernance))
-	if intentBlock == nil {
+	switch authProv {
+	case provSignedManifest:
+		fmt.Fprintln(stdout, "provenance: signed-manifest (AUTHORITATIVE — author-signature-covered)")
+	case provBundleRow:
+		fmt.Fprintln(stdout, "provenance: bundle-row (ADVISORY — mutable post-admit PATCH, NOT author-signed)")
+	default:
+		fmt.Fprintln(stdout, "provenance: (none declared)")
+	}
+	if view.hasSigned() && view.hasRow() {
+		fmt.Fprintln(stdout, "note:       both a signed-manifest and a bundle-row declaration exist; the signed-manifest one is authoritative.")
+	}
+
+	printIntentSource(stdout, provSignedManifest, "AUTHORITATIVE", view.signedIntent, view.signedDeps)
+	printIntentSource(stdout, provBundleRow, "ADVISORY", view.rowIntent, view.rowDeps)
+	if !view.hasSigned() && !view.hasRow() {
 		fmt.Fprintln(stdout, "intent:     (none declared)")
-	} else {
-		fmt.Fprintln(stdout, "intent:")
-		if b, err := json.MarshalIndent(intentBlock, "  ", "  "); err == nil {
-			fmt.Fprintf(stdout, "  %s\n", string(b))
-		}
-	}
-	if len(dataDeps) == 0 {
 		fmt.Fprintln(stdout, "data_dependencies: (none declared)")
-	} else {
-		fmt.Fprintf(stdout, "data_dependencies (%d):\n", len(dataDeps))
-		for _, d := range dataDeps {
-			if b, err := json.Marshal(d); err == nil {
-				fmt.Fprintf(stdout, "  - %s\n", string(b))
-			}
-		}
 	}
+	fmt.Fprintln(stdout, "(authoritative signed-binding verification: `skillctl verify --bundle <file.skb>`)")
 	return exitOK
 }
 
-// extractDeclaredIntent pulls the declared intent + data_dependencies out of a
-// BundleMeta. The post-hoc `intent declare` PATCH writes them onto the registry
-// row (BundleMeta.Bundle); a pack-time binding writes them into bundle.json
-// (BundleMeta.Manifest). We prefer the row (it is the post-admission source of
-// truth) and fall back to the manifest.
-func extractDeclaredIntent(meta *registry.BundleMeta) (map[string]any, []map[string]any) {
-	pick := func(src map[string]any) (map[string]any, []map[string]any, bool) {
+// printIntentSource renders one provenance source's intent + data_dependencies,
+// each line tagged with the provenance label so a CISO sees which declaration is
+// author-signed vs post-admit. Prints nothing when the source is empty.
+func printIntentSource(stdout io.Writer, provenance, marker string, intentBlock map[string]any, deps []map[string]any) {
+	if intentBlock == nil && len(deps) == 0 {
+		return
+	}
+	fmt.Fprintf(stdout, "[%s] %s:\n", provenance, marker)
+	if intentBlock != nil {
+		if b, err := json.MarshalIndent(intentBlock, "    ", "  "); err == nil {
+			fmt.Fprintf(stdout, "  intent: %s\n", string(b))
+		}
+	}
+	if len(deps) > 0 {
+		fmt.Fprintf(stdout, "  data_dependencies (%d):\n", len(deps))
+		for _, d := range deps {
+			if b, err := json.Marshal(d); err == nil {
+				fmt.Fprintf(stdout, "    - %s\n", string(b))
+			}
+		}
+	}
+}
+
+// scopeProvenance labels WHERE a declared scope came from, so a CISO can tell at
+// a glance whether today's declaration is author-signed or post-admit
+// (SPEC-0196 §12 Q1 / P2b). Mirrors verify.ScopeProvenance string values.
+const (
+	provSignedManifest = "signed-manifest" // from the author-signed bundle.json (authoritative)
+	provBundleRow      = "bundle-row"      // from the mutable post-admit PATCH row (advisory)
+)
+
+// declaredView is the provenance-tagged result of reading a BundleMeta's
+// declared intent + data_dependencies. The signed-manifest source is the
+// author-bound bundle.json the registry parsed at admit time; the bundle-row
+// source is the mutable `intent declare` PATCH target. BOTH are surfaced — a
+// CISO must see which is author-signed, not just the winning one.
+type declaredView struct {
+	signedIntent map[string]any
+	signedDeps   []map[string]any
+	rowIntent    map[string]any
+	rowDeps      []map[string]any
+}
+
+// hasSigned reports whether any author-signed declaration is present.
+func (v declaredView) hasSigned() bool {
+	return v.signedIntent != nil || len(v.signedDeps) > 0
+}
+
+// hasRow reports whether any mutable bundle-row declaration is present.
+func (v declaredView) hasRow() bool {
+	return v.rowIntent != nil || len(v.rowDeps) > 0
+}
+
+// authoritativeIntent returns the declaration a consumer should treat as
+// binding: the signed-manifest one when present, else the bundle-row one. The
+// second return value is the provenance of what was returned.
+func (v declaredView) authoritativeIntent() (map[string]any, []map[string]any, string) {
+	if v.hasSigned() {
+		return v.signedIntent, v.signedDeps, provSignedManifest
+	}
+	if v.hasRow() {
+		return v.rowIntent, v.rowDeps, provBundleRow
+	}
+	return nil, nil, ""
+}
+
+// extractDeclaredView pulls the declared intent + data_dependencies out of a
+// BundleMeta from BOTH sources, tagged with provenance. The author-signed
+// pack-time binding (SPEC-0196 §12 Q1 / P2b) lands in the parsed bundle.json
+// (BundleMeta.Manifest); the post-hoc `intent declare` PATCH lands on the
+// registry row (BundleMeta.Bundle). For an authoritative cryptographic check of
+// the signed binding, run `skillctl verify --bundle` against the .skb itself —
+// `intent show` reads the registry's representation.
+func extractDeclaredView(meta *registry.BundleMeta) declaredView {
+	pick := func(src map[string]any) (map[string]any, []map[string]any) {
 		if src == nil {
-			return nil, nil, false
+			return nil, nil
 		}
 		in, _ := src["intent"].(map[string]any)
 		var deps []map[string]any
@@ -476,16 +560,12 @@ func extractDeclaredIntent(meta *registry.BundleMeta) (map[string]any, []map[str
 				}
 			}
 		}
-		if in != nil || len(deps) > 0 {
-			return in, deps, true
-		}
-		return nil, nil, false
-	}
-	if in, deps, ok := pick(meta.Bundle); ok {
 		return in, deps
 	}
-	in, deps, _ := pick(meta.Manifest)
-	return in, deps
+	var v declaredView
+	v.signedIntent, v.signedDeps = pick(meta.Manifest)
+	v.rowIntent, v.rowDeps = pick(meta.Bundle)
+	return v
 }
 
 func dashOrValue(s string) string {

--- a/cmd/skillctl/intent_cmds.go
+++ b/cmd/skillctl/intent_cmds.go
@@ -377,18 +377,26 @@ func runIntentShow(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	registryURL := fs.String("registry", "", "Registry base URL (required).")
 	asJSON := fs.Bool("json", false, "Emit the declared intent + data_dependencies as JSON.")
-	bundleFlag := fs.String("bundle", "", "Path to the local .skb. When given, its bundle.json scope is DIGEST-VERIFIED (recompute + match the registry-advertised+signed digest) and shown as signed-manifest / AUTHORITATIVE. WITHOUT it, only the UNVERIFIED registry view is shown.")
+	bundleFlag := fs.String("bundle", "", "Path to the local .skb. When given, the bundle's AUTHOR SIGNATURE is verified against the pinned trust-roots (full verify.Verify chain). Its bundle.json scope is shown as signed-manifest / AUTHORITATIVE ONLY when that verification succeeds; otherwise it is digest-matched / UNVERIFIED. WITHOUT --bundle, only the UNVERIFIED registry view is shown.")
+	metaFlag := fs.String("meta", "", "Path to a BundleMeta envelope JSON for --bundle (carries the author/registry signatures). Default: fetch the meta from --registry. Use a sidecar to verify fully offline.")
+	trustRootsPath := fs.String("trust-roots", "", "Path to a trust-roots YAML to use instead of the default (~/.claude/skill-trust-roots.yaml). The pinned author key is what gates the AUTHORITATIVE label for --bundle.")
+	governanceMin := fs.String("governance-min", "", "Override the trust-root's governance_minimum (green | yellow) for the --bundle author-sig verification.")
+	allowYellow := fs.Bool("allow-yellow", false, "Permit a yellow bundle against a green-required trust root during --bundle verification.")
+	tenantFlag := fs.String("tenant", "", "Pin the --bundle verification to a tenant scope (SPEC-0188 §7 step 5.5).")
 	timeout := fs.Duration("timeout", registry.DefaultTimeout, "HTTP timeout.")
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "Usage: skillctl intent show <skill-name|@digest> --registry URL [--bundle file.skb] [--json]")
+		fmt.Fprintln(stderr, "Usage: skillctl intent show <skill-name|@digest> --registry URL [--bundle file.skb [--trust-roots f] [--meta f]] [--json]")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Prints the declared SPEC-0196 intent + data_dependencies for a bundle.")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Provenance (SECURITY): a scope is shown as signed-manifest / AUTHORITATIVE")
-		fmt.Fprintln(stderr, "ONLY when read from a local .skb whose digest this tool recomputed and")
-		fmt.Fprintln(stderr, "matched the registry-advertised+author-signed digest (pass --bundle). The")
-		fmt.Fprintln(stderr, "registry's own scope view is UNVERIFIED (registry-reported) — a registry")
-		fmt.Fprintln(stderr, "is untrusted and could serve an unsigned scope.")
+		fmt.Fprintln(stderr, "ONLY when the local .skb's AUTHOR SIGNATURE is cryptographically verified")
+		fmt.Fprintln(stderr, "against a PINNED trust-root author key (the full `skillctl verify` chain).")
+		fmt.Fprintln(stderr, "A bare digest match against the registry-advertised digest is NOT enough —")
+		fmt.Fprintln(stderr, "that field is unsigned and registry-supplied, so a malicious registry could")
+		fmt.Fprintln(stderr, "serve its own .skb + digest. Without a verifiable author signature the scope")
+		fmt.Fprintln(stderr, "is digest-matched / UNVERIFIED. The registry's own scope view is always")
+		fmt.Fprintln(stderr, "registry-reported / UNVERIFIED.")
 		fs.PrintDefaults()
 	}
 
@@ -431,24 +439,30 @@ func runIntentShow(args []string, stdout, stderr io.Writer) int {
 	// labeled registry-reported / bundle-row, NEVER author-signed.
 	view := extractDeclaredView(meta)
 
-	// AUTHORITATIVE path: only a local .skb whose digest we recompute and match
-	// against the registry-advertised+author-signed digest yields a signed-manifest
-	// scope. This reuses verify's exact P2b trust boundary
-	// (verify.ReadDigestVerifiedScopes) — no weaker check is acceptable.
+	// AUTHORITATIVE path (P2b re-challenge fix): a scope is signed-manifest /
+	// AUTHORITATIVE ONLY when the bundle's AUTHOR SIGNATURE verifies against a
+	// PINNED trust-root author key — i.e. the full verify.Verify chain (digest
+	// recompute + stepVerifyAuthor ed25519 + registry sig + governance + tenant)
+	// succeeds. A bare digest match against the registry-advertised, UNSIGNED
+	// `bundle.bundle_digest` is NOT author-signature verification: a malicious
+	// registry can serve ITS OWN .skb, advertise ITS digest, and the bytes match
+	// without any pinned author having signed them (Attack-d). On any verify
+	// failure (no trust-roots, from-registry root with no pinned author, author sig
+	// invalid, digest mismatch, governance/revocation failure) we DOWNGRADE to
+	// digest-matched / UNVERIFIED — we never print AUTHORITATIVE and never fail the
+	// whole command, so the CISO still sees the (untrusted) scope with the right
+	// label. The signed bundle.json bytes are always read from the digest-verified
+	// .skb path (verify.ReadDigestVerifiedManifest), never from the registry copy.
 	if *bundleFlag != "" {
-		advertised := advertisedDigest(meta, digest)
-		signedManifest, verr := verify.ReadDigestVerifiedManifest(*bundleFlag, advertised)
-		if verr != nil {
-			// Fail-closed: a bundle that doesn't digest-verify must NOT be shown as
-			// authoritative. We refuse rather than silently downgrade so a CISO never
-			// mistakes "couldn't verify" for "no signed scope".
-			fmt.Fprintf(stderr, "skillctl intent show: --bundle %s did not digest-verify against %s: %v\n", *bundleFlag, advertised, verr)
-			return verify.ExitCode(verr)
-		}
-		// signedManifest is the digest-verified bundle.json; its `intent` and
-		// `data_dependencies` are author-signature-covered (the digest just matched).
-		signedIntent, signedDeps := pickDeclared(signedManifest)
-		view.overlaySignedScope(signedIntent, signedDeps)
+		verifyBundleAuthorScope(bundleScopeParams{
+			bundlePath:     *bundleFlag,
+			metaPath:       *metaFlag,
+			trustRootsPath: *trustRootsPath,
+			registryURL:    *registryURL,
+			governanceMin:  *governanceMin,
+			allowYellow:    *allowYellow,
+			tenantFlag:     *tenantFlag,
+		}, meta, digest, c, ctx, &view, stderr)
 	}
 
 	authIntent, authDeps, authProv := view.authoritativeIntent()
@@ -456,9 +470,14 @@ func runIntentShow(args []string, stdout, stderr io.Writer) int {
 	if *asJSON {
 		// Emit the strongest-available declaration flat (back-compat) PLUS a
 		// provenance-tagged breakdown of ALL sources so a CISO tool can tell
-		// signed-manifest (authoritative) from registry-reported (UNVERIFIED) and
-		// bundle-row (advisory) without scraping text. `declaration_provenance` is
-		// signed-manifest ONLY when a digest-verified --bundle was supplied.
+		// signed-manifest (authoritative) from digest-matched/registry-reported
+		// (UNVERIFIED) and bundle-row (advisory) without scraping text.
+		// `authoritative` is true ONLY when the author signature was cryptographically
+		// verified against a pinned trust-root key (provSignedManifest).
+		digestTrust := "UNVERIFIED (digest matched the advertised digest, but author signature NOT verified — configure trust-roots or run `skillctl verify --bundle`)"
+		if view.digestDetail != "" {
+			digestTrust = "UNVERIFIED (author signature NOT verified: " + view.digestDetail + ")"
+		}
 		out := map[string]any{
 			"digest":                 digest,
 			"governance":             meta.CurrentGovernance,
@@ -470,12 +489,17 @@ func runIntentShow(args []string, stdout, stderr io.Writer) int {
 				provSignedManifest: map[string]any{
 					"intent":            view.signedIntent,
 					"data_dependencies": view.signedDeps,
-					"trust":             "AUTHORITATIVE (author-signature-covered, digest-verified)",
+					"trust":             "AUTHORITATIVE (author signature verified against a pinned trust-root key)",
+				},
+				provDigestMatched: map[string]any{
+					"intent":            view.digestIntent,
+					"data_dependencies": view.digestDeps,
+					"trust":             digestTrust,
 				},
 				provRegistryReported: map[string]any{
 					"intent":            view.regIntent,
 					"data_dependencies": view.regDeps,
-					"trust":             "UNVERIFIED (registry-reported; run `intent show --bundle` for authoritative)",
+					"trust":             "UNVERIFIED (registry-reported; run `intent show --bundle` with pinned trust-roots for authoritative)",
 				},
 				provBundleRow: map[string]any{
 					"intent":            view.rowIntent,
@@ -493,28 +517,152 @@ func runIntentShow(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "governance: %s\n", dashOrValue(meta.CurrentGovernance))
 	switch authProv {
 	case provSignedManifest:
-		fmt.Fprintln(stdout, "provenance: signed-manifest (AUTHORITATIVE — author-signature-covered)")
+		fmt.Fprintln(stdout, "provenance: signed-manifest (AUTHORITATIVE — author signature verified against a pinned trust-root key)")
+	case provDigestMatched:
+		fmt.Fprintln(stdout, "provenance: digest-matched (author signature NOT verified — configure trust-roots or run `skillctl verify --bundle`)")
+		if view.digestDetail != "" {
+			fmt.Fprintf(stdout, "            reason: %s\n", view.digestDetail)
+		}
 	case provRegistryReported:
-		fmt.Fprintln(stdout, "provenance: registry-reported (UNVERIFIED — run `intent show --bundle <file.skb>` for authoritative)")
+		fmt.Fprintln(stdout, "provenance: registry-reported (UNVERIFIED — run `intent show --bundle <file.skb>` with pinned trust-roots for authoritative)")
 	case provBundleRow:
 		fmt.Fprintln(stdout, "provenance: bundle-row (ADVISORY — mutable post-admit PATCH, NOT author-signed)")
 	default:
 		fmt.Fprintln(stdout, "provenance: (none declared)")
 	}
-	if !view.hasSigned() && (view.hasRegistry() || view.hasRow()) {
-		fmt.Fprintln(stdout, "warning:    NO digest-verified signed scope shown — the registry's view is UNTRUSTED.")
-		fmt.Fprintln(stdout, "            Pass --bundle <file.skb> to verify the author-signed scope cryptographically.")
+	if !view.hasSigned() && (view.hasDigestMatched() || view.hasRegistry() || view.hasRow()) {
+		fmt.Fprintln(stdout, "warning:    NO author-signature-verified scope shown — the displayed scope is UNTRUSTED.")
+		fmt.Fprintln(stdout, "            Pass --bundle <file.skb> with pinned trust-roots to verify the author signature cryptographically.")
 	}
 
 	printIntentSource(stdout, provSignedManifest, "AUTHORITATIVE", view.signedIntent, view.signedDeps)
+	printIntentSource(stdout, provDigestMatched, "UNVERIFIED", view.digestIntent, view.digestDeps)
 	printIntentSource(stdout, provRegistryReported, "UNVERIFIED", view.regIntent, view.regDeps)
 	printIntentSource(stdout, provBundleRow, "ADVISORY", view.rowIntent, view.rowDeps)
-	if !view.hasSigned() && !view.hasRegistry() && !view.hasRow() {
+	if !view.hasSigned() && !view.hasDigestMatched() && !view.hasRegistry() && !view.hasRow() {
 		fmt.Fprintln(stdout, "intent:     (none declared)")
 		fmt.Fprintln(stdout, "data_dependencies: (none declared)")
 	}
 	fmt.Fprintln(stdout, "(authoritative signed-binding verification: `skillctl verify --bundle <file.skb>`)")
 	return exitOK
+}
+
+// bundleScopeParams carries the resolved flags the --bundle author-sig
+// verification needs. Grouped so verifyBundleAuthorScope stays a single call.
+type bundleScopeParams struct {
+	bundlePath     string
+	metaPath       string // optional sidecar override; "" → use the registry-fetched meta
+	trustRootsPath string
+	registryURL    string
+	governanceMin  string
+	allowYellow    bool
+	tenantFlag     string
+}
+
+// verifyBundleAuthorScope runs the FULL author-signature verification for the
+// `intent show --bundle` path and overlays the resulting scope onto view with the
+// correct trust label (P2b re-challenge fix).
+//
+// It gates AUTHORITATIVE on verify.Verify success — the SAME §7 chain
+// (stepRecomputeDigest + stepCompareDigest + stepVerifyAuthor ed25519 against the
+// PINNED trust-root author key + registry sig + governance + tenant) the rest of
+// the CLI runs. The registry-supplied `bundle.bundle_digest` alone is never
+// sufficient: it is plain, unsigned and could be lied about by a malicious
+// registry (Attack-d).
+//
+// Outcomes:
+//   - verify.Verify SUCCEEDS → read bundle.json from the digest-verified .skb and
+//     overlay it as provSignedManifest / AUTHORITATIVE (overlaySignedScope).
+//   - meta lacks an advertised digest, trust-roots not configured/match, root is
+//     from-registry with no pinned author, author sig invalid, digest mismatch, or
+//     any other verify failure → if the .skb STILL digest-matches the advertised
+//     value, overlay it as provDigestMatched / UNVERIFIED with an actionable
+//     reason; otherwise surface nothing signed (the registry-reported view stands).
+//
+// It NEVER aborts the command and NEVER prints AUTHORITATIVE without a verified
+// author signature.
+func verifyBundleAuthorScope(p bundleScopeParams, meta *registry.BundleMeta, digest string, c *registry.Client, ctx context.Context, view *declaredView, stderr io.Writer) {
+	advertised := advertisedDigest(meta, digest)
+
+	// Read the bundle.json from the DIGEST-VERIFIED .skb up front. This both (a)
+	// confirms the on-disk bytes reproduce the advertised digest and (b) gives us
+	// the scope to surface regardless of the author-sig outcome. If the digest does
+	// NOT match, the bundle is not the one the registry described — surface nothing
+	// signed and let the registry-reported view stand (it is already UNVERIFIED).
+	signedManifest, derr := verify.ReadDigestVerifiedManifest(p.bundlePath, advertised)
+	if derr != nil {
+		fmt.Fprintf(stderr, "skillctl intent show: --bundle %s did not digest-match the advertised digest %s: %v\n", p.bundlePath, advertised, derr)
+		fmt.Fprintln(stderr, "            (showing the registry view as UNVERIFIED; no signed scope)")
+		return
+	}
+	bundleIntent, bundleDeps := pickDeclared(signedManifest)
+
+	// Now attempt FULL author-signature verification. Any failure → UNVERIFIED.
+	if reason, ok := verifyBundleAuthor(p, meta, c, ctx); ok {
+		// Author signature verified against a pinned trust-root key → AUTHORITATIVE.
+		view.overlaySignedScope(bundleIntent, bundleDeps)
+		return
+	} else {
+		// Digest matched but author sig NOT verified → digest-matched / UNVERIFIED.
+		fmt.Fprintf(stderr, "skillctl intent show: --bundle digest matched but author signature NOT verified: %s\n", reason)
+		view.overlayDigestMatchedScope(bundleIntent, bundleDeps, reason)
+	}
+}
+
+// verifyBundleAuthor loads the pinned trust-roots + BundleMeta envelope and runs
+// the full verify.Verify chain. It returns (reason, true) ONLY when verification
+// succeeds (author signature is valid against a pinned trust-root key); otherwise
+// (reason, false) with an actionable, CISO-facing explanation of why the bundle is
+// not author-signature-verified. It never aborts.
+func verifyBundleAuthor(p bundleScopeParams, regMeta *registry.BundleMeta, c *registry.Client, ctx context.Context) (string, bool) {
+	// 1. The BundleMeta envelope carrying the author/registry signatures. Default
+	//    to the registry-fetched meta; a --meta sidecar lets a CISO verify fully
+	//    offline against signatures they obtained out-of-band.
+	meta := regMeta
+	if p.metaPath != "" {
+		m, err := loadBundleMetaSidecar(p.metaPath)
+		if err != nil {
+			return fmt.Sprintf("could not read --meta envelope: %v", err), false
+		}
+		meta = m
+	}
+	if meta == nil {
+		return "no BundleMeta envelope (signatures) available", false
+	}
+
+	// 2. The PINNED trust-roots — this is where the author key comes from. With no
+	//    pinned author key there is nothing to verify the author signature against,
+	//    so the bundle is UNVERIFIED (configure trust-roots).
+	tr, root, err := loadAndPickRootFromPath(p.trustRootsPath, p.registryURL)
+	if err != nil {
+		return fmt.Sprintf("trust-roots not usable (%v); configure with `skillctl trust add`", err), false
+	}
+
+	// 3. Identity fetcher: a from-registry root resolves the author key via the
+	//    registry client; a pinned root needs none (fully offline). We deliberately
+	//    do NOT pass a fetcher for pinned roots so the author key MUST come from the
+	//    local pin, not the (untrusted) registry.
+	var fetcher interface {
+		GetIdentity(ctx context.Context, id string) (*registry.Identity, error)
+	}
+	if root.IdentityKeysAuthorized != "pinned" {
+		fetcher = c
+	}
+
+	res, verr := verify.Verify(verify.VerifyOpts{
+		BundlePath:      p.bundlePath,
+		BundleMeta:      meta,
+		TrustRoot:       root,
+		IdentityFetcher: fetcher,
+		GovernanceMin:   p.governanceMin,
+		AllowYellow:     p.allowYellow,
+		Tenant:          resolveTenant(p.tenantFlag, tr),
+		Ctx:             ctx,
+	})
+	if verr != nil {
+		return fmt.Sprintf("author-signature chain failed: %v", verr), false
+	}
+	return "author signature verified, author=" + res.AuthorIdentity, true
 }
 
 // advertisedDigest returns the digest to compare a local .skb against in the
@@ -560,28 +708,44 @@ func printIntentSource(stdout io.Writer, provenance, marker string, intentBlock 
 // a glance whether today's declaration is author-signed or merely reported by an
 // untrusted registry (SPEC-0196 §12 Q1 / P2b).
 //
-// SECURITY INVARIANT (P2b challenge-gate fix): a scope may be labeled
-// provSignedManifest / AUTHORITATIVE *only* when it was read from a
-// DIGEST-VERIFIED local .skb (unpack + recompute digest + compare against the
-// advertised+signed digest — verify.ReadDigestVerifiedManifest). The registry's
-// parsed `manifest` copy (meta.Manifest) arrives over plain HTTP with NO digest
-// recompute and NO signature check, so it is provRegistryReported / UNVERIFIED —
-// a malicious registry could otherwise serve an UNSIGNED scope and have it
-// displayed as author-signed. The mutable post-admit PATCH row (meta.Bundle) is
-// provBundleRow / advisory. Mirrors verify.ScopeProvenance for the signed case.
+// SECURITY INVARIANT (P2b re-challenge fix): a scope may be labeled
+// provSignedManifest / AUTHORITATIVE *only* when the bundle's AUTHOR SIGNATURE was
+// cryptographically verified against a PINNED trust-root author key — i.e. the
+// full `verify.Verify` chain (digest recompute + stepVerifyAuthor ed25519 +
+// registry sig + governance + revocation) succeeded. A bare digest match against
+// the registry-advertised `bundle.bundle_digest` is NOT author-signature
+// verification: that field is plain, unsigned, registry-supplied, so a malicious
+// registry can serve ITS OWN .skb, advertise ITS digest, and the bytes "match"
+// without any pinned author having signed them (red-team Attack-d).
+//
+// When the .skb digest-matches the advertised digest but the author signature
+// could NOT be verified (no trust-roots, from-registry root with no pinned
+// author, author sig invalid, governance/revocation failure, or any verify
+// error), the scope is labeled provDigestMatched / UNVERIFIED — NEVER
+// AUTHORITATIVE. The registry's parsed `manifest` copy (meta.Manifest) is
+// provRegistryReported / UNVERIFIED and the mutable post-admit PATCH row
+// (meta.Bundle) is provBundleRow / advisory. Mirrors verify.ScopeProvenance for
+// the signed case.
 const (
-	provSignedManifest   = "signed-manifest"   // from the DIGEST-VERIFIED local .skb's bundle.json (authoritative)
+	provSignedManifest   = "signed-manifest"   // author-signature VERIFIED against a pinned trust-root key (AUTHORITATIVE)
+	provDigestMatched    = "digest-matched"    // local .skb digest matched advertised digest, but author sig NOT verified (UNVERIFIED)
 	provRegistryReported = "registry-reported" // from the registry's untrusted parsed manifest copy (UNVERIFIED)
 	provBundleRow        = "bundle-row"        // from the mutable post-admit PATCH row (advisory)
 )
 
 // declaredView is the provenance-tagged result of reading a bundle's declared
-// intent + data_dependencies from up to three sources, in DECREASING trust:
+// intent + data_dependencies from up to four sources, in DECREASING trust:
 //
-//   - signed:   read from a DIGEST-VERIFIED local .skb's bundle.json
-//     (verify.ReadDigestVerifiedManifest). AUTHORITATIVE — author-signature-covered.
-//     Populated ONLY when `intent show --bundle <file.skb>` could locate and
-//     digest-verify the bundle. NEVER populated from the registry response.
+//   - signed:   read from a local .skb whose AUTHOR SIGNATURE was cryptographically
+//     verified against a pinned trust-root key (full verify.Verify chain succeeded).
+//     AUTHORITATIVE — author-signature-covered. Populated ONLY when
+//     `intent show --bundle <file.skb>` ran the real verify chain to success.
+//     NEVER populated from a bare digest match or the registry response.
+//   - digestMatched: read from a local .skb whose digest matched the advertised
+//     digest, but whose author signature could NOT be verified (no trust-roots,
+//     from-registry root with no pinned author, author sig invalid, or any verify
+//     failure). UNVERIFIED — a digest match against a registry-supplied, unsigned
+//     `bundle_digest` is NOT author-signature verification (Attack-d).
 //   - registry: read from the registry's parsed `manifest` copy (meta.Manifest).
 //     UNVERIFIED — plain HTTP, no digest recompute, no signature check. A
 //     malicious registry can put anything here, so it is NOT authoritative.
@@ -592,15 +756,25 @@ const (
 type declaredView struct {
 	signedIntent map[string]any
 	signedDeps   []map[string]any
+	digestIntent map[string]any
+	digestDeps   []map[string]any
+	digestDetail string // why the author sig could not be verified (for the UNVERIFIED label)
 	regIntent    map[string]any
 	regDeps      []map[string]any
 	rowIntent    map[string]any
 	rowDeps      []map[string]any
 }
 
-// hasSigned reports whether a DIGEST-VERIFIED author-signed declaration is present.
+// hasSigned reports whether an AUTHOR-SIGNATURE-VERIFIED declaration is present.
 func (v declaredView) hasSigned() bool {
 	return v.signedIntent != nil || len(v.signedDeps) > 0
+}
+
+// hasDigestMatched reports whether a digest-matched-but-UNVERIFIED declaration is
+// present (the .skb bytes reproduced the advertised digest, but no pinned author
+// signature was verified over them).
+func (v declaredView) hasDigestMatched() bool {
+	return v.digestIntent != nil || len(v.digestDeps) > 0
 }
 
 // hasRegistry reports whether the untrusted registry-manifest copy carried a
@@ -616,12 +790,16 @@ func (v declaredView) hasRow() bool {
 
 // authoritativeIntent returns the declaration a consumer should treat as the
 // strongest available, plus its provenance. The ONLY authoritative source is the
-// digest-verified local bundle (provSignedManifest); the registry-manifest copy
-// (provRegistryReported) and the bundle row (provBundleRow) are both UNVERIFIED /
-// advisory and are NEVER labeled author-signed.
+// AUTHOR-SIGNATURE-VERIFIED local bundle (provSignedManifest). A digest-matched
+// bundle whose author signature was NOT verified (provDigestMatched), the
+// registry-manifest copy (provRegistryReported) and the bundle row (provBundleRow)
+// are all UNVERIFIED / advisory and are NEVER labeled author-signed.
 func (v declaredView) authoritativeIntent() (map[string]any, []map[string]any, string) {
 	if v.hasSigned() {
 		return v.signedIntent, v.signedDeps, provSignedManifest
+	}
+	if v.hasDigestMatched() {
+		return v.digestIntent, v.digestDeps, provDigestMatched
 	}
 	if v.hasRegistry() {
 		return v.regIntent, v.regDeps, provRegistryReported
@@ -668,12 +846,23 @@ func extractDeclaredView(meta *registry.BundleMeta) declaredView {
 }
 
 // overlaySignedScope populates the AUTHORITATIVE signed source of a declaredView
-// from a digest-verified local .skb. signedDeps came from
-// verify.ReadDigestVerifiedScopes (digest recomputed + matched), so the bytes are
-// author-signature-covered. This is the ONLY path that may set provSignedManifest.
+// from a local .skb whose AUTHOR SIGNATURE was cryptographically verified against a
+// pinned trust-root key (the full verify.Verify chain succeeded). This is the ONLY
+// path that may set provSignedManifest. The caller MUST have run verify.Verify to
+// success before calling this — a bare digest match is NOT sufficient.
 func (v *declaredView) overlaySignedScope(signedIntent map[string]any, signedDeps []map[string]any) {
 	v.signedIntent = signedIntent
 	v.signedDeps = signedDeps
+}
+
+// overlayDigestMatchedScope populates the UNVERIFIED digest-matched source from a
+// local .skb whose digest matched the advertised digest but whose author signature
+// could NOT be verified. detail explains why (no trust-roots, invalid sig, etc.) so
+// the CISO-facing label is actionable. This NEVER yields provSignedManifest.
+func (v *declaredView) overlayDigestMatchedScope(intent map[string]any, deps []map[string]any, detail string) {
+	v.digestIntent = intent
+	v.digestDeps = deps
+	v.digestDetail = detail
 }
 
 func dashOrValue(s string) string {
@@ -908,7 +1097,8 @@ func extractSkillPositional(args []string) (skill string, rest []string) {
 			case "registry", "side-effects", "destructive", "network",
 				"human-review-required", "subprocess", "summary",
 				"data-dep", "data-scopes", "from-yaml", "timeout",
-				"bundle", "governance-intent":
+				"bundle", "governance-intent", "meta", "trust-roots",
+				"governance-min", "tenant":
 				skipNextValue = true
 			}
 			continue

--- a/cmd/skillctl/intent_cmds.go
+++ b/cmd/skillctl/intent_cmds.go
@@ -377,11 +377,18 @@ func runIntentShow(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	registryURL := fs.String("registry", "", "Registry base URL (required).")
 	asJSON := fs.Bool("json", false, "Emit the declared intent + data_dependencies as JSON.")
+	bundleFlag := fs.String("bundle", "", "Path to the local .skb. When given, its bundle.json scope is DIGEST-VERIFIED (recompute + match the registry-advertised+signed digest) and shown as signed-manifest / AUTHORITATIVE. WITHOUT it, only the UNVERIFIED registry view is shown.")
 	timeout := fs.Duration("timeout", registry.DefaultTimeout, "HTTP timeout.")
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "Usage: skillctl intent show <skill-name|@digest> --registry URL [--json]")
+		fmt.Fprintln(stderr, "Usage: skillctl intent show <skill-name|@digest> --registry URL [--bundle file.skb] [--json]")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Prints the declared SPEC-0196 intent + data_dependencies for a bundle.")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "Provenance (SECURITY): a scope is shown as signed-manifest / AUTHORITATIVE")
+		fmt.Fprintln(stderr, "ONLY when read from a local .skb whose digest this tool recomputed and")
+		fmt.Fprintln(stderr, "matched the registry-advertised+author-signed digest (pass --bundle). The")
+		fmt.Fprintln(stderr, "registry's own scope view is UNVERIFIED (registry-reported) — a registry")
+		fmt.Fprintln(stderr, "is untrusted and could serve an unsigned scope.")
 		fs.PrintDefaults()
 	}
 
@@ -420,27 +427,60 @@ func runIntentShow(args []string, stdout, stderr io.Writer) int {
 		return exitGeneric
 	}
 
+	// The registry response is UNTRUSTED — its parsed manifest and bundle row are
+	// labeled registry-reported / bundle-row, NEVER author-signed.
 	view := extractDeclaredView(meta)
+
+	// AUTHORITATIVE path: only a local .skb whose digest we recompute and match
+	// against the registry-advertised+author-signed digest yields a signed-manifest
+	// scope. This reuses verify's exact P2b trust boundary
+	// (verify.ReadDigestVerifiedScopes) — no weaker check is acceptable.
+	if *bundleFlag != "" {
+		advertised := advertisedDigest(meta, digest)
+		signedManifest, verr := verify.ReadDigestVerifiedManifest(*bundleFlag, advertised)
+		if verr != nil {
+			// Fail-closed: a bundle that doesn't digest-verify must NOT be shown as
+			// authoritative. We refuse rather than silently downgrade so a CISO never
+			// mistakes "couldn't verify" for "no signed scope".
+			fmt.Fprintf(stderr, "skillctl intent show: --bundle %s did not digest-verify against %s: %v\n", *bundleFlag, advertised, verr)
+			return verify.ExitCode(verr)
+		}
+		// signedManifest is the digest-verified bundle.json; its `intent` and
+		// `data_dependencies` are author-signature-covered (the digest just matched).
+		signedIntent, signedDeps := pickDeclared(signedManifest)
+		view.overlaySignedScope(signedIntent, signedDeps)
+	}
+
 	authIntent, authDeps, authProv := view.authoritativeIntent()
 
 	if *asJSON {
-		// Emit the authoritative declaration flat (back-compat with existing
-		// consumers) PLUS a provenance-tagged breakdown so a CISO tool can tell
-		// signed-manifest from bundle-row without scraping text.
+		// Emit the strongest-available declaration flat (back-compat) PLUS a
+		// provenance-tagged breakdown of ALL sources so a CISO tool can tell
+		// signed-manifest (authoritative) from registry-reported (UNVERIFIED) and
+		// bundle-row (advisory) without scraping text. `declaration_provenance` is
+		// signed-manifest ONLY when a digest-verified --bundle was supplied.
 		out := map[string]any{
 			"digest":                 digest,
 			"governance":             meta.CurrentGovernance,
 			"intent":                 authIntent,
 			"data_dependencies":      authDeps,
 			"declaration_provenance": authProv,
+			"authoritative":          authProv == provSignedManifest,
 			"sources": map[string]any{
 				provSignedManifest: map[string]any{
 					"intent":            view.signedIntent,
 					"data_dependencies": view.signedDeps,
+					"trust":             "AUTHORITATIVE (author-signature-covered, digest-verified)",
+				},
+				provRegistryReported: map[string]any{
+					"intent":            view.regIntent,
+					"data_dependencies": view.regDeps,
+					"trust":             "UNVERIFIED (registry-reported; run `intent show --bundle` for authoritative)",
 				},
 				provBundleRow: map[string]any{
 					"intent":            view.rowIntent,
 					"data_dependencies": view.rowDeps,
+					"trust":             "ADVISORY (mutable post-admit PATCH; NOT author-signed)",
 				},
 			},
 		}
@@ -454,23 +494,43 @@ func runIntentShow(args []string, stdout, stderr io.Writer) int {
 	switch authProv {
 	case provSignedManifest:
 		fmt.Fprintln(stdout, "provenance: signed-manifest (AUTHORITATIVE — author-signature-covered)")
+	case provRegistryReported:
+		fmt.Fprintln(stdout, "provenance: registry-reported (UNVERIFIED — run `intent show --bundle <file.skb>` for authoritative)")
 	case provBundleRow:
 		fmt.Fprintln(stdout, "provenance: bundle-row (ADVISORY — mutable post-admit PATCH, NOT author-signed)")
 	default:
 		fmt.Fprintln(stdout, "provenance: (none declared)")
 	}
-	if view.hasSigned() && view.hasRow() {
-		fmt.Fprintln(stdout, "note:       both a signed-manifest and a bundle-row declaration exist; the signed-manifest one is authoritative.")
+	if !view.hasSigned() && (view.hasRegistry() || view.hasRow()) {
+		fmt.Fprintln(stdout, "warning:    NO digest-verified signed scope shown — the registry's view is UNTRUSTED.")
+		fmt.Fprintln(stdout, "            Pass --bundle <file.skb> to verify the author-signed scope cryptographically.")
 	}
 
 	printIntentSource(stdout, provSignedManifest, "AUTHORITATIVE", view.signedIntent, view.signedDeps)
+	printIntentSource(stdout, provRegistryReported, "UNVERIFIED", view.regIntent, view.regDeps)
 	printIntentSource(stdout, provBundleRow, "ADVISORY", view.rowIntent, view.rowDeps)
-	if !view.hasSigned() && !view.hasRow() {
+	if !view.hasSigned() && !view.hasRegistry() && !view.hasRow() {
 		fmt.Fprintln(stdout, "intent:     (none declared)")
 		fmt.Fprintln(stdout, "data_dependencies: (none declared)")
 	}
 	fmt.Fprintln(stdout, "(authoritative signed-binding verification: `skillctl verify --bundle <file.skb>`)")
 	return exitOK
+}
+
+// advertisedDigest returns the digest to compare a local .skb against in the
+// --bundle path: the registry-advertised `bundle.bundle_digest` (the value the
+// author signature covers). Falls back to the digest the caller resolved (e.g. an
+// @sha256 pin) when the registry row omits it. Either way the comparison is
+// against a value the bundle.json bytes must reproduce — a malicious registry that
+// lies about the digest can only cause a fail-closed mismatch, never an
+// authoritative display of an unsigned scope.
+func advertisedDigest(meta *registry.BundleMeta, resolved string) string {
+	if meta != nil && meta.Bundle != nil {
+		if d, ok := meta.Bundle["bundle_digest"].(string); ok && strings.TrimSpace(d) != "" {
+			return d
+		}
+	}
+	return resolved
 }
 
 // printIntentSource renders one provenance source's intent + data_dependencies,
@@ -497,28 +557,56 @@ func printIntentSource(stdout io.Writer, provenance, marker string, intentBlock 
 }
 
 // scopeProvenance labels WHERE a declared scope came from, so a CISO can tell at
-// a glance whether today's declaration is author-signed or post-admit
-// (SPEC-0196 §12 Q1 / P2b). Mirrors verify.ScopeProvenance string values.
+// a glance whether today's declaration is author-signed or merely reported by an
+// untrusted registry (SPEC-0196 §12 Q1 / P2b).
+//
+// SECURITY INVARIANT (P2b challenge-gate fix): a scope may be labeled
+// provSignedManifest / AUTHORITATIVE *only* when it was read from a
+// DIGEST-VERIFIED local .skb (unpack + recompute digest + compare against the
+// advertised+signed digest — verify.ReadDigestVerifiedManifest). The registry's
+// parsed `manifest` copy (meta.Manifest) arrives over plain HTTP with NO digest
+// recompute and NO signature check, so it is provRegistryReported / UNVERIFIED —
+// a malicious registry could otherwise serve an UNSIGNED scope and have it
+// displayed as author-signed. The mutable post-admit PATCH row (meta.Bundle) is
+// provBundleRow / advisory. Mirrors verify.ScopeProvenance for the signed case.
 const (
-	provSignedManifest = "signed-manifest" // from the author-signed bundle.json (authoritative)
-	provBundleRow      = "bundle-row"      // from the mutable post-admit PATCH row (advisory)
+	provSignedManifest   = "signed-manifest"   // from the DIGEST-VERIFIED local .skb's bundle.json (authoritative)
+	provRegistryReported = "registry-reported" // from the registry's untrusted parsed manifest copy (UNVERIFIED)
+	provBundleRow        = "bundle-row"        // from the mutable post-admit PATCH row (advisory)
 )
 
-// declaredView is the provenance-tagged result of reading a BundleMeta's
-// declared intent + data_dependencies. The signed-manifest source is the
-// author-bound bundle.json the registry parsed at admit time; the bundle-row
-// source is the mutable `intent declare` PATCH target. BOTH are surfaced — a
-// CISO must see which is author-signed, not just the winning one.
+// declaredView is the provenance-tagged result of reading a bundle's declared
+// intent + data_dependencies from up to three sources, in DECREASING trust:
+//
+//   - signed:   read from a DIGEST-VERIFIED local .skb's bundle.json
+//     (verify.ReadDigestVerifiedManifest). AUTHORITATIVE — author-signature-covered.
+//     Populated ONLY when `intent show --bundle <file.skb>` could locate and
+//     digest-verify the bundle. NEVER populated from the registry response.
+//   - registry: read from the registry's parsed `manifest` copy (meta.Manifest).
+//     UNVERIFIED — plain HTTP, no digest recompute, no signature check. A
+//     malicious registry can put anything here, so it is NOT authoritative.
+//   - row:      read from the mutable post-admit PATCH row (meta.Bundle). Advisory.
+//
+// ALL present sources are surfaced — a CISO must see what is author-signed vs what
+// the registry merely claims, not just the winning one.
 type declaredView struct {
 	signedIntent map[string]any
 	signedDeps   []map[string]any
+	regIntent    map[string]any
+	regDeps      []map[string]any
 	rowIntent    map[string]any
 	rowDeps      []map[string]any
 }
 
-// hasSigned reports whether any author-signed declaration is present.
+// hasSigned reports whether a DIGEST-VERIFIED author-signed declaration is present.
 func (v declaredView) hasSigned() bool {
 	return v.signedIntent != nil || len(v.signedDeps) > 0
+}
+
+// hasRegistry reports whether the untrusted registry-manifest copy carried a
+// declaration. Present ≠ authoritative — see provRegistryReported.
+func (v declaredView) hasRegistry() bool {
+	return v.regIntent != nil || len(v.regDeps) > 0
 }
 
 // hasRow reports whether any mutable bundle-row declaration is present.
@@ -526,12 +614,17 @@ func (v declaredView) hasRow() bool {
 	return v.rowIntent != nil || len(v.rowDeps) > 0
 }
 
-// authoritativeIntent returns the declaration a consumer should treat as
-// binding: the signed-manifest one when present, else the bundle-row one. The
-// second return value is the provenance of what was returned.
+// authoritativeIntent returns the declaration a consumer should treat as the
+// strongest available, plus its provenance. The ONLY authoritative source is the
+// digest-verified local bundle (provSignedManifest); the registry-manifest copy
+// (provRegistryReported) and the bundle row (provBundleRow) are both UNVERIFIED /
+// advisory and are NEVER labeled author-signed.
 func (v declaredView) authoritativeIntent() (map[string]any, []map[string]any, string) {
 	if v.hasSigned() {
 		return v.signedIntent, v.signedDeps, provSignedManifest
+	}
+	if v.hasRegistry() {
+		return v.regIntent, v.regDeps, provRegistryReported
 	}
 	if v.hasRow() {
 		return v.rowIntent, v.rowDeps, provBundleRow
@@ -539,33 +632,48 @@ func (v declaredView) authoritativeIntent() (map[string]any, []map[string]any, s
 	return nil, nil, ""
 }
 
-// extractDeclaredView pulls the declared intent + data_dependencies out of a
-// BundleMeta from BOTH sources, tagged with provenance. The author-signed
-// pack-time binding (SPEC-0196 §12 Q1 / P2b) lands in the parsed bundle.json
-// (BundleMeta.Manifest); the post-hoc `intent declare` PATCH lands on the
-// registry row (BundleMeta.Bundle). For an authoritative cryptographic check of
-// the signed binding, run `skillctl verify --bundle` against the .skb itself —
-// `intent show` reads the registry's representation.
-func extractDeclaredView(meta *registry.BundleMeta) declaredView {
-	pick := func(src map[string]any) (map[string]any, []map[string]any) {
-		if src == nil {
-			return nil, nil
-		}
-		in, _ := src["intent"].(map[string]any)
-		var deps []map[string]any
-		if raw, ok := src["data_dependencies"].([]any); ok {
-			for _, item := range raw {
-				if m, ok := item.(map[string]any); ok {
-					deps = append(deps, m)
-				}
+// pickDeclared pulls (intent, data_dependencies) out of a raw map (a registry
+// envelope source, or a digest-verified bundle.json). Tolerates absence and
+// non-object entries.
+func pickDeclared(src map[string]any) (map[string]any, []map[string]any) {
+	if src == nil {
+		return nil, nil
+	}
+	in, _ := src["intent"].(map[string]any)
+	var deps []map[string]any
+	if raw, ok := src["data_dependencies"].([]any); ok {
+		for _, item := range raw {
+			if m, ok := item.(map[string]any); ok {
+				deps = append(deps, m)
 			}
 		}
-		return in, deps
 	}
+	return in, deps
+}
+
+// extractDeclaredView pulls the declared intent + data_dependencies out of the
+// UNTRUSTED registry response. CRITICAL P2b invariant: this reads only the
+// registry's representation, so NOTHING it returns is authoritative. The registry
+// `manifest` copy (meta.Manifest) is tagged registry-reported / UNVERIFIED and the
+// post-admit PATCH row (meta.Bundle) is tagged bundle-row / advisory. The
+// author-signed scope is populated SEPARATELY, only from a digest-verified local
+// .skb via overlaySignedScope — see runIntentShow's `--bundle` path. This is the
+// SAME trust boundary `verify` enforces (verify.go collectDeclaredScopes:
+// "deliberately do NOT read scope from meta.Manifest").
+func extractDeclaredView(meta *registry.BundleMeta) declaredView {
 	var v declaredView
-	v.signedIntent, v.signedDeps = pick(meta.Manifest)
-	v.rowIntent, v.rowDeps = pick(meta.Bundle)
+	v.regIntent, v.regDeps = pickDeclared(meta.Manifest)
+	v.rowIntent, v.rowDeps = pickDeclared(meta.Bundle)
 	return v
+}
+
+// overlaySignedScope populates the AUTHORITATIVE signed source of a declaredView
+// from a digest-verified local .skb. signedDeps came from
+// verify.ReadDigestVerifiedScopes (digest recomputed + matched), so the bytes are
+// author-signature-covered. This is the ONLY path that may set provSignedManifest.
+func (v *declaredView) overlaySignedScope(signedIntent map[string]any, signedDeps []map[string]any) {
+	v.signedIntent = signedIntent
+	v.signedDeps = signedDeps
 }
 
 func dashOrValue(s string) string {
@@ -799,7 +907,8 @@ func extractSkillPositional(args []string) (skill string, rest []string) {
 			switch name {
 			case "registry", "side-effects", "destructive", "network",
 				"human-review-required", "subprocess", "summary",
-				"data-dep", "from-yaml", "timeout":
+				"data-dep", "data-scopes", "from-yaml", "timeout",
+				"bundle", "governance-intent":
 				skipNextValue = true
 			}
 			continue

--- a/cmd/skillctl/intent_show_test.go
+++ b/cmd/skillctl/intent_show_test.go
@@ -1,0 +1,193 @@
+package main
+
+// SPEC-0196 §12 Q1 / P2b — `skillctl intent show` provenance.
+//
+// A CISO must see at a glance whether a declared scope is author-signed
+// (signed-manifest, from the parsed bundle.json) or post-admit (bundle-row, the
+// mutable `intent declare` PATCH target). These tests cover the provenance
+// classifier (extractDeclaredView) and the end-to-end `intent show` rendering.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+)
+
+func TestExtractDeclaredView_Provenance(t *testing.T) {
+	signedDep := map[string]any{"id": "ds:signed", "kind": "er1_collection", "access": "read"}
+	rowDep := map[string]any{"id": "ds:row", "kind": "local_fs", "access": "read"}
+
+	t.Run("manifest only → signed-manifest authoritative", func(t *testing.T) {
+		meta := &registry.BundleMeta{
+			Manifest: map[string]any{"data_dependencies": []any{signedDep}},
+		}
+		v := extractDeclaredView(meta)
+		if !v.hasSigned() || v.hasRow() {
+			t.Fatalf("hasSigned=%v hasRow=%v", v.hasSigned(), v.hasRow())
+		}
+		_, deps, prov := v.authoritativeIntent()
+		if prov != provSignedManifest {
+			t.Errorf("provenance = %q, want signed-manifest", prov)
+		}
+		if len(deps) != 1 || deps[0]["id"] != "ds:signed" {
+			t.Errorf("authoritative deps wrong: %+v", deps)
+		}
+	})
+
+	t.Run("row only → bundle-row authoritative", func(t *testing.T) {
+		meta := &registry.BundleMeta{
+			Bundle: map[string]any{"data_dependencies": []any{rowDep}},
+		}
+		v := extractDeclaredView(meta)
+		if v.hasSigned() || !v.hasRow() {
+			t.Fatalf("hasSigned=%v hasRow=%v", v.hasSigned(), v.hasRow())
+		}
+		_, _, prov := v.authoritativeIntent()
+		if prov != provBundleRow {
+			t.Errorf("provenance = %q, want bundle-row", prov)
+		}
+	})
+
+	t.Run("both → signed-manifest wins as authoritative", func(t *testing.T) {
+		meta := &registry.BundleMeta{
+			Manifest: map[string]any{"data_dependencies": []any{signedDep}},
+			Bundle:   map[string]any{"data_dependencies": []any{rowDep}},
+		}
+		v := extractDeclaredView(meta)
+		if !v.hasSigned() || !v.hasRow() {
+			t.Fatalf("expected both present")
+		}
+		_, deps, prov := v.authoritativeIntent()
+		if prov != provSignedManifest || deps[0]["id"] != "ds:signed" {
+			t.Errorf("signed-manifest must win: prov=%q deps=%+v", prov, deps)
+		}
+	})
+
+	t.Run("neither → empty", func(t *testing.T) {
+		v := extractDeclaredView(&registry.BundleMeta{})
+		if v.hasSigned() || v.hasRow() {
+			t.Fatalf("expected nothing declared")
+		}
+		_, _, prov := v.authoritativeIntent()
+		if prov != "" {
+			t.Errorf("provenance = %q, want empty", prov)
+		}
+	})
+}
+
+// metaServer serves a fixed BundleMeta for any /bundles/<digest>?meta=1 GET.
+func metaServer(t *testing.T, meta registry.BundleMeta) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/bundles/") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(meta)
+	}))
+}
+
+// TestIntentShow_SignedManifestProvenance: a scope present in the parsed
+// bundle.json is rendered as signed-manifest / AUTHORITATIVE.
+func TestIntentShow_SignedManifestProvenance(t *testing.T) {
+	meta := registry.BundleMeta{
+		Bundle:            map[string]any{"bundle_digest": "sha256:abc", "status": "admitted"},
+		CurrentGovernance: "yellow",
+		Manifest: map[string]any{
+			"data_dependencies": []any{
+				map[string]any{"id": "ds:fs/cwd", "kind": "local_fs", "access": "write", "scope": "<cwd>/decks/**"},
+			},
+		},
+	}
+	srv := metaServer(t, meta)
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runIntentShow([]string{"@sha256:abc", "--registry", srv.URL}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("intent show exit=%d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "provenance: signed-manifest (AUTHORITATIVE") {
+		t.Errorf("expected signed-manifest provenance line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ds:fs/cwd") {
+		t.Errorf("expected the scope to be printed, got:\n%s", out)
+	}
+}
+
+// TestIntentShow_BundleRowProvenance: a scope present ONLY on the mutable
+// registry row is rendered as bundle-row / ADVISORY, never as author-signed.
+func TestIntentShow_BundleRowProvenance(t *testing.T) {
+	meta := registry.BundleMeta{
+		Bundle: map[string]any{
+			"bundle_digest": "sha256:abc",
+			"status":        "admitted",
+			"data_dependencies": []any{
+				map[string]any{"id": "ds:er1/x", "kind": "er1_collection", "access": "read"},
+			},
+		},
+		CurrentGovernance: "yellow",
+		Manifest:          map[string]any{}, // no signed scope
+	}
+	srv := metaServer(t, meta)
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runIntentShow([]string{"@sha256:abc", "--registry", srv.URL}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("intent show exit=%d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "provenance: bundle-row (ADVISORY") {
+		t.Errorf("expected bundle-row provenance line, got:\n%s", out)
+	}
+	if strings.Contains(out, "signed-manifest (AUTHORITATIVE") {
+		t.Errorf("bundle-row scope must NOT be reported as author-signed, got:\n%s", out)
+	}
+}
+
+// TestIntentShow_BothProvenancesShownSignedAuthoritative: when both exist, both
+// are listed and the note flags signed-manifest as authoritative.
+func TestIntentShow_BothProvenancesShown(t *testing.T) {
+	meta := registry.BundleMeta{
+		Bundle: map[string]any{
+			"bundle_digest": "sha256:abc",
+			"status":        "admitted",
+			"data_dependencies": []any{
+				map[string]any{"id": "ds:row", "kind": "er1_collection", "access": "read"},
+			},
+		},
+		CurrentGovernance: "yellow",
+		Manifest: map[string]any{
+			"data_dependencies": []any{
+				map[string]any{"id": "ds:signed", "kind": "er1_collection", "access": "read"},
+			},
+		},
+	}
+	srv := metaServer(t, meta)
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runIntentShow([]string{"@sha256:abc", "--registry", srv.URL, "--json"}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("intent show exit=%d, stderr=%s", code, stderr.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("intent show --json not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if got["declaration_provenance"] != provSignedManifest {
+		t.Errorf("declaration_provenance = %v, want signed-manifest", got["declaration_provenance"])
+	}
+	sources, _ := got["sources"].(map[string]any)
+	if sources == nil || sources[provSignedManifest] == nil || sources[provBundleRow] == nil {
+		t.Errorf("both provenance sources must be present in --json: %+v", got["sources"])
+	}
+}

--- a/cmd/skillctl/intent_show_test.go
+++ b/cmd/skillctl/intent_show_test.go
@@ -1,51 +1,63 @@
 package main
 
-// SPEC-0196 §12 Q1 / P2b — `skillctl intent show` provenance.
+// SPEC-0196 §12 Q1 / P2b — `skillctl intent show` provenance (P2b challenge-gate fix).
 //
-// A CISO must see at a glance whether a declared scope is author-signed
-// (signed-manifest, from the parsed bundle.json) or post-admit (bundle-row, the
-// mutable `intent declare` PATCH target). These tests cover the provenance
-// classifier (extractDeclaredView) and the end-to-end `intent show` rendering.
+// A CISO must NEVER see an UNVERIFIED registry-served scope labeled as
+// author-signed. The registry response (meta.Manifest = its parsed manifest copy,
+// meta.Bundle = the mutable post-admit row) arrives over plain HTTP with NO digest
+// recompute and NO signature check, so neither is authoritative. A scope is
+// labeled signed-manifest / AUTHORITATIVE ONLY when read from a local .skb whose
+// digest this tool recomputed and matched the registry-advertised+author-signed
+// digest (the `--bundle` path → verify.ReadDigestVerifiedManifest), which is the
+// SAME trust boundary `verify` enforces.
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/kamir/m3c-tools/pkg/skillbundle"
 	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
 )
 
 func TestExtractDeclaredView_Provenance(t *testing.T) {
-	signedDep := map[string]any{"id": "ds:signed", "kind": "er1_collection", "access": "read"}
+	regDep := map[string]any{"id": "ds:reg", "kind": "er1_collection", "access": "read"}
 	rowDep := map[string]any{"id": "ds:row", "kind": "local_fs", "access": "read"}
 
-	t.Run("manifest only → signed-manifest authoritative", func(t *testing.T) {
+	t.Run("registry manifest only → registry-reported, NEVER signed", func(t *testing.T) {
 		meta := &registry.BundleMeta{
-			Manifest: map[string]any{"data_dependencies": []any{signedDep}},
+			Manifest: map[string]any{"data_dependencies": []any{regDep}},
 		}
 		v := extractDeclaredView(meta)
-		if !v.hasSigned() || v.hasRow() {
-			t.Fatalf("hasSigned=%v hasRow=%v", v.hasSigned(), v.hasRow())
+		if v.hasSigned() {
+			t.Fatalf("registry manifest must NOT populate the signed source")
+		}
+		if !v.hasRegistry() || v.hasRow() {
+			t.Fatalf("hasRegistry=%v hasRow=%v", v.hasRegistry(), v.hasRow())
 		}
 		_, deps, prov := v.authoritativeIntent()
-		if prov != provSignedManifest {
-			t.Errorf("provenance = %q, want signed-manifest", prov)
+		if prov != provRegistryReported {
+			t.Errorf("provenance = %q, want registry-reported", prov)
 		}
-		if len(deps) != 1 || deps[0]["id"] != "ds:signed" {
-			t.Errorf("authoritative deps wrong: %+v", deps)
+		if len(deps) != 1 || deps[0]["id"] != "ds:reg" {
+			t.Errorf("registry-reported deps wrong: %+v", deps)
 		}
 	})
 
-	t.Run("row only → bundle-row authoritative", func(t *testing.T) {
+	t.Run("row only → bundle-row advisory", func(t *testing.T) {
 		meta := &registry.BundleMeta{
 			Bundle: map[string]any{"data_dependencies": []any{rowDep}},
 		}
 		v := extractDeclaredView(meta)
-		if v.hasSigned() || !v.hasRow() {
-			t.Fatalf("hasSigned=%v hasRow=%v", v.hasSigned(), v.hasRow())
+		if v.hasSigned() || v.hasRegistry() || !v.hasRow() {
+			t.Fatalf("hasSigned=%v hasRegistry=%v hasRow=%v", v.hasSigned(), v.hasRegistry(), v.hasRow())
 		}
 		_, _, prov := v.authoritativeIntent()
 		if prov != provBundleRow {
@@ -53,29 +65,41 @@ func TestExtractDeclaredView_Provenance(t *testing.T) {
 		}
 	})
 
-	t.Run("both → signed-manifest wins as authoritative", func(t *testing.T) {
+	t.Run("extractDeclaredView never sets the signed source", func(t *testing.T) {
 		meta := &registry.BundleMeta{
-			Manifest: map[string]any{"data_dependencies": []any{signedDep}},
+			Manifest: map[string]any{"data_dependencies": []any{regDep}},
 			Bundle:   map[string]any{"data_dependencies": []any{rowDep}},
 		}
 		v := extractDeclaredView(meta)
-		if !v.hasSigned() || !v.hasRow() {
-			t.Fatalf("expected both present")
+		if v.hasSigned() {
+			t.Fatalf("the untrusted registry response must never produce a signed scope")
 		}
-		_, deps, prov := v.authoritativeIntent()
-		if prov != provSignedManifest || deps[0]["id"] != "ds:signed" {
-			t.Errorf("signed-manifest must win: prov=%q deps=%+v", prov, deps)
+		_, _, prov := v.authoritativeIntent()
+		if prov != provRegistryReported {
+			t.Errorf("registry-reported must win over bundle-row when both present: %q", prov)
 		}
 	})
 
 	t.Run("neither → empty", func(t *testing.T) {
 		v := extractDeclaredView(&registry.BundleMeta{})
-		if v.hasSigned() || v.hasRow() {
+		if v.hasSigned() || v.hasRegistry() || v.hasRow() {
 			t.Fatalf("expected nothing declared")
 		}
 		_, _, prov := v.authoritativeIntent()
 		if prov != "" {
 			t.Errorf("provenance = %q, want empty", prov)
+		}
+	})
+
+	t.Run("overlaySignedScope is the ONLY path to signed provenance", func(t *testing.T) {
+		v := extractDeclaredView(&registry.BundleMeta{})
+		v.overlaySignedScope(nil, []map[string]any{{"id": "ds:authoritative"}})
+		if !v.hasSigned() {
+			t.Fatalf("overlaySignedScope should populate the signed source")
+		}
+		_, deps, prov := v.authoritativeIntent()
+		if prov != provSignedManifest || deps[0]["id"] != "ds:authoritative" {
+			t.Errorf("signed scope must be authoritative: prov=%q deps=%+v", prov, deps)
 		}
 	})
 }
@@ -93,101 +117,203 @@ func metaServer(t *testing.T, meta registry.BundleMeta) *httptest.Server {
 	}))
 }
 
-// TestIntentShow_SignedManifestProvenance: a scope present in the parsed
-// bundle.json is rendered as signed-manifest / AUTHORITATIVE.
-func TestIntentShow_SignedManifestProvenance(t *testing.T) {
+// TestIntentShow_MaliciousRegistryScopeIsUnverified is the red-team scenario the
+// challenge-gate finding describes: a registry serves a `secrets_store` /
+// `keychain://*` scope that is in NO signed artifact, stuffed into BOTH the parsed
+// manifest copy AND the mutable row, hoping `intent show` displays it to a CISO as
+// author-signed. With NO --bundle, the tool has only the untrusted registry view,
+// so the scope MUST print registry-reported / UNVERIFIED — never AUTHORITATIVE /
+// author-signature-covered.
+func TestIntentShow_MaliciousRegistryScopeIsUnverified(t *testing.T) {
+	evil := map[string]any{
+		"id":     "ds:secrets/keychain",
+		"kind":   "secrets_store",
+		"access": "read",
+		"scope":  "keychain://*",
+		"reason": "smuggled by a malicious registry",
+	}
 	meta := registry.BundleMeta{
-		Bundle:            map[string]any{"bundle_digest": "sha256:abc", "status": "admitted"},
+		Bundle: map[string]any{
+			"bundle_digest":     "sha256:" + strings.Repeat("ab", 32),
+			"status":            "admitted",
+			"data_dependencies": []any{evil}, // mutable row
+		},
 		CurrentGovernance: "yellow",
-		Manifest: map[string]any{
-			"data_dependencies": []any{
-				map[string]any{"id": "ds:fs/cwd", "kind": "local_fs", "access": "write", "scope": "<cwd>/decks/**"},
-			},
+		Manifest: map[string]any{ // untrusted parsed-manifest copy
+			"data_dependencies": []any{evil},
 		},
 	}
 	srv := metaServer(t, meta)
 	defer srv.Close()
 
-	var stdout, stderr bytes.Buffer
-	code := runIntentShow([]string{"@sha256:abc", "--registry", srv.URL}, &stdout, &stderr)
-	if code != exitOK {
-		t.Fatalf("intent show exit=%d, stderr=%s", code, stderr.String())
-	}
-	out := stdout.String()
-	if !strings.Contains(out, "provenance: signed-manifest (AUTHORITATIVE") {
-		t.Errorf("expected signed-manifest provenance line, got:\n%s", out)
-	}
-	if !strings.Contains(out, "ds:fs/cwd") {
-		t.Errorf("expected the scope to be printed, got:\n%s", out)
+	for _, asJSON := range []bool{false, true} {
+		var stdout, stderr bytes.Buffer
+		args := []string{"@sha256:" + strings.Repeat("ab", 32), "--registry", srv.URL}
+		if asJSON {
+			args = append(args, "--json")
+		}
+		code := runIntentShow(args, &stdout, &stderr)
+		if code != exitOK {
+			t.Fatalf("intent show exit=%d, stderr=%s", code, stderr.String())
+		}
+		out := stdout.String()
+		// The smuggled scope IS surfaced (transparency) ...
+		if !strings.Contains(out, "keychain://*") {
+			t.Errorf("(json=%v) expected the registry scope to be surfaced, got:\n%s", asJSON, out)
+		}
+		if asJSON {
+			// In JSON the security claim is the STRUCTURED verdict, not text: the
+			// authoritative declaration must be registry-reported, not signed, and
+			// the signed-manifest source must be empty (nothing digest-verified).
+			var got map[string]any
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatalf("intent show --json not valid JSON: %v\n%s", err, out)
+			}
+			if got["declaration_provenance"] != provRegistryReported {
+				t.Errorf("declaration_provenance = %v, want registry-reported", got["declaration_provenance"])
+			}
+			if got["authoritative"] != false {
+				t.Errorf("authoritative = %v, want false", got["authoritative"])
+			}
+			sources, _ := got["sources"].(map[string]any)
+			signed, _ := sources[provSignedManifest].(map[string]any)
+			if signed == nil || signed["data_dependencies"] != nil {
+				t.Errorf("signed-manifest source must be empty (no digest-verified scope): %+v", sources[provSignedManifest])
+			}
+		} else {
+			// In the human-readable view the smuggled scope must NEVER be labeled
+			// AUTHORITATIVE / author-signature-covered.
+			if strings.Contains(out, "AUTHORITATIVE") || strings.Contains(out, "author-signature-covered") {
+				t.Errorf("UNSIGNED registry scope shown as AUTHORITATIVE:\n%s", out)
+			}
+			if !strings.Contains(out, "registry-reported (UNVERIFIED") {
+				t.Errorf("expected registry-reported/UNVERIFIED provenance line, got:\n%s", out)
+			}
+		}
 	}
 }
 
-// TestIntentShow_BundleRowProvenance: a scope present ONLY on the mutable
-// registry row is rendered as bundle-row / ADVISORY, never as author-signed.
-func TestIntentShow_BundleRowProvenance(t *testing.T) {
+// TestIntentShow_BundleRowOnlyIsAdvisory: a scope present only on the mutable row
+// (no signed scope) is advisory, never author-signed.
+func TestIntentShow_BundleRowOnlyIsAdvisory(t *testing.T) {
 	meta := registry.BundleMeta{
 		Bundle: map[string]any{
-			"bundle_digest": "sha256:abc",
+			"bundle_digest": "sha256:" + strings.Repeat("cd", 32),
 			"status":        "admitted",
 			"data_dependencies": []any{
 				map[string]any{"id": "ds:er1/x", "kind": "er1_collection", "access": "read"},
 			},
 		},
 		CurrentGovernance: "yellow",
-		Manifest:          map[string]any{}, // no signed scope
+		Manifest:          map[string]any{}, // no registry-manifest scope
 	}
 	srv := metaServer(t, meta)
 	defer srv.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := runIntentShow([]string{"@sha256:abc", "--registry", srv.URL}, &stdout, &stderr)
+	code := runIntentShow([]string{"@sha256:" + strings.Repeat("cd", 32), "--registry", srv.URL}, &stdout, &stderr)
 	if code != exitOK {
 		t.Fatalf("intent show exit=%d, stderr=%s", code, stderr.String())
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "provenance: bundle-row (ADVISORY") {
+	if !strings.Contains(out, "bundle-row (ADVISORY") {
 		t.Errorf("expected bundle-row provenance line, got:\n%s", out)
 	}
-	if strings.Contains(out, "signed-manifest (AUTHORITATIVE") {
+	if strings.Contains(out, "AUTHORITATIVE") {
 		t.Errorf("bundle-row scope must NOT be reported as author-signed, got:\n%s", out)
 	}
 }
 
-// TestIntentShow_BothProvenancesShownSignedAuthoritative: when both exist, both
-// are listed and the note flags signed-manifest as authoritative.
-func TestIntentShow_BothProvenancesShown(t *testing.T) {
+// packIntentBundle packs a real .skb whose signed bundle.json carries the given
+// data_dependencies and returns (path, "sha256:hex").
+func packIntentBundle(t *testing.T, deps []skillbundle.DataDependency) (string, string) {
+	t.Helper()
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("---\nname: t\n---\n# t\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "scoped.skb")
+	m := skillbundle.BundleManifest{
+		Name:                   "scoped",
+		Version:                "1.0.0",
+		AuthorGovernanceIntent: "yellow",
+		DataDependencies:       deps,
+	}
+	if _, err := skillbundle.Pack(src, out, skillbundle.PackOptions{Manifest: m, BuiltBy: "skillctl/test"}); err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	blob, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read packed: %v", err)
+	}
+	d := sha256.Sum256(blob)
+	return out, "sha256:" + hex.EncodeToString(d[:])
+}
+
+// TestIntentShow_DigestVerifiedBundleIsAuthoritative: when --bundle points at a
+// .skb whose digest matches the registry-advertised digest, its signed scope is
+// shown as signed-manifest / AUTHORITATIVE.
+func TestIntentShow_DigestVerifiedBundleIsAuthoritative(t *testing.T) {
+	deps := []skillbundle.DataDependency{
+		{ID: "ds:fs/cwd", Kind: "local_fs", Access: "read", Scope: "<cwd>/decks/**", Reason: "read decks"},
+	}
+	bundlePath, digest := packIntentBundle(t, deps)
+
 	meta := registry.BundleMeta{
 		Bundle: map[string]any{
-			"bundle_digest": "sha256:abc",
+			"bundle_digest": digest, // honest registry advertises the real digest
 			"status":        "admitted",
-			"data_dependencies": []any{
-				map[string]any{"id": "ds:row", "kind": "er1_collection", "access": "read"},
-			},
 		},
 		CurrentGovernance: "yellow",
-		Manifest: map[string]any{
-			"data_dependencies": []any{
-				map[string]any{"id": "ds:signed", "kind": "er1_collection", "access": "read"},
-			},
-		},
+		Manifest:          map[string]any{},
 	}
 	srv := metaServer(t, meta)
 	defer srv.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := runIntentShow([]string{"@sha256:abc", "--registry", srv.URL, "--json"}, &stdout, &stderr)
+	code := runIntentShow([]string{"@" + digest, "--registry", srv.URL, "--bundle", bundlePath}, &stdout, &stderr)
 	if code != exitOK {
 		t.Fatalf("intent show exit=%d, stderr=%s", code, stderr.String())
 	}
-	var got map[string]any
-	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
-		t.Fatalf("intent show --json not valid JSON: %v\n%s", err, stdout.String())
+	out := stdout.String()
+	if !strings.Contains(out, "signed-manifest (AUTHORITATIVE") {
+		t.Errorf("digest-verified bundle scope must be AUTHORITATIVE, got:\n%s", out)
 	}
-	if got["declaration_provenance"] != provSignedManifest {
-		t.Errorf("declaration_provenance = %v, want signed-manifest", got["declaration_provenance"])
+	if !strings.Contains(out, "ds:fs/cwd") {
+		t.Errorf("expected the signed scope to be printed, got:\n%s", out)
 	}
-	sources, _ := got["sources"].(map[string]any)
-	if sources == nil || sources[provSignedManifest] == nil || sources[provBundleRow] == nil {
-		t.Errorf("both provenance sources must be present in --json: %+v", got["sources"])
+}
+
+// TestIntentShow_BundleDigestMismatchFailsClosed: a --bundle whose digest does NOT
+// match the registry-advertised digest (the adversary swapped bytes) must fail
+// closed — NOT silently show the tampered scope as authoritative.
+func TestIntentShow_BundleDigestMismatchFailsClosed(t *testing.T) {
+	deps := []skillbundle.DataDependency{
+		{ID: "ds:fs/cwd", Kind: "local_fs", Access: "read", Scope: "<cwd>/decks/**", Reason: "read decks"},
+	}
+	bundlePath, _ := packIntentBundle(t, deps)
+
+	// Registry advertises a DIFFERENT digest than the local .skb actually has.
+	meta := registry.BundleMeta{
+		Bundle: map[string]any{
+			"bundle_digest": "sha256:" + strings.Repeat("ff", 32),
+			"status":        "admitted",
+		},
+		CurrentGovernance: "yellow",
+		Manifest:          map[string]any{},
+	}
+	srv := metaServer(t, meta)
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runIntentShow([]string{"@sha256:" + strings.Repeat("ff", 32), "--registry", srv.URL, "--bundle", bundlePath}, &stdout, &stderr)
+	if code == exitOK {
+		t.Fatalf("digest mismatch must NOT exit 0; stdout=%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "AUTHORITATIVE") {
+		t.Errorf("a digest-mismatched bundle must NOT be shown as authoritative:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "did not digest-verify") {
+		t.Errorf("expected a digest-verify failure message, got stderr:\n%s", stderr.String())
 	}
 }

--- a/cmd/skillctl/intent_show_test.go
+++ b/cmd/skillctl/intent_show_test.go
@@ -13,7 +13,10 @@ package main
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
@@ -250,70 +253,288 @@ func packIntentBundle(t *testing.T, deps []skillbundle.DataDependency) (string, 
 	return out, "sha256:" + hex.EncodeToString(d[:])
 }
 
-// TestIntentShow_DigestVerifiedBundleIsAuthoritative: when --bundle points at a
-// .skb whose digest matches the registry-advertised digest, its signed scope is
-// shown as signed-manifest / AUTHORITATIVE.
-func TestIntentShow_DigestVerifiedBundleIsAuthoritative(t *testing.T) {
+// signedIntentFixture is a fully-wired `intent show --bundle` scenario on disk:
+// a real packed .skb carrying a typed data-scope, signed by an author key whose
+// pubkey is PINNED in trust-roots, with a BundleMeta (served by an httptest
+// registry) carrying the author + registry signature rows. This is the (b)
+// scenario the re-challenge requires — and the substrate the Attack-d test
+// perturbs by swapping in an attacker-signed bundle the pinned author never
+// signed.
+type signedIntentFixture struct {
+	bundlePath string
+	digest     string // "sha256:<hex>"
+	authorID   string
+	regURL     string
+	trPath     string
+	authorPriv ed25519.PrivateKey
+	regPriv    ed25519.PrivateKey
+	srv        *httptest.Server
+}
+
+// buildSignedIntentFixture packs+signs a scoped bundle and stands up a registry
+// that advertises its digest + signatures. The trust-roots pin the author key, so
+// verify.Verify can validate the author signature fully offline (pinned mode).
+func buildSignedIntentFixture(t *testing.T, deps []skillbundle.DataDependency) signedIntentFixture {
+	t.Helper()
+	bundlePath, digest := packIntentBundle(t, deps)
+
+	authorPub, authorPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("author keygen: %v", err)
+	}
+	regPub, regPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("reg keygen: %v", err)
+	}
+	authorID := "id:kamir@m3c"
+
+	dRaw := digestRaw(t, digest)
+	meta := registry.BundleMeta{
+		Bundle: map[string]any{
+			"bundle_digest": digest,
+			"name":          "scoped",
+			"version":       "1.0.0",
+			"status":        "admitted",
+		},
+		Signatures: []registry.SignatureRow{
+			{Role: "author", IdentityID: authorID, SignatureB64: signB64(authorPriv, dRaw), Status: "active"},
+			{Role: "registry", IdentityID: "id:registry@aims-core", SignatureB64: signB64(regPriv, dRaw), Status: "active"},
+		},
+		CurrentGovernance: "green",
+		Manifest:          map[string]any{},
+	}
+	srv := metaServer(t, meta)
+	t.Cleanup(srv.Close)
+
+	// The trust-root is matched by the live --registry URL, so it MUST pin the
+	// httptest server URL (known only after the server starts).
+	trPath := filepath.Join(t.TempDir(), "trust-roots.pinned.yaml")
+	writePinnedTrustRoots(t, trPath, srv.URL,
+		base64.StdEncoding.EncodeToString(regPub),
+		authorID, base64.StdEncoding.EncodeToString(authorPub))
+
+	return signedIntentFixture{
+		bundlePath: bundlePath, digest: digest, authorID: authorID, regURL: srv.URL,
+		trPath: trPath, authorPriv: authorPriv, regPriv: regPriv, srv: srv,
+	}
+}
+
+// digestRaw decodes a "sha256:<hex>" digest back to its 32 raw bytes for signing.
+func digestRaw(t *testing.T, digest string) [32]byte {
+	t.Helper()
+	hexPart := strings.TrimPrefix(digest, "sha256:")
+	raw, err := hex.DecodeString(hexPart)
+	if err != nil || len(raw) != 32 {
+		t.Fatalf("bad digest %q: %v", digest, err)
+	}
+	var out [32]byte
+	copy(out[:], raw)
+	return out
+}
+
+// servePinnedMeta restands a registry that serves a custom BundleMeta but reuses
+// the fixture's registry URL pin (so the trust-root still matches). Used by
+// Attack-d to swap in attacker signatures while keeping the same --registry pin.
+func servePinnedMeta(t *testing.T, meta registry.BundleMeta) *httptest.Server {
+	t.Helper()
+	srv := metaServer(t, meta)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestIntentShow_PinnedAuthorSignedBundleIsAuthoritative (re-challenge scenario b):
+// a genuinely author-signed bundle whose author key IS pinned in trust-roots is
+// shown as signed-manifest / AUTHORITATIVE — and ONLY because the author signature
+// verified, not because a digest happened to match.
+func TestIntentShow_PinnedAuthorSignedBundleIsAuthoritative(t *testing.T) {
+	deps := []skillbundle.DataDependency{
+		{ID: "ds:fs/cwd", Kind: "local_fs", Access: "read", Scope: "<cwd>/decks/**", Reason: "read decks"},
+	}
+	f := buildSignedIntentFixture(t, deps)
+
+	for _, asJSON := range []bool{false, true} {
+		var stdout, stderr bytes.Buffer
+		args := []string{"@" + f.digest, "--registry", f.srv.URL, "--bundle", f.bundlePath, "--trust-roots", f.trPath}
+		if asJSON {
+			args = append(args, "--json")
+		}
+		code := runIntentShow(args, &stdout, &stderr)
+		if code != exitOK {
+			t.Fatalf("(json=%v) intent show exit=%d, stderr=%s", asJSON, code, stderr.String())
+		}
+		out := stdout.String()
+		if !strings.Contains(out, "ds:fs/cwd") {
+			t.Errorf("(json=%v) expected the signed scope printed, got:\n%s", asJSON, out)
+		}
+		if asJSON {
+			var got map[string]any
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatalf("not JSON: %v\n%s", err, out)
+			}
+			if got["authoritative"] != true {
+				t.Errorf("authoritative=%v, want true (author sig pinned+verified)", got["authoritative"])
+			}
+			if got["declaration_provenance"] != provSignedManifest {
+				t.Errorf("declaration_provenance=%v, want signed-manifest", got["declaration_provenance"])
+			}
+		} else if !strings.Contains(out, "signed-manifest (AUTHORITATIVE") {
+			t.Errorf("pinned-author-signed scope must be AUTHORITATIVE, got:\n%s", out)
+		}
+	}
+}
+
+// TestIntentShow_AttackD_MaliciousRegistryUnsignedBundle (re-challenge scenario a,
+// the MERGE-BLOCKER): an attacker packs their OWN .skb (carrying a scope the pinned
+// author never signed) and a malicious registry advertises ITS digest — but there
+// is NO valid pinned-author signature over those bytes. `intent show --bundle` must
+// print digest-matched / UNVERIFIED, authoritative:false, and NEVER
+// author-signature-covered / AUTHORITATIVE.
+func TestIntentShow_AttackD_MaliciousRegistryUnsignedBundle(t *testing.T) {
+	// The attacker's bundle carries a scope a CISO would refuse if it looked signed.
+	evil := []skillbundle.DataDependency{
+		{ID: "ds:secrets/keychain", Kind: "secrets_store", Access: "read", Scope: "keychain://*", Reason: "smuggled scope"},
+	}
+	attackerBundle, attackerDigest := packIntentBundle(t, evil)
+
+	// A legitimate pinned-author trust-root exists, but the attacker bundle was
+	// NOT signed by that author. The malicious registry advertises the attacker's
+	// digest and stuffs an ATTACKER-signed author row (a key the trust-root does
+	// NOT pin) hoping it passes for author-signed.
+	authorPub, _, _ := ed25519.GenerateKey(rand.Reader)    // pinned author (never signed the attacker bundle)
+	_, attackerPriv, _ := ed25519.GenerateKey(rand.Reader) // attacker key (not pinned)
+	regPub, regPriv, _ := ed25519.GenerateKey(rand.Reader) // registry key (pinned, so the chain reaches author)
+	authorID := "id:kamir@m3c"
+	dRaw := digestRaw(t, attackerDigest)
+
+	meta := registry.BundleMeta{
+		Bundle: map[string]any{
+			"bundle_digest": attackerDigest, // registry advertises ITS bundle's digest
+			"status":        "admitted",
+		},
+		Signatures: []registry.SignatureRow{
+			// Author row signed by the ATTACKER key, claiming the pinned author's id.
+			{Role: "author", IdentityID: authorID, SignatureB64: signB64(attackerPriv, dRaw), Status: "active"},
+			{Role: "registry", IdentityID: "id:registry@aims-core", SignatureB64: signB64(regPriv, dRaw), Status: "active"},
+		},
+		CurrentGovernance: "green",
+		Manifest: map[string]any{
+			"data_dependencies": []any{map[string]any{
+				"id": "ds:secrets/keychain", "kind": "secrets_store", "access": "read", "scope": "keychain://*",
+			}},
+		},
+	}
+	srv := servePinnedMeta(t, meta)
+
+	// Pin the live server URL so the trust-root matches the --registry passed below.
+	trPath := filepath.Join(t.TempDir(), "trust-roots.pinned.yaml")
+	writePinnedTrustRoots(t, trPath, srv.URL,
+		base64.StdEncoding.EncodeToString(regPub),
+		authorID, base64.StdEncoding.EncodeToString(authorPub))
+
+	for _, asJSON := range []bool{false, true} {
+		var stdout, stderr bytes.Buffer
+		args := []string{"@" + attackerDigest, "--registry", srv.URL, "--bundle", attackerBundle, "--trust-roots", trPath}
+		if asJSON {
+			args = append(args, "--json")
+		}
+		code := runIntentShow(args, &stdout, &stderr)
+		if code != exitOK {
+			t.Fatalf("(json=%v) intent show exit=%d, stderr=%s", asJSON, code, stderr.String())
+		}
+		out := stdout.String()
+		if asJSON {
+			var got map[string]any
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatalf("not JSON: %v\n%s", err, out)
+			}
+			if got["authoritative"] != false {
+				t.Errorf("Attack-d: authoritative=%v, want false (no valid pinned-author signature)", got["authoritative"])
+			}
+			if got["declaration_provenance"] == provSignedManifest {
+				t.Errorf("Attack-d: declaration_provenance must NOT be signed-manifest")
+			}
+			sources, _ := got["sources"].(map[string]any)
+			signed, _ := sources[provSignedManifest].(map[string]any)
+			if signed == nil || signed["data_dependencies"] != nil {
+				t.Errorf("Attack-d: signed-manifest source must be EMPTY (author sig not verified): %+v", signed)
+			}
+		} else {
+			if strings.Contains(out, "AUTHORITATIVE") || strings.Contains(out, "author-signature-covered") {
+				t.Errorf("Attack-d: attacker bundle shown as AUTHORITATIVE:\n%s", out)
+			}
+			if !strings.Contains(out, "digest-matched (author signature NOT verified") {
+				t.Errorf("Attack-d: expected digest-matched/UNVERIFIED label, got:\n%s", out)
+			}
+		}
+	}
+}
+
+// TestIntentShow_AttackD_NoTrustRootsIsUnverified (re-challenge scenario d): an
+// honest @sha256 out-of-band digest pin WITHOUT trust-roots configured is NOT
+// author-signature verification — it is a user-asserted digest. Without a pinned
+// author key the scope must be digest-matched / UNVERIFIED, never
+// author-signature-covered.
+func TestIntentShow_AttackD_NoTrustRootsIsUnverified(t *testing.T) {
+	// Point HOME at an empty dir so the DEFAULT trust-roots path does not exist.
+	t.Setenv("HOME", t.TempDir())
+
 	deps := []skillbundle.DataDependency{
 		{ID: "ds:fs/cwd", Kind: "local_fs", Access: "read", Scope: "<cwd>/decks/**", Reason: "read decks"},
 	}
 	bundlePath, digest := packIntentBundle(t, deps)
-
 	meta := registry.BundleMeta{
 		Bundle: map[string]any{
-			"bundle_digest": digest, // honest registry advertises the real digest
+			"bundle_digest": digest, // honest registry, real digest
 			"status":        "admitted",
 		},
 		CurrentGovernance: "yellow",
 		Manifest:          map[string]any{},
 	}
-	srv := metaServer(t, meta)
-	defer srv.Close()
+	srv := servePinnedMeta(t, meta)
 
 	var stdout, stderr bytes.Buffer
+	// No --trust-roots flag → default path (under the empty HOME) → none configured.
 	code := runIntentShow([]string{"@" + digest, "--registry", srv.URL, "--bundle", bundlePath}, &stdout, &stderr)
 	if code != exitOK {
 		t.Fatalf("intent show exit=%d, stderr=%s", code, stderr.String())
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "signed-manifest (AUTHORITATIVE") {
-		t.Errorf("digest-verified bundle scope must be AUTHORITATIVE, got:\n%s", out)
+	if strings.Contains(out, "AUTHORITATIVE") || strings.Contains(out, "author-signature-covered") {
+		t.Errorf("no trust-roots: out-of-band digest pin must NOT be author-signature-covered:\n%s", out)
 	}
-	if !strings.Contains(out, "ds:fs/cwd") {
-		t.Errorf("expected the signed scope to be printed, got:\n%s", out)
+	if !strings.Contains(out, "digest-matched (author signature NOT verified") {
+		t.Errorf("no trust-roots: expected digest-matched/UNVERIFIED label, got:\n%s", out)
+	}
+	if !strings.Contains(stderr.String(), "trust-roots not usable") {
+		t.Errorf("expected an actionable trust-roots reason on stderr, got:\n%s", stderr.String())
 	}
 }
 
-// TestIntentShow_BundleDigestMismatchFailsClosed: a --bundle whose digest does NOT
-// match the registry-advertised digest (the adversary swapped bytes) must fail
-// closed — NOT silently show the tampered scope as authoritative.
-func TestIntentShow_BundleDigestMismatchFailsClosed(t *testing.T) {
+// TestIntentShow_AttackD_DigestMismatchNotAuthoritative (re-challenge scenario c):
+// a --bundle whose digest does NOT match the registry-advertised digest (the
+// adversary swapped bytes after signing) fails closed — the swapped scope is NEVER
+// shown as authoritative; only the UNVERIFIED registry view stands.
+func TestIntentShow_AttackD_DigestMismatchNotAuthoritative(t *testing.T) {
 	deps := []skillbundle.DataDependency{
 		{ID: "ds:fs/cwd", Kind: "local_fs", Access: "read", Scope: "<cwd>/decks/**", Reason: "read decks"},
 	}
-	bundlePath, _ := packIntentBundle(t, deps)
+	f := buildSignedIntentFixture(t, deps)
 
-	// Registry advertises a DIFFERENT digest than the local .skb actually has.
-	meta := registry.BundleMeta{
-		Bundle: map[string]any{
-			"bundle_digest": "sha256:" + strings.Repeat("ff", 32),
-			"status":        "admitted",
-		},
-		CurrentGovernance: "yellow",
-		Manifest:          map[string]any{},
+	// Append a byte to the .skb AFTER the meta was signed → digest mismatch.
+	skb, _ := os.ReadFile(f.bundlePath)
+	if err := os.WriteFile(f.bundlePath, append(skb, 'X'), 0o644); err != nil {
+		t.Fatalf("tamper: %v", err)
 	}
-	srv := metaServer(t, meta)
-	defer srv.Close()
 
 	var stdout, stderr bytes.Buffer
-	code := runIntentShow([]string{"@sha256:" + strings.Repeat("ff", 32), "--registry", srv.URL, "--bundle", bundlePath}, &stdout, &stderr)
-	if code == exitOK {
-		t.Fatalf("digest mismatch must NOT exit 0; stdout=%s", stdout.String())
+	code := runIntentShow([]string{"@" + f.digest, "--registry", f.srv.URL, "--bundle", f.bundlePath, "--trust-roots", f.trPath}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("intent show exit=%d, stderr=%s", code, stderr.String())
 	}
 	if strings.Contains(stdout.String(), "AUTHORITATIVE") {
 		t.Errorf("a digest-mismatched bundle must NOT be shown as authoritative:\n%s", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "did not digest-verify") {
-		t.Errorf("expected a digest-verify failure message, got stderr:\n%s", stderr.String())
+	if !strings.Contains(stderr.String(), "did not digest-match") {
+		t.Errorf("expected a digest-match failure note, got stderr:\n%s", stderr.String())
 	}
 }

--- a/cmd/skillctl/pack.go
+++ b/cmd/skillctl/pack.go
@@ -1,98 +1,400 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
 	"github.com/kamir/m3c-tools/pkg/skillbundle"
+	"github.com/kamir/m3c-tools/pkg/skillctl/datascope"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
 )
 
 // cmdPack implements `skillctl pack` per SPEC-0188 §3 — produce a deterministic
-// `.skb` archive from a local skill directory. Phase 1: packing only.
+// `.skb` archive from a local skill directory.
+//
+// SPEC-0196 §12 Q1 / P2b: `--data-scopes` binds a typed, validated data-scope
+// declaration INTO the signed `bundle.json` (manifest.Intent + manifest.
+// DataDependencies) BEFORE the digest is computed and the author signs — so the
+// declaration is covered by the author signature, not the mutable post-admit
+// PATCH row. The validation is fail-closed at pack time: an invalid or §3.3-
+// contradictory scope is rejected before any bundle is produced, with the SAME
+// `failed_rule` + exit 18 the client/server `intent declare` path returns.
+//
+// cmdPack is the os.Exit wrapper; runPack is the testable core (returns an exit
+// code, prints to the injected writers) so the challenge gate can drive the
+// pack-time binding without spawning a process.
 func cmdPack(args []string) {
-	skillDir := ""
-	outFile := ""
-	m := skillbundle.BundleManifest{}
-	var dependsOn []string
+	os.Exit(runPack(args, os.Stdout, os.Stderr))
+}
 
-	take := func(args []string, i int, flag string) string {
+// packInputs holds the parsed flag set. Separated from runPack so the parser is
+// unit-testable and the runner stays a straight build → validate → pack flow.
+type packInputs struct {
+	skillDir  string
+	outFile   string
+	manifest  skillbundle.BundleManifest
+	dependsOn []string
+
+	// SPEC-0196 P2b data-scope inputs.
+	dataScopeJSON []string // repeated --data-scopes / --data-dep JSON blobs (datascope wire shape)
+	usedDataDep   bool     // true if the deprecated --data-dep alias was used (warn once)
+
+	// SPEC-0196 §3.1 intent toggles — only the fields the §3.3 cross-rules read
+	// are first-class flags; the rest of the intent block stays advisory.
+	sideEffects string // comma-separated §5 side-effect tokens
+	destructive string // "" | true | false (pointer-ish: "" = unset)
+	network     string // "" | true | false
+}
+
+// runPack parses, validates, and emits. Returns a SPEC-0188 §11 numeric exit
+// code. A §3.3 cross-rule failure returns exit 18 (verify.ExitIntentInconsistent),
+// matching `intent declare`; a malformed scope returns exit 2 (usage).
+func runPack(args []string, stdout, stderr io.Writer) int {
+	in, code, ok := parsePackArgs(args, stderr)
+	if !ok {
+		return code
+	}
+
+	if in.skillDir == "" || in.outFile == "" || in.manifest.Name == "" || in.manifest.Version == "" {
+		fmt.Fprintln(stderr, "Error: --skill, --output, --name, and --version are required.")
+		printPackUsage(stderr)
+		return exitUsage
+	}
+
+	deps, err := parseDependencies(in.dependsOn)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return exitGeneric
+	}
+	in.manifest.DependsOn = deps
+
+	// SPEC-0196 §12 Q1 / P2b — bind the validated data-scope into the manifest
+	// BEFORE Pack computes the digest. Fail-closed: an invalid declaration aborts
+	// the pack so no bundle is ever produced with an unvalidated scope.
+	if code, ok := bindDataScope(&in, stderr); !ok {
+		return code
+	}
+
+	digest, err := skillbundle.Pack(in.skillDir, in.outFile, skillbundle.PackOptions{
+		Manifest: in.manifest,
+		BuiltBy:  fmt.Sprintf("skillctl/%s", in.manifest.Version),
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "pack failed: %v\n", err)
+		return exitGeneric
+	}
+
+	fmt.Fprintf(stdout, "bundle_digest: %s\n", digest)
+	fmt.Fprintf(stdout, "output:        %s\n", in.outFile)
+	if len(in.manifest.DataDependencies) > 0 {
+		fmt.Fprintf(stdout, "data_scopes:   %d declared (author-signed, in bundle.json)\n", len(in.manifest.DataDependencies))
+	}
+	return exitOK
+}
+
+// parsePackArgs walks os.Args-style flags. Returns (inputs, exitCode, ok); on
+// ok=false the caller returns exitCode. Keeps the existing manual-parse style
+// (no cobra) so it matches the rest of the skillctl CLI.
+func parsePackArgs(args []string, stderr io.Writer) (packInputs, int, bool) {
+	var in packInputs
+
+	take := func(i int, flag string) (string, bool) {
 		if i >= len(args) {
-			fmt.Fprintf(os.Stderr, "Error: %s requires a value\n", flag)
-			os.Exit(1)
+			fmt.Fprintf(stderr, "Error: %s requires a value\n", flag)
+			return "", false
 		}
-		return args[i]
+		return args[i], true
 	}
 
 	for i := 0; i < len(args); i++ {
+		var v string
+		var ok bool
 		switch args[i] {
 		case "--skill":
 			i++
-			skillDir = take(args, i, "--skill")
+			if v, ok = take(i, "--skill"); !ok {
+				return in, exitUsage, false
+			}
+			in.skillDir = v
 		case "-o", "--output":
 			i++
-			outFile = take(args, i, "--output")
+			if v, ok = take(i, "--output"); !ok {
+				return in, exitUsage, false
+			}
+			in.outFile = v
 		case "--name":
 			i++
-			m.Name = take(args, i, "--name")
+			if v, ok = take(i, "--name"); !ok {
+				return in, exitUsage, false
+			}
+			in.manifest.Name = v
 		case "--version":
 			i++
-			m.Version = take(args, i, "--version")
+			if v, ok = take(i, "--version"); !ok {
+				return in, exitUsage, false
+			}
+			in.manifest.Version = v
 		case "--summary":
 			i++
-			m.Summary = take(args, i, "--summary")
+			if v, ok = take(i, "--summary"); !ok {
+				return in, exitUsage, false
+			}
+			in.manifest.Summary = v
 		case "--source-repo":
 			i++
-			m.SourceRepo = take(args, i, "--source-repo")
+			if v, ok = take(i, "--source-repo"); !ok {
+				return in, exitUsage, false
+			}
+			in.manifest.SourceRepo = v
 		case "--source-commit":
 			i++
-			m.SourceCommit = take(args, i, "--source-commit")
+			if v, ok = take(i, "--source-commit"); !ok {
+				return in, exitUsage, false
+			}
+			in.manifest.SourceCommit = v
 		case "--source-path":
 			i++
-			m.SourcePath = take(args, i, "--source-path")
+			if v, ok = take(i, "--source-path"); !ok {
+				return in, exitUsage, false
+			}
+			in.manifest.SourcePath = v
 		case "--author-intent":
 			i++
-			m.AuthorGovernanceIntent = take(args, i, "--author-intent")
+			if v, ok = take(i, "--author-intent"); !ok {
+				return in, exitUsage, false
+			}
+			in.manifest.AuthorGovernanceIntent = v
 		case "--author-intent-rationale":
 			i++
-			m.AuthorGovernanceRationale = take(args, i, "--author-intent-rationale")
+			if v, ok = take(i, "--author-intent-rationale"); !ok {
+				return in, exitUsage, false
+			}
+			in.manifest.AuthorGovernanceRationale = v
 		case "--compatibility":
 			i++
-			m.Compatibility = take(args, i, "--compatibility")
+			if v, ok = take(i, "--compatibility"); !ok {
+				return in, exitUsage, false
+			}
+			in.manifest.Compatibility = v
 		case "--depends-on":
 			i++
-			dependsOn = append(dependsOn, take(args, i, "--depends-on"))
+			if v, ok = take(i, "--depends-on"); !ok {
+				return in, exitUsage, false
+			}
+			in.dependsOn = append(in.dependsOn, v)
+		case "--data-scopes":
+			i++
+			if v, ok = take(i, "--data-scopes"); !ok {
+				return in, exitUsage, false
+			}
+			in.dataScopeJSON = append(in.dataScopeJSON, v)
+		case "--data-dep":
+			// Deprecated alias for --data-scopes (same JSON shape, same
+			// validation) — kept symmetric with `intent declare`.
+			i++
+			if v, ok = take(i, "--data-dep"); !ok {
+				return in, exitUsage, false
+			}
+			in.dataScopeJSON = append(in.dataScopeJSON, v)
+			in.usedDataDep = true
+		case "--side-effects":
+			i++
+			if v, ok = take(i, "--side-effects"); !ok {
+				return in, exitUsage, false
+			}
+			in.sideEffects = v
+		case "--destructive":
+			i++
+			if v, ok = take(i, "--destructive"); !ok {
+				return in, exitUsage, false
+			}
+			in.destructive = v
+		case "--network":
+			i++
+			if v, ok = take(i, "--network"); !ok {
+				return in, exitUsage, false
+			}
+			in.network = v
 		default:
-			fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
-			printPackUsage()
-			os.Exit(1)
+			fmt.Fprintf(stderr, "Unknown flag: %s\n", args[i])
+			printPackUsage(stderr)
+			return in, exitUsage, false
 		}
 	}
+	return in, exitOK, true
+}
 
-	if skillDir == "" || outFile == "" || m.Name == "" || m.Version == "" {
-		fmt.Fprintln(os.Stderr, "Error: --skill, --output, --name, and --version are required.")
-		printPackUsage()
-		os.Exit(1)
+// bindDataScope decodes the --data-scopes JSON blobs, runs them through the
+// shared SPEC-0196 validator (per-scope + §5 side-effects + §3.3 cross-rules)
+// FAIL-CLOSED against the bundle's --author-intent governance Ampel, and writes
+// the validated typed scope into in.manifest.Intent + in.manifest.DataDependencies
+// so the binding is covered by the author signature.
+//
+// Returns (exitCode, ok). When ok=false the caller aborts before Pack — no
+// bundle is produced. Exit-code policy mirrors `intent declare`:
+//   - §3.3 cross-rule fired   → exit 18 (verify.ExitIntentInconsistent), failed_rule printed
+//   - malformed scope/json    → exit 2  (usage)
+//
+// When no --data-scopes were passed, this is a no-op (scope absent → unchanged
+// behavior; bundles packed without the flag verify exactly as before).
+func bindDataScope(in *packInputs, stderr io.Writer) (int, bool) {
+	// Parse intent toggles into the typed cross-rule projection. These are only
+	// needed to feed the §3.3 cross-rules; we ALSO mirror them into the signed
+	// manifest.Intent so the declared intent is itself author-signed.
+	intent, code, ok := buildPackIntent(in, stderr)
+	if !ok {
+		return code, false
 	}
 
-	deps, err := parseDependencies(dependsOn)
+	if len(in.dataScopeJSON) == 0 {
+		// No data-scopes declared. Still mirror any intent toggles that were set
+		// (so `pack --destructive true` alone is signed), but skip validation
+		// that requires scopes. An intent with no scopes still gets the §3.3
+		// destructive↔green check via the shared validator below.
+		if intent != nil {
+			in.manifest.Intent = intent
+		}
+		if intent != nil {
+			if verr := datascope.Validate(typedIntent(intent), nil, in.manifest.AuthorGovernanceIntent); verr != nil {
+				return reportScopeValidationError(verr, stderr)
+			}
+		}
+		return exitOK, true
+	}
+
+	if in.usedDataDep {
+		fmt.Fprintln(stderr, "skillctl pack: NOTE --data-dep is deprecated; use --data-scopes (same JSON shape, same validation).")
+	}
+
+	// Decode each JSON blob to a raw map, then to a typed DataScope. A decode
+	// error is a usage error (malformed input), distinct from a semantic
+	// validation failure.
+	rawMaps := make([]map[string]any, 0, len(in.dataScopeJSON))
+	for i, raw := range in.dataScopeJSON {
+		var m map[string]any
+		if err := json.Unmarshal([]byte(raw), &m); err != nil {
+			fmt.Fprintf(stderr, "skillctl pack: --data-scopes[%d]: invalid JSON: %v\n", i, err)
+			return exitUsage, false
+		}
+		rawMaps = append(rawMaps, m)
+	}
+	scopes, err := datascope.FromMaps(rawMaps)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "skillctl pack: %v\n", err)
+		return exitUsage, false
 	}
-	m.DependsOn = deps
 
-	digest, err := skillbundle.Pack(skillDir, outFile, skillbundle.PackOptions{
-		Manifest: m,
-		BuiltBy:  fmt.Sprintf("skillctl/%s", m.Version),
-	})
+	// FAIL-CLOSED validation: the full SPEC-0196 check (per-scope + §5 vocab +
+	// §3.3 cross-rules) against the bundle's governance Ampel. This is the SAME
+	// shared validator the client/server `intent declare` path uses, so the
+	// pack-time refusal is byte-for-byte the same diagnostic.
+	if verr := datascope.Validate(typedIntent(intent), scopes, in.manifest.AuthorGovernanceIntent); verr != nil {
+		return reportScopeValidationError(verr, stderr)
+	}
+
+	// Bind the validated scope into the signed manifest. Marshal each typed
+	// DataScope through its JSON tags into the manifest's DataDependency — the
+	// tags are identical (SPEC-0196 §3.2 wire shape), so this is a lossless
+	// round-trip and the bytes that land in bundle.json match the declaration.
+	deps, err := scopesToManifestDeps(scopes)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "pack failed: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "skillctl pack: bind data-scope: %v\n", err)
+		return exitGeneric, false
 	}
+	in.manifest.DataDependencies = deps
+	if intent != nil {
+		in.manifest.Intent = intent
+	}
+	return exitOK, true
+}
 
-	fmt.Printf("bundle_digest: %s\n", digest)
-	fmt.Printf("output:        %s\n", outFile)
+// buildPackIntent assembles the signed-manifest *skillbundle.Intent from the
+// intent toggle flags. Returns nil when no intent flag was supplied (the
+// common case — most skills declare scopes without overriding intent). A
+// malformed bool flag is a usage error.
+func buildPackIntent(in *packInputs, stderr io.Writer) (*skillbundle.Intent, int, bool) {
+	if in.sideEffects == "" && in.destructive == "" && in.network == "" {
+		return nil, exitOK, true
+	}
+	intent := &skillbundle.Intent{}
+	if in.sideEffects != "" {
+		intent.SideEffects = splitCommaTrim(in.sideEffects)
+	}
+	if in.destructive != "" {
+		b, err := parseBoolFlag(in.destructive, "--destructive")
+		if err != nil {
+			fmt.Fprintf(stderr, "skillctl pack: %v\n", err)
+			return nil, exitUsage, false
+		}
+		intent.Destructive = b
+	}
+	if in.network != "" {
+		b, err := parseBoolFlag(in.network, "--network")
+		if err != nil {
+			fmt.Fprintf(stderr, "skillctl pack: %v\n", err)
+			return nil, exitUsage, false
+		}
+		intent.Network = &b
+	}
+	return intent, exitOK, true
+}
+
+// typedIntent projects a signed-manifest *skillbundle.Intent onto the datascope
+// validator's typed Intent (only the §3.3 cross-rule fields). A nil manifest
+// intent yields the zero datascope.Intent (all-absent), which the cross-rules
+// treat as "nothing declared" — the safe default.
+func typedIntent(m *skillbundle.Intent) datascope.Intent {
+	if m == nil {
+		return datascope.Intent{}
+	}
+	var dest *bool
+	// skillbundle.Intent.Destructive is a plain bool; project true/false through
+	// a pointer so the §3.3 write_access_non_destructive rule (which only fires
+	// when destructive is explicitly false) behaves identically to the CLI path.
+	d := m.Destructive
+	dest = &d
+	return datascope.Intent{
+		SideEffects: m.SideEffects,
+		Destructive: dest,
+		Network:     m.Network,
+	}
+}
+
+// scopesToManifestDeps round-trips each typed DataScope through its JSON tags
+// into a manifest DataDependency. The tags match exactly (SPEC-0196 §3.2), so
+// the bytes are conserved — the verifier reads back the identical declaration.
+func scopesToManifestDeps(scopes []datascope.DataScope) ([]skillbundle.DataDependency, error) {
+	deps := make([]skillbundle.DataDependency, 0, len(scopes))
+	for i, s := range scopes {
+		b, err := json.Marshal(s)
+		if err != nil {
+			return nil, fmt.Errorf("data_dependencies[%d]: marshal: %w", i, err)
+		}
+		var d skillbundle.DataDependency
+		if err := json.Unmarshal(b, &d); err != nil {
+			return nil, fmt.Errorf("data_dependencies[%d]: decode: %w", i, err)
+		}
+		deps = append(deps, d)
+	}
+	return deps, nil
+}
+
+// reportScopeValidationError maps a datascope.ValidationError to the same exit
+// codes the `intent declare` path uses: a fired §3.3 cross-rule → exit 18 with
+// the stable failed_rule; a structural/vocabulary failure → exit 2 (usage).
+func reportScopeValidationError(verr error, stderr io.Writer) (int, bool) {
+	var ve *datascope.ValidationError
+	if errors.As(verr, &ve) && ve.FailedRule != "" {
+		fmt.Fprintf(stderr, "skillctl pack: rejected at pack time — failed_rule=%s\n", ve.FailedRule)
+		fmt.Fprintf(stderr, "detail: %s\n", ve.Detail)
+		return verify.ExitCode(fmt.Errorf("rule=%s: %w", ve.FailedRule, verify.ErrIntentInconsistent)), false
+	}
+	fmt.Fprintf(stderr, "skillctl pack: invalid data-scope declaration: %v\n", verr)
+	return exitUsage, false
 }
 
 // parseDependencies parses repeated `--depends-on kind:name:constraint` flags.
@@ -119,8 +421,8 @@ func parseDependencies(specs []string) ([]skillbundle.Dependency, error) {
 	return out, nil
 }
 
-func printPackUsage() {
-	fmt.Fprintln(os.Stderr, `Usage:
+func printPackUsage(w io.Writer) {
+	fmt.Fprintln(w, `Usage:
   skillctl pack --skill <dir> -o <out.skb> --name <n> --version <v> [options]
 
 Required:
@@ -137,5 +439,16 @@ Optional manifest fields:
   --author-intent <s>      green | yellow | red (advisory only — verifier ignores; signed attestations bind)
   --author-intent-rationale <s>
   --compatibility <s>
-  --depends-on kind:name:constraint   Repeatable, e.g. python:requests:>=2.31`)
+  --depends-on kind:name:constraint   Repeatable, e.g. python:requests:>=2.31
+
+SPEC-0196 §12 Q1 / P2b — author-signed declared data-scope (bound INTO bundle.json):
+  --data-scopes <json>     Typed SPEC-0196 data-scope (repeatable). Validated fail-closed
+                           at pack time through pkg/skillctl/datascope (per-kind scope,
+                           §5 side-effect vocab, §3.3 cross-rules) BEFORE the digest is
+                           computed, so the author signature covers it. Example:
+                           --data-scopes '{"id":"ds:fs/cwd","kind":"local_fs","access":"write","scope":"<cwd>/decks/**","reason":"write deck"}'
+  --data-dep <json>        DEPRECATED alias for --data-scopes (same JSON shape, same validation).
+  --side-effects <list>    Comma-separated §5 side-effect tokens (signed into intent).
+  --destructive true|false Author claim: irreversible changes (§3.3 cross-rule input).
+  --network true|false     Author claim: outbound network (§3.3 cross-rule input).`)
 }

--- a/cmd/skillctl/pack_test.go
+++ b/cmd/skillctl/pack_test.go
@@ -1,0 +1,237 @@
+package main
+
+// SPEC-0196 §12 Q1 / P2b — `skillctl pack --data-scopes` binds a typed,
+// validated data-scope INTO the signed bundle.json. These tests drive runPack
+// directly (no process spawn) and assert:
+//
+//   - a declared scope lands INSIDE bundle.json (so it is digest-covered → the
+//     author signature covers it; the byte-level tamper proof lives in
+//     pkg/skillbundle/datascope_binding_test.go),
+//   - pack REJECTS a §3.3-contradictory scope fail-closed with exit 18 and the
+//     SAME failed_rule the client/server `intent declare` validator emits,
+//   - a malformed scope JSON is a usage error (exit 2), distinct from a
+//     semantic rejection,
+//   - packing WITHOUT --data-scopes leaves the manifest scope absent (unchanged
+//     behavior — back-compat).
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillbundle"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// writePackSkillDir builds a minimal valid skill dir with a SKILL.md.
+func writePackSkillDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: t\n---\n# t\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	return dir
+}
+
+// readBundleJSON extracts and decodes bundle.json from a packed .skb.
+func readBundleJSON(t *testing.T, skbPath string) skillbundle.BundleManifest {
+	t.Helper()
+	f, err := os.Open(skbPath)
+	if err != nil {
+		t.Fatalf("open skb: %v", err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("gzip: %v", err)
+	}
+	tr := tar.NewReader(gz)
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar: %v", err)
+		}
+		if h.Name == "bundle.json" {
+			raw, _ := io.ReadAll(tr)
+			var m skillbundle.BundleManifest
+			if err := json.Unmarshal(raw, &m); err != nil {
+				t.Fatalf("decode bundle.json: %v", err)
+			}
+			return m
+		}
+	}
+	t.Fatalf("bundle.json not found in %s", skbPath)
+	return skillbundle.BundleManifest{}
+}
+
+func baseArgs(skillDir, out string) []string {
+	return []string{
+		"--skill", skillDir,
+		"-o", out,
+		"--name", "t",
+		"--version", "1.0.0",
+		"--author-intent", "yellow",
+	}
+}
+
+// TestPackDataScopeBoundIntoSignedManifest: a declared scope is present in the
+// signed bundle.json with every field conserved.
+func TestPackDataScopeBoundIntoSignedManifest(t *testing.T) {
+	dir := writePackSkillDir(t)
+	out := filepath.Join(t.TempDir(), "t@1.0.0.skb")
+	var stdout, stderr bytes.Buffer
+
+	scope := `{"id":"ds:fs/cwd","kind":"local_fs","access":"write","scope":"<cwd>/decks/**","reason":"write the scaffolded decks","payload_class":"config","retention":"persistent"}`
+	args := append(baseArgs(dir, out),
+		"--destructive", "true", // write access requires destructive=true (§3.3 rule 3)
+		"--data-scopes", scope,
+	)
+
+	if code := runPack(args, &stdout, &stderr); code != exitOK {
+		t.Fatalf("runPack exit=%d, stderr=%s", code, stderr.String())
+	}
+
+	m := readBundleJSON(t, out)
+	if len(m.DataDependencies) != 1 {
+		t.Fatalf("want 1 data_dependency in signed manifest, got %d", len(m.DataDependencies))
+	}
+	d := m.DataDependencies[0]
+	if d.ID != "ds:fs/cwd" || d.Kind != "local_fs" || d.Access != "write" ||
+		d.Scope != "<cwd>/decks/**" || d.Reason != "write the scaffolded decks" ||
+		d.PayloadClass != "config" || d.Retention != "persistent" {
+		t.Fatalf("data_dependency fields not conserved into signed manifest: %+v", d)
+	}
+	if m.Intent == nil || !m.Intent.Destructive {
+		t.Fatalf("intent.destructive not bound into signed manifest: %+v", m.Intent)
+	}
+	if !strings.Contains(stdout.String(), "author-signed") {
+		t.Errorf("stdout should note author-signed binding, got: %s", stdout.String())
+	}
+}
+
+// TestPackRejectsContradictoryScopeFailClosed: a write scope paired with
+// intent.destructive=false fires §3.3 rule write_access_non_destructive →
+// exit 18, the SAME failed_rule the intent-declare validator emits, and NO
+// bundle is produced.
+func TestPackRejectsContradictoryScopeFailClosed(t *testing.T) {
+	dir := writePackSkillDir(t)
+	out := filepath.Join(t.TempDir(), "bad.skb")
+	var stdout, stderr bytes.Buffer
+
+	scope := `{"id":"ds:fs/cwd","kind":"local_fs","access":"write","scope":"<cwd>/x/**","reason":"r"}`
+	args := append(baseArgs(dir, out),
+		"--destructive", "false", // contradiction: write access but not destructive
+		"--data-scopes", scope,
+	)
+
+	code := runPack(args, &stdout, &stderr)
+	if code != verify.ExitIntentInconsistent {
+		t.Fatalf("want exit %d (intent_inconsistent), got %d; stderr=%s",
+			verify.ExitIntentInconsistent, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "failed_rule=write_access_non_destructive") {
+		t.Errorf("stderr should name the §3.3 rule, got: %s", stderr.String())
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Errorf("fail-closed violated: bundle was produced at %s despite invalid scope", out)
+	}
+}
+
+// TestPackRejectsDestructiveGreen: destructive=true + green Ampel fires
+// §3.3 rule destructive_green → exit 18.
+func TestPackRejectsDestructiveGreen(t *testing.T) {
+	dir := writePackSkillDir(t)
+	out := filepath.Join(t.TempDir(), "bad.skb")
+	var stdout, stderr bytes.Buffer
+
+	args := []string{
+		"--skill", dir, "-o", out, "--name", "t", "--version", "1.0.0",
+		"--author-intent", "green",
+		"--destructive", "true",
+	}
+	code := runPack(args, &stdout, &stderr)
+	if code != verify.ExitIntentInconsistent {
+		t.Fatalf("want exit %d, got %d; stderr=%s", verify.ExitIntentInconsistent, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "failed_rule=destructive_green") {
+		t.Errorf("stderr should name destructive_green, got: %s", stderr.String())
+	}
+}
+
+// TestPackRejectsMalformedScopeJSON: a non-JSON scope is a usage error (exit 2),
+// NOT a semantic §3.3 rejection.
+func TestPackRejectsMalformedScopeJSON(t *testing.T) {
+	dir := writePackSkillDir(t)
+	out := filepath.Join(t.TempDir(), "bad.skb")
+	var stdout, stderr bytes.Buffer
+
+	args := append(baseArgs(dir, out), "--data-scopes", "{not json")
+	code := runPack(args, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("want exit %d (usage) for malformed JSON, got %d; stderr=%s", exitUsage, code, stderr.String())
+	}
+}
+
+// TestPackRejectsStructurallyInvalidScope: a scope with an unknown kind is a
+// structural failure → usage error (exit 2), distinct from a cross-rule.
+func TestPackRejectsStructurallyInvalidScope(t *testing.T) {
+	dir := writePackSkillDir(t)
+	out := filepath.Join(t.TempDir(), "bad.skb")
+	var stdout, stderr bytes.Buffer
+
+	scope := `{"id":"ds:x","kind":"not_a_kind","access":"read","reason":"r"}`
+	args := append(baseArgs(dir, out), "--data-scopes", scope)
+	code := runPack(args, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("want exit %d (usage) for unknown kind, got %d; stderr=%s", exitUsage, code, stderr.String())
+	}
+}
+
+// TestPackWithoutDataScopeUnchanged: omitting --data-scopes leaves the manifest
+// scope absent — back-compat (a bundle packed the old way is unchanged).
+func TestPackWithoutDataScopeUnchanged(t *testing.T) {
+	dir := writePackSkillDir(t)
+	out := filepath.Join(t.TempDir(), "t.skb")
+	var stdout, stderr bytes.Buffer
+
+	if code := runPack(baseArgs(dir, out), &stdout, &stderr); code != exitOK {
+		t.Fatalf("runPack exit=%d, stderr=%s", code, stderr.String())
+	}
+	m := readBundleJSON(t, out)
+	if len(m.DataDependencies) != 0 {
+		t.Errorf("expected no data_dependencies when --data-scopes omitted, got %d", len(m.DataDependencies))
+	}
+	if m.Intent != nil {
+		t.Errorf("expected nil intent when no intent flags set, got %+v", m.Intent)
+	}
+}
+
+// TestPackDataDepAliasWarns: the deprecated --data-dep alias is accepted and
+// behaves identically, with a one-line deprecation note.
+func TestPackDataDepAliasWarns(t *testing.T) {
+	dir := writePackSkillDir(t)
+	out := filepath.Join(t.TempDir(), "t.skb")
+	var stdout, stderr bytes.Buffer
+
+	scope := `{"id":"ds:er1/x","kind":"er1_collection","access":"read","reason":"r"}`
+	args := append(baseArgs(dir, out), "--data-dep", scope)
+	if code := runPack(args, &stdout, &stderr); code != exitOK {
+		t.Fatalf("runPack exit=%d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--data-dep is deprecated") {
+		t.Errorf("expected deprecation note for --data-dep, got: %s", stderr.String())
+	}
+	m := readBundleJSON(t, out)
+	if len(m.DataDependencies) != 1 {
+		t.Fatalf("want 1 data_dependency via alias, got %d", len(m.DataDependencies))
+	}
+}

--- a/cmd/skillctl/verify_bundle_cmds.go
+++ b/cmd/skillctl/verify_bundle_cmds.go
@@ -62,10 +62,15 @@ type bundleVerifyResult struct {
 	// SelfAttested (SPEC-0246 §5) surfaces whether the binding governance
 	// attestation was reviewed by the bundle's own author. Pointer-valued:
 	// true (self), false (independent), null (unknown / no binding attestation).
-	SelfAttested *bool  `json:"self_attested"`
-	ChainSummary string `json:"chain_summary,omitempty"`
-	Error        string `json:"error,omitempty"`
-	ExitCode     int    `json:"exit_code"`
+	SelfAttested *bool `json:"self_attested"`
+	// DataScopes (SPEC-0196 §12 Q1 / P2b) surfaces the declared data-scope with
+	// provenance — "signed-manifest" (author-signature-covered, authoritative)
+	// vs "bundle-row" (mutable post-admit PATCH, advisory). A CISO consumer can
+	// branch on `.data_scopes[].provenance` to tell author-bound from post-admit.
+	DataScopes   []verify.DeclaredScope `json:"data_scopes,omitempty"`
+	ChainSummary string                 `json:"chain_summary,omitempty"`
+	Error        string                 `json:"error,omitempty"`
+	ExitCode     int                    `json:"exit_code"`
 }
 
 // runVerifyBundle implements the --bundle path. Returns the SPEC-0188 §11
@@ -157,6 +162,7 @@ func runVerifyBundle(p verifyBundleParams, stdout, stderr io.Writer) int {
 			out.Governance = res.GovernanceLevel
 			out.GovernanceVerified = res.GovernanceVerified
 			out.SelfAttested = res.SelfAttested
+			out.DataScopes = res.DataScopes
 			out.ChainSummary = res.ChainSummary
 			out.ExitCode = exitOK
 		}
@@ -178,7 +184,42 @@ func runVerifyBundle(p verifyBundleParams, stdout, stderr io.Writer) int {
 		return exitBundleRevoked
 	}
 	fmt.Fprintln(stdout, res.ChainSummary+" (offline, bundle)")
+	printDeclaredScopes(stdout, res.DataScopes)
 	return exitOK
+}
+
+// printDeclaredScopes renders the declared data-scope with its provenance so a
+// CISO sees at a glance which declarations are author-signed (authoritative) vs
+// post-admit PATCH-row (advisory). SPEC-0196 §12 Q1 / P2b.
+func printDeclaredScopes(stdout io.Writer, scopes []verify.DeclaredScope) {
+	if len(scopes) == 0 {
+		return
+	}
+	fmt.Fprintf(stdout, "data-scopes (%d):\n", len(scopes))
+	for _, s := range scopes {
+		marker := "ADVISORY"
+		if s.Provenance == verify.ScopeProvenanceSignedManifest {
+			marker = "AUTHORITATIVE"
+		}
+		id, _ := s.Raw["id"].(string)
+		kind, _ := s.Raw["kind"].(string)
+		access, _ := s.Raw["access"].(string)
+		scope, _ := s.Raw["scope"].(string)
+		fmt.Fprintf(stdout, "  [%s] %s  id=%s kind=%s access=%s",
+			s.Provenance, marker, dashOr(id), dashOr(kind), dashOr(access))
+		if scope != "" {
+			fmt.Fprintf(stdout, " scope=%s", scope)
+		}
+		fmt.Fprintln(stdout)
+	}
+}
+
+// dashOr returns s or "-" when empty, for compact tabular output.
+func dashOr(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
 }
 
 // checkBundleRevoked loads a signed revocation list, verifies its signature

--- a/pkg/skillbundle/datascope_binding_test.go
+++ b/pkg/skillbundle/datascope_binding_test.go
@@ -1,0 +1,145 @@
+package skillbundle
+
+// SPEC-0196 §12 Q1 / P2b — the load-bearing security proof: a data-scope bound
+// into bundle.json at pack time is INSIDE the signed bytes (the author signs
+// the SHA-256 of the whole .skb), so EDITING the scope after pack changes the
+// digest and BREAKS author-signature verification.
+//
+// This is the property the challenge gate checks: a red-teamer cannot strip or
+// edit the signed scope without invalidating the signature.
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// scopedManifest returns a manifest carrying one author-signed write-scope plus
+// the consistent intent (destructive=true so the §3.3 cross-rules are satisfied
+// — this test is about binding, not validation).
+func scopedManifest() BundleManifest {
+	m := fixtureManifest()
+	m.AuthorGovernanceIntent = "yellow"
+	m.Intent = &Intent{
+		SideEffects: []string{"fs:write"},
+		Destructive: true,
+	}
+	m.DataDependencies = []DataDependency{
+		{
+			ID:     "ds:fs/cwd",
+			Kind:   "local_fs",
+			Access: "write",
+			Scope:  "<cwd>/decks/**",
+			Reason: "write the scaffolded decks",
+		},
+	}
+	return m
+}
+
+// signDigest signs the SHA-256 of a packed .skb exactly as SignBundle does
+// (ed25519 over the raw 32-byte digest, SPEC-0188 §4.1).
+func signDigest(t *testing.T, priv ed25519.PrivateKey, skbPath string) ([]byte, [32]byte) {
+	t.Helper()
+	raw, err := os.ReadFile(skbPath)
+	if err != nil {
+		t.Fatalf("read skb: %v", err)
+	}
+	d := sha256.Sum256(raw)
+	return ed25519.Sign(priv, d[:]), d
+}
+
+// TestDataScopeIsInsideSignedBytes proves a packed scope is digest-covered and
+// that tampering the scope after pack breaks signature verification.
+func TestDataScopeIsInsideSignedBytes(t *testing.T) {
+	src := writeFixtureSkill(t)
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+
+	// 1. Pack the bundle WITH the author-signed scope, then sign its digest.
+	good := filepath.Join(t.TempDir(), "good.skb")
+	if _, err := Pack(src, good, PackOptions{Manifest: scopedManifest(), BuiltAt: fixedTime, BuiltBy: "skillctl/test"}); err != nil {
+		t.Fatalf("pack good: %v", err)
+	}
+	sig, goodDigest := signDigest(t, priv, good)
+
+	// The author signature verifies against the bundle's true digest.
+	if !ed25519.Verify(pub, goodDigest[:], sig) {
+		t.Fatal("author signature must verify against the unmodified bundle")
+	}
+
+	// The scope is genuinely present in the signed bundle.json.
+	bj := readTarFile(t, good, "bundle.json")
+	if !containsBytes(bj, "<cwd>/decks/**") {
+		t.Fatal("scope must be present in the signed bundle.json")
+	}
+
+	// 2. Re-pack the SAME skill but with the scope EDITED (the tamper). A
+	// red-teamer who edits the declared scope must change the bytes that were
+	// signed. Re-packing is the most faithful model of "edit bundle.json and
+	// re-tar" — it produces the archive an attacker would have to substitute.
+	tampered := scopedManifest()
+	tampered.DataDependencies[0].Scope = "<cwd>/**" // widened from decks/** to everything
+	bad := filepath.Join(t.TempDir(), "bad.skb")
+	if _, err := Pack(src, bad, PackOptions{Manifest: tampered, BuiltAt: fixedTime, BuiltBy: "skillctl/test"}); err != nil {
+		t.Fatalf("pack tampered: %v", err)
+	}
+	_, badDigest := signDigest(t, priv, bad)
+
+	// 3. The digest MUST differ — proof the scope is inside the signed bytes.
+	if goodDigest == badDigest {
+		t.Fatal("editing the scope did not change the digest — scope is NOT digest-covered")
+	}
+
+	// 4. The ORIGINAL author signature MUST NOT verify against the tampered
+	// digest — the tamper is detected.
+	if ed25519.Verify(pub, badDigest[:], sig) {
+		t.Fatal("author signature verified against a TAMPERED scope — binding is broken")
+	}
+}
+
+// TestStrippingScopeBreaksSignature proves removing the scope entirely (the
+// "strip" attack) also changes the digest and breaks the signature.
+func TestStrippingScopeBreaksSignature(t *testing.T) {
+	src := writeFixtureSkill(t)
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+
+	good := filepath.Join(t.TempDir(), "good.skb")
+	if _, err := Pack(src, good, PackOptions{Manifest: scopedManifest(), BuiltAt: fixedTime, BuiltBy: "skillctl/test"}); err != nil {
+		t.Fatalf("pack good: %v", err)
+	}
+	sig, goodDigest := signDigest(t, priv, good)
+
+	// Strip: re-pack with no data_dependencies and no intent.
+	stripped := scopedManifest()
+	stripped.DataDependencies = nil
+	stripped.Intent = nil
+	bad := filepath.Join(t.TempDir(), "stripped.skb")
+	if _, err := Pack(src, bad, PackOptions{Manifest: stripped, BuiltAt: fixedTime, BuiltBy: "skillctl/test"}); err != nil {
+		t.Fatalf("pack stripped: %v", err)
+	}
+	_, badDigest := signDigest(t, priv, bad)
+
+	if goodDigest == badDigest {
+		t.Fatal("stripping the scope did not change the digest — scope is NOT digest-covered")
+	}
+	if ed25519.Verify(pub, badDigest[:], sig) {
+		t.Fatal("author signature verified against a STRIPPED scope — binding is broken")
+	}
+}
+
+func containsBytes(haystack []byte, needle string) bool {
+	n := []byte(needle)
+	for i := 0; i+len(n) <= len(haystack); i++ {
+		if string(haystack[i:i+len(n)]) == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/skillbundle/manifest.go
+++ b/pkg/skillbundle/manifest.go
@@ -34,10 +34,25 @@ type Intent struct {
 
 // DataDependency declares one data source the skill reads or writes.
 // Mirrors SPEC-0196 §3 `data_dependencies[]`.
+//
+// The JSON tags match the SPEC-0196 §3.2 wire shape AND the
+// `pkg/skillctl/datascope.DataScope` projection exactly, so a typed data-scope
+// declared at pack time (`skillctl pack --data-scopes`, SPEC-0196 §12 Q1 / P2b)
+// round-trips byte-for-byte into the signed `bundle.json` and back out of the
+// verifier with no translation layer. `ID`/`Scope`/`Reason`/`PayloadClass`/
+// `Retention` are the P2b signed-binding fields; `Kind`/`Access` are also read
+// by the §3.3 cross-rules (ValidateIntentDataCrossRules). `Ref` is the legacy
+// pre-P2b identifier kept so manifests written before the datascope shape
+// existed still decode.
 type DataDependency struct {
-	Kind   string `json:"kind"`             // er1 | firestore_collection | http_endpoint | filesystem | kafka_topic
-	Ref    string `json:"ref,omitempty"`    // identifier within Kind
-	Access string `json:"access,omitempty"` // read | write | passthrough | transform
+	ID           string `json:"id,omitempty"`     // SPEC-0196 §3.2 "ds:"-prefixed identifier
+	Kind         string `json:"kind"`             // local_fs | http_endpoint | er1_collection | firestore_collection | gcs_bucket | secrets_store
+	Ref          string `json:"ref,omitempty"`    // legacy identifier within Kind (pre-P2b)
+	Access       string `json:"access,omitempty"` // read | write | passthrough | transform
+	Scope        string `json:"scope,omitempty"`  // narrow specifier — path glob / URL pattern / collection path
+	Reason       string `json:"reason,omitempty"` // human rationale (§3.2 required for new declarations)
+	PayloadClass string `json:"payload_class,omitempty"`
+	Retention    string `json:"retention,omitempty"`
 }
 
 // BundleManifest is the on-disk `bundle.json` document inside an `.skb` archive.
@@ -45,30 +60,30 @@ type DataDependency struct {
 // which matters for canonicalization: BundleDigest is positioned last among
 // the digest-relevant fields and is always serialized empty for the digest pass.
 type BundleManifest struct {
-	Schema              string       `json:"schema"`
-	Name                string       `json:"name"`
-	Version             string       `json:"version"`
-	Summary             string       `json:"summary"`
-	SourceRepo          string       `json:"source_repo"`
-	SourceCommit        string       `json:"source_commit"`
-	SourcePath          string       `json:"source_path"`
+	Schema       string `json:"schema"`
+	Name         string `json:"name"`
+	Version      string `json:"version"`
+	Summary      string `json:"summary"`
+	SourceRepo   string `json:"source_repo"`
+	SourceCommit string `json:"source_commit"`
+	SourcePath   string `json:"source_path"`
 	// AuthorGovernanceIntent is advisory metadata only — verifiers MUST NOT
 	// use it for trust decisions. The binding governance verdict comes from
 	// signed attestations (SPEC-0188 §4.3). See SPEC-0188 §3.2 "Author intent
 	// vs binding governance verdict".
-	AuthorGovernanceIntent     string       `json:"author_governance_intent"`
-	AuthorGovernanceRationale  string       `json:"author_governance_rationale"`
+	AuthorGovernanceIntent    string `json:"author_governance_intent"`
+	AuthorGovernanceRationale string `json:"author_governance_rationale"`
 	// Intent and DataDependencies (SPEC-0196 §3). Optional in v1; pack-time
 	// validator enforces cross-rule consistency via ValidateIntentDataCrossRules.
-	Intent              *Intent          `json:"intent,omitempty"`
-	DataDependencies    []DataDependency `json:"data_dependencies,omitempty"`
-	DependsOn           []Dependency `json:"depends_on"`
-	Supersedes          *string      `json:"supersedes"`
-	DerivedFrom         *string      `json:"derived_from"`
-	Compatibility       string       `json:"compatibility"`
-	BundleDigest        string       `json:"bundle_digest"`
-	BuiltAt             time.Time    `json:"built_at"`
-	BuiltBy             string       `json:"built_by"`
+	Intent           *Intent          `json:"intent,omitempty"`
+	DataDependencies []DataDependency `json:"data_dependencies,omitempty"`
+	DependsOn        []Dependency     `json:"depends_on"`
+	Supersedes       *string          `json:"supersedes"`
+	DerivedFrom      *string          `json:"derived_from"`
+	Compatibility    string           `json:"compatibility"`
+	BundleDigest     string           `json:"bundle_digest"`
+	BuiltAt          time.Time        `json:"built_at"`
+	BuiltBy          string           `json:"built_by"`
 }
 
 // withEmptyDigest returns a shallow copy of m with BundleDigest cleared.

--- a/pkg/skillbundle/pack.go
+++ b/pkg/skillbundle/pack.go
@@ -50,6 +50,20 @@ func Pack(skillDir, outFile string, opts PackOptions) (digest string, err error)
 		return "", fmt.Errorf("skill dir %q must contain SKILL.md: %w", skillDir, err)
 	}
 
+	// LIBRARY-BOUNDARY SCOPE GATE (P2b challenge-gate fix). The author signature
+	// covers manifest.Intent + manifest.DataDependencies, so NO unvalidated scope
+	// may ever be author-signed — the gate must live HERE, at the pack/sign
+	// boundary, not only in the CLI. A programmatic producer (e.g.
+	// publish_cmds.go ensureBundle) that calls Pack directly is now bound by the
+	// SAME datascope.Validate rule the CLI runs. Fail-closed: an invalid or §3.3-
+	// contradictory scope returns an error and writes NO bundle. The CLI still
+	// pre-validates to map exact exit codes (18/2) before calling Pack; this is a
+	// belt-and-braces enforcement, not a different verdict (same validator, same
+	// failed_rule).
+	if err := ValidateManifestDataScope(opts.Manifest); err != nil {
+		return "", err
+	}
+
 	contentFiles, err := collectFiles(skillDir)
 	if err != nil {
 		return "", fmt.Errorf("collecting files: %w", err)

--- a/pkg/skillbundle/pack_datascope_gate_test.go
+++ b/pkg/skillbundle/pack_datascope_gate_test.go
@@ -1,0 +1,102 @@
+package skillbundle
+
+// SPEC-0196 §12 Q1 / P2b — LIBRARY-BOUNDARY scope gate (challenge-gate finding #2).
+//
+// The author signature covers manifest.Intent + manifest.DataDependencies, so the
+// validation gate MUST live at the pack/sign boundary itself — not only in the CLI.
+// A programmatic producer that calls skillbundle.Pack directly (e.g.
+// publish_cmds.go ensureBundle) must be bound by the SAME datascope.Validate rule.
+// These tests prove Pack fails CLOSED on an invalid/contradictory scope and writes
+// NO bundle.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/datascope"
+)
+
+// TestPack_RejectsInvalidScope_NoBundleWritten: an unbounded local_fs WRITE scope
+// (no path glob) is invalid; Pack must return an error and write no file.
+func TestPack_RejectsInvalidScope_NoBundleWritten(t *testing.T) {
+	src := writeFixtureSkill(t)
+	out := filepath.Join(t.TempDir(), "should-not-exist.skb")
+
+	m := fixtureManifest()
+	m.AuthorGovernanceIntent = "yellow"
+	m.Intent = &Intent{SideEffects: []string{"fs:write"}, Destructive: true}
+	m.DataDependencies = []DataDependency{
+		// local_fs WRITE with NO scope → unbounded write, rejected by datascope.
+		{ID: "ds:fs/cwd", Kind: "local_fs", Access: "write", Reason: "write somewhere"},
+	}
+
+	digest, err := Pack(src, out, PackOptions{Manifest: m, BuiltAt: fixedTime, BuiltBy: "skillctl/test"})
+	if err == nil {
+		t.Fatal("Pack must reject an unbounded local_fs write scope")
+	}
+	if digest != "" {
+		t.Errorf("Pack returned a digest %q on rejection; want empty", digest)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf("Pack wrote a bundle despite an invalid scope (stat err=%v)", statErr)
+	}
+}
+
+// TestPack_RejectsContradictoryCrossRule_Exit18Mappable: a §3.3 cross-rule
+// violation (write access but destructive=false) is rejected at the library
+// boundary, and the error carries the stable FailedRule so the CLI can map it to
+// exit 18 exactly as before.
+func TestPack_RejectsContradictoryCrossRule_Exit18Mappable(t *testing.T) {
+	src := writeFixtureSkill(t)
+	out := filepath.Join(t.TempDir(), "should-not-exist.skb")
+
+	m := fixtureManifest()
+	m.AuthorGovernanceIntent = "yellow"
+	dFalse := false
+	m.Intent = &Intent{SideEffects: []string{"fs:write"}, Destructive: dFalse}
+	m.DataDependencies = []DataDependency{
+		{ID: "ds:fs/cwd", Kind: "local_fs", Access: "write", Scope: "<cwd>/decks/**", Reason: "write decks"},
+	}
+
+	_, err := Pack(src, out, PackOptions{Manifest: m, BuiltAt: fixedTime, BuiltBy: "skillctl/test"})
+	if err == nil {
+		t.Fatal("Pack must reject write-access with destructive=false (§3.3)")
+	}
+	var ve *datascope.ValidationError
+	if !errors.As(err, &ve) || ve.FailedRule != datascope.RuleWriteAccessNonDestr {
+		t.Errorf("Pack error must carry FailedRule=%q (got err=%v)", datascope.RuleWriteAccessNonDestr, err)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf("Pack wrote a bundle despite a cross-rule violation (stat err=%v)", statErr)
+	}
+}
+
+// TestPack_AcceptsValidScope: the consistent scope from scopedManifest still packs
+// successfully — the gate is fail-closed, not break-everything.
+func TestPack_AcceptsValidScope(t *testing.T) {
+	src := writeFixtureSkill(t)
+	out := filepath.Join(t.TempDir(), "ok.skb")
+	if _, err := Pack(src, out, PackOptions{Manifest: scopedManifest(), BuiltAt: fixedTime, BuiltBy: "skillctl/test"}); err != nil {
+		t.Fatalf("Pack must accept a valid scope: %v", err)
+	}
+	if _, statErr := os.Stat(out); statErr != nil {
+		t.Errorf("Pack should have written the bundle: %v", statErr)
+	}
+}
+
+// TestPack_NoScopeUnchanged: a manifest with neither intent nor data deps packs
+// exactly as before (back-compat — the gate is a no-op when there is nothing to
+// validate).
+func TestPack_NoScopeUnchanged(t *testing.T) {
+	src := writeFixtureSkill(t)
+	out := filepath.Join(t.TempDir(), "plain.skb")
+	m := fixtureManifest() // no Intent, no DataDependencies
+	if _, err := Pack(src, out, PackOptions{Manifest: m, BuiltAt: fixedTime, BuiltBy: "skillctl/test"}); err != nil {
+		t.Fatalf("Pack must accept a scope-free manifest: %v", err)
+	}
+	if _, statErr := os.Stat(out); statErr != nil {
+		t.Errorf("Pack should have written the bundle: %v", statErr)
+	}
+}

--- a/pkg/skillbundle/validate.go
+++ b/pkg/skillbundle/validate.go
@@ -1,18 +1,36 @@
 package skillbundle
 
-// SPEC-0196 §3.3 — Intent / data-dependencies cross-rule validator.
+// SPEC-0196 §3.3 — Intent / data-dependencies cross-rule validation.
 //
-// Go port of aims-core/flask/modules/skill_registry/skill_service.py
-// `_validate_intent_data_cross_rules`. The two implementations MUST stay
-// behavior-identical: the server uses this exact rule set at admission time
-// (admit_from_scan step 1.5, intent-PATCH); skillctl pack must reject the
-// same shapes pre-pack so the trainer sees the failure before signing.
+// TWO validators name a `network_*_http_dep` rule. They are NOT interchangeable
+// (P2b challenge-gate finding #3 — the "duplicate name, opposite semantics"
+// foot-gun). Read this before wiring either:
+//
+//   - THE AUTHORITATIVE GATE is pkg/skillctl/datascope.Validate. It is the SINGLE
+//     source of truth for SPEC-0196 declared-scope validity (per-kind scope, §5
+//     side-effect vocabulary, §3.3 cross-rules) and is what the pack/sign boundary
+//     now enforces — see ValidateManifestDataScope below, which Pack calls so NO
+//     unvalidated scope is ever author-signed. Its Rule 2
+//     (datascope.RuleNetworkFalseHTTPDep) fires on network=TRUE with NO
+//     http_endpoint dep.
+//
+//   - THE LEGACY bundle-shaped helpers in THIS file
+//     (ValidateIntentDataCrossRules / ValidateManifestCrossRules /
+//     ExitCodeForViolation) predate the typed datascope package. They model the
+//     COMPLEMENTARY direction — network=FALSE with an http_endpoint dep present —
+//     under the SAME stable failed_rule string "network_false_http_dep". They are
+//     retained for API + test compatibility and a forensic/legacy read of a raw
+//     manifest, but they are NOT the security gate and MUST NOT be used to decide
+//     whether a scope may be signed. Use ValidateManifestDataScope / datascope for
+//     that. DO NOT introduce a third copy of this rule.
 //
 // Locked decisions (S3-DECISIONS.md S3.2):
 //   Q1 = A — pre-pack validation; same shape as the Python server-side rule.
 //   Q2 = A — exit codes 11 (missing_governance_intent) for green+destructive,
 //            12 (intent_data_inconsistent) for the other two cross-rules.
 //   Q3 = A — no override flag in v1.
+
+import "github.com/kamir/m3c-tools/pkg/skillctl/datascope"
 
 // CrossRuleViolation names a SPEC-0196 §3.3 cross-rule failure.
 type CrossRuleViolation string
@@ -28,19 +46,93 @@ const (
 	// the missing piece, since destructive=true requires yellow or red).
 	RuleDestructiveGreen CrossRuleViolation = "destructive_green"
 
-	// RuleNetworkFalseHttpDep — Rule 2: intent.network=false but a
-	// data_dependency declares kind="http_endpoint". Maps to pack-time
-	// exit 12 (intent_data_inconsistent).
+	// RuleNetworkFalseHttpDep — Rule 2 (this package's LEGACY framing):
+	// intent.network=false but a data_dependency declares kind="http_endpoint".
+	//
+	// FOOT-GUN CROSS-REFERENCE (P2b finding #3): datascope.RuleNetworkFalseHTTPDep
+	// uses the SAME failed_rule string "network_false_http_dep" for the OPPOSITE
+	// trigger (network=TRUE with NO http dep). Both express the same §3.3 "network
+	// claim disagrees with the http dependency set" signal; the authoritative
+	// validator is datascope. This constant exists only for the legacy helpers in
+	// this file — do not route signing decisions through it.
 	RuleNetworkFalseHttpDep CrossRuleViolation = "network_false_http_dep"
 
 	// RuleWriteAccessNonDestructive — Rule 3: a data_dependency with
-	// access="write" is inconsistent with intent.destructive=false. Maps
-	// to pack-time exit 12 (intent_data_inconsistent).
+	// access="write" is inconsistent with intent.destructive=false. Maps to
+	// pack-time exit 12 (intent_data_inconsistent).
 	RuleWriteAccessNonDestructive CrossRuleViolation = "write_access_non_destructive"
 )
 
+// ValidateManifestDataScope is the LIBRARY-BOUNDARY gate Pack calls before it
+// produces (and the author signs) any bytes (P2b challenge-gate finding #2). It
+// runs the FULL SPEC-0196 check — per-kind scope, §5 side-effect vocabulary, and
+// the §3.3 cross-rules — via the SINGLE authoritative validator
+// (datascope.Validate), against the manifest's declared intent, data dependencies,
+// and author governance Ampel.
+//
+// This is what makes "no unvalidated scope is ever author-signed" hold at the
+// library boundary itself, not only in the CLI: any programmatic producer that
+// calls skillbundle.Pack (e.g. publish_cmds.go ensureBundle) is now bound by the
+// same rule the CLI runs.
+//
+// Returns nil when there is nothing to validate (no intent and no data deps — the
+// common legacy case) so old bundles pack exactly as before. Returns a non-nil
+// error (wrapping *datascope.ValidationError, so callers can errors.As the
+// FailedRule) on the FIRST failure — fail-closed; Pack then writes no bundle.
+func ValidateManifestDataScope(m BundleManifest) error {
+	if m.Intent == nil && len(m.DataDependencies) == 0 {
+		return nil
+	}
+	return datascope.Validate(
+		manifestIntentToDatascope(m.Intent),
+		manifestDepsToDatascope(m.DataDependencies),
+		m.AuthorGovernanceIntent,
+	)
+}
+
+// manifestIntentToDatascope projects a manifest *Intent onto the datascope.Intent
+// the cross-rules read. A nil manifest intent yields the zero datascope.Intent
+// (all-absent). The Destructive bool is projected through a pointer so the §3.3
+// write_access_non_destructive rule (which only fires when destructive is
+// EXPLICITLY false) behaves identically to the CLI path.
+func manifestIntentToDatascope(in *Intent) datascope.Intent {
+	if in == nil {
+		return datascope.Intent{}
+	}
+	d := in.Destructive
+	return datascope.Intent{
+		SideEffects: in.SideEffects,
+		Destructive: &d,
+		Network:     in.Network,
+	}
+}
+
+// manifestDepsToDatascope projects manifest DataDependency entries onto typed
+// datascope.DataScope values. The JSON tags are identical (SPEC-0196 §3.2), so the
+// mapping is field-for-field and lossless for the validated fields.
+func manifestDepsToDatascope(deps []DataDependency) []datascope.DataScope {
+	out := make([]datascope.DataScope, 0, len(deps))
+	for _, d := range deps {
+		out = append(out, datascope.DataScope{
+			ID:           d.ID,
+			Kind:         datascope.Kind(d.Kind),
+			Access:       datascope.Access(d.Access),
+			Scope:        d.Scope,
+			Reason:       d.Reason,
+			PayloadClass: d.PayloadClass,
+			Retention:    d.Retention,
+		})
+	}
+	return out
+}
+
 // ValidateIntentDataCrossRules applies the three SPEC-0196 §3.3 cross-rules
 // to a triplet of (intent, author_governance_intent, data_dependencies).
+//
+// LEGACY helper — see the file header. The AUTHORITATIVE gate is
+// ValidateManifestDataScope / datascope.Validate. This retains the original
+// bundle-shaped semantics (including the network=FALSE+http-dep direction of
+// Rule 2) for back-compat and forensic reads of a raw manifest.
 //
 // Returns RuleNone when the record is internally consistent. Returns the
 // matching violation constant when a rule fires; rules are checked in the
@@ -90,9 +182,10 @@ func ValidateIntentDataCrossRules(
 }
 
 // ValidateManifestCrossRules is the bundle-shaped wrapper around
-// ValidateIntentDataCrossRules. Pack-time callers (skillctl pack) use this
-// to gate archive emission on a fully-formed BundleManifest. Returns
-// RuleNone on a valid or sentinel-shaped manifest.
+// ValidateIntentDataCrossRules. LEGACY: Pack now gates on the stronger
+// ValidateManifestDataScope (which also catches structural/vocab errors via
+// datascope); this is kept for API compatibility. Returns RuleNone on a valid or
+// sentinel-shaped manifest.
 func ValidateManifestCrossRules(m BundleManifest) CrossRuleViolation {
 	return ValidateIntentDataCrossRules(
 		m.Intent,

--- a/pkg/skillctl/signing/keygen.go
+++ b/pkg/skillctl/signing/keygen.go
@@ -23,10 +23,14 @@
 //	         NOT base64. NOT hex. NOT PEM.
 //	Signed:  the 32-byte raw SHA-256 of the bundle file bytes.
 //
-// Phase-1 (`pkg/skillbundle/`) is intentionally NOT a build-time dependency
-// of this package: signing only needs the file bytes' SHA-256, and the
-// stream needs to compile cleanly on a worktree branched from master that
-// has not yet absorbed the Phase-1 PoC.
+// SignBundle now depends on `pkg/skillbundle` to enforce the SPEC-0196
+// declared-scope gate at the sign boundary (P2b re-challenge finding #2): the
+// author signature covers the manifest's intent + data dependencies, so signing
+// MUST refuse a scope the authoritative validator rejects — "no unvalidated scope
+// is ever author-signed" has to hold at EVERY sign entrypoint, not only in Pack.
+// This is safe: skillbundle does not import signing, so there is no cycle. (The
+// rest of signing — keygen, digest, detached verify — still needs only the file
+// bytes' SHA-256.)
 package signing
 
 import (

--- a/pkg/skillctl/signing/sign.go
+++ b/pkg/skillctl/signing/sign.go
@@ -4,11 +4,14 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/kamir/m3c-tools/pkg/skillbundle"
 )
 
 // signatureSize is the exact length of an ed25519 detached signature.
@@ -94,6 +97,21 @@ func SignBundle(bundlePath, keyPath, identityID string) (sigPath, digestHex stri
 		return "", "", fmt.Errorf("sign: bundle %s is empty", bundlePath)
 	}
 
+	// SCOPE GATE AT THE SIGN BOUNDARY (P2b re-challenge finding #2). Pack already
+	// validates the declared data-scope before it produces bytes, but SignBundle is
+	// a SECOND author-sign entrypoint: a hand-built .skb (assembled WITHOUT Pack)
+	// can carry a Pack-rejected, §3.3-contradictory scope and still reach here. The
+	// author signature covers manifest.Intent + manifest.DataDependencies, so we
+	// MUST refuse to sign an invalid scope — otherwise "no unvalidated scope is ever
+	// author-signed" does not actually hold at every sign boundary. Fail-closed: an
+	// invalid scope returns an error and writes NO signature. This is the SAME
+	// validator Pack runs (skillbundle.ValidateManifestDataScope → datascope.Validate);
+	// same verdict, same failed_rule. No import cycle: skillbundle does not import
+	// signing.
+	if err := validateBundleScope(bundlePath); err != nil {
+		return "", "", err
+	}
+
 	priv, err := LoadPrivateKey(keyPath)
 	if err != nil {
 		return "", "", err
@@ -129,6 +147,49 @@ func SignBundle(bundlePath, keyPath, identityID string) (sigPath, digestHex stri
 
 	_ = identityID // reserved for future use (see doc comment above)
 	return sigPath, digestHex, nil
+}
+
+// validateBundleScope unpacks the .skb at bundlePath, reads its bundle.json
+// manifest, and runs the FULL SPEC-0196 declared-scope check via the single
+// authoritative validator (skillbundle.ValidateManifestDataScope →
+// datascope.Validate): per-kind scope, §5 side-effect vocabulary, and the §3.3
+// cross-rules. This is the sign-boundary half of "no unvalidated scope is ever
+// author-signed" (the pack boundary is enforced in skillbundle.Pack).
+//
+// Fail-closed: an invalid or §3.3-contradictory scope returns a non-nil error
+// (wrapping *datascope.ValidationError, so callers can errors.As the FailedRule)
+// and SignBundle then writes no signature. A bundle whose manifest declares no
+// intent and no data dependencies (the common legacy case) validates trivially, so
+// pre-P2b bundles still sign exactly as before.
+//
+// A bundle that cannot be unpacked or whose bundle.json cannot be decoded is NOT
+// silently accepted: signing must not vouch for bytes it cannot read, so any such
+// failure is surfaced as an error (fail-closed).
+func validateBundleScope(bundlePath string) error {
+	blob, err := os.ReadFile(bundlePath)
+	if err != nil {
+		return fmt.Errorf("sign: read bundle %s: %w", bundlePath, err)
+	}
+	entries, err := skillbundle.Unpack(blob, skillbundle.UnpackOptions{})
+	if err != nil {
+		return fmt.Errorf("sign: unpack bundle %s for scope validation: %w", bundlePath, err)
+	}
+	for _, e := range entries {
+		if e.Rel != "bundle.json" {
+			continue
+		}
+		var m skillbundle.BundleManifest
+		if err := json.Unmarshal(e.Content, &m); err != nil {
+			return fmt.Errorf("sign: decode bundle.json in %s: %w", bundlePath, err)
+		}
+		if err := skillbundle.ValidateManifestDataScope(m); err != nil {
+			return fmt.Errorf("sign: refusing to author-sign %s — invalid declared scope: %w", bundlePath, err)
+		}
+		return nil
+	}
+	// No bundle.json in the archive: there is no declared scope to validate. This
+	// is unusual for a real .skb but not a scope violation — let signing proceed.
+	return nil
 }
 
 // SignaturePath returns the canonical detached-signature path for a

--- a/pkg/skillctl/signing/sign_scope_test.go
+++ b/pkg/skillctl/signing/sign_scope_test.go
@@ -1,0 +1,158 @@
+package signing
+
+// SPEC-0196 P2b re-challenge finding #2 — the SIGN-BOUNDARY scope gate.
+//
+// Pack already refuses to produce bytes for an invalid declared scope. But
+// SignBundle is a SECOND author-sign entrypoint: a hand-built .skb (assembled
+// WITHOUT Pack) can carry a Pack-rejected, §3.3-contradictory scope and still
+// reach the signer. The author signature covers manifest.Intent +
+// manifest.DataDependencies, so SignBundle MUST refuse such a bundle — otherwise
+// "no unvalidated scope is ever author-signed" does not hold at every sign
+// boundary. These tests drive the real SignBundle with hand-built archives that
+// bypass Pack.
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillbundle"
+	"github.com/kamir/m3c-tools/pkg/skillctl/datascope"
+)
+
+// makeBundleWithManifest hand-builds a .skb (gzip tar) carrying a SKILL.md plus a
+// bundle.json marshaled from m — deliberately NOT via skillbundle.Pack, so a
+// scope Pack would reject can still be assembled and handed to the signer.
+func makeBundleWithManifest(t *testing.T, dir, name string, m skillbundle.BundleManifest) string {
+	t.Helper()
+
+	manifestBytes, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+
+	var raw bytes.Buffer
+	gz := gzip.NewWriter(&raw)
+	tw := tar.NewWriter(gz)
+
+	write := func(rel string, body []byte) {
+		if err := tw.WriteHeader(&tar.Header{Name: rel, Mode: 0o644, Size: int64(len(body))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("SKILL.md", []byte("---\nname: t\n---\n# t\n"))
+	write("bundle.json", manifestBytes)
+
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, raw.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestSignBundle_RefusesContradictoryScope is the finding #2 proof: a hand-built
+// .skb whose manifest carries a §3.3-contradictory scope (destructive=true with
+// author_governance_intent="green", Rule 1) must be REFUSED by SignBundle, and NO
+// signature file may be written.
+func TestSignBundle_RefusesContradictoryScope(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "k")
+	if err := Generate(keyOut); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rule 1 violation: a destructive skill cannot be governance-green.
+	m := skillbundle.BundleManifest{
+		Name:                   "evil",
+		Version:                "1.0.0",
+		AuthorGovernanceIntent: "green",
+		Intent:                 &skillbundle.Intent{Destructive: true, SideEffects: []string{"fs:write"}},
+		DataDependencies: []skillbundle.DataDependency{
+			{ID: "ds:fs/cwd", Kind: "local_fs", Access: "write", Scope: "<cwd>/**", Reason: "writes"},
+		},
+	}
+	bundle := makeBundleWithManifest(t, dir, "evil.skb", m)
+
+	_, _, err := SignBundle(bundle, keyOut+".priv", "id:test@m3c")
+	if err == nil {
+		t.Fatal("SignBundle author-signed a contradictory scope; want fail-closed refusal")
+	}
+
+	// The error must carry the structured validation failure so callers can map it.
+	var ve *datascope.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("error should wrap *datascope.ValidationError, got: %v", err)
+	}
+	if ve.FailedRule != datascope.RuleDestructiveGreen {
+		t.Errorf("failed_rule = %q, want %q", ve.FailedRule, datascope.RuleDestructiveGreen)
+	}
+
+	// NO signature file may have been written (fail-closed).
+	matches, _ := filepath.Glob(filepath.Join(dir, "*.author.sig"))
+	if len(matches) != 0 {
+		t.Errorf("a signature file was written despite the refusal: %v", matches)
+	}
+}
+
+// TestSignBundle_AcceptsValidScope: the gate is a guard, not a wall — a hand-built
+// .skb whose manifest carries a CONSISTENT scope still signs (proves the gate does
+// not reject everything with a scope).
+func TestSignBundle_AcceptsValidScope(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "k")
+	if err := Generate(keyOut); err != nil {
+		t.Fatal(err)
+	}
+
+	m := skillbundle.BundleManifest{
+		Name:                   "ok",
+		Version:                "1.0.0",
+		AuthorGovernanceIntent: "yellow", // destructive ⇒ NOT green: consistent
+		Intent:                 &skillbundle.Intent{Destructive: true, SideEffects: []string{"fs:write"}},
+		DataDependencies: []skillbundle.DataDependency{
+			{ID: "ds:fs/cwd", Kind: "local_fs", Access: "write", Scope: "<cwd>/decks/**", Reason: "writes decks"},
+		},
+	}
+	bundle := makeBundleWithManifest(t, dir, "ok.skb", m)
+
+	sigPath, _, err := SignBundle(bundle, keyOut+".priv", "id:test@m3c")
+	if err != nil {
+		t.Fatalf("SignBundle refused a VALID scope: %v", err)
+	}
+	if _, err := os.Stat(sigPath); err != nil {
+		t.Errorf("expected a signature file at %s: %v", sigPath, err)
+	}
+}
+
+// TestSignBundle_NoScopeStillSigns: a legacy .skb whose manifest declares no
+// intent and no data dependencies has nothing to validate and signs exactly as
+// before (no regression for pre-P2b bundles).
+func TestSignBundle_NoScopeStillSigns(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "k")
+	if err := Generate(keyOut); err != nil {
+		t.Fatal(err)
+	}
+
+	m := skillbundle.BundleManifest{Name: "legacy", Version: "1.0.0"}
+	bundle := makeBundleWithManifest(t, dir, "legacy.skb", m)
+
+	if _, _, err := SignBundle(bundle, keyOut+".priv", ""); err != nil {
+		t.Fatalf("SignBundle refused a no-scope legacy bundle: %v", err)
+	}
+}

--- a/pkg/skillctl/verify/datascope_surface_test.go
+++ b/pkg/skillctl/verify/datascope_surface_test.go
@@ -1,0 +1,209 @@
+package verify
+
+// SPEC-0196 §12 Q1 / P2b — the verifier surfaces declared data-scope WITH
+// provenance: a scope read from the author-signed bundle.json INSIDE the
+// digest-verified .skb is "signed-manifest" (authoritative); a scope on the
+// mutable post-admit registry row is "bundle-row" (advisory). These tests prove
+// the verifier distinguishes the two and that a bundle-row scope can NEVER
+// masquerade as signed-manifest.
+
+import (
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillbundle"
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+)
+
+// packBundleWithScope packs a real .skb whose signed bundle.json carries the
+// given data_dependencies, and returns (path, rawDigest, "sha256:hex").
+func packBundleWithScope(t *testing.T, deps []skillbundle.DataDependency, intent *skillbundle.Intent) (string, [32]byte, string) {
+	t.Helper()
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("---\nname: t\n---\n# t\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "scoped.skb")
+	m := skillbundle.BundleManifest{
+		Name:                   "scoped",
+		Version:                "1.0.0",
+		AuthorGovernanceIntent: "yellow",
+		Intent:                 intent,
+		DataDependencies:       deps,
+	}
+	if _, err := skillbundle.Pack(src, out, skillbundle.PackOptions{Manifest: m, BuiltBy: "skillctl/test"}); err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	blob, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read packed: %v", err)
+	}
+	d := sha256.Sum256(blob)
+	return out, d, "sha256:" + hexLower(d[:])
+}
+
+// scopedOpts wires a complete pinned-mode VerifyOpts around a real packed .skb,
+// optionally seeding a bundle-row scope on meta.Bundle.
+func scopedOpts(t *testing.T, signedDeps []skillbundle.DataDependency, intent *skillbundle.Intent, bundleRowDeps []any) VerifyOpts {
+	t.Helper()
+	authorKey := mustKeypair(t)
+	regKey := mustKeypair(t)
+	bundlePath, digestRaw, digestStr := packBundleWithScope(t, signedDeps, intent)
+	authorSig := signOver(t, authorKey.priv, digestRaw)
+	regSig := signOver(t, regKey.priv, digestRaw)
+	authorID := "id:author@m3c"
+
+	meta := &registry.BundleMeta{
+		Bundle: map[string]any{
+			"bundle_digest": digestStr,
+			"name":          "scoped",
+			"version":       "1.0.0",
+			"status":        "admitted",
+		},
+		Signatures: []registry.SignatureRow{
+			{Role: "author", IdentityID: authorID, SignatureB64: authorSig, Status: "active"},
+			{Role: "registry", IdentityID: "id:registry@aims-core", SignatureB64: regSig, Status: "active"},
+		},
+		Manifest:          map[string]any{"depends_on": []any{}},
+		CurrentGovernance: "yellow",
+		Attestations: []registry.AttestationRow{
+			{Level: "yellow", ReviewerID: "id:reviewer@m3c", AttestedAt: "2026-05-05T20:00:00Z"},
+		},
+	}
+	if bundleRowDeps != nil {
+		meta.Bundle["data_dependencies"] = bundleRowDeps
+	}
+
+	return VerifyOpts{
+		BundlePath: bundlePath,
+		BundleMeta: meta,
+		TrustRoot:  goodTrustRoot(t, regKey.pub, "yellow"),
+		IdentityFetcher: &fakeFetcher{identities: map[string]*registry.Identity{
+			authorID: {ID: authorID, PubkeyB64: authorKey.b64, AuthSource: "manual"},
+		}},
+	}
+}
+
+// TestVerify_SurfacesSignedManifestScope: a pack-time scope is surfaced with
+// signed-manifest provenance.
+func TestVerify_SurfacesSignedManifestScope(t *testing.T) {
+	deps := []skillbundle.DataDependency{
+		{ID: "ds:fs/cwd", Kind: "local_fs", Access: "write", Scope: "<cwd>/decks/**", Reason: "write decks"},
+	}
+	opts := scopedOpts(t, deps, &skillbundle.Intent{Destructive: true, SideEffects: []string{"fs:write"}}, nil)
+
+	res, err := Verify(opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if len(res.DataScopes) != 1 {
+		t.Fatalf("want 1 surfaced scope, got %d", len(res.DataScopes))
+	}
+	s := res.DataScopes[0]
+	if s.Provenance != ScopeProvenanceSignedManifest {
+		t.Fatalf("want signed-manifest provenance, got %q", s.Provenance)
+	}
+	if id, _ := s.Raw["id"].(string); id != "ds:fs/cwd" {
+		t.Errorf("scope id not surfaced: %+v", s.Raw)
+	}
+	if scope, _ := s.Raw["scope"].(string); scope != "<cwd>/decks/**" {
+		t.Errorf("scope specifier not surfaced: %+v", s.Raw)
+	}
+}
+
+// TestVerify_SurfacesBundleRowScope: a PATCH-only scope (present only on the
+// registry row, NOT in the signed manifest) is surfaced as bundle-row.
+func TestVerify_SurfacesBundleRowScope(t *testing.T) {
+	// Signed manifest carries NO scope; only the mutable registry row does.
+	bundleRow := []any{
+		map[string]any{"id": "ds:er1/x", "kind": "er1_collection", "access": "read", "reason": "post-admit declare"},
+	}
+	opts := scopedOpts(t, nil, nil, bundleRow)
+
+	res, err := Verify(opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if len(res.DataScopes) != 1 {
+		t.Fatalf("want 1 surfaced scope, got %d", len(res.DataScopes))
+	}
+	s := res.DataScopes[0]
+	if s.Provenance != ScopeProvenanceBundleRow {
+		t.Fatalf("want bundle-row provenance, got %q", s.Provenance)
+	}
+	if id, _ := s.Raw["id"].(string); id != "ds:er1/x" {
+		t.Errorf("bundle-row scope id not surfaced: %+v", s.Raw)
+	}
+}
+
+// TestVerify_BundleRowCannotMasqueradeAsSigned: the red-team scenario — a
+// bundle-row scope that DIFFERS from the (absent) signed manifest must NOT be
+// reported as signed-manifest. The signed-manifest provenance is reserved for
+// scope read from the digest-verified .skb; a registry that injects a scope into
+// meta.Manifest (the untrusted parsed copy) cannot get it past the verifier as
+// author-bound.
+func TestVerify_BundleRowCannotMasqueradeAsSigned(t *testing.T) {
+	bundleRow := []any{
+		map[string]any{"id": "ds:evil", "kind": "local_fs", "access": "write", "scope": "<cwd>/**", "reason": "smuggled"},
+	}
+	opts := scopedOpts(t, nil, nil, bundleRow)
+	// Adversary also stuffs the SAME scope into the untrusted parsed manifest
+	// copy, hoping the verifier reads scope from there and labels it signed.
+	opts.BundleMeta.Manifest["data_dependencies"] = bundleRow
+
+	res, err := Verify(opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	for _, s := range res.DataScopes {
+		if s.Provenance == ScopeProvenanceSignedManifest {
+			t.Fatalf("a non-signed scope was reported as signed-manifest: %+v", s.Raw)
+		}
+	}
+	// And it IS still surfaced — as the advisory bundle-row it really is.
+	if len(res.DataScopes) != 1 || res.DataScopes[0].Provenance != ScopeProvenanceBundleRow {
+		t.Fatalf("want exactly one bundle-row scope, got %+v", res.DataScopes)
+	}
+}
+
+// TestVerify_NoScopeUnchanged: a bundle with no declared scope surfaces none —
+// back-compat (an old bundle verifies exactly as before, DataScopes empty).
+func TestVerify_NoScopeUnchanged(t *testing.T) {
+	opts := scopedOpts(t, nil, nil, nil)
+	res, err := Verify(opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if len(res.DataScopes) != 0 {
+		t.Fatalf("want no surfaced scope, got %d: %+v", len(res.DataScopes), res.DataScopes)
+	}
+}
+
+// TestVerify_BothScopesSurfacedSignedFirst: when BOTH a signed-manifest scope
+// and a bundle-row scope exist, both surface and the authoritative
+// signed-manifest one is listed first.
+func TestVerify_BothScopesSurfacedSignedFirst(t *testing.T) {
+	signed := []skillbundle.DataDependency{
+		{ID: "ds:signed", Kind: "er1_collection", Access: "read", Reason: "author-bound"},
+	}
+	bundleRow := []any{
+		map[string]any{"id": "ds:row", "kind": "er1_collection", "access": "read", "reason": "post-admit"},
+	}
+	opts := scopedOpts(t, signed, nil, bundleRow)
+
+	res, err := Verify(opts)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if len(res.DataScopes) != 2 {
+		t.Fatalf("want 2 surfaced scopes, got %d", len(res.DataScopes))
+	}
+	if res.DataScopes[0].Provenance != ScopeProvenanceSignedManifest {
+		t.Errorf("authoritative signed-manifest scope must be listed first, got %q", res.DataScopes[0].Provenance)
+	}
+	if res.DataScopes[1].Provenance != ScopeProvenanceBundleRow {
+		t.Errorf("second entry should be bundle-row, got %q", res.DataScopes[1].Provenance)
+	}
+}

--- a/pkg/skillctl/verify/verify.go
+++ b/pkg/skillctl/verify/verify.go
@@ -992,6 +992,70 @@ func readSignedManifestScopes(bundlePath string) ([]map[string]any, error) {
 	return nil, errors.New("bundle.json not found in archive")
 }
 
+// ReadDigestVerifiedManifest is the SAME P2b trust boundary `Verify` uses,
+// exported so read-only inspectors (e.g. `skillctl intent show --bundle`) can label
+// a scope AUTHORITATIVE / signed-manifest WITHOUT reimplementing — or weakening —
+// the rule.
+//
+// It is the ONLY way to obtain author-signature-covered bundle.json content: it
+//
+//  1. recomputes the digest of the on-disk .skb at bundlePath (NEVER trusts an
+//     advertised/embedded value — see stepRecomputeDigest), then
+//  2. constant-time-compares it against expectedDigest ("sha256:<hex>", the digest
+//     the registry advertised AND that the author signature covers), failing
+//     CLOSED with ErrDigestMismatch on any mismatch, then
+//  3. only on a match, unpacks and returns the parsed bundle.json map — these bytes
+//     are author-signature-covered (tampering them breaks the digest, which we just
+//     matched). The caller reads `intent` / `data_dependencies` from it.
+//
+// This deliberately does NOT read meta.Manifest or any registry row: the registry
+// copy is untrusted (plain HTTP, no signature). A caller that has only the registry
+// view MUST label the scope registry-reported / UNVERIFIED, never authoritative —
+// that is the invariant documented at collectDeclaredScopes above, and `intent
+// show` now honors it too.
+func ReadDigestVerifiedManifest(bundlePath, expectedDigest string) (map[string]any, error) {
+	if bundlePath == "" {
+		return nil, errors.New("no bundle path")
+	}
+	if strings.TrimSpace(expectedDigest) == "" {
+		return nil, fmt.Errorf("verify: no expected digest to compare against: %w", ErrDigestMismatch)
+	}
+	// 1. Recompute the digest of THIS exact file — never trust an advertised value.
+	recomputed, err := signing.ComputeBundleDigest(bundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("verify: recompute digest %s: %w", bundlePath, errors.Join(ErrDigestMismatch, err))
+	}
+	// 2. Fail-closed compare against the registry-advertised + author-signed digest.
+	rawExpected, err := decodeShaHexDigest(expectedDigest)
+	if err != nil {
+		return nil, fmt.Errorf("verify: expected digest %q: %w", expectedDigest, errors.Join(ErrDigestMismatch, err))
+	}
+	if subtle.ConstantTimeCompare(recomputed[:], rawExpected) != 1 {
+		return nil, fmt.Errorf("verify: digest mismatch (recomputed=sha256:%s, expected=%s): %w",
+			hexLower(recomputed[:]), expectedDigest, ErrDigestMismatch)
+	}
+	// 3. Digest matched → the bundle.json bytes are author-signature-covered.
+	blob, err := os.ReadFile(bundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("read bundle: %w", err)
+	}
+	entries, err := skillbundle.Unpack(blob, skillbundle.UnpackOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unpack bundle: %w", err)
+	}
+	for _, e := range entries {
+		if e.Rel != "bundle.json" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(e.Content, &m); err != nil {
+			return nil, fmt.Errorf("decode bundle.json: %w", err)
+		}
+		return m, nil
+	}
+	return nil, errors.New("bundle.json not found in archive")
+}
+
 // rawScopeList pulls `data_dependencies` out of a map as a slice of raw entry
 // maps. Tolerates absence (returns nil) and non-object entries (skipped).
 func rawScopeList(src map[string]any) []map[string]any {

--- a/pkg/skillctl/verify/verify.go
+++ b/pkg/skillctl/verify/verify.go
@@ -29,11 +29,14 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
+	"github.com/kamir/m3c-tools/pkg/skillbundle"
 	"github.com/kamir/m3c-tools/pkg/skillctl/govlevel"
 	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
 	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
@@ -142,8 +145,41 @@ type VerifyResult struct {
 	// on this when the trust root sets require_independent_review.
 	SelfAttested *bool
 
+	// DataScopes (SPEC-0196 §12 Q1 / P2b) is the declared data-scope surfaced
+	// from the bundle, each tagged with its provenance: ScopeProvenanceSignedManifest
+	// (read from the author-signed bundle.json INSIDE the digest-verified .skb —
+	// authoritative) vs ScopeProvenanceBundleRow (the mutable post-admit PATCH
+	// value on the registry row — advisory). When both carry a declaration, the
+	// signed-manifest one is authoritative; the verifier surfaces both so a CISO
+	// can see at a glance whether today's declaration is author-bound. Advisory:
+	// surfacing a scope never changes the pass/fail verdict (SPEC-0196 §11).
+	DataScopes []DeclaredScope
+
 	// ChainSummary is a human-readable one-liner suitable for stdout.
 	ChainSummary string
+}
+
+// ScopeProvenance distinguishes WHERE a declared data-scope came from. This is
+// the security-relevant fact a CISO needs: a signed-manifest scope is covered by
+// the author signature (tampering it breaks the chain — SPEC-0196 §12 Q1); a
+// bundle-row scope rides the mutable post-admit PATCH and is NOT author-bound.
+type ScopeProvenance string
+
+const (
+	// ScopeProvenanceSignedManifest — read from the author-signed bundle.json
+	// inside the digest-verified .skb. Authoritative; author-signature-covered.
+	ScopeProvenanceSignedManifest ScopeProvenance = "signed-manifest"
+	// ScopeProvenanceBundleRow — read from the mutable post-admit registry row
+	// (the `intent declare` PATCH target). Advisory; NOT author-bound.
+	ScopeProvenanceBundleRow ScopeProvenance = "bundle-row"
+)
+
+// DeclaredScope is one declared data-scope plus its provenance. The Raw map is
+// the verbatim wire entry (SPEC-0196 §3.2 shape) so consumers can render every
+// field without this package re-modeling the whole schema.
+type DeclaredScope struct {
+	Provenance ScopeProvenance `json:"provenance"`
+	Raw        map[string]any  `json:"scope"`
 }
 
 // Verify runs the SPEC-0188 §7 client-side algorithm end-to-end.
@@ -267,6 +303,15 @@ func Verify(opts VerifyOpts) (*VerifyResult, error) {
 	case "false":
 		reviewDesc = ", independently reviewed"
 	}
+	// SPEC-0196 §12 Q1 / P2b — surface the declared data-scope with provenance.
+	// The signed-manifest scope is read from the bundle.json INSIDE the .skb
+	// whose digest we just verified, so it is author-signature-covered; the
+	// bundle-row scope is read from the mutable registry row. Advisory: this
+	// never changes the verdict. A read failure is non-fatal — a chain that
+	// otherwise passed must not fail just because we could not surface scope.
+	dataScopes := collectDeclaredScopes(opts.BundlePath, opts.BundleMeta, opts.Logger)
+	logStep(opts.Logger, "datascope_ok", "scopes=%d", len(dataScopes))
+
 	res := &VerifyResult{
 		Digest:             digestStr,
 		AuthorIdentity:     authorID,
@@ -274,6 +319,7 @@ func Verify(opts VerifyOpts) (*VerifyResult, error) {
 		GovernanceLevel:    govLevel,
 		GovernanceVerified: govVerified,
 		SelfAttested:       selfAttested,
+		DataScopes:         dataScopes,
 		ChainSummary: fmt.Sprintf(
 			"%s: signed by %s, admitted by %s, %s%s",
 			digestStr, authorID, regKeyID, govDesc, reviewDesc,
@@ -876,6 +922,93 @@ func stepResolveDeps(meta *registry.BundleMeta) error {
 		}
 	}
 	return nil
+}
+
+// collectDeclaredScopes surfaces the declared data-scope from BOTH sources,
+// each tagged with its provenance (SPEC-0196 §12 Q1 / P2b):
+//
+//   - signed-manifest: the `data_dependencies` in the bundle.json INSIDE the
+//     .skb at bundlePath. The verifier has already recomputed + matched the
+//     digest of this exact file (steps 1/1b), so its bundle.json is covered by
+//     the author signature — a scope read here is AUTHORITATIVE and cannot have
+//     been tampered without breaking the chain.
+//   - bundle-row: the `data_dependencies` on the mutable registry row
+//     (meta.Bundle), the post-admit `intent declare` PATCH target. Advisory.
+//
+// We deliberately do NOT read scope from meta.Manifest: the registry's parsed
+// manifest is an untrusted copy and could disagree with the bytes that were
+// signed. Only the on-disk .skb's bundle.json is trustworthy here.
+//
+// The signed-manifest scopes are listed first so the authoritative declaration
+// is what a CISO reads at the top. Errors are swallowed (logged): surfacing is
+// advisory and must never turn a passing chain into a failure.
+func collectDeclaredScopes(bundlePath string, meta *registry.BundleMeta, logger io.Writer) []DeclaredScope {
+	var out []DeclaredScope
+
+	// 1. Author-signed scope from the digest-verified .skb's bundle.json.
+	if signed, err := readSignedManifestScopes(bundlePath); err != nil {
+		logStep(logger, "datascope_signed_skip", "err=%v", err)
+	} else {
+		for _, raw := range signed {
+			out = append(out, DeclaredScope{Provenance: ScopeProvenanceSignedManifest, Raw: raw})
+		}
+	}
+
+	// 2. Mutable bundle-row scope from the registry envelope.
+	if meta != nil {
+		for _, raw := range rawScopeList(meta.Bundle) {
+			out = append(out, DeclaredScope{Provenance: ScopeProvenanceBundleRow, Raw: raw})
+		}
+	}
+	return out
+}
+
+// readSignedManifestScopes opens the .skb, finds bundle.json, and returns its
+// `data_dependencies` entries as raw maps. Because the caller only invokes this
+// AFTER the digest of this exact file matched the advertised + signed digest,
+// the bytes returned here are author-signature-covered.
+func readSignedManifestScopes(bundlePath string) ([]map[string]any, error) {
+	if bundlePath == "" {
+		return nil, errors.New("no bundle path")
+	}
+	blob, err := os.ReadFile(bundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("read bundle: %w", err)
+	}
+	entries, err := skillbundle.Unpack(blob, skillbundle.UnpackOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unpack bundle: %w", err)
+	}
+	for _, e := range entries {
+		if e.Rel != "bundle.json" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(e.Content, &m); err != nil {
+			return nil, fmt.Errorf("decode bundle.json: %w", err)
+		}
+		return rawScopeList(m), nil
+	}
+	return nil, errors.New("bundle.json not found in archive")
+}
+
+// rawScopeList pulls `data_dependencies` out of a map as a slice of raw entry
+// maps. Tolerates absence (returns nil) and non-object entries (skipped).
+func rawScopeList(src map[string]any) []map[string]any {
+	if src == nil {
+		return nil
+	}
+	raw, ok := src["data_dependencies"].([]any)
+	if !ok {
+		return nil
+	}
+	var out []map[string]any
+	for _, item := range raw {
+		if m, ok := item.(map[string]any); ok {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // ----- helpers -----


### PR DESCRIPTION
## What & why

Closes the gap the **P2 challenge gate flagged**: declared data-scope rode the *mutable post-admit* `PATCH /bundles/<digest>/intent` row, **NOT** the author-signed tarball (SPEC-0196 §12 Q1; ADR-P2-datascope-and-runtime-envelope §2A item 2 / §4.4, marked DEFERRED→P2b). This PR **wires** the already-shared `datascope` validator into pack time so the scope lands **inside the signed bytes**, covered by the author signature. This is wiring, not new design — the validator is reused.

## The exact signing point (where scope is now author-signature-covered)

- `cmd/skillctl/pack.go:78` — `bindDataScope(&in, …)` validates + writes the scope into `manifest.Intent` + `manifest.DataDependencies` **before**
- `cmd/skillctl/pack.go:82` — `skillbundle.Pack(...)`, which computes the digest at
- `pkg/skillbundle/pack.go:90` — `sha256.Sum256(canonicalArchive)` (the canonical archive **includes** `bundle.json`, so the scope is digest-covered). The author then signs that digest (`ed25519.Sign(priv, digest[:])`, SPEC-0188 §4.1). Tampering the scope ⇒ different digest ⇒ signature no longer verifies.

## Changes (smallest-first)

1. **`pack --data-scopes`** (+ deprecated `--data-dep` alias, `--destructive`/`--network`/`--side-effects` intent toggles). Runs the typed scope through `datascope.Validate` (per-kind scope + §5 vocab + §3.3 cross-rules) **FAIL-CLOSED at pack time** — an invalid/contradictory scope is rejected *before any bundle is produced*, with the **same `failed_rule` + exit 18** the client/server `intent declare` validator returns. The manifest `DataDependency` type gains the full SPEC-0196 §3.2 wire fields (`id/scope/reason/payload_class/retention`) so the binding round-trips losslessly. Packing **without** the flag is unchanged (scope absent → identical behavior).
2. **Verifier surfacing** — `verify` reads the author-signed scope from the `bundle.json` **inside the digest-verified `.skb`** (`signed-manifest`, authoritative) and the mutable registry-row scope (`bundle-row`, advisory), tagging each on `VerifyResult.DataScopes`. It deliberately does **not** read scope from the untrusted parsed `meta.Manifest`, so a registry cannot make a row scope masquerade as author-signed. Surfaced in `verify --bundle` (human + `--json`).
3. **`intent show` provenance** — flags each declaration `signed-manifest (AUTHORITATIVE)` vs `bundle-row (ADVISORY)`; both sources shown so a CISO sees at a glance whether today's declaration is author-signed or post-admit.
4. **`intent declare`/PATCH preserved** as the back-compat repair route for legacy bundles; pack-time signed binding is now the primary path for new bundles.

## Tests the challenge gate checks

- **Tamper/strip breaks signature** — editing or removing the scope after pack changes the digest and breaks author-signature verification (`pkg/skillbundle/datascope_binding_test.go`).
- **Fail-closed rejection** — `pack` rejects an invalid/contradictory scope with the same `failed_rule` (`write_access_non_destructive`, `destructive_green`) and exit 18, producing **no bundle** (`cmd/skillctl/pack_test.go`).
- **Provenance** — verifier reports `signed-manifest` for a pack-time scope, `bundle-row` for a PATCH-only one, and **refuses to let a row scope masquerade as signed** even when the adversary stuffs it into `meta.Manifest` (`pkg/skillctl/verify/datascope_surface_test.go`).
- **Back-compat** — a bundle packed without `--data-scopes` verifies unchanged.

## Gates

`go build ./... && go vet ./...` clean · `gofmt -l` empty · `golangci-lint run` **0 issues** on changed packages · `go test` green for `cmd/skillctl`, `pkg/skillctl/{datascope,verify}`, `pkg/skillbundle` (full repo green except the pre-existing `cmd/thinking-engine` tests that require a prebuilt binary artifact — untouched by this change).

CORE LOGIC STDLIB-ONLY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)