### PR TITLE
SPEC-0278 P5: L1 transparency log (Merkle inclusion/consistency proofs + Signed Tree Head + split-view detection)

### DIFF
--- a/cmd/skillctl/attest_cmds.go
+++ b/cmd/skillctl/attest_cmds.go
@@ -290,6 +290,11 @@ func runAttestWithClient(
 	if authorKnownLocally {
 		fmt.Fprintf(stdout, "self_attested: %t\n", selfAttested)
 	}
+
+	// SPEC-0278 L1: best-effort mirror of this signed attestation's digest
+	// into the local transparency log (opt-in via M3C_TRANSLOG=1). Never
+	// alters the attest decision above — the attestation already succeeded.
+	bestEffortTranslogAppend(translogEventAttest, bundleDigest, *level, stderr)
 	return exitOK
 }
 

--- a/cmd/skillctl/awareness_cmds.go
+++ b/cmd/skillctl/awareness_cmds.go
@@ -410,6 +410,10 @@ func printSyncSummary(stderr io.Writer, res *awareness.SyncResult) {
 		resp.SessionTag, resp.Summary.Admitted, resp.Summary.Skipped, resp.Summary.Received)
 	for _, row := range resp.Admitted {
 		fmt.Fprintf(stderr, "  ADMIT  %-30s  %s\n", row.Name, row.LocalDigest)
+		// SPEC-0278 L1: best-effort mirror of each admit into the local
+		// transparency log (opt-in via M3C_TRANSLOG=1). Malformed digests
+		// are skipped by the entry validator; never blocks the sync.
+		bestEffortTranslogAppend(translogEventAdmit, row.LocalDigest, row.Name, stderr)
 	}
 	for _, row := range resp.Skipped {
 		fmt.Fprintf(stderr, "  SKIP   %-30s  %s\n", row.Name, row.Reason)

--- a/cmd/skillctl/main.go
+++ b/cmd/skillctl/main.go
@@ -141,6 +141,10 @@ func main() {
 	case "intent":
 		runWithExit(func() int { return runIntent(os.Args[2:], os.Stdout, os.Stderr) })
 	// === END SPEC-0195 S2 ===
+	// === SPEC-0278 P5: L1 transparency log ===
+	case "translog":
+		os.Exit(runTranslog(os.Args[2:], os.Stdout, os.Stderr))
+	// === END SPEC-0278 P5 ===
 	// === SPEC-0214 (PLM v2 / SPEC-0216): project-context resolution ===
 	// Reads `.m3c/project.yaml` (a committed projection of the PLM project
 	// object) to resolve project id + ER1 target/context for the cwd, with a
@@ -243,6 +247,13 @@ func printUsage(w *os.File) {
 	fmt.Fprintln(w, "  session list       List session-state items (--project / --host / --open-only).")
 	fmt.Fprintln(w, "  session show       Show a session-state item by session_id or doc_id.")
 	fmt.Fprintln(w, "  session resume     Print a resume hint for a prior session.")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Commands (SPEC-0278 / L1 transparency log):")
+	fmt.Fprintln(w, "  translog append    Append an event (admit/attest/revoke/agentid-*).")
+	fmt.Fprintln(w, "  translog sth       Show / sign the current tree head.")
+	fmt.Fprintln(w, "  translog prove     Emit an offline inclusion receipt.")
+	fmt.Fprintln(w, "  translog verify    Offline inclusion check vs a pinned log key.")
+	fmt.Fprintln(w, "  translog witness   Cross-witness STHs for a split view (equivocation).")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Run any command with --help for its flags.")
 }

--- a/cmd/skillctl/revoke_cmds.go
+++ b/cmd/skillctl/revoke_cmds.go
@@ -58,21 +58,21 @@ var validRevocationRoles = map[string]struct{}{
 // revokeRequest is the wire shape of POST /api/skills/bundles/<digest>/revoke.
 // Field names match the Python handler's request.get_json() keys.
 type revokeRequest struct {
-	ActorRole            string `json:"actor_role"`
-	ActorIdentity        string `json:"actor_identity,omitempty"`
-	Reason               string `json:"reason"`
-	RevocationTimestamp  string `json:"revocation_timestamp"`
-	RequestSignatureB64  string `json:"request_signature_b64,omitempty"`
+	ActorRole           string `json:"actor_role"`
+	ActorIdentity       string `json:"actor_identity,omitempty"`
+	Reason              string `json:"reason"`
+	RevocationTimestamp string `json:"revocation_timestamp"`
+	RequestSignatureB64 string `json:"request_signature_b64,omitempty"`
 }
 
 // revokeResponse is the success-shape from the server (the updated bundle row).
 type revokeResponse struct {
-	Status         string `json:"status"`
-	BundleDigest   string `json:"bundle_digest"`
-	RevokedAt      string `json:"revoked_at"`
-	RevokedReason  string `json:"revoked_reason"`
-	RevokedBy      string `json:"revoked_by"`
-	RevokedByRole  string `json:"revoked_by_role"`
+	Status        string `json:"status"`
+	BundleDigest  string `json:"bundle_digest"`
+	RevokedAt     string `json:"revoked_at"`
+	RevokedReason string `json:"revoked_reason"`
+	RevokedBy     string `json:"revoked_by"`
+	RevokedByRole string `json:"revoked_by_role"`
 }
 
 // revokeError is the failure-shape with a `reason` discriminator.
@@ -84,10 +84,10 @@ type revokeError struct {
 
 // runRevoke is main's dispatch entry point. Returns a numeric exit code:
 //
-//   0  — revoked.
-//   1  — generic / network / server 5xx.
-//   2  — usage / flag error.
-//   15 — server returned 409 already_revoked OR 404 not_admitted.
+//	0  — revoked.
+//	1  — generic / network / server 5xx.
+//	2  — usage / flag error.
+//	15 — server returned 409 already_revoked OR 404 not_admitted.
 //
 // Exit 15 reuses the SPEC-0188 §11 ExitBlobMissing class because the
 // trust-chain semantics are identical: the bundle is not in a state
@@ -235,6 +235,11 @@ func runRevoke(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "revoked_at:    %s\n", ok.RevokedAt)
 		fmt.Fprintf(stdout, "revoked_by:    %s (%s)\n", ok.RevokedBy, ok.RevokedByRole)
 		fmt.Fprintf(stdout, "reason:        %s\n", ok.RevokedReason)
+
+		// SPEC-0278 L1: best-effort mirror of this signed revocation's digest
+		// into the local transparency log (opt-in via M3C_TRANSLOG=1). Never
+		// alters the revoke decision above — the revocation already succeeded.
+		bestEffortTranslogAppend(translogEventRevoke, ok.BundleDigest, ok.RevokedByRole, stderr)
 		return exitOK
 	}
 

--- a/cmd/skillctl/translog_cmds.go
+++ b/cmd/skillctl/translog_cmds.go
@@ -1,0 +1,596 @@
+package main
+
+// SPEC-0278 L1 CLI: `skillctl translog <verb>`.
+//
+// Verbs:
+//
+//	append <type> <digest> [--subject S] [--log PATH] [--log-id ID]
+//	    Append an event (admit|attest|revoke|agentid-issue|agentid-revoke)
+//	    to the local append-only transparency log. Logs the DIGEST of an
+//	    already-signed event — data stays OFF the log (SPEC-0278 §5).
+//
+//	sth [--log PATH] [--log-id ID] [--key PATH.priv]
+//	    Show the current tree head. With --key, sign it into an STH (JSON).
+//
+//	prove <digest> [--log PATH] [--log-id ID] --key PATH.priv [--out FILE]
+//	    Emit a portable inclusion RECEIPT (entry + proof + signed STH) for
+//	    the event with the given digest.
+//
+//	verify --receipt FILE --log-pubkey PATH.pub
+//	    OFFLINE: verify an inclusion receipt against a pinned log public key.
+//	    No network. Exit 0 ok | 23 not-included/invalid | 1 other | 2 usage.
+//
+//	consistency --sth1 FILE --sth2 FILE --proof FILE --log-pubkey PATH.pub
+//	    Verify a consistency proof between two signed heads (append-only /
+//	    anti-rewrite). DETECTS a log that dropped or rewrote an entry.
+//
+//	witness --sths FILE --log-pubkey PATH.pub
+//	    Cross-witness a JSON array of STHs for split-view / equivocation.
+//	    DETECTS two same-size heads with different roots. Closes SPEC-0279
+//	    AC4 (the cross-company STH freshness / split-view check).
+//
+// Honesty: L1 makes equivocation/withholding DETECTABLE, not impossible.
+// Only the DEFERRED L2 (BFT consortium ledger) could PREVENT a single
+// operator from equivocating. The Kafka/SPEC-0190 gossip transport is also
+// DEFERRED — these verbs operate on locally-held STHs/proofs.
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
+	"github.com/kamir/m3c-tools/pkg/skillctl/translog"
+)
+
+// bestEffortTranslogAppend appends one event to the LOCAL transparency log
+// at the existing admit/attest/revoke/agentid emit points. It is
+// BEST-EFFORT and MUST NEVER change the primary decision: the caller has
+// ALREADY produced and (for attest/revoke) posted the signed event; we only
+// mirror its DIGEST into the local append-only log so the verifier can later
+// prove inclusion. Any error is written to stderr as a non-fatal note and
+// swallowed — mirroring the SPEC-0202 audit-trail pattern.
+//
+// Disabled by default unless the operator opts in via M3C_TRANSLOG=1 (so the
+// existing commands' behaviour and output are unchanged for users who have
+// not adopted L1). When enabled, the log id defaults to "skillctl-local" or
+// $M3C_TRANSLOG_ID.
+func bestEffortTranslogAppend(evType translog.EventType, digest, subject string, stderr io.Writer) {
+	if os.Getenv("M3C_TRANSLOG") != "1" {
+		return
+	}
+	path, err := translog.DefaultLogFilePath()
+	if err != nil {
+		fmt.Fprintf(stderr, "note: transparency-log append skipped: %v\n", err)
+		return
+	}
+	logID := os.Getenv("M3C_TRANSLOG_ID")
+	if logID == "" {
+		logID = "skillctl-local"
+	}
+	l, err := translog.OpenLog(path, logID)
+	if err != nil {
+		fmt.Fprintf(stderr, "note: transparency-log append skipped: %v\n", err)
+		return
+	}
+	idx, err := l.Append(translog.LogEntry{
+		Type:      evType,
+		Digest:    digest,
+		Timestamp: translog.FormatSTHTimestamp(time.Now()),
+		Subject:   subject,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "note: transparency-log append failed (non-fatal): %v\n", err)
+		return
+	}
+	fmt.Fprintf(stderr, "note: logged %s event to transparency log at index %d (tree size %d)\n", evType, idx, l.Size())
+}
+
+// splitPositionalThenFlags separates leading positional arguments (those
+// that do NOT start with "-") from the trailing flag arguments. The Go
+// `flag` package stops parsing at the first non-flag token, so to support
+// the natural `translog append <type> <digest> --log X` ordering we pull the
+// leading positionals off first and hand only the flag tail to fs.Parse.
+//
+// want is the exact number of leading positionals required; it returns the
+// positionals, the remaining (flag) args, and ok=false if fewer than `want`
+// positionals are present before the first flag.
+func splitPositionalThenFlags(args []string, want int) (pos, rest []string, ok bool) {
+	i := 0
+	for i < len(args) && i < want {
+		if len(args[i]) > 0 && args[i][0] == '-' {
+			break
+		}
+		i++
+	}
+	if i < want {
+		return nil, nil, false
+	}
+	return args[:want], args[want:], true
+}
+
+// decodeHex32 decodes a 64-char hex string into a 32-byte array, rejecting
+// any other length so a malformed proof element can't be padded into shape.
+func decodeHex32(s string) ([translog.HashSize]byte, error) {
+	var out [translog.HashSize]byte
+	raw, err := hex.DecodeString(s)
+	if err != nil {
+		return out, fmt.Errorf("not hex: %w", err)
+	}
+	if len(raw) != translog.HashSize {
+		return out, fmt.Errorf("is %d bytes, want %d", len(raw), translog.HashSize)
+	}
+	copy(out[:], raw)
+	return out, nil
+}
+
+// translog-specific exit codes, layered on the generic 0/1/2. The
+// "not-included" code is 23 to match the verify package's
+// verify.ExitLogInclusionMissing (20/21/22 are taken by ExitSelfAttested /
+// agentid-expired / ExitRevocationStale); split-view and rewrite detection
+// are this subcommand's own distinct signals.
+const (
+	exitTranslogNotIncluded = 23 // receipt did not verify / not included
+	exitTranslogSplitView   = 24 // a split view (equivocation) was DETECTED
+	exitTranslogRewrite     = 25 // a consistency/rewrite violation DETECTED
+)
+
+// Package-local event-type aliases so the emit-point command files
+// (attest_cmds.go, revoke_cmds.go) can call bestEffortTranslogAppend without
+// each importing the translog package directly.
+const (
+	translogEventAttest = translog.EventAttest
+	translogEventRevoke = translog.EventRevoke
+	translogEventAdmit  = translog.EventAdmit
+)
+
+// runTranslog is the `skillctl translog` dispatcher.
+func runTranslog(args []string, stdout, stderr io.Writer) int {
+	if len(args) < 1 {
+		translogUsage(stderr)
+		return exitUsage
+	}
+	switch args[0] {
+	case "append":
+		return runTranslogAppend(args[1:], stdout, stderr)
+	case "sth":
+		return runTranslogSTH(args[1:], stdout, stderr)
+	case "prove":
+		return runTranslogProve(args[1:], stdout, stderr)
+	case "verify":
+		return runTranslogVerify(args[1:], stdout, stderr)
+	case "consistency":
+		return runTranslogConsistency(args[1:], stdout, stderr)
+	case "witness":
+		return runTranslogWitness(args[1:], stdout, stderr)
+	case "help", "-h", "--help":
+		translogUsage(stdout)
+		return exitOK
+	default:
+		fmt.Fprintf(stderr, "translog: unknown verb %q\n\n", args[0])
+		translogUsage(stderr)
+		return exitUsage
+	}
+}
+
+func translogUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage: skillctl translog <verb> [args]")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "SPEC-0278 L1 transparency log (RFC-6962 Merkle, stdlib-only).")
+	fmt.Fprintln(w, "L1 makes equivocation/withholding DETECTABLE, not impossible;")
+	fmt.Fprintln(w, "L2 (BFT consortium ledger) and L3 (public anchoring) are DEFERRED.")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Verbs:")
+	fmt.Fprintln(w, "  append <type> <digest>   Append an event (data stays OFF the log).")
+	fmt.Fprintln(w, "  sth                      Show / sign the current tree head.")
+	fmt.Fprintln(w, "  prove <digest>           Emit an offline inclusion receipt.")
+	fmt.Fprintln(w, "  verify --receipt F       Offline inclusion check vs a pinned log key.")
+	fmt.Fprintln(w, "  consistency ...          Verify append-only between two heads.")
+	fmt.Fprintln(w, "  witness --sths F         Cross-witness STHs for a split view.")
+}
+
+// resolveLogPath returns the explicit --log or the default
+// ~/.claude/skillctl/transparency-log.jsonl.
+func resolveLogPath(explicit string, stderr io.Writer) (string, bool) {
+	if explicit != "" {
+		return explicit, true
+	}
+	p, err := translog.DefaultLogFilePath()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return "", false
+	}
+	return p, true
+}
+
+func runTranslogAppend(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("translog append", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	subject := fs.String("subject", "", "Optional event subject (skill name, agent id, ...).")
+	logPath := fs.String("log", "", "Log file path (default ~/.claude/skillctl/transparency-log.jsonl).")
+	logID := fs.String("log-id", "skillctl-local", "Log id.")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl translog append <type> <digest> [--subject S] [--log PATH] [--log-id ID]")
+		fmt.Fprintln(stderr, "  type:   admit | attest | revoke | agentid-issue | agentid-revoke")
+		fmt.Fprintln(stderr, "  digest: sha256:<64 lowercase hex> of the already-signed event")
+		fs.PrintDefaults()
+	}
+	pos, rest, ok := splitPositionalThenFlags(args, 2)
+	if !ok {
+		fs.Usage()
+		return exitUsage
+	}
+	if err := fs.Parse(rest); err != nil {
+		return exitUsage
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return exitUsage
+	}
+	evType := translog.EventType(pos[0])
+	digest := pos[1]
+
+	path, ok := resolveLogPath(*logPath, stderr)
+	if !ok {
+		return exitGeneric
+	}
+	l, err := translog.OpenLog(path, *logID)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	entry := translog.LogEntry{
+		Type:      evType,
+		Digest:    digest,
+		Timestamp: translog.FormatSTHTimestamp(time.Now()),
+		Subject:   *subject,
+	}
+	idx, err := l.Append(entry)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	fmt.Fprintf(stdout, "appended %s event at index %d (tree size now %d)\n", evType, idx, l.Size())
+	fmt.Fprintf(stdout, "note: only the event digest is logged; the event data stays off the log.\n")
+	return exitOK
+}
+
+func runTranslogSTH(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("translog sth", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	logPath := fs.String("log", "", "Log file path (default ~/.claude/skillctl/transparency-log.jsonl).")
+	logID := fs.String("log-id", "skillctl-local", "Log id.")
+	keyPath := fs.String("key", "", "Log ed25519 private key (PEM). If set, sign the head into an STH.")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl translog sth [--log PATH] [--log-id ID] [--key PATH.priv]")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	path, ok := resolveLogPath(*logPath, stderr)
+	if !ok {
+		return exitGeneric
+	}
+	l, err := translog.OpenLog(path, *logID)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	if l.Size() == 0 {
+		fmt.Fprintln(stderr, "translog: log is empty; nothing to sign")
+		return exitGeneric
+	}
+	if *keyPath == "" {
+		root, err := l.Root()
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return exitGeneric
+		}
+		fmt.Fprintf(stdout, "tree_size: %d\nroot_hash: %x\nlog_id:    %s\n", l.Size(), root, l.LogID())
+		fmt.Fprintln(stdout, "(pass --key to sign this head into an STH)")
+		return exitOK
+	}
+	priv, err := signing.LoadPrivateKey(*keyPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	sth, err := l.SignHead(priv, time.Now())
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	out, err := json.MarshalIndent(sth, "", "  ")
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	fmt.Fprintln(stdout, string(out))
+	return exitOK
+}
+
+func runTranslogProve(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("translog prove", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	logPath := fs.String("log", "", "Log file path (default ~/.claude/skillctl/transparency-log.jsonl).")
+	logID := fs.String("log-id", "skillctl-local", "Log id.")
+	keyPath := fs.String("key", "", "Log ed25519 private key (PEM) to sign the head. Required.")
+	outPath := fs.String("out", "", "Write the receipt JSON to this file (default: stdout).")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl translog prove <digest> --key PATH.priv [--log PATH] [--log-id ID] [--out FILE]")
+		fs.PrintDefaults()
+	}
+	pos, rest, ok := splitPositionalThenFlags(args, 1)
+	if !ok {
+		fs.Usage()
+		return exitUsage
+	}
+	if err := fs.Parse(rest); err != nil {
+		return exitUsage
+	}
+	if fs.NArg() != 0 || *keyPath == "" {
+		fs.Usage()
+		return exitUsage
+	}
+	digest := pos[0]
+	path, ok := resolveLogPath(*logPath, stderr)
+	if !ok {
+		return exitGeneric
+	}
+	l, err := translog.OpenLog(path, *logID)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	hits := l.FindByDigest(digest)
+	if len(hits) == 0 {
+		fmt.Fprintf(stderr, "translog: no logged event with digest %s\n", digest)
+		return exitGeneric
+	}
+	idx := hits[0]
+	entry, err := l.EntryAt(idx)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	proof, size, _, err := l.ProveInclusion(idx)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	priv, err := signing.LoadPrivateKey(*keyPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	sth, err := l.SignHead(priv, time.Now())
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	receipt := translog.NewReceipt(entry, idx, size, proof, sth)
+	data, err := receipt.JSON()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	if *outPath != "" {
+		if err := os.WriteFile(*outPath, append(data, '\n'), 0o644); err != nil { //nolint:gosec // receipt is public
+			fmt.Fprintln(stderr, err)
+			return exitGeneric
+		}
+		fmt.Fprintf(stdout, "wrote inclusion receipt for index %d to %s\n", idx, *outPath)
+		return exitOK
+	}
+	fmt.Fprintln(stdout, string(data))
+	return exitOK
+}
+
+func runTranslogVerify(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("translog verify", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	receiptPath := fs.String("receipt", "", "Inclusion receipt JSON (from `prove`). Required.")
+	pubPath := fs.String("log-pubkey", "", "Pinned log ed25519 public key (PEM SPKI). Required.")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl translog verify --receipt FILE --log-pubkey PATH.pub")
+		fmt.Fprintln(stderr, "Offline inclusion check. Exit: 0 ok | 23 not-included | 1 other | 2 usage.")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *receiptPath == "" || *pubPath == "" {
+		fs.Usage()
+		return exitUsage
+	}
+	data, err := os.ReadFile(*receiptPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	receipt, err := translog.ParseReceipt(data)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitTranslogNotIncluded
+	}
+	pub, err := signing.LoadPublicKey(*pubPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	if err := receipt.VerifyOffline(ed25519.PublicKey(pub)); err != nil {
+		fmt.Fprintf(stderr, "NOT INCLUDED: %v\n", err)
+		return exitTranslogNotIncluded
+	}
+	fmt.Fprintf(stdout, "OK: event included under signed tree head (size %d, log %s).\n",
+		receipt.STH.TreeSize, receipt.STH.LogID)
+	fmt.Fprintln(stdout, "note: this proves the event is committed under a head you trust;")
+	fmt.Fprintln(stdout, "it makes later withholding/equivocation detectable, not impossible.")
+	return exitOK
+}
+
+func runTranslogConsistency(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("translog consistency", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	sth1Path := fs.String("sth1", "", "Earlier (smaller) STH JSON. Required.")
+	sth2Path := fs.String("sth2", "", "Later (larger) STH JSON. Required.")
+	proofPath := fs.String("proof", "", "Consistency proof JSON (array of hex hashes). Required.")
+	pubPath := fs.String("log-pubkey", "", "Pinned log ed25519 public key (PEM SPKI). Required.")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl translog consistency --sth1 F --sth2 F --proof F --log-pubkey PATH.pub")
+		fmt.Fprintln(stderr, "Verifies the later head is a pure append of the earlier (anti-rewrite).")
+		fmt.Fprintln(stderr, "Exit: 0 ok | 25 rewrite-detected | 1 other | 2 usage.")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *sth1Path == "" || *sth2Path == "" || *proofPath == "" || *pubPath == "" {
+		fs.Usage()
+		return exitUsage
+	}
+	pub, err := signing.LoadPublicKey(*pubPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	s1, err := readSTHFile(*sth1Path)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	s2, err := readSTHFile(*sth2Path)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	// Both heads must be authentic (signed by the pinned key) before we
+	// trust their roots.
+	if err := translog.VerifySTH(ed25519.PublicKey(pub), s1); err != nil {
+		fmt.Fprintf(stderr, "sth1 invalid: %v\n", err)
+		return exitGeneric
+	}
+	if err := translog.VerifySTH(ed25519.PublicKey(pub), s2); err != nil {
+		fmt.Fprintf(stderr, "sth2 invalid: %v\n", err)
+		return exitGeneric
+	}
+	proof, err := readProofFile(*proofPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	r1, err := s1.RootBytes()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	r2, err := s2.RootBytes()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	if err := translog.VerifyConsistency(s1.TreeSize, s2.TreeSize, r1, r2, proof); err != nil {
+		fmt.Fprintf(stderr, "REWRITE DETECTED: the later head is NOT a pure append: %v\n", err)
+		return exitTranslogRewrite
+	}
+	fmt.Fprintf(stdout, "OK: size %d -> %d is append-only (no entry was dropped or rewritten).\n", s1.TreeSize, s2.TreeSize)
+	return exitOK
+}
+
+func runTranslogWitness(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("translog witness", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	sthsPath := fs.String("sths", "", "JSON array of STHs from different witnesses. Required.")
+	pubPath := fs.String("log-pubkey", "", "Pinned log ed25519 public key (PEM SPKI). Required.")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl translog witness --sths FILE --log-pubkey PATH.pub")
+		fmt.Fprintln(stderr, "Cross-witness STHs for a split view (equivocation).")
+		fmt.Fprintln(stderr, "Exit: 0 consistent | 24 split-view-detected | 1 other | 2 usage.")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *sthsPath == "" || *pubPath == "" {
+		fs.Usage()
+		return exitUsage
+	}
+	data, err := os.ReadFile(*sthsPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	var sths []translog.STH
+	if err := json.Unmarshal(data, &sths); err != nil {
+		fmt.Fprintf(stderr, "translog: parse STH array: %v\n", err)
+		return exitGeneric
+	}
+	pub, err := signing.LoadPublicKey(*pubPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	// Verify each STH against the pinned key — an unsigned/unpinned head is
+	// not admissible evidence and could otherwise hide or fabricate a split.
+	for i, s := range sths {
+		if err := translog.VerifySTH(ed25519.PublicKey(pub), s); err != nil {
+			fmt.Fprintf(stderr, "witness[%d] STH invalid under pinned key: %v\n", i, err)
+			return exitGeneric
+		}
+	}
+	conflict, err := translog.VerifyWitnessConsistency(sths)
+	if errors.Is(err, translog.ErrSplitView) {
+		fmt.Fprintf(stderr, "SPLIT VIEW DETECTED: %v\n", conflict)
+		fmt.Fprintln(stderr, "The log equivocated: two heads at the same size with different roots.")
+		fmt.Fprintln(stderr, "Both STHs are independently signed = non-repudiable evidence.")
+		return exitTranslogSplitView
+	}
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	fmt.Fprintf(stdout, "OK: %d witnessed STH(s) are consistent — no split view detected.\n", len(sths))
+	fmt.Fprintln(stdout, "note: L1 detects equivocation; only L2 (deferred BFT ledger) prevents it.")
+	return exitOK
+}
+
+// readSTHFile loads and JSON-decodes a single STH.
+func readSTHFile(path string) (translog.STH, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // operator-supplied path
+	if err != nil {
+		return translog.STH{}, err
+	}
+	var s translog.STH
+	if err := json.Unmarshal(data, &s); err != nil {
+		return translog.STH{}, fmt.Errorf("parse STH %s: %w", path, err)
+	}
+	return s, nil
+}
+
+// readProofFile loads a JSON array of hex hashes into fixed-size nodes.
+func readProofFile(path string) ([][translog.HashSize]byte, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // operator-supplied path
+	if err != nil {
+		return nil, err
+	}
+	var hexes []string
+	if err := json.Unmarshal(data, &hexes); err != nil {
+		return nil, fmt.Errorf("parse proof %s: %w", path, err)
+	}
+	out := make([][translog.HashSize]byte, len(hexes))
+	for i, h := range hexes {
+		raw, err := decodeHex32(h)
+		if err != nil {
+			return nil, fmt.Errorf("proof[%d]: %w", i, err)
+		}
+		out[i] = raw
+	}
+	return out, nil
+}

--- a/cmd/skillctl/translog_cmds_test.go
+++ b/cmd/skillctl/translog_cmds_test.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
+	"github.com/kamir/m3c-tools/pkg/skillctl/translog"
+)
+
+// loadPrivForTest loads a PEM private key via the same loader the CLI uses.
+func loadPrivForTest(t *testing.T, path string) ed25519.PrivateKey {
+	t.Helper()
+	priv, err := signing.LoadPrivateKey(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return priv
+}
+
+// mustTime is a fixed timestamp for deterministic STHs in tests.
+func mustTime() time.Time {
+	return time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+}
+
+// writeLogKeypair writes a PEM PKCS#8 priv (0600) + SPKI pub for the log.
+func writeLogKeypair(t *testing.T, dir string) (privPath, pubPath string, pub ed25519.PublicKey) {
+	t.Helper()
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privDER, err := x509.MarshalPKCS8PrivateKey(privKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privPath = filepath.Join(dir, "log.priv")
+	pubPath = filepath.Join(dir, "log.pub")
+	if err := os.WriteFile(privPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pubPath, pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return privPath, pubPath, pubKey
+}
+
+func digestN(n int) string {
+	return "sha256:" + strings.Repeat("0", 63) + string(rune('0'+n))
+}
+
+// TestTranslogCLI_AppendProveVerify exercises the happy path end-to-end.
+func TestTranslogCLI_AppendProveVerify(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "log.jsonl")
+	privPath, pubPath, _ := writeLogKeypair(t, dir)
+
+	// Append three events.
+	for i, ty := range []string{"admit", "attest", "revoke"} {
+		var out, errb bytes.Buffer
+		rc := runTranslog([]string{"append", ty, digestN(i), "--log", logFile, "--log-id", "log-cli"}, &out, &errb)
+		if rc != exitOK {
+			t.Fatalf("append %s rc=%d err=%s", ty, rc, errb.String())
+		}
+	}
+
+	// Prove the attest event (digest index 1) → write a receipt.
+	receiptPath := filepath.Join(dir, "receipt.json")
+	var out, errb bytes.Buffer
+	rc := runTranslog([]string{"prove", digestN(1), "--log", logFile, "--log-id", "log-cli", "--key", privPath, "--out", receiptPath}, &out, &errb)
+	if rc != exitOK {
+		t.Fatalf("prove rc=%d err=%s", rc, errb.String())
+	}
+
+	// Verify the receipt offline against the pinned log pubkey.
+	var vout, verr bytes.Buffer
+	rc = runTranslog([]string{"verify", "--receipt", receiptPath, "--log-pubkey", pubPath}, &vout, &verr)
+	if rc != exitOK {
+		t.Fatalf("verify rc=%d err=%s", rc, verr.String())
+	}
+	if !strings.Contains(vout.String(), "OK: event included") {
+		t.Fatalf("verify output missing success line: %s", vout.String())
+	}
+}
+
+// TestTranslogCLI_VerifyWrongKeyFails: a receipt verified against the WRONG
+// log key must fail with the not-included exit code.
+func TestTranslogCLI_VerifyWrongKeyFails(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "log.jsonl")
+	d1 := filepath.Join(dir, "k1")
+	d2 := filepath.Join(dir, "k2")
+	if err := os.MkdirAll(d1, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(d2, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	privPath, _, _ := writeLogKeypair(t, d1)
+	_, wrongPubPath, _ := writeLogKeypair(t, d2) // a DIFFERENT key's pub
+
+	var out, errb bytes.Buffer
+	runTranslog([]string{"append", "attest", digestN(1), "--log", logFile, "--log-id", "log-cli"}, &out, &errb)
+
+	receiptPath := filepath.Join(dir, "r.json")
+	runTranslog([]string{"prove", digestN(1), "--log", logFile, "--log-id", "log-cli", "--key", privPath, "--out", receiptPath}, &out, &errb)
+
+	var verr bytes.Buffer
+	rc := runTranslog([]string{"verify", "--receipt", receiptPath, "--log-pubkey", wrongPubPath}, &out, &verr)
+	if rc != exitTranslogNotIncluded {
+		t.Fatalf("wrong key: want exit %d, got %d (%s)", exitTranslogNotIncluded, rc, verr.String())
+	}
+}
+
+// TestTranslogCLI_WitnessSplitView: two honestly-signed STHs at the same
+// size with different roots → the witness verb DETECTS the split view.
+func TestTranslogCLI_WitnessSplitView(t *testing.T) {
+	dir := t.TempDir()
+	privPath, pubPath, pub := writeLogKeypair(t, dir)
+	_ = pub
+
+	// Build STH A over one history of size 4, STH B over a forked history
+	// of size 4. We use the package directly to construct, then the CLI to
+	// detect.
+	mkSTH := func(forkLeaf string) translog.STH {
+		logFile := filepath.Join(dir, "tmp-"+forkLeaf+".jsonl")
+		l, err := translog.OpenLog(logFile, "log-cli")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 4; i++ {
+			subj := "s" + string(rune('0'+i))
+			if i == 2 && forkLeaf != "" {
+				subj = forkLeaf
+			}
+			if _, err := l.Append(translog.LogEntry{
+				Type:      translog.EventAttest,
+				Digest:    digestN(i),
+				Timestamp: "2026-06-24T12:00:0" + string(rune('0'+i)) + "Z",
+				Subject:   subj,
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		// Load priv via the signing loader path the CLI uses.
+		priv := loadPrivForTest(t, privPath)
+		sth, err := l.SignHead(priv, mustTime())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return sth
+	}
+
+	sthA := mkSTH("")       // honest
+	sthB := mkSTH("FORKED") // forked at leaf 2 → same size 4, different root
+	if sthA.RootHash == sthB.RootHash {
+		t.Fatal("test setup: expected divergent roots")
+	}
+
+	sthsPath := filepath.Join(dir, "sths.json")
+	data, _ := json.Marshal([]translog.STH{sthA, sthB})
+	if err := os.WriteFile(sthsPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errb bytes.Buffer
+	rc := runTranslog([]string{"witness", "--sths", sthsPath, "--log-pubkey", pubPath}, &out, &errb)
+	if rc != exitTranslogSplitView {
+		t.Fatalf("split view: want exit %d, got %d (out=%s err=%s)", exitTranslogSplitView, rc, out.String(), errb.String())
+	}
+	if !strings.Contains(errb.String(), "SPLIT VIEW DETECTED") {
+		t.Fatalf("expected split-view diagnostic, got: %s", errb.String())
+	}
+}
+
+// TestTranslogCLI_WitnessConsistent: two consistent heads (same head) →
+// witness reports OK.
+func TestTranslogCLI_WitnessConsistent(t *testing.T) {
+	dir := t.TempDir()
+	privPath, pubPath, _ := writeLogKeypair(t, dir)
+	logFile := filepath.Join(dir, "log.jsonl")
+	l, _ := translog.OpenLog(logFile, "log-cli")
+	for i := 0; i < 4; i++ {
+		if _, err := l.Append(translog.LogEntry{Type: translog.EventAdmit, Digest: digestN(i), Timestamp: "2026-06-24T12:00:00Z", Subject: "x"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	priv := loadPrivForTest(t, privPath)
+	sth, _ := l.SignHead(priv, mustTime())
+
+	sthsPath := filepath.Join(dir, "sths.json")
+	data, _ := json.Marshal([]translog.STH{sth, sth})
+	if err := os.WriteFile(sthsPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	rc := runTranslog([]string{"witness", "--sths", sthsPath, "--log-pubkey", pubPath}, &out, &errb)
+	if rc != exitOK {
+		t.Fatalf("consistent witness: want exit 0, got %d (%s)", rc, errb.String())
+	}
+}
+
+// TestTranslogCLI_UnknownVerb returns usage exit.
+func TestTranslogCLI_UnknownVerb(t *testing.T) {
+	var out, errb bytes.Buffer
+	if rc := runTranslog([]string{"bogus"}, &out, &errb); rc != exitUsage {
+		t.Fatalf("unknown verb: want exit %d, got %d", exitUsage, rc)
+	}
+}
+
+// TestBestEffortAppend_DisabledByDefault: with M3C_TRANSLOG unset the emit
+// helper is a no-op (no file is created, no note emitted) so existing
+// command behaviour is unchanged for users who have not adopted L1.
+func TestBestEffortAppend_DisabledByDefault(t *testing.T) {
+	t.Setenv("M3C_TRANSLOG", "") // explicitly off
+	var errb bytes.Buffer
+	bestEffortTranslogAppend(translogEventAttest, "sha256:"+strings.Repeat("a", 64), "x", &errb)
+	if errb.Len() != 0 {
+		t.Fatalf("disabled emit should be silent, got: %s", errb.String())
+	}
+}
+
+// TestBestEffortAppend_EnabledLogs: with M3C_TRANSLOG=1 and a HOME pointing
+// at a temp dir, the helper appends an entry and reports it.
+func TestBestEffortAppend_EnabledLogs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// On windows-latest CI os.UserHomeDir() (inside DefaultLogFilePath) reads
+	// %USERPROFILE% and ignores $HOME, so pin both to the temp dir.
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("M3C_TRANSLOG", "1")
+	t.Setenv("M3C_TRANSLOG_ID", "skillctl-local")
+
+	var errb bytes.Buffer
+	digest := "sha256:" + strings.Repeat("b", 64)
+	bestEffortTranslogAppend(translogEventAttest, digest, "my-skill", &errb)
+	if !strings.Contains(errb.String(), "logged attest event") {
+		t.Fatalf("enabled emit should report a log append, got: %s", errb.String())
+	}
+	// The log file must now exist and be reloadable with the entry.
+	logFile := filepath.Join(home, ".claude", "skillctl", "transparency-log.jsonl")
+	l, err := translog.OpenLog(logFile, "skillctl-local")
+	if err != nil {
+		t.Fatalf("reopen log: %v", err)
+	}
+	if l.Size() != 1 {
+		t.Fatalf("want 1 logged entry, got %d", l.Size())
+	}
+	if got := l.FindByDigest(digest); len(got) != 1 {
+		t.Fatalf("logged digest not found: %v", got)
+	}
+}
+
+// TestBestEffortAppend_MalformedDigestSwallowed: a bad digest is rejected by
+// the entry validator but the helper must NOT panic or fail the caller (it
+// is best-effort) — it emits a non-fatal note.
+func TestBestEffortAppend_MalformedDigestSwallowed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Windows CI: pin %USERPROFILE% too (os.UserHomeDir ignores $HOME there).
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("M3C_TRANSLOG", "1")
+	var errb bytes.Buffer
+	bestEffortTranslogAppend(translogEventAdmit, "not-a-digest", "x", &errb)
+	if !strings.Contains(errb.String(), "non-fatal") {
+		t.Fatalf("malformed digest should produce a non-fatal note, got: %s", errb.String())
+	}
+}

--- a/pkg/skillctl/translog/doc.go
+++ b/pkg/skillctl/translog/doc.go
@@ -1,0 +1,56 @@
+// Package translog implements the L1 transparency log for SPEC-0278:
+// an RFC-6962 / Sigstore-Rekor-style append-only Merkle tree built from
+// the Go standard library only (crypto/sha256, crypto/ed25519). No
+// Trillian, no Rekor, no blockchain, no Kafka.
+//
+// # What L1 buys, and what it deliberately does NOT
+//
+// L1 makes equivocation, censorship and withholding DETECTABLE — it does
+// NOT make them impossible. Concretely:
+//
+//   - An inclusion proof lets a verifier confirm offline that a specific
+//     event is committed under a Signed Tree Head (STH) it trusts.
+//   - A consistency proof lets a verifier confirm that a newer tree is a
+//     pure append of an older one — i.e. nothing in history was rewritten
+//     or dropped. A log that drops/rewrites an entry FAILS this check, so
+//     a rewrite becomes DETECTABLE.
+//   - Cross-witnessed STHs let two parties notice when a log operator
+//     showed them different histories at the same tree size (a split
+//     view). That equivocation becomes DETECTABLE.
+//
+// What L1 does NOT do: it cannot PREVENT a single log operator from
+// equivocating, withholding, or censoring. Preventing that requires the
+// deferred L2 (a no-single-operator BFT consortium ledger), where M-of-N
+// consensus stops any one operator from rewriting or withholding. L2 and
+// L3 (public-chain anchoring of tree heads) are buyer-gated per SPEC-0278
+// §5/§6 and are NOT built here. The Kafka/SPEC-0190 gossip TRANSPORT is
+// also deferred: this package implements the STH-comparison / witness
+// LOGIC offline, not the wire transport.
+//
+// # Data stays off the log
+//
+// Per SPEC-0278 §5 (EU data sovereignty) NO artifact or personal data
+// ever goes on the log. A leaf commits only the DIGEST of an
+// already-signed event plus its type and timestamp (see LogEntry). The
+// signed event itself stays off-log. The log adds ordering, freshness,
+// non-equivocation and shared availability — and nothing more.
+//
+// # Domain separation (second-preimage resistance)
+//
+// RFC-6962 prefixes the data being hashed with a one-byte domain tag so a
+// leaf hash can never collide with an internal-node hash:
+//
+//	leaf hash  = SHA-256( 0x00 || leaf_bytes )
+//	node hash  = SHA-256( 0x01 || left_hash || right_hash )
+//
+// Without the prefixes an attacker who controls a leaf value could feed
+// in the concatenation of two child hashes and have the verifier treat an
+// internal node as a leaf (or vice versa) — the classic Merkle
+// second-preimage / leaf-vs-node confusion. The prefixes (LeafPrefix /
+// NodePrefix below) close that.
+//
+// The STH carries its OWN distinct domain separator ("skillctl-sth-v1",
+// see sth.go) so an ed25519 signature produced over an STH can never be
+// replayed as an attestation, a revocation, or any other envelope in the
+// spine — and vice versa.
+package translog

--- a/pkg/skillctl/translog/emit.go
+++ b/pkg/skillctl/translog/emit.go
@@ -1,0 +1,75 @@
+package translog
+
+import (
+	"time"
+)
+
+// Best-effort emit helpers for wiring the transparency log into the
+// existing admit/attest/revoke/agentid emit points.
+//
+// CONTRACT (mirrors the SPEC-0202 audit-trail pattern): logging an event is
+// BEST-EFFORT and MUST NEVER alter the primary decision. A caller appends
+// to the log AFTER the signed event already exists; if the append fails
+// (disk full, permission, etc.) the caller logs the error and proceeds —
+// the absence of a log entry is later surfaced by the verifier's inclusion
+// check (advisory by default, hard only under require_log_inclusion), not
+// by breaking the admit/attest/revoke operation itself.
+//
+// These helpers exist so the call sites don't each re-derive the canonical
+// LogEntry shape. They return the assigned index and any error; callers
+// treat the error as advisory.
+
+// EmitAdmit appends an admit event (a bundle was admitted). digest is the
+// "sha256:<hex>" of the admitted bundle; subject is the skill name (or "").
+func EmitAdmit(l *Log, digest, subject string, t time.Time) (int, error) {
+	return l.Append(LogEntry{
+		Type:      EventAdmit,
+		Digest:    digest,
+		Timestamp: FormatSTHTimestamp(t),
+		Subject:   subject,
+	})
+}
+
+// EmitAttest appends a governance attestation event. digest is the attested
+// bundle digest; subject may carry the governance level or reviewer.
+func EmitAttest(l *Log, digest, subject string, t time.Time) (int, error) {
+	return l.Append(LogEntry{
+		Type:      EventAttest,
+		Digest:    digest,
+		Timestamp: FormatSTHTimestamp(t),
+		Subject:   subject,
+	})
+}
+
+// EmitRevoke appends a revocation event. digest is the revoked bundle
+// digest; subject may carry the actor role.
+func EmitRevoke(l *Log, digest, subject string, t time.Time) (int, error) {
+	return l.Append(LogEntry{
+		Type:      EventRevoke,
+		Digest:    digest,
+		Timestamp: FormatSTHTimestamp(t),
+		Subject:   subject,
+	})
+}
+
+// EmitAgentIDIssue appends an AgentID issue/sign-off event (SPEC-0277).
+// digest is the digest of the signed AgentID document; subject is the agent
+// id.
+func EmitAgentIDIssue(l *Log, digest, agentID string, t time.Time) (int, error) {
+	return l.Append(LogEntry{
+		Type:      EventAgentIDIssue,
+		Digest:    digest,
+		Timestamp: FormatSTHTimestamp(t),
+		Subject:   agentID,
+	})
+}
+
+// EmitAgentIDRevoke appends an AgentID revocation event (SPEC-0277).
+func EmitAgentIDRevoke(l *Log, digest, agentID string, t time.Time) (int, error) {
+	return l.Append(LogEntry{
+		Type:      EventAgentIDRevoke,
+		Digest:    digest,
+		Timestamp: FormatSTHTimestamp(t),
+		Subject:   agentID,
+	})
+}

--- a/pkg/skillctl/translog/entry.go
+++ b/pkg/skillctl/translog/entry.go
@@ -1,0 +1,156 @@
+package translog
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// EventType enumerates the kinds of already-signed events whose DIGESTS get
+// committed to the transparency log. We log the digest of the signed event,
+// never the event payload itself (SPEC-0278 §5 — data stays off-log; only
+// hashes/commitments are logged for EU data sovereignty).
+type EventType string
+
+const (
+	// EventAdmit — a registry admit decision (a skill bundle was admitted).
+	EventAdmit EventType = "admit"
+	// EventAttest — a governance attestation (green/yellow/red verdict).
+	EventAttest EventType = "attest"
+	// EventRevoke — a revocation of a bundle/attestation.
+	EventRevoke EventType = "revoke"
+	// EventAgentIDIssue — an AgentID lifecycle issue/sign-off (SPEC-0277).
+	EventAgentIDIssue EventType = "agentid-issue"
+	// EventAgentIDRevoke — an AgentID revocation (SPEC-0277).
+	EventAgentIDRevoke EventType = "agentid-revoke"
+)
+
+// validEventTypes is the closed acceptance set. An unknown event type is
+// refused before it can be hashed into a leaf — the log's vocabulary is
+// fixed, not open-ended.
+var validEventTypes = map[EventType]struct{}{
+	EventAdmit:         {},
+	EventAttest:        {},
+	EventRevoke:        {},
+	EventAgentIDIssue:  {},
+	EventAgentIDRevoke: {},
+}
+
+// IsValid reports whether t is one of the recognised event types.
+func (t EventType) IsValid() bool {
+	_, ok := validEventTypes[t]
+	return ok
+}
+
+// entryDigestPattern matches the canonical digest form a LogEntry commits:
+// "sha256:" followed by exactly 64 lowercase hex characters. This is the
+// SAME form signing.CanonicalizeAttestationMessage / ...RevocationMessage
+// already use, so an event's logged digest lines up 1:1 with the digest its
+// signature was produced over.
+var entryDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// entryTimestampPattern reuses the strict RFC3339-UTC-seconds shape used by
+// the STH and the attestation/revocation envelopes.
+var entryTimestampPattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)
+
+// LogEntry errors.
+var (
+	// ErrEntryInvalid — a LogEntry failed structural validation.
+	ErrEntryInvalid = errors.New("translog: invalid log entry")
+)
+
+// LogEntry is one append to the transparency log. It records WHAT KIND of
+// signed event happened and the DIGEST of that event — never the event
+// body. The canonical encoding (see Canonical) is what gets leaf-hashed
+// (HashLeaf) into the Merkle tree.
+//
+// Field order in the struct does NOT define the canonical byte order;
+// Canonical fixes that explicitly and deterministically.
+type LogEntry struct {
+	// Type is the event class (admit/attest/revoke/agentid-issue/
+	// agentid-revoke).
+	Type EventType `json:"type"`
+
+	// Digest is the "sha256:<64 hex>" of the already-signed event. For an
+	// attestation this is the attestation's bundle digest; for an admit it
+	// is the admitted bundle's digest; for an AgentID event it is the
+	// digest of the signed AgentID document. The point is that this is the
+	// SAME bytes the event's own signature was computed over, so an
+	// inclusion proof ties the log entry back to a verifiable signature.
+	Digest string `json:"digest"`
+
+	// Timestamp is when the event was logged, RFC3339 UTC seconds.
+	Timestamp string `json:"timestamp"`
+
+	// Subject is an optional, newline-free, human/machine identifier for
+	// the event subject (e.g. a skill name, an identity id, an agent id).
+	// It is bound into the canonical bytes so two events that share a
+	// digest+type+timestamp but concern different subjects hash to distinct
+	// leaves. Empty is allowed.
+	Subject string `json:"subject,omitempty"`
+}
+
+// Validate runs strict structural checks. Called by Canonical before any
+// bytes are produced so a malformed entry can never become a leaf hash.
+func (e LogEntry) Validate() error {
+	if !e.Type.IsValid() {
+		return fmt.Errorf("%w: unknown event type %q", ErrEntryInvalid, e.Type)
+	}
+	if !entryDigestPattern.MatchString(e.Digest) {
+		return fmt.Errorf("%w: digest %q must be sha256:<64 lowercase hex>", ErrEntryInvalid, e.Digest)
+	}
+	if !entryTimestampPattern.MatchString(e.Timestamp) {
+		return fmt.Errorf("%w: timestamp %q must be RFC3339 UTC seconds", ErrEntryInvalid, e.Timestamp)
+	}
+	if strings.ContainsAny(e.Subject, "\n\r") {
+		return fmt.Errorf("%w: subject must not contain newline characters", ErrEntryInvalid)
+	}
+	return nil
+}
+
+// Canonical returns the deterministic byte encoding of the entry that gets
+// leaf-hashed. It follows the same sorted-canonical / LF-delimited pattern
+// as the spine's other signed messages (attestation, revocation), with a
+// leading "logentry-v1" tag so a leaf encoding can never be confused with
+// any other signed-message family even before the 0x00 leaf prefix is
+// applied.
+//
+// Format (UTF-8, LF-separated, trailing LF):
+//
+//	logentry-v1\n
+//	<type>\n
+//	<digest>\n
+//	<timestamp>\n
+//	<subject>\n        (may be empty, but the line is always present)
+//
+// Determinism: every field is a closed-vocabulary or strictly-patterned
+// value, so the same logical event always yields identical bytes — a
+// requirement for reproducible inclusion proofs across machines.
+func (e LogEntry) Canonical() ([]byte, error) {
+	if err := e.Validate(); err != nil {
+		return nil, err
+	}
+	var b strings.Builder
+	b.WriteString("logentry-v1")
+	b.WriteByte('\n')
+	b.WriteString(string(e.Type))
+	b.WriteByte('\n')
+	b.WriteString(e.Digest)
+	b.WriteByte('\n')
+	b.WriteString(e.Timestamp)
+	b.WriteByte('\n')
+	b.WriteString(e.Subject)
+	b.WriteByte('\n')
+	return []byte(b.String()), nil
+}
+
+// LeafHash returns the RFC-6962 leaf hash of the entry's canonical bytes:
+// HashLeaf(Canonical()). This is what goes into the Merkle tree.
+func (e LogEntry) LeafHash() ([HashSize]byte, error) {
+	canon, err := e.Canonical()
+	if err != nil {
+		return [HashSize]byte{}, err
+	}
+	return HashLeaf(canon), nil
+}

--- a/pkg/skillctl/translog/entry_test.go
+++ b/pkg/skillctl/translog/entry_test.go
@@ -1,0 +1,91 @@
+package translog
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func goodEntry() LogEntry {
+	return LogEntry{
+		Type:      EventAttest,
+		Digest:    "sha256:" + strings.Repeat("ab", 32),
+		Timestamp: "2026-06-24T12:00:00Z",
+		Subject:   "skill:my-skill",
+	}
+}
+
+func TestLogEntry_CanonicalDeterministic(t *testing.T) {
+	e := goodEntry()
+	a, err := e.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := e.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a) != string(b) {
+		t.Fatal("Canonical must be deterministic")
+	}
+	// Format check: exactly 5 LF-terminated lines, leading tag.
+	want := "logentry-v1\nattest\nsha256:" + strings.Repeat("ab", 32) + "\n2026-06-24T12:00:00Z\nskill:my-skill\n"
+	if string(a) != want {
+		t.Fatalf("canonical bytes:\n got %q\nwant %q", string(a), want)
+	}
+}
+
+func TestLogEntry_AllTypesValid(t *testing.T) {
+	for _, ty := range []EventType{EventAdmit, EventAttest, EventRevoke, EventAgentIDIssue, EventAgentIDRevoke} {
+		e := goodEntry()
+		e.Type = ty
+		if _, err := e.LeafHash(); err != nil {
+			t.Fatalf("type %q should produce a leaf hash: %v", ty, err)
+		}
+	}
+}
+
+func TestLogEntry_RejectsBadFields(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(LogEntry) LogEntry
+	}{
+		{"unknown type", func(e LogEntry) LogEntry { e.Type = "frobnicate"; return e }},
+		{"empty digest", func(e LogEntry) LogEntry { e.Digest = ""; return e }},
+		{"uppercase digest", func(e LogEntry) LogEntry { e.Digest = "sha256:" + strings.Repeat("AB", 32); return e }},
+		{"no prefix digest", func(e LogEntry) LogEntry { e.Digest = strings.Repeat("ab", 32); return e }},
+		{"bad timestamp", func(e LogEntry) LogEntry { e.Timestamp = "yesterday"; return e }},
+		{"subject newline", func(e LogEntry) LogEntry { e.Subject = "a\nb"; return e }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := c.mut(goodEntry()).Canonical(); !errors.Is(err, ErrEntryInvalid) {
+				t.Fatalf("%s: want ErrEntryInvalid, got %v", c.name, err)
+			}
+		})
+	}
+}
+
+// TestLogEntry_DistinctSubjectsDistinctLeaves: two events identical except
+// for subject must hash to different leaves (no collision).
+func TestLogEntry_DistinctSubjectsDistinctLeaves(t *testing.T) {
+	a := goodEntry()
+	b := goodEntry()
+	b.Subject = "skill:other-skill"
+	ha, _ := a.LeafHash()
+	hb, _ := b.LeafHash()
+	if ha == hb {
+		t.Fatal("entries with different subjects must hash to different leaves")
+	}
+}
+
+// TestLogEntry_NotConfusableWithRawLeaf: the "logentry-v1" tag plus the
+// 0x00 leaf prefix means a crafted raw byte string can't trivially match a
+// log entry's leaf hash.
+func TestLogEntry_TaggedEncoding(t *testing.T) {
+	e := goodEntry()
+	canon, _ := e.Canonical()
+	if !strings.HasPrefix(string(canon), "logentry-v1\n") {
+		t.Fatal("canonical encoding must carry the logentry-v1 domain tag")
+	}
+}

--- a/pkg/skillctl/translog/log.go
+++ b/pkg/skillctl/translog/log.go
@@ -1,0 +1,285 @@
+package translog
+
+import (
+	"bufio"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// DefaultLogPath is the conventional on-disk location of the local
+// append-only transparency log, relative to the user's home directory.
+const DefaultLogPath = ".claude/skillctl/transparency-log.jsonl"
+
+// Log is an in-memory RFC-6962 Merkle log backed by an append-only JSONL
+// file. Each line is one LogEntry; the file order IS the leaf order. The
+// log is the authoritative local record from which STHs and inclusion
+// proofs are produced.
+//
+// Concurrency: a single process mutex guards Append + persistence. The file
+// is opened O_APPEND so concurrent processes append atomically at the OS
+// level for lines below PIPE_BUF; cross-process ordering beyond that is out
+// of L1 scope (a single local agent owns its log).
+type Log struct {
+	mu      sync.Mutex
+	path    string
+	logID   string
+	entries []LogEntry
+	leaves  [][HashSize]byte
+}
+
+// Errors specific to the log container.
+var (
+	// ErrLogIDRequired — a Log needs a non-empty, well-formed log id.
+	ErrLogIDRequired = errors.New("translog: log_id is required")
+)
+
+// OpenLog loads (or initialises) the append-only log at path for the given
+// logID. A missing file yields an empty log ready to Append; a malformed
+// line aborts the load (we never silently skip corrupt history — that would
+// hide tampering). logID must satisfy logIDPattern.
+func OpenLog(path, logID string) (*Log, error) {
+	if path == "" {
+		return nil, errors.New("translog: log path is required")
+	}
+	if !logIDPattern.MatchString(logID) {
+		return nil, fmt.Errorf("%w: %q invalid (allowed [A-Za-z0-9._:-], 1-128 chars)", ErrLogIDRequired, logID)
+	}
+	l := &Log{path: path, logID: logID}
+
+	f, err := os.Open(path) //nolint:gosec // path is operator-provided, not attacker-tainted
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return l, nil // fresh log
+		}
+		return nil, fmt.Errorf("translog: open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	// Allow long lines (a JSON entry is small, but be generous).
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		raw := sc.Bytes()
+		if len(raw) == 0 {
+			continue
+		}
+		var e LogEntry
+		if err := json.Unmarshal(raw, &e); err != nil {
+			return nil, fmt.Errorf("translog: %s line %d: bad JSON: %w", path, lineNo, err)
+		}
+		leaf, err := e.LeafHash()
+		if err != nil {
+			return nil, fmt.Errorf("translog: %s line %d: invalid entry: %w", path, lineNo, err)
+		}
+		l.entries = append(l.entries, e)
+		l.leaves = append(l.leaves, leaf)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("translog: read %s: %w", path, err)
+	}
+	return l, nil
+}
+
+// DefaultLogFilePath returns the absolute default log path under the user's
+// home directory.
+func DefaultLogFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("translog: resolve home dir: %w", err)
+	}
+	return filepath.Join(home, DefaultLogPath), nil
+}
+
+// Size returns the current number of leaves (entries) in the log.
+func (l *Log) Size() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.entries)
+}
+
+// LogID returns the log's identifier.
+func (l *Log) LogID() string { return l.logID }
+
+// Append validates the entry, appends it to the in-memory tree, and
+// durably appends one JSON line to the backing file. It returns the index
+// the entry was assigned (its leaf position) so the caller can immediately
+// request an inclusion proof.
+//
+// Persistence is fsync'd before returning so a crash cannot lose an entry
+// that a caller believes was logged. If the disk write fails the in-memory
+// state is rolled back so the tree and the file never diverge.
+func (l *Log) Append(e LogEntry) (int, error) {
+	leaf, err := e.LeafHash()
+	if err != nil {
+		return -1, err
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	line, err := json.Marshal(e)
+	if err != nil {
+		return -1, fmt.Errorf("translog: marshal entry: %w", err)
+	}
+
+	if err := l.appendLine(line); err != nil {
+		return -1, err
+	}
+
+	idx := len(l.entries)
+	l.entries = append(l.entries, e)
+	l.leaves = append(l.leaves, leaf)
+	return idx, nil
+}
+
+// appendLine writes one JSONL record (line + '\n') to the backing file with
+// O_APPEND and fsyncs. Best-effort directory creation on first write.
+func (l *Log) appendLine(line []byte) error {
+	if dir := filepath.Dir(l.path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("translog: create dir %s: %w", dir, err)
+		}
+	}
+	f, err := os.OpenFile(l.path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("translog: open for append %s: %w", l.path, err)
+	}
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("translog: append %s: %w", l.path, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("translog: fsync %s: %w", l.path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("translog: close %s: %w", l.path, err)
+	}
+	return nil
+}
+
+// Root returns the current Merkle Tree Hash over all entries. Errors with
+// ErrEmptyTree when the log has no entries.
+func (l *Log) Root() ([HashSize]byte, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return MerkleTreeHash(l.leaves)
+}
+
+// SignHead builds and signs an STH over the current tree state with the
+// log's ed25519 private key, stamped at time t (UTC seconds). Errors with
+// ErrEmptyTree on an empty log — there is nothing to commit.
+func (l *Log) SignHead(logKey ed25519.PrivateKey, t time.Time) (STH, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	root, err := MerkleTreeHash(l.leaves)
+	if err != nil {
+		return STH{}, err
+	}
+	s := STH{
+		TreeSize:  len(l.leaves),
+		RootHash:  hex.EncodeToString(root[:]),
+		Timestamp: FormatSTHTimestamp(t),
+		LogID:     l.logID,
+	}
+	return SignSTH(logKey, s)
+}
+
+// ProveInclusion returns the inclusion proof for the entry at index against
+// the CURRENT tree size. The returned proof verifies (with the leaf hash
+// and the current root) via VerifyInclusion.
+func (l *Log) ProveInclusion(index int) (proof [][HashSize]byte, size int, leaf [HashSize]byte, err error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	size = len(l.leaves)
+	if index < 0 || index >= size {
+		return nil, size, leaf, fmt.Errorf("%w: index=%d size=%d", ErrIndexOutOfRange, index, size)
+	}
+	leaf = l.leaves[index]
+	p, err := InclusionProof(index, size, l.leaves)
+	if err != nil {
+		return nil, size, leaf, err
+	}
+	return p, size, leaf, nil
+}
+
+// ProveConsistency returns the consistency proof between an earlier size
+// `from` and the current size. Errors if from is out of range.
+func (l *Log) ProveConsistency(from int) (proof [][HashSize]byte, second int, err error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	second = len(l.leaves)
+	if from < 0 || from > second {
+		return nil, second, fmt.Errorf("%w: from=%d size=%d", ErrBadConsistencyArgs, from, second)
+	}
+	p, err := ConsistencyProof(from, second, l.leaves)
+	if err != nil {
+		return nil, second, err
+	}
+	return p, second, nil
+}
+
+// EntryAt returns a copy of the entry at index (read-only access for CLI
+// display and proof export).
+func (l *Log) EntryAt(index int) (LogEntry, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if index < 0 || index >= len(l.entries) {
+		return LogEntry{}, fmt.Errorf("%w: index=%d size=%d", ErrIndexOutOfRange, index, len(l.entries))
+	}
+	return l.entries[index], nil
+}
+
+// FindByDigest returns the indices of all entries whose Digest matches.
+// Used by the CLI `prove <event>` verb to resolve an event reference to its
+// leaf position without the caller tracking indices.
+func (l *Log) FindByDigest(digest string) []int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var out []int
+	for i, e := range l.entries {
+		if e.Digest == digest {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// LeafHashes returns a copy of the current leaf-hash slice, so a caller can
+// build proofs externally without holding the lock. Defensive copy: callers
+// must not be able to mutate the log's internal state.
+func (l *Log) LeafHashes() [][HashSize]byte {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([][HashSize]byte, len(l.leaves))
+	copy(out, l.leaves)
+	return out
+}
+
+// writeJSONLines is a small helper for tests / export: dump the entries as
+// JSONL to w in order.
+func (l *Log) writeJSONLines(w io.Writer) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	bw := bufio.NewWriter(w)
+	for _, e := range l.entries {
+		b, err := json.Marshal(e)
+		if err != nil {
+			return err
+		}
+		if _, err := bw.Write(append(b, '\n')); err != nil {
+			return err
+		}
+	}
+	return bw.Flush()
+}

--- a/pkg/skillctl/translog/log_test.go
+++ b/pkg/skillctl/translog/log_test.go
@@ -1,0 +1,203 @@
+package translog
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func tmpLogPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "transparency-log.jsonl")
+}
+
+func mkEntry(ty EventType, n int) LogEntry {
+	// Deterministic digest from n.
+	d := "sha256:" + strings.Repeat("0", 63) + itoa(n%10)
+	return LogEntry{
+		Type:      ty,
+		Digest:    d,
+		Timestamp: "2026-06-24T12:00:0" + itoa(n%10) + "Z",
+		Subject:   "subject-" + itoa(n),
+	}
+}
+
+func TestLog_AppendAndProve(t *testing.T) {
+	path := tmpLogPath(t)
+	l, err := OpenLog(path, "skillctl-log-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var idxs []int
+	for i := 0; i < 7; i++ {
+		idx, err := l.Append(mkEntry(EventAttest, i))
+		if err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+		idxs = append(idxs, idx)
+	}
+	if l.Size() != 7 {
+		t.Fatalf("size = %d, want 7", l.Size())
+	}
+
+	root, err := l.Root()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Every appended entry must have a verifiable inclusion proof against
+	// the current root.
+	for _, idx := range idxs {
+		proof, size, leaf, err := l.ProveInclusion(idx)
+		if err != nil {
+			t.Fatalf("prove idx %d: %v", idx, err)
+		}
+		if err := VerifyInclusion(leaf, idx, size, proof, root); err != nil {
+			t.Fatalf("verify inclusion idx %d: %v", idx, err)
+		}
+	}
+}
+
+func TestLog_PersistAndReload(t *testing.T) {
+	path := tmpLogPath(t)
+	l, err := OpenLog(path, "log-A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		if _, err := l.Append(mkEntry(EventAdmit, i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rootBefore, _ := l.Root()
+
+	// Reopen from disk: same entries, same root (append-only persistence).
+	l2, err := OpenLog(path, "log-A")
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if l2.Size() != 5 {
+		t.Fatalf("reloaded size = %d, want 5", l2.Size())
+	}
+	rootAfter, _ := l2.Root()
+	if rootBefore != rootAfter {
+		t.Fatal("root changed across reload — persistence is not faithful")
+	}
+}
+
+func TestLog_SignHeadAndVerify(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	l, _ := OpenLog(tmpLogPath(t), "log-A")
+	for i := 0; i < 4; i++ {
+		if _, err := l.Append(mkEntry(EventRevoke, i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sth, err := l.SignHead(priv, time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifySTH(pub, sth); err != nil {
+		t.Fatalf("STH should verify: %v", err)
+	}
+	if sth.TreeSize != 4 || sth.LogID != "log-A" {
+		t.Fatalf("STH fields wrong: %+v", sth)
+	}
+	// The STH root must match the tree root, and an inclusion proof must
+	// verify against it.
+	root, _ := sth.RootBytes()
+	proof, size, leaf, _ := l.ProveInclusion(2)
+	if err := VerifyInclusion(leaf, 2, size, proof, root); err != nil {
+		t.Fatalf("inclusion under STH root failed: %v", err)
+	}
+}
+
+func TestLog_ConsistencyAcrossGrowth(t *testing.T) {
+	l, _ := OpenLog(tmpLogPath(t), "log-A")
+	for i := 0; i < 4; i++ {
+		if _, err := l.Append(mkEntry(EventAttest, i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rootAt4, _ := l.Root()
+
+	for i := 4; i < 10; i++ {
+		if _, err := l.Append(mkEntry(EventAttest, i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rootAt10, _ := l.Root()
+
+	proof, second, err := l.ProveConsistency(4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second != 10 {
+		t.Fatalf("second = %d, want 10", second)
+	}
+	if err := VerifyConsistency(4, 10, rootAt4, rootAt10, proof); err != nil {
+		t.Fatalf("growth must be append-consistent: %v", err)
+	}
+}
+
+func TestLog_RejectsCorruptLine(t *testing.T) {
+	path := tmpLogPath(t)
+	// Hand-write a file with a valid line then garbage.
+	l, _ := OpenLog(path, "log-A")
+	if _, err := l.Append(mkEntry(EventAdmit, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := appendRaw(path, "{not json"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenLog(path, "log-A"); err == nil {
+		t.Fatal("expected reload to fail on corrupt line (silent skip would hide tampering)")
+	}
+}
+
+func TestLog_FindByDigest(t *testing.T) {
+	l, _ := OpenLog(tmpLogPath(t), "log-A")
+	e := mkEntry(EventAttest, 3)
+	if _, err := l.Append(e); err != nil {
+		t.Fatal(err)
+	}
+	hits := l.FindByDigest(e.Digest)
+	if len(hits) != 1 || hits[0] != 0 {
+		t.Fatalf("FindByDigest = %v, want [0]", hits)
+	}
+	if got := l.FindByDigest("sha256:" + strings.Repeat("f", 64)); len(got) != 0 {
+		t.Fatalf("unknown digest should find nothing, got %v", got)
+	}
+}
+
+func TestLog_BadLogID(t *testing.T) {
+	if _, err := OpenLog(tmpLogPath(t), "bad id with spaces"); !errors.Is(err, ErrLogIDRequired) {
+		t.Fatalf("want ErrLogIDRequired, got %v", err)
+	}
+}
+
+func TestLog_WriteJSONLinesRoundTrips(t *testing.T) {
+	l, _ := OpenLog(tmpLogPath(t), "log-A")
+	for i := 0; i < 3; i++ {
+		if _, err := l.Append(mkEntry(EventAttest, i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var buf bytes.Buffer
+	if err := l.writeJSONLines(&buf); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 JSONL lines, got %d", len(lines))
+	}
+}
+
+// appendRaw appends a raw line to a file (test helper for corruption).
+func appendRaw(path, line string) error {
+	l := &Log{path: path}
+	return l.appendLine([]byte(line))
+}

--- a/pkg/skillctl/translog/merkle.go
+++ b/pkg/skillctl/translog/merkle.go
@@ -1,0 +1,120 @@
+package translog
+
+import (
+	"crypto/sha256"
+	"errors"
+)
+
+// RFC-6962 domain-separation prefixes. These single bytes are hashed in
+// FRONT of the data so a leaf hash and an internal-node hash live in
+// disjoint pre-image spaces. Removing them would reopen the classic
+// Merkle second-preimage / leaf-vs-node confusion (see doc.go).
+const (
+	// LeafPrefix (0x00) tags a leaf hash: SHA-256(0x00 || leaf_bytes).
+	LeafPrefix byte = 0x00
+	// NodePrefix (0x01) tags an internal-node hash:
+	// SHA-256(0x01 || left_hash || right_hash).
+	NodePrefix byte = 0x01
+)
+
+// HashSize is the width of every node and leaf hash in the tree (SHA-256).
+const HashSize = sha256.Size // 32
+
+// ErrEmptyTree is returned when a root hash is requested for zero leaves.
+// RFC-6962 defines MTH({}) = SHA-256() (the hash of the empty string), but
+// our log never commits an empty tree to an STH, so we treat zero leaves
+// as a caller error to surface bugs loudly rather than sign over a
+// degenerate root.
+var ErrEmptyTree = errors.New("translog: cannot hash an empty tree")
+
+// HashLeaf returns the RFC-6962 leaf hash of leafBytes:
+//
+//	SHA-256( 0x00 || leafBytes )
+//
+// leafBytes is the canonical event encoding (see LogEntry.Canonical). The
+// 0x00 prefix is what stops a leaf value from ever colliding with an
+// internal node hash.
+func HashLeaf(leafBytes []byte) [HashSize]byte {
+	h := sha256.New()
+	h.Write([]byte{LeafPrefix})
+	h.Write(leafBytes)
+	var out [HashSize]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+// hashChildren returns the RFC-6962 internal-node hash of two child
+// hashes:
+//
+//	SHA-256( 0x01 || left || right )
+//
+// The 0x01 prefix is the counterpart to HashLeaf's 0x00: it guarantees an
+// internal node and a leaf can never share a pre-image.
+func hashChildren(left, right [HashSize]byte) [HashSize]byte {
+	h := sha256.New()
+	h.Write([]byte{NodePrefix})
+	h.Write(left[:])
+	h.Write(right[:])
+	var out [HashSize]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+// MerkleTreeHash computes the RFC-6962 Merkle Tree Hash (MTH) over the
+// ordered slice of already-hashed leaves.
+//
+// The recurrence (RFC-6962 §2.1) for n > 1 leaves D[0:n] is:
+//
+//	MTH(D[0:n]) = HASH( 0x01 || MTH(D[0:k]) || MTH(D[k:n]) )
+//
+// where k is the LARGEST power of two strictly less than n. This split —
+// not a simple round-up — is the load-bearing detail that makes inclusion
+// and consistency proofs interoperate with every other RFC-6962
+// implementation.
+//
+// Callers pass leaf HASHES (the output of HashLeaf), not raw event bytes;
+// keeping leaf hashing separate lets the inclusion-proof verifier work
+// from a single leaf hash without re-encoding the event.
+//
+// Returns ErrEmptyTree for an empty slice.
+func MerkleTreeHash(leaves [][HashSize]byte) ([HashSize]byte, error) {
+	var zero [HashSize]byte
+	n := len(leaves)
+	if n == 0 {
+		return zero, ErrEmptyTree
+	}
+	return merkleTreeHash(leaves), nil
+}
+
+// merkleTreeHash is the unchecked recursive core. Precondition: len > 0.
+func merkleTreeHash(leaves [][HashSize]byte) [HashSize]byte {
+	n := len(leaves)
+	if n == 1 {
+		// A single leaf's tree hash is the leaf hash itself — NOT a
+		// re-hash. RFC-6962 §2.1: MTH(D[0:1]) = the leaf's hash.
+		return leaves[0]
+	}
+	k := largestPowerOfTwoLessThan(n)
+	left := merkleTreeHash(leaves[:k])
+	right := merkleTreeHash(leaves[k:])
+	return hashChildren(left, right)
+}
+
+// largestPowerOfTwoLessThan returns the largest power of two STRICTLY less
+// than n, for n >= 2. This is RFC-6962's "k" split point. For n a power of
+// two it returns n/2; otherwise it returns the highest power of two below
+// n (e.g. n=5 → 4, n=7 → 4, n=8 → 4).
+//
+// Implemented without bit-twiddling cleverness so the property is obvious:
+// double a candidate until the NEXT double would meet or exceed n.
+func largestPowerOfTwoLessThan(n int) int {
+	if n < 2 {
+		// Caller invariant violation; the recursion never asks for this.
+		panic("translog: largestPowerOfTwoLessThan requires n >= 2")
+	}
+	k := 1
+	for k<<1 < n {
+		k <<= 1
+	}
+	return k
+}

--- a/pkg/skillctl/translog/merkle_test.go
+++ b/pkg/skillctl/translog/merkle_test.go
@@ -1,0 +1,202 @@
+package translog
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+// leafHashes builds n leaf hashes from deterministic byte payloads
+// "leaf-0", "leaf-1", ... so tests are reproducible.
+func leafHashes(n int) [][HashSize]byte {
+	out := make([][HashSize]byte, n)
+	for i := 0; i < n; i++ {
+		out[i] = HashLeaf([]byte("leaf-" + itoa(i)))
+	}
+	return out
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+// refRoot is an INDEPENDENT reference implementation of the RFC-6962 MTH,
+// written as plainly as possible so it can't share a bug with the
+// production merkleTreeHash. Tests cross-check production against this.
+func refRoot(leaves [][HashSize]byte) [HashSize]byte {
+	n := len(leaves)
+	if n == 1 {
+		return leaves[0]
+	}
+	// largest power of two < n
+	k := 1
+	for k*2 < n {
+		k *= 2
+	}
+	l := refRoot(leaves[:k])
+	r := refRoot(leaves[k:])
+	h := sha256.New()
+	h.Write([]byte{0x01})
+	h.Write(l[:])
+	h.Write(r[:])
+	var out [HashSize]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+func TestHashLeaf_DomainPrefix(t *testing.T) {
+	// A leaf hash MUST be SHA-256(0x00 || bytes) — verify against a manual
+	// computation so the prefix can never be silently dropped.
+	data := []byte("hello-world")
+	got := HashLeaf(data)
+
+	h := sha256.New()
+	h.Write([]byte{0x00})
+	h.Write(data)
+	var want [HashSize]byte
+	copy(want[:], h.Sum(nil))
+
+	if got != want {
+		t.Fatalf("HashLeaf mismatch:\n got %x\nwant %x", got, want)
+	}
+
+	// And it must DIFFER from the bare SHA-256 (no prefix) — that's the
+	// whole point of domain separation.
+	bare := sha256.Sum256(data)
+	if got == bare {
+		t.Fatal("HashLeaf must not equal bare SHA-256 (domain prefix missing?)")
+	}
+}
+
+// TestSecondPreimage_LeafNodeConfusion is the adversarial guard: feeding
+// the CONCATENATION of two child hashes in as a LEAF value must produce a
+// different hash than the INTERNAL NODE over those same two children. If
+// the prefixes were absent, an attacker could present a leaf whose hash
+// equals an internal node and confuse the verifier.
+func TestSecondPreimage_LeafNodeConfusion(t *testing.T) {
+	a := HashLeaf([]byte("a"))
+	b := HashLeaf([]byte("b"))
+
+	node := hashChildren(a, b) // 0x01 || a || b
+
+	// An attacker crafts a leaf whose raw bytes are exactly a||b and hopes
+	// HashLeaf(a||b) == node.
+	var concat []byte
+	concat = append(concat, a[:]...)
+	concat = append(concat, b[:]...)
+	leaf := HashLeaf(concat) // 0x00 || (a||b)
+
+	if leaf == node {
+		t.Fatal("leaf-vs-node confusion: HashLeaf(a||b) collided with hashChildren(a,b) — domain prefixes broken")
+	}
+}
+
+func TestMerkleTreeHash_EmptyIsError(t *testing.T) {
+	if _, err := MerkleTreeHash(nil); err == nil {
+		t.Fatal("expected ErrEmptyTree for zero leaves")
+	}
+}
+
+func TestMerkleTreeHash_SingleLeafIsLeaf(t *testing.T) {
+	leaves := leafHashes(1)
+	root, err := MerkleTreeHash(leaves)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != leaves[0] {
+		t.Fatalf("single-leaf root must equal the leaf hash itself")
+	}
+}
+
+// TestMerkleTreeHash_MatchesReference cross-checks production MTH against
+// the independent reference for many sizes, including non-powers-of-two
+// where the k-split matters most.
+func TestMerkleTreeHash_MatchesReference(t *testing.T) {
+	for n := 1; n <= 33; n++ {
+		leaves := leafHashes(n)
+		got, err := MerkleTreeHash(leaves)
+		if err != nil {
+			t.Fatalf("n=%d: %v", n, err)
+		}
+		want := refRoot(leaves)
+		if got != want {
+			t.Fatalf("n=%d root mismatch:\n got %x\nwant %x", n, got, want)
+		}
+	}
+}
+
+// TestMerkleTreeHash_GoldenVectors pins a few small trees to exact hex so
+// any future change to the hashing construction is caught loudly. The
+// vectors are derived from the construction itself (self-consistent golden
+// values), then frozen.
+func TestMerkleTreeHash_GoldenVectors(t *testing.T) {
+	cases := []struct {
+		n   int
+		hex string
+	}{
+		{1, hexOf(HashLeaf([]byte("leaf-0")))},
+		{2, hexOf(hashChildren(HashLeaf([]byte("leaf-0")), HashLeaf([]byte("leaf-1"))))},
+	}
+	for _, c := range cases {
+		leaves := leafHashes(c.n)
+		root, err := MerkleTreeHash(leaves)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hexOf(root) != c.hex {
+			t.Fatalf("n=%d golden mismatch:\n got %s\nwant %s", c.n, hexOf(root), c.hex)
+		}
+	}
+
+	// n=4 must equal H(H(l0,l1), H(l2,l3)) — a balanced tree.
+	l := leafHashes(4)
+	want4 := hashChildren(hashChildren(l[0], l[1]), hashChildren(l[2], l[3]))
+	got4, _ := MerkleTreeHash(l)
+	if got4 != want4 {
+		t.Fatal("n=4 balanced-tree shape mismatch")
+	}
+
+	// n=3 must equal H(H(l0,l1), l2) — k=2, right subtree is a lone leaf.
+	l3 := leafHashes(3)
+	want3 := hashChildren(hashChildren(l3[0], l3[1]), l3[2])
+	got3, _ := MerkleTreeHash(l3)
+	if got3 != want3 {
+		t.Fatal("n=3 unbalanced-tree shape mismatch (k-split wrong?)")
+	}
+}
+
+func TestLargestPowerOfTwoLessThan(t *testing.T) {
+	cases := map[int]int{2: 1, 3: 2, 4: 2, 5: 4, 7: 4, 8: 4, 9: 8, 16: 8, 17: 16}
+	for n, want := range cases {
+		if got := largestPowerOfTwoLessThan(n); got != want {
+			t.Fatalf("largestPowerOfTwoLessThan(%d)=%d want %d", n, got, want)
+		}
+	}
+}
+
+func hexOf(h [HashSize]byte) string { return hex.EncodeToString(h[:]) }
+
+// sanity: the bytes helper used in proof tests behaves.
+func TestBytesEqualHelper(t *testing.T) {
+	a := HashLeaf([]byte("x"))
+	b := HashLeaf([]byte("x"))
+	if !bytes.Equal(a[:], b[:]) {
+		t.Fatal("deterministic leaf hashing broken")
+	}
+}

--- a/pkg/skillctl/translog/proof.go
+++ b/pkg/skillctl/translog/proof.go
@@ -1,0 +1,381 @@
+package translog
+
+import (
+	"crypto/subtle"
+	"errors"
+	"fmt"
+)
+
+// Proof errors. All proof-shape problems are sentinel-wrapped so callers
+// (and the adversarial gate) can branch on the failure class without
+// parsing strings.
+var (
+	// ErrIndexOutOfRange — a leaf index is not in [0, size).
+	ErrIndexOutOfRange = errors.New("translog: leaf index out of range")
+	// ErrBadProofSize — a proof has the wrong number of hashes for the
+	// (index, size) it claims to prove. A forged or truncated proof trips
+	// this before any hashing happens.
+	ErrBadProofSize = errors.New("translog: proof has wrong length for tree size")
+	// ErrInclusionMismatch — the root recomputed from the leaf + proof
+	// does not equal the expected root. This is the catch-all rejection
+	// for a tampered leaf, a wrong index, or a forged proof path.
+	ErrInclusionMismatch = errors.New("translog: inclusion proof does not reconstruct the root")
+	// ErrConsistencyMismatch — a consistency proof failed to reconstruct
+	// BOTH the old and the new root. A log that dropped or rewrote an
+	// entry between the two sizes trips this — the append-only property
+	// is violated and the rewrite is DETECTED.
+	ErrConsistencyMismatch = errors.New("translog: consistency proof failed (log is not a pure append)")
+	// ErrBadConsistencyArgs — nonsensical sizes (e.g. first > second, or
+	// a zero first size with a non-empty proof).
+	ErrBadConsistencyArgs = errors.New("translog: invalid consistency proof arguments")
+)
+
+// InclusionProof returns the RFC-6962 audit path proving that the leaf at
+// index `index` is included in a tree of `size` leaves. The returned slice
+// is ordered from the leaf's sibling upward to (but excluding) the root.
+//
+// `leaves` MUST be the full ordered set of leaf hashes for the tree of the
+// given size (len(leaves) must equal size). Production callers hold these
+// in the local log file; the proof is computed once and can be checked
+// later by VerifyInclusion WITHOUT the leaf set — only the single leaf
+// hash, the proof, and the trusted root are needed.
+func InclusionProof(index, size int, leaves [][HashSize]byte) ([][HashSize]byte, error) {
+	if size <= 0 {
+		return nil, fmt.Errorf("%w: size=%d", ErrEmptyTree, size)
+	}
+	if index < 0 || index >= size {
+		return nil, fmt.Errorf("%w: index=%d size=%d", ErrIndexOutOfRange, index, size)
+	}
+	if len(leaves) != size {
+		return nil, fmt.Errorf("%w: have %d leaves, size says %d", ErrBadProofSize, len(leaves), size)
+	}
+	return inclusionPath(index, leaves), nil
+}
+
+// inclusionPath is RFC-6962 §2.1.1 PATH(m, D[0:n]). Precondition: n>=1 and
+// 0<=m<n. The proof for a single-leaf tree is empty.
+func inclusionPath(m int, leaves [][HashSize]byte) [][HashSize]byte {
+	n := len(leaves)
+	if n == 1 {
+		return nil
+	}
+	k := largestPowerOfTwoLessThan(n)
+	if m < k {
+		// Leaf is in the left subtree; sibling is the right subtree root.
+		sub := inclusionPath(m, leaves[:k])
+		return append(sub, merkleTreeHash(leaves[k:]))
+	}
+	// Leaf is in the right subtree; sibling is the left subtree root.
+	sub := inclusionPath(m-k, leaves[k:])
+	return append(sub, merkleTreeHash(leaves[:k]))
+}
+
+// VerifyInclusion checks an RFC-6962 inclusion (audit) proof OFFLINE: it
+// reconstructs the tree root from the single leaf hash, its index/size,
+// and the audit path, then compares (constant-time) against the expected
+// root.
+//
+// No network, no leaf set, no log operator is consulted — this is the
+// property that lets a verifier confirm "this event is committed under the
+// STH I already trust" without trusting any server. A tampered leaf, a
+// wrong index, a wrong size, or a forged path all reduce to a
+// reconstructed root that differs from `root`, returning
+// ErrInclusionMismatch.
+func VerifyInclusion(leafHash [HashSize]byte, index, size int, proof [][HashSize]byte, root [HashSize]byte) error {
+	if size <= 0 {
+		return fmt.Errorf("%w: size=%d", ErrEmptyTree, size)
+	}
+	if index < 0 || index >= size {
+		return fmt.Errorf("%w: index=%d size=%d", ErrIndexOutOfRange, index, size)
+	}
+	// The audit path length is exactly ceil(log2) of the position of the
+	// leaf within its subtree decomposition. We compute the expected
+	// length and reject a mismatched proof BEFORE hashing so a forged
+	// proof of the wrong shape can never be massaged into a valid root.
+	want := inclusionProofLen(index, size)
+	if len(proof) != want {
+		return fmt.Errorf("%w: have %d hashes, want %d for index=%d size=%d",
+			ErrBadProofSize, len(proof), want, index, size)
+	}
+
+	computed := rebuildRootFromInclusion(leafHash, index, size, proof)
+	if subtle.ConstantTimeCompare(computed[:], root[:]) != 1 {
+		return ErrInclusionMismatch
+	}
+	return nil
+}
+
+// rebuildRootFromInclusion folds the audit path into a root hash.
+//
+// inclusionPath emits siblings DEEPEST-FIRST (the recursion appends the
+// current level's sibling AFTER recursing into the subtree containing the
+// leaf). So proof[0] is the leaf's immediate sibling and proof[len-1] is
+// the root's-child sibling. To consume them in that order we must first
+// record each level's left/right decision walking TOP-DOWN, then apply the
+// proof BOTTOM-UP. Precondition: len(proof)==inclusionProofLen(index,size),
+// 0<=index<size.
+func rebuildRootFromInclusion(leafHash [HashSize]byte, index, size int, proof [][HashSize]byte) [HashSize]byte {
+	// onLeft[d] is true when, at decomposition depth d (0 = whole tree),
+	// the leaf sits in the LEFT subtree (so its sibling is on the right).
+	onLeft := make([]bool, 0, len(proof))
+	fn := index
+	sn := size
+	for sn > 1 {
+		k := largestPowerOfTwoLessThan(sn)
+		if fn < k {
+			onLeft = append(onLeft, true)
+			sn = k
+		} else {
+			onLeft = append(onLeft, false)
+			fn -= k
+			sn -= k
+		}
+	}
+	// Apply proof bottom-up: the deepest decision is the LAST recorded, and
+	// it pairs with proof[0].
+	hash := leafHash
+	for i := 0; i < len(proof); i++ {
+		// Deepest decision first.
+		d := len(onLeft) - 1 - i
+		if onLeft[d] {
+			// Leaf subtree is on the LEFT; sibling on the RIGHT.
+			hash = hashChildren(hash, proof[i])
+		} else {
+			// Leaf subtree is on the RIGHT; sibling on the LEFT.
+			hash = hashChildren(proof[i], hash)
+		}
+	}
+	return hash
+}
+
+// inclusionProofLen returns the exact number of hashes an inclusion proof
+// for (index, size) must contain. Computed by the same decomposition the
+// proof-builder uses, so the length check in VerifyInclusion is tight.
+func inclusionProofLen(index, size int) int {
+	n := 0
+	fn := index
+	sn := size
+	for sn > 1 {
+		k := largestPowerOfTwoLessThan(sn)
+		if fn < k {
+			sn = k
+		} else {
+			fn -= k
+			sn -= k
+		}
+		n++
+	}
+	return n
+}
+
+// ConsistencyProof returns the RFC-6962 §2.1.2 consistency proof that a
+// tree of `second` leaves is a pure APPEND of a tree of `first` leaves —
+// i.e. the first `first` leaves are unchanged and nothing was rewritten.
+//
+// `leaves` must be the full ordered leaf-hash set of the LARGER (second)
+// tree. A verifier later checks the proof with VerifyConsistency against
+// the two roots it independently trusts (the old root from an old STH, the
+// new root from a new STH) WITHOUT the leaf set.
+//
+// first == second yields an empty proof (trivially consistent). first == 0
+// also yields an empty proof (everything is "new"); VerifyConsistency
+// treats both as a no-op success.
+func ConsistencyProof(first, second int, leaves [][HashSize]byte) ([][HashSize]byte, error) {
+	if first < 0 || second < 0 || first > second {
+		return nil, fmt.Errorf("%w: first=%d second=%d", ErrBadConsistencyArgs, first, second)
+	}
+	if second == 0 {
+		return nil, fmt.Errorf("%w: second=0", ErrEmptyTree)
+	}
+	if len(leaves) != second {
+		return nil, fmt.Errorf("%w: have %d leaves, second says %d", ErrBadProofSize, len(leaves), second)
+	}
+	if first == 0 || first == second {
+		return [][HashSize]byte{}, nil
+	}
+	return consistencySubproof(first, leaves, true), nil
+}
+
+// consistencySubproof is RFC-6962 §2.1.2 SUBPROOF(m, D[0:n], b). `m` is the
+// first (smaller) size; `leaves` is D[0:n] for the current subtree; `b`
+// indicates whether the current subtree's root is "known" to the verifier
+// from the old tree (true at the top, where m may equal n on the left
+// spine).
+func consistencySubproof(m int, leaves [][HashSize]byte, b bool) [][HashSize]byte {
+	n := len(leaves)
+	if m == n {
+		if b {
+			// The whole subtree is the old tree; nothing to prove here.
+			return [][HashSize]byte{}
+		}
+		// The old tree root is an interior node the verifier must be
+		// given so it can reconstruct the old root.
+		return [][HashSize]byte{merkleTreeHash(leaves)}
+	}
+	k := largestPowerOfTwoLessThan(n)
+	if m <= k {
+		// Old tree lives entirely in the left subtree; append the right
+		// subtree root (the part that is purely new at this level).
+		sub := consistencySubproof(m, leaves[:k], b)
+		return append(sub, merkleTreeHash(leaves[k:]))
+	}
+	// Old tree spans into the right subtree; the left subtree is fully
+	// shared (carry b=false so its root is surfaced), recurse right.
+	sub := consistencySubproof(m-k, leaves[k:], false)
+	return append(sub, merkleTreeHash(leaves[:k]))
+}
+
+// VerifyConsistency checks an RFC-6962 consistency proof OFFLINE: that
+// `secondRoot` (size `second`) is a pure append of `firstRoot` (size
+// `first`). It reconstructs BOTH roots from the proof and compares each
+// (constant-time) against the trusted values.
+//
+// A log that dropped, reordered, or rewrote any of the first `first`
+// entries cannot produce a proof that reconstructs the original
+// `firstRoot` AND the advertised `secondRoot` — so the rewrite is DETECTED
+// as ErrConsistencyMismatch. This is the anti-rewrite property.
+func VerifyConsistency(first, second int, firstRoot, secondRoot [HashSize]byte, proof [][HashSize]byte) error {
+	if first < 0 || second < 0 || first > second {
+		return fmt.Errorf("%w: first=%d second=%d", ErrBadConsistencyArgs, first, second)
+	}
+	if first == 0 {
+		// Old tree was empty: nothing to be consistent WITH. By RFC-6962
+		// convention an empty old tree is trivially consistent; we still
+		// reject a non-empty proof so a forged path can't sneak in.
+		if len(proof) != 0 {
+			return fmt.Errorf("%w: first=0 expects empty proof, got %d hashes", ErrBadProofSize, len(proof))
+		}
+		return nil
+	}
+	if first == second {
+		// Same tree: roots must be identical and the proof empty.
+		if len(proof) != 0 {
+			return fmt.Errorf("%w: first==second expects empty proof, got %d hashes", ErrBadProofSize, len(proof))
+		}
+		if subtle.ConstantTimeCompare(firstRoot[:], secondRoot[:]) != 1 {
+			return ErrConsistencyMismatch
+		}
+		return nil
+	}
+
+	// firstIsPowerOfTwo: when the old size is an exact power of two, its
+	// root is a clean subtree of the new tree and is NOT carried in the
+	// proof — the verifier seeds it from firstRoot. Otherwise the first
+	// proof element is the old tree's left-spine node.
+	firstIsPow2 := isPowerOfTwo(first)
+
+	want := consistencyProofLen(first, second)
+	if len(proof) != want {
+		return fmt.Errorf("%w: have %d hashes, want %d for first=%d second=%d",
+			ErrBadProofSize, len(proof), want, first, second)
+	}
+
+	gotFirst, gotSecond, ok := rebuildConsistencyRoots(first, second, firstRoot, proof, firstIsPow2)
+	if !ok {
+		return ErrConsistencyMismatch
+	}
+	if subtle.ConstantTimeCompare(gotFirst[:], firstRoot[:]) != 1 {
+		return ErrConsistencyMismatch
+	}
+	if subtle.ConstantTimeCompare(gotSecond[:], secondRoot[:]) != 1 {
+		return ErrConsistencyMismatch
+	}
+	return nil
+}
+
+// rebuildConsistencyRoots folds a consistency proof into the old and new
+// roots. This is the verification counterpart to consistencySubproof,
+// following the standard RFC-6962 reference algorithm (the same shape used
+// by Trillian's merkle/proof verifier). Returns (oldRoot, newRoot, ok).
+func rebuildConsistencyRoots(first, second int, firstRoot [HashSize]byte, proof [][HashSize]byte, firstIsPow2 bool) ([HashSize]byte, [HashSize]byte, bool) {
+	// Seed the proof working set. When first is a power of two, firstRoot
+	// is the implicit first node; otherwise proof[0] is.
+	var seed [][HashSize]byte
+	if firstIsPow2 {
+		seed = append([][HashSize]byte{firstRoot}, proof...)
+	} else {
+		seed = proof
+	}
+	if len(seed) == 0 {
+		return [HashSize]byte{}, [HashSize]byte{}, false
+	}
+
+	fn := first - 1
+	sn := second - 1
+	// Shift fn,sn right until fn is odd (or zero) — aligns to the rightmost
+	// node of the old tree on the shared left spine.
+	for fn&1 == 1 {
+		fn >>= 1
+		sn >>= 1
+	}
+
+	hash1 := seed[0]
+	hash2 := seed[0]
+	for _, c := range seed[1:] {
+		if sn == 0 {
+			// Ran out of tree to climb but still have proof nodes →
+			// malformed proof.
+			return [HashSize]byte{}, [HashSize]byte{}, false
+		}
+		if fn&1 == 1 || fn == sn {
+			// Right child (or both indices coincide): the proof node is
+			// the LEFT sibling for both running hashes that still track
+			// the old tree.
+			hash1 = hashChildren(c, hash1)
+			hash2 = hashChildren(c, hash2)
+			for fn != 0 && fn&1 == 0 {
+				fn >>= 1
+				sn >>= 1
+			}
+		} else {
+			// Left child: only the new-tree hash extends to the right.
+			hash2 = hashChildren(hash2, c)
+		}
+		fn >>= 1
+		sn >>= 1
+	}
+	if sn != 0 {
+		// Did not consume the full new tree → malformed proof.
+		return [HashSize]byte{}, [HashSize]byte{}, false
+	}
+	return hash1, hash2, true
+}
+
+// consistencyProofLen returns the expected hash count for a consistency
+// proof between first and second (1 <= first < second). Derived from the
+// same decomposition consistencySubproof uses so the length check is
+// tight.
+func consistencyProofLen(first, second int) int {
+	return len(consistencyShape(first, second))
+}
+
+// consistencyShape replays the SUBPROOF recursion counting only how many
+// hashes it would emit, given the sizes alone (no leaf data). Keeping this
+// independent of the actual hashes lets VerifyConsistency reject a
+// wrong-length proof up front.
+func consistencyShape(m, n int) []struct{} {
+	if m == n {
+		// b=true at the entry point: empty.
+		return nil
+	}
+	return shapeSub(m, n, true)
+}
+
+func shapeSub(m, n int, b bool) []struct{} {
+	if m == n {
+		if b {
+			return nil
+		}
+		return []struct{}{{}}
+	}
+	k := largestPowerOfTwoLessThan(n)
+	if m <= k {
+		return append(shapeSub(m, k, b), struct{}{})
+	}
+	return append(shapeSub(m-k, n-k, false), struct{}{})
+}
+
+// isPowerOfTwo reports whether x is a positive power of two.
+func isPowerOfTwo(x int) bool {
+	return x > 0 && x&(x-1) == 0
+}

--- a/pkg/skillctl/translog/proof_test.go
+++ b/pkg/skillctl/translog/proof_test.go
@@ -1,0 +1,232 @@
+package translog
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestInclusion_RoundTripAllSizes proves every leaf in every tree up to a
+// decent size. This exercises the k-split decomposition on both balanced
+// and unbalanced trees.
+func TestInclusion_RoundTripAllSizes(t *testing.T) {
+	for size := 1; size <= 33; size++ {
+		leaves := leafHashes(size)
+		root, err := MerkleTreeHash(leaves)
+		if err != nil {
+			t.Fatalf("size=%d: %v", size, err)
+		}
+		for idx := 0; idx < size; idx++ {
+			proof, err := InclusionProof(idx, size, leaves)
+			if err != nil {
+				t.Fatalf("size=%d idx=%d: build proof: %v", size, idx, err)
+			}
+			if err := VerifyInclusion(leaves[idx], idx, size, proof, root); err != nil {
+				t.Fatalf("size=%d idx=%d: verify: %v", size, idx, err)
+			}
+		}
+	}
+}
+
+func TestInclusion_TamperedLeafRejected(t *testing.T) {
+	size := 7
+	leaves := leafHashes(size)
+	root, _ := MerkleTreeHash(leaves)
+	idx := 3
+	proof, _ := InclusionProof(idx, size, leaves)
+
+	// Flip the leaf hash → reconstruction diverges from root.
+	bad := leaves[idx]
+	bad[0] ^= 0xFF
+	if err := VerifyInclusion(bad, idx, size, proof, root); !errors.Is(err, ErrInclusionMismatch) {
+		t.Fatalf("tampered leaf: want ErrInclusionMismatch, got %v", err)
+	}
+}
+
+func TestInclusion_WrongIndexRejected(t *testing.T) {
+	size := 8
+	leaves := leafHashes(size)
+	root, _ := MerkleTreeHash(leaves)
+	// Proof for index 2, but verify claims index 5.
+	proof, _ := InclusionProof(2, size, leaves)
+	if err := VerifyInclusion(leaves[2], 5, size, proof, root); err == nil {
+		t.Fatal("wrong index: expected rejection, got nil")
+	}
+}
+
+func TestInclusion_TamperedProofPathRejected(t *testing.T) {
+	size := 9
+	leaves := leafHashes(size)
+	root, _ := MerkleTreeHash(leaves)
+	idx := 4
+	proof, _ := InclusionProof(idx, size, leaves)
+	if len(proof) == 0 {
+		t.Fatal("expected a non-empty proof")
+	}
+	// Corrupt one sibling hash.
+	proof[0][0] ^= 0x01
+	if err := VerifyInclusion(leaves[idx], idx, size, proof, root); !errors.Is(err, ErrInclusionMismatch) {
+		t.Fatalf("tampered path: want ErrInclusionMismatch, got %v", err)
+	}
+}
+
+func TestInclusion_WrongSizeProofRejected(t *testing.T) {
+	size := 8
+	leaves := leafHashes(size)
+	root, _ := MerkleTreeHash(leaves)
+	idx := 1
+	proof, _ := InclusionProof(idx, size, leaves)
+	// Claim a different size than the proof was built for: the length
+	// check must catch it before any hashing.
+	if err := VerifyInclusion(leaves[idx], idx, 16, proof, root); !errors.Is(err, ErrBadProofSize) {
+		t.Fatalf("wrong size: want ErrBadProofSize, got %v", err)
+	}
+}
+
+func TestInclusion_ForgedProofForNonLoggedLeaf(t *testing.T) {
+	// Adversarial: an event that was NEVER logged. Its leaf hash is not in
+	// the tree. No proof of the correct length can reconstruct the trusted
+	// root, so VerifyInclusion must reject for every index.
+	size := 8
+	leaves := leafHashes(size)
+	root, _ := MerkleTreeHash(leaves)
+
+	forged := HashLeaf([]byte("event-that-was-never-logged"))
+	for idx := 0; idx < size; idx++ {
+		// Reuse a genuine-shape proof (length is right) but the leaf is
+		// alien → must fail.
+		proof, _ := InclusionProof(idx, size, leaves)
+		if err := VerifyInclusion(forged, idx, size, proof, root); err == nil {
+			t.Fatalf("idx=%d: forged inclusion for non-logged leaf accepted", idx)
+		}
+	}
+}
+
+func TestInclusion_IndexOutOfRange(t *testing.T) {
+	size := 4
+	leaves := leafHashes(size)
+	if _, err := InclusionProof(4, size, leaves); !errors.Is(err, ErrIndexOutOfRange) {
+		t.Fatalf("want ErrIndexOutOfRange, got %v", err)
+	}
+	if _, err := InclusionProof(-1, size, leaves); !errors.Is(err, ErrIndexOutOfRange) {
+		t.Fatalf("want ErrIndexOutOfRange for negative, got %v", err)
+	}
+}
+
+// TestConsistency_RoundTripAllPairs is the anti-rewrite workhorse: for
+// every (first <= second) up to a decent size, the proof must reconstruct
+// BOTH the old and new roots.
+func TestConsistency_RoundTripAllPairs(t *testing.T) {
+	const max = 24
+	full := leafHashes(max)
+	roots := make([][HashSize]byte, max+1)
+	for n := 1; n <= max; n++ {
+		r, err := MerkleTreeHash(full[:n])
+		if err != nil {
+			t.Fatal(err)
+		}
+		roots[n] = r
+	}
+
+	for second := 1; second <= max; second++ {
+		for first := 0; first <= second; first++ {
+			proof, err := ConsistencyProof(first, second, full[:second])
+			if err != nil {
+				t.Fatalf("first=%d second=%d: build: %v", first, second, err)
+			}
+			var fRoot [HashSize]byte
+			if first > 0 {
+				fRoot = roots[first]
+			}
+			if err := VerifyConsistency(first, second, fRoot, roots[second], proof); err != nil {
+				t.Fatalf("first=%d second=%d: verify: %v (prooflen=%d)", first, second, err, len(proof))
+			}
+		}
+	}
+}
+
+// TestConsistency_RewriteDetected is the headline property: a log that
+// REWROTE an early entry produces a different old-root; the consistency
+// proof from the honest log cannot reconcile the rewritten new tree with
+// the genuine old root → DETECTED.
+func TestConsistency_RewriteDetected(t *testing.T) {
+	first, second := 4, 8
+	honest := leafHashes(second)
+	oldRoot, _ := MerkleTreeHash(honest[:first])
+	newRootHonest, _ := MerkleTreeHash(honest)
+
+	// Attacker rewrites leaf 1 in the new tree (history tampering) but
+	// still wants verifiers pinned to oldRoot to accept it.
+	tampered := leafHashes(second)
+	tampered[1] = HashLeaf([]byte("REWRITTEN"))
+	newRootTampered, _ := MerkleTreeHash(tampered)
+
+	// Honest proof for the honest new tree verifies fine.
+	goodProof, _ := ConsistencyProof(first, second, honest)
+	if err := VerifyConsistency(first, second, oldRoot, newRootHonest, goodProof); err != nil {
+		t.Fatalf("honest consistency should pass: %v", err)
+	}
+
+	// The tampered new tree, presented with the genuine old root, must NOT
+	// verify — regardless of which proof the attacker supplies.
+	tamperedProof, _ := ConsistencyProof(first, second, tampered)
+	if err := VerifyConsistency(first, second, oldRoot, newRootTampered, tamperedProof); !errors.Is(err, ErrConsistencyMismatch) {
+		t.Fatalf("rewrite via tampered proof: want ErrConsistencyMismatch, got %v", err)
+	}
+	// Attacker tries the HONEST proof against the tampered new root.
+	if err := VerifyConsistency(first, second, oldRoot, newRootTampered, goodProof); !errors.Is(err, ErrConsistencyMismatch) {
+		t.Fatalf("rewrite via honest proof: want ErrConsistencyMismatch, got %v", err)
+	}
+}
+
+func TestConsistency_TamperedProofRejected(t *testing.T) {
+	first, second := 3, 9
+	leaves := leafHashes(second)
+	oldRoot, _ := MerkleTreeHash(leaves[:first])
+	newRoot, _ := MerkleTreeHash(leaves)
+	proof, _ := ConsistencyProof(first, second, leaves)
+	if len(proof) == 0 {
+		t.Fatal("expected non-empty consistency proof")
+	}
+	proof[0][0] ^= 0x80
+	if err := VerifyConsistency(first, second, oldRoot, newRoot, proof); !errors.Is(err, ErrConsistencyMismatch) {
+		t.Fatalf("tampered consistency proof: want ErrConsistencyMismatch, got %v", err)
+	}
+}
+
+func TestConsistency_WrongLengthRejected(t *testing.T) {
+	first, second := 3, 9
+	leaves := leafHashes(second)
+	oldRoot, _ := MerkleTreeHash(leaves[:first])
+	newRoot, _ := MerkleTreeHash(leaves)
+	proof, _ := ConsistencyProof(first, second, leaves)
+	// Drop a hash → wrong length must be rejected up front.
+	short := proof[:len(proof)-1]
+	if err := VerifyConsistency(first, second, oldRoot, newRoot, short); !errors.Is(err, ErrBadProofSize) {
+		t.Fatalf("short proof: want ErrBadProofSize, got %v", err)
+	}
+}
+
+func TestConsistency_BadArgs(t *testing.T) {
+	leaves := leafHashes(4)
+	if _, err := ConsistencyProof(5, 4, leaves); !errors.Is(err, ErrBadConsistencyArgs) {
+		t.Fatalf("first>second: want ErrBadConsistencyArgs, got %v", err)
+	}
+}
+
+// TestConsistency_FirstEqualsSecond_RootMustMatch ensures the same-size
+// path still checks root equality (a verifier shouldn't accept two
+// different roots claimed at the same size — that's the split-view shape,
+// caught here at the proof layer too).
+func TestConsistency_FirstEqualsSecond_RootMustMatch(t *testing.T) {
+	leaves := leafHashes(5)
+	root, _ := MerkleTreeHash(leaves)
+	var other [HashSize]byte
+	copy(other[:], root[:])
+	other[0] ^= 0xFF
+	if err := VerifyConsistency(5, 5, root, other, nil); !errors.Is(err, ErrConsistencyMismatch) {
+		t.Fatalf("same size, different roots: want ErrConsistencyMismatch, got %v", err)
+	}
+	if err := VerifyConsistency(5, 5, root, root, nil); err != nil {
+		t.Fatalf("same size, same root: want pass, got %v", err)
+	}
+}

--- a/pkg/skillctl/translog/receipt.go
+++ b/pkg/skillctl/translog/receipt.go
@@ -1,0 +1,136 @@
+package translog
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Receipt is a portable, self-contained inclusion receipt: everything a
+// verifier needs to confirm OFFLINE that one event is committed under a
+// signed tree head — the event, its leaf position, the inclusion proof, and
+// the STH. It is the JSON artifact the CLI `prove` verb emits and the
+// `verify` verb consumes, and the "log receipt" that can ride alongside a
+// signed bundle.
+//
+// The proof hashes are hex-encoded for JSON portability. NO event data
+// beyond the LogEntry (which is itself just a digest + type + timestamp +
+// subject) is carried — data stays off the log (SPEC-0278 §5).
+type Receipt struct {
+	// Entry is the logged event. Its leaf hash is RECOMPUTED on verify —
+	// the receipt never carries a trusted leaf hash.
+	Entry LogEntry `json:"entry"`
+
+	// Index is the leaf position the proof claims.
+	Index int `json:"index"`
+
+	// TreeSize is the size the proof was produced against (and that the
+	// STH must commit).
+	TreeSize int `json:"tree_size"`
+
+	// ProofHex is the inclusion (audit) path, each node hex-encoded.
+	ProofHex []string `json:"proof"`
+
+	// STH is the signed tree head the proof verifies against.
+	STH STH `json:"sth"`
+}
+
+// ErrReceiptInvalid — a receipt failed structural validation (bad proof
+// hex, size/STH mismatch, etc.).
+var ErrReceiptInvalid = errors.New("translog: invalid inclusion receipt")
+
+// NewReceipt assembles a receipt from raw proof hashes and an STH.
+func NewReceipt(entry LogEntry, index, treeSize int, proof [][HashSize]byte, sth STH) Receipt {
+	hexes := make([]string, len(proof))
+	for i, p := range proof {
+		hexes[i] = hex.EncodeToString(p[:])
+	}
+	return Receipt{Entry: entry, Index: index, TreeSize: treeSize, ProofHex: hexes, STH: sth}
+}
+
+// MarshalJSON-friendly dump.
+func (r Receipt) JSON() ([]byte, error) {
+	return json.MarshalIndent(r, "", "  ")
+}
+
+// ParseReceipt decodes a receipt from JSON and validates its shape.
+func ParseReceipt(data []byte) (Receipt, error) {
+	var r Receipt
+	if err := json.Unmarshal(data, &r); err != nil {
+		return Receipt{}, fmt.Errorf("%w: %v", ErrReceiptInvalid, err)
+	}
+	if err := r.validate(); err != nil {
+		return Receipt{}, err
+	}
+	return r, nil
+}
+
+// proofBytes decodes ProofHex into fixed-size node hashes, rejecting any
+// element that is not exactly HashSize bytes of hex.
+func (r Receipt) proofBytes() ([][HashSize]byte, error) {
+	out := make([][HashSize]byte, len(r.ProofHex))
+	for i, h := range r.ProofHex {
+		raw, err := hex.DecodeString(h)
+		if err != nil {
+			return nil, fmt.Errorf("%w: proof[%d] not hex: %v", ErrReceiptInvalid, i, err)
+		}
+		if len(raw) != HashSize {
+			return nil, fmt.Errorf("%w: proof[%d] is %d bytes, want %d", ErrReceiptInvalid, i, len(raw), HashSize)
+		}
+		copy(out[i][:], raw)
+	}
+	return out, nil
+}
+
+func (r Receipt) validate() error {
+	if r.TreeSize < 1 {
+		return fmt.Errorf("%w: tree_size must be >= 1", ErrReceiptInvalid)
+	}
+	if r.Index < 0 || r.Index >= r.TreeSize {
+		return fmt.Errorf("%w: index %d out of range for tree_size %d", ErrReceiptInvalid, r.Index, r.TreeSize)
+	}
+	if r.STH.TreeSize != r.TreeSize {
+		return fmt.Errorf("%w: STH tree_size %d != receipt tree_size %d", ErrReceiptInvalid, r.STH.TreeSize, r.TreeSize)
+	}
+	if _, err := r.Entry.Canonical(); err != nil {
+		return fmt.Errorf("%w: %v", ErrReceiptInvalid, err)
+	}
+	if _, err := r.proofBytes(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// VerifyOffline checks the receipt end-to-end against a pinned log public
+// key, with NO network access:
+//
+//  1. the STH signature verifies under logPub (so the head is authentic and
+//     from the pinned log);
+//  2. the event's leaf hash (RECOMPUTED from the entry) is included at
+//     r.Index in a tree of r.TreeSize whose root is the STH's root.
+//
+// Returns nil on success; a wrapped sentinel on any failure. This is the
+// single call the CLI `verify` verb makes — it is the offline inclusion
+// check a cross-org verifier runs against a head it already trusts.
+func (r Receipt) VerifyOffline(logPub []byte) error {
+	if err := r.validate(); err != nil {
+		return err
+	}
+	if err := VerifySTH(logPub, r.STH); err != nil {
+		return err
+	}
+	root, err := r.STH.RootBytes()
+	if err != nil {
+		return err
+	}
+	leaf, err := r.Entry.LeafHash()
+	if err != nil {
+		return err
+	}
+	proof, err := r.proofBytes()
+	if err != nil {
+		return err
+	}
+	return VerifyInclusion(leaf, r.Index, r.TreeSize, proof, root)
+}

--- a/pkg/skillctl/translog/receipt_test.go
+++ b/pkg/skillctl/translog/receipt_test.go
@@ -1,0 +1,107 @@
+package translog
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildReceipt(t *testing.T) (Receipt, ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	l, _ := OpenLog(tmpLogPath(t), "log-1")
+	var entries []LogEntry
+	for i := 0; i < 6; i++ {
+		e := mkEntry(EventAttest, i)
+		entries = append(entries, e)
+		if _, err := l.Append(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sth, err := l.SignHead(priv, time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof, size, _, err := l.ProveInclusion(3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := NewReceipt(entries[3], 3, size, proof, sth)
+	return r, pub, priv
+}
+
+func TestReceipt_VerifyOfflineRoundTrip(t *testing.T) {
+	r, pub, _ := buildReceipt(t)
+	if err := r.VerifyOffline(pub); err != nil {
+		t.Fatalf("receipt should verify offline: %v", err)
+	}
+}
+
+func TestReceipt_JSONRoundTrip(t *testing.T) {
+	r, pub, _ := buildReceipt(t)
+	data, err := r.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseReceipt(data)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := parsed.VerifyOffline(pub); err != nil {
+		t.Fatalf("parsed receipt should verify: %v", err)
+	}
+}
+
+func TestReceipt_UnpinnedKeyRefused(t *testing.T) {
+	r, _, _ := buildReceipt(t)
+	otherPub, _, _ := ed25519.GenerateKey(nil)
+	if err := r.VerifyOffline(otherPub); !errors.Is(err, ErrSTHSignatureInvalid) {
+		t.Fatalf("wrong log key: want ErrSTHSignatureInvalid, got %v", err)
+	}
+}
+
+func TestReceipt_TamperedEntryRefused(t *testing.T) {
+	r, pub, _ := buildReceipt(t)
+	// Tamper the event subject after the proof was made → leaf changes →
+	// inclusion fails.
+	r.Entry.Subject = "tampered"
+	if err := r.VerifyOffline(pub); err == nil {
+		t.Fatal("tampered entry should fail inclusion")
+	}
+}
+
+func TestReceipt_BadProofHexRefused(t *testing.T) {
+	r, pub, _ := buildReceipt(t)
+	if len(r.ProofHex) == 0 {
+		t.Fatal("expected a non-empty proof")
+	}
+	r.ProofHex[0] = "zz" + r.ProofHex[0][2:] // invalid hex
+	if err := r.VerifyOffline(pub); !errors.Is(err, ErrReceiptInvalid) {
+		t.Fatalf("bad proof hex: want ErrReceiptInvalid, got %v", err)
+	}
+}
+
+func TestReceipt_SizeMismatchRefused(t *testing.T) {
+	r, _, _ := buildReceipt(t)
+	r.TreeSize = 99 // STH still says 6
+	if _, err := ParseReceiptRoundtrip(t, r); !errors.Is(err, ErrReceiptInvalid) {
+		t.Fatalf("size mismatch: want ErrReceiptInvalid, got %v", err)
+	}
+}
+
+// ParseReceiptRoundtrip marshals then parses, surfacing validation errors.
+func ParseReceiptRoundtrip(t *testing.T, r Receipt) (Receipt, error) {
+	t.Helper()
+	data, err := r.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Defeat the JSON marshal hiding the mismatch: the marshal preserves
+	// fields, so ParseReceipt's validate() catches the STH/tree_size skew.
+	if strings.Count(string(data), "tree_size") < 2 {
+		t.Fatal("expected both receipt and STH tree_size in JSON")
+	}
+	return ParseReceipt(data)
+}

--- a/pkg/skillctl/translog/sth.go
+++ b/pkg/skillctl/translog/sth.go
@@ -1,0 +1,212 @@
+package translog
+
+import (
+	"crypto/ed25519"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// STHDomain is the domain separator for a Signed Tree Head signature. It is
+// DISTINCT from every other signed-message family in the spine
+// ("attestation" in signing/attest.go, "revoke" in signing/revoke.go, the
+// AgentID envelopes, the device-token envelope, ...). Because the domain
+// string is the FIRST line of the signed message, an ed25519 signature
+// produced over an STH can never be byte-equal to — and therefore never be
+// replayed as — an attestation, a revocation, or any other envelope; and
+// vice versa. Bumping the "-v1" suffix is how we'd migrate the STH format
+// without a cross-family collision.
+const STHDomain = "skillctl-sth-v1"
+
+// STHTimestampLayout is the exact wire format for the STH timestamp: RFC
+// 3339, UTC, second precision, "Z" suffix. No fractional seconds and no
+// numeric offset, so the signed bytes are deterministic across platforms
+// (mirrors signing.AttestationTimestampLayout).
+const STHTimestampLayout = "2006-01-02T15:04:05Z"
+
+// sthTimestampPattern is the strict acceptance pattern for the timestamp
+// line: it must match the layout above exactly.
+var sthTimestampPattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)
+
+// logIDPattern restricts a log id to a small safe character set so it can
+// never inject a newline into the canonical message (which would let an
+// attacker shift field boundaries).
+var logIDPattern = regexp.MustCompile(`^[A-Za-z0-9._:-]{1,128}$`)
+
+// STH errors.
+var (
+	// ErrSTHMalformed — the STH failed structural validation before any
+	// crypto check (bad size, bad timestamp, empty root, bad log id).
+	ErrSTHMalformed = errors.New("translog: malformed signed tree head")
+	// ErrSTHSignatureInvalid — the ed25519 signature did not verify
+	// against the pinned log key. Covers BOTH a forged signature and an
+	// STH signed by a NON-pinned key (the caller passes the pinned key;
+	// any other signer fails here).
+	ErrSTHSignatureInvalid = errors.New("translog: STH signature invalid (wrong or unpinned log key)")
+)
+
+// STH is a Signed Tree Head: a log operator's signed commitment to "at
+// this timestamp, my log had exactly TreeSize entries and this RootHash."
+// It is the anchor a verifier pins (with the log's public key) and checks
+// inclusion proofs against — entirely offline.
+//
+// Per SPEC-0278 §3.4 the trust-roots file pins the log public key plus a
+// recent STH (or a witnessed-STH set); this struct is that pinned object.
+type STH struct {
+	// TreeSize is the number of leaves committed. Must be >= 1 — we never
+	// sign over an empty tree.
+	TreeSize int `json:"tree_size" yaml:"tree_size"`
+
+	// RootHash is the RFC-6962 Merkle Tree Hash over the TreeSize leaves,
+	// hex-encoded (64 lowercase hex chars).
+	RootHash string `json:"root_hash" yaml:"root_hash"`
+
+	// Timestamp is when the operator signed this head, in STHTimestampLayout.
+	Timestamp string `json:"timestamp" yaml:"timestamp"`
+
+	// LogID identifies WHICH log this head belongs to. Cross-witness
+	// split-view detection only compares STHs carrying the SAME LogID (two
+	// heads of two different logs at the same size are not a conflict).
+	LogID string `json:"log_id" yaml:"log_id"`
+
+	// Signature is the ed25519 signature over CanonicalSTHMessage, hex-
+	// encoded (128 lowercase hex chars). Empty on an unsigned STH.
+	Signature string `json:"signature,omitempty" yaml:"signature,omitempty"`
+}
+
+// RootBytes decodes RootHash into a fixed [HashSize]byte. Returns
+// ErrSTHMalformed if the hex is the wrong length or not valid hex — so a
+// caller can never hand a half-decoded root into VerifyInclusion.
+func (s STH) RootBytes() ([HashSize]byte, error) {
+	var out [HashSize]byte
+	raw, err := hex.DecodeString(s.RootHash)
+	if err != nil {
+		return out, fmt.Errorf("%w: root_hash not hex: %v", ErrSTHMalformed, err)
+	}
+	if len(raw) != HashSize {
+		return out, fmt.Errorf("%w: root_hash is %d bytes, want %d", ErrSTHMalformed, len(raw), HashSize)
+	}
+	copy(out[:], raw)
+	return out, nil
+}
+
+// validateShape runs the non-crypto structural checks shared by signing and
+// verification. Doing them BEFORE assembling the canonical message means we
+// never sign over malformed bytes and never attempt a verify against a
+// nonsense head.
+func (s STH) validateShape() error {
+	if s.TreeSize < 1 {
+		return fmt.Errorf("%w: tree_size must be >= 1, got %d", ErrSTHMalformed, s.TreeSize)
+	}
+	if len(s.RootHash) != HashSize*2 {
+		return fmt.Errorf("%w: root_hash must be %d hex chars, got %d", ErrSTHMalformed, HashSize*2, len(s.RootHash))
+	}
+	if _, err := s.RootBytes(); err != nil {
+		return err
+	}
+	if !sthTimestampPattern.MatchString(s.Timestamp) {
+		return fmt.Errorf("%w: timestamp %q is not RFC3339 UTC seconds", ErrSTHMalformed, s.Timestamp)
+	}
+	if !logIDPattern.MatchString(s.LogID) {
+		return fmt.Errorf("%w: log_id %q invalid (allowed: [A-Za-z0-9._:-], 1-128 chars)", ErrSTHMalformed, s.LogID)
+	}
+	return nil
+}
+
+// CanonicalSTHMessage returns the exact bytes signed/verified for this STH.
+// Format (UTF-8, LF-separated, trailing LF):
+//
+//	skillctl-sth-v1\n
+//	<tree_size>\n          decimal, no leading zeros
+//	<root_hash>\n          64 lowercase hex
+//	<timestamp>\n          RFC3339 UTC seconds
+//	<log_id>\n
+//
+// The leading domain line is what isolates STH signatures from every other
+// envelope family. Strict shape validation runs first.
+func (s STH) CanonicalSTHMessage() ([]byte, error) {
+	if err := s.validateShape(); err != nil {
+		return nil, err
+	}
+	// Re-encode tree_size from the int so the bytes are canonical (no
+	// stray leading zeros could ever be smuggled in via a struct field).
+	var b strings.Builder
+	b.WriteString(STHDomain)
+	b.WriteByte('\n')
+	b.WriteString(strconv.Itoa(s.TreeSize))
+	b.WriteByte('\n')
+	b.WriteString(strings.ToLower(s.RootHash))
+	b.WriteByte('\n')
+	b.WriteString(s.Timestamp)
+	b.WriteByte('\n')
+	b.WriteString(s.LogID)
+	b.WriteByte('\n')
+	return []byte(b.String()), nil
+}
+
+// SignSTH signs an STH with the log's ed25519 private key and returns a
+// copy with Signature populated (hex). The input's Signature field is
+// ignored. logKey must be the LOG signing key — distinct from author /
+// registry / attestation keys.
+func SignSTH(logKey ed25519.PrivateKey, s STH) (STH, error) {
+	if len(logKey) != ed25519.PrivateKeySize {
+		return STH{}, fmt.Errorf("%w: log private key is %d bytes, want %d", ErrSTHMalformed, len(logKey), ed25519.PrivateKeySize)
+	}
+	msg, err := s.CanonicalSTHMessage()
+	if err != nil {
+		return STH{}, err
+	}
+	sig := ed25519.Sign(logKey, msg)
+	out := s
+	out.Signature = hex.EncodeToString(sig)
+	return out, nil
+}
+
+// VerifySTH checks the STH signature against the PINNED log public key.
+//
+// This is the single chokepoint for "is this STH authentic and from the
+// log I trust." An STH signed by ANY key other than logPub fails with
+// ErrSTHSignatureInvalid — so a head signed by an unpinned key is refused,
+// and a forged head whose root does not match its signed bytes is refused.
+// (Whether the root actually matches a set of leaves is a separate concern,
+// checked by VerifyInclusion / the log builder.)
+func VerifySTH(logPub ed25519.PublicKey, s STH) error {
+	if len(logPub) != ed25519.PublicKeySize {
+		return fmt.Errorf("%w: log public key is %d bytes, want %d", ErrSTHMalformed, len(logPub), ed25519.PublicKeySize)
+	}
+	msg, err := s.CanonicalSTHMessage()
+	if err != nil {
+		return err
+	}
+	sig, err := hex.DecodeString(s.Signature)
+	if err != nil {
+		return fmt.Errorf("%w: signature not hex: %v", ErrSTHMalformed, err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("%w: signature is %d bytes, want %d", ErrSTHMalformed, len(sig), ed25519.SignatureSize)
+	}
+	if !ed25519.Verify(logPub, msg, sig) {
+		return ErrSTHSignatureInvalid
+	}
+	return nil
+}
+
+// Equal reports whether two STHs commit to the same (tree_size, root_hash,
+// log_id). Timestamp and signature are intentionally excluded: two honest
+// re-signings of the same head at different times are NOT a conflict, but
+// the same size with a DIFFERENT root IS (see VerifyWitnessConsistency).
+func (s STH) Equal(o STH) bool {
+	return s.TreeSize == o.TreeSize &&
+		s.LogID == o.LogID &&
+		subtle.ConstantTimeCompare([]byte(strings.ToLower(s.RootHash)), []byte(strings.ToLower(o.RootHash))) == 1
+}
+
+// FormatSTHTimestamp renders t as the canonical STH timestamp string.
+func FormatSTHTimestamp(t time.Time) string {
+	return t.UTC().Truncate(time.Second).Format(STHTimestampLayout)
+}

--- a/pkg/skillctl/translog/sth_test.go
+++ b/pkg/skillctl/translog/sth_test.go
@@ -1,0 +1,173 @@
+package translog
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
+)
+
+// makeSTH builds and signs an STH over the tree of the given leaf payloads.
+func makeSTH(t *testing.T, logKey ed25519.PrivateKey, logID string, leaves [][HashSize]byte) STH {
+	t.Helper()
+	root, err := MerkleTreeHash(leaves)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := STH{
+		TreeSize:  len(leaves),
+		RootHash:  hexOf(root),
+		Timestamp: FormatSTHTimestamp(time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)),
+		LogID:     logID,
+	}
+	signed, err := SignSTH(logKey, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signed
+}
+
+func TestSTH_SignVerifyRoundTrip(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	leaves := leafHashes(5)
+	s := makeSTH(t, priv, "skillctl-log-A", leaves)
+	if err := VerifySTH(pub, s); err != nil {
+		t.Fatalf("round-trip verify failed: %v", err)
+	}
+}
+
+// TestSTH_UnpinnedKeyRefused: an STH signed by a key the verifier did NOT
+// pin must be refused. This is the headline trust check.
+func TestSTH_UnpinnedKeyRefused(t *testing.T) {
+	_, attackerPriv, _ := ed25519.GenerateKey(nil)
+	pinnedPub, _, _ := ed25519.GenerateKey(nil) // the key we trust
+
+	leaves := leafHashes(4)
+	forged := makeSTH(t, attackerPriv, "skillctl-log-A", leaves)
+
+	if err := VerifySTH(pinnedPub, forged); !errors.Is(err, ErrSTHSignatureInvalid) {
+		t.Fatalf("STH by unpinned key: want ErrSTHSignatureInvalid, got %v", err)
+	}
+}
+
+// TestSTH_ForgedRootRefused: an attacker keeps a valid signature but swaps
+// the root_hash → the signed bytes no longer match → rejected.
+func TestSTH_ForgedRootRefused(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	leaves := leafHashes(6)
+	s := makeSTH(t, priv, "skillctl-log-A", leaves)
+
+	// Swap the root to a different tree's root, keep the old signature.
+	other, _ := MerkleTreeHash(leafHashes(7))
+	s.RootHash = hexOf(other)
+	if err := VerifySTH(pub, s); !errors.Is(err, ErrSTHSignatureInvalid) {
+		t.Fatalf("forged root: want ErrSTHSignatureInvalid, got %v", err)
+	}
+}
+
+func TestSTH_TamperedTreeSizeRefused(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	s := makeSTH(t, priv, "skillctl-log-A", leafHashes(5))
+	s.TreeSize = 9 // lie about the size, keep signature
+	if err := VerifySTH(pub, s); !errors.Is(err, ErrSTHSignatureInvalid) {
+		t.Fatalf("tampered tree_size: want ErrSTHSignatureInvalid, got %v", err)
+	}
+}
+
+func TestSTH_MalformedRejectedBeforeCrypto(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	good := makeSTH(t, priv, "log", leafHashes(3))
+
+	cases := []struct {
+		name string
+		mut  func(STH) STH
+	}{
+		{"zero size", func(s STH) STH { s.TreeSize = 0; return s }},
+		{"short root", func(s STH) STH { s.RootHash = "abcd"; return s }},
+		{"bad timestamp", func(s STH) STH { s.Timestamp = "2026-06-24 12:00:00"; return s }},
+		{"bad logid newline", func(s STH) STH { s.LogID = "log\nevil"; return s }},
+		{"empty logid", func(s STH) STH { s.LogID = ""; return s }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bad := c.mut(good)
+			if err := VerifySTH(pub, bad); !errors.Is(err, ErrSTHMalformed) {
+				t.Fatalf("%s: want ErrSTHMalformed, got %v", c.name, err)
+			}
+		})
+	}
+}
+
+// TestSTH_CrossDomain_SignatureReuseRefused is the adversarial cross-domain
+// test: a signature minted over an ATTESTATION message (signing.Attestation
+// domain) by a key must NOT verify as an STH, and an STH signature must NOT
+// verify as an attestation. The distinct leading domain separators
+// guarantee the signed-byte spaces are disjoint.
+func TestSTH_CrossDomain_SignatureReuseRefused(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+
+	// 1) Take a real STH and try to pass its signed bytes off as an
+	//    attestation: the attestation canonical message starts with
+	//    "attestation\n", the STH with "skillctl-sth-v1\n" — they can
+	//    never be equal, so an STH signature can't satisfy an attestation
+	//    verify and vice versa. We assert the messages are byte-distinct
+	//    AND that signatures don't cross-verify.
+	leaves := leafHashes(4)
+	root, _ := MerkleTreeHash(leaves)
+	sth := STH{
+		TreeSize:  len(leaves),
+		RootHash:  hexOf(root),
+		Timestamp: "2026-06-24T12:00:00Z",
+		LogID:     "log",
+	}
+	sthMsg, err := sth.CanonicalSTHMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build an attestation message that happens to reference the SAME
+	// digest material, to make the reuse attempt maximally realistic.
+	attMsg, err := signing.CanonicalizeAttestationMessage(
+		"sha256:"+hexOf(root), "green", "2026-06-24T12:00:00Z", "reviewer-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The signed-byte spaces must be disjoint (different domain prefix).
+	if string(sthMsg) == string(attMsg) {
+		t.Fatal("STH and attestation canonical messages collided — domain separation broken")
+	}
+
+	// Sign the ATTESTATION with this key, then try to use that signature
+	// as the STH signature → must fail.
+	attSig := ed25519.Sign(priv, attMsg)
+	sth.Signature = hex.EncodeToString(attSig)
+	if err := VerifySTH(pub, sth); !errors.Is(err, ErrSTHSignatureInvalid) {
+		t.Fatalf("attestation signature reused as STH: want ErrSTHSignatureInvalid, got %v", err)
+	}
+
+	// Conversely: sign the STH, then try to verify that signature as an
+	// attestation → ed25519.Verify over attMsg must fail.
+	sthSig := ed25519.Sign(priv, sthMsg)
+	if ed25519.Verify(pub, attMsg, sthSig) {
+		t.Fatal("STH signature verified as an attestation — cross-domain reuse possible")
+	}
+}
+
+func TestSTH_Equal(t *testing.T) {
+	leaves := leafHashes(5)
+	root, _ := MerkleTreeHash(leaves)
+	a := STH{TreeSize: 5, RootHash: hexOf(root), Timestamp: "2026-06-24T12:00:00Z", LogID: "L"}
+	b := STH{TreeSize: 5, RootHash: hexOf(root), Timestamp: "2026-06-24T13:00:00Z", LogID: "L"} // diff ts
+	if !a.Equal(b) {
+		t.Fatal("same (size,root,logid) STHs should be Equal regardless of timestamp")
+	}
+	c := a
+	c.RootHash = hexOf(leafHashes(1)[0]) // different root, same size
+	if a.Equal(c) {
+		t.Fatal("same size + different root must NOT be Equal (that's a split view)")
+	}
+}

--- a/pkg/skillctl/translog/witness.go
+++ b/pkg/skillctl/translog/witness.go
@@ -1,0 +1,211 @@
+package translog
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// Split-view / equivocation detection.
+//
+// A transparency log operator equivocates when it shows DIFFERENT histories
+// to different observers — e.g. "this skill is revoked for company A but
+// still valid for company B." With L1 we cannot PREVENT that (only the
+// deferred L2 BFT consortium ledger could), but we CAN make it DETECTABLE by
+// cross-witnessing Signed Tree Heads: if two witnesses report STHs for the
+// same log at the SAME tree_size with DIFFERENT root_hash, the operator
+// signed two incompatible histories — a split view.
+//
+// This is exactly the cross-company STH freshness / split-view check that
+// SPEC-0279 AC4 (the P4 freshness checkpoint) deferred: an STH cross-checked
+// here IS the SPEC-0279 R4 freshness checkpoint, composed where the verifier
+// reaches for it (see verify integration).
+//
+// NOTE on scope: this is the OFFLINE comparison LOGIC. The wire transport
+// that gossips STHs between org nodes (SPEC-0190 / Kafka) is DEFERRED — a
+// caller hands us the witnessed STH set however it obtained them.
+
+// ErrSplitView is returned when two STHs for the same log equivocate: same
+// tree_size, different root_hash. This is the detectable equivocation
+// signal. It is sentinel-wrapped so callers can branch on it.
+var ErrSplitView = errors.New("translog: split view detected (log equivocated)")
+
+// ErrWitnessInconsistent is returned when two STHs for the same log are not
+// a same-size conflict but still cannot be a pure append of one another —
+// i.e. a supplied consistency proof between them FAILS. A log that rewrote
+// history between two sizes trips this.
+var ErrWitnessInconsistent = errors.New("translog: witnessed STHs are not append-consistent")
+
+// SplitViewConflict describes a detected equivocation between two witnessed
+// STHs. It carries both heads so an operator can attach them to an incident
+// report (they are each independently signed and therefore non-repudiable
+// evidence that the LOG produced both).
+type SplitViewConflict struct {
+	// LogID is the log that equivocated.
+	LogID string
+	// TreeSize is the size at which the two heads disagree.
+	TreeSize int
+	// RootA and RootB are the two conflicting root hashes (hex).
+	RootA string
+	RootB string
+	// A and B are the full conflicting STHs (signed evidence).
+	A STH
+	B STH
+}
+
+// Error implements error so a conflict can be returned directly.
+func (c *SplitViewConflict) Error() string {
+	return fmt.Sprintf(
+		"%v: log %q reports tree_size %d with two different roots (%s vs %s)",
+		ErrSplitView, c.LogID, c.TreeSize, c.RootA, c.RootB)
+}
+
+// Unwrap lets errors.Is(conflict, ErrSplitView) succeed.
+func (c *SplitViewConflict) Unwrap() error { return ErrSplitView }
+
+// VerifyWitnessConsistency scans a set of STHs (typically gathered from
+// different witnesses) for the SAME log and returns the first detectable
+// equivocation: two heads at the same tree_size with different root_hash.
+//
+// It returns:
+//   - (nil, nil) when no same-size conflict exists among the inputs;
+//   - (*SplitViewConflict, error) where the error wraps ErrSplitView when a
+//     split view is found.
+//
+// STHs carrying DIFFERENT LogIDs are never compared against each other
+// (they are different logs; a size collision is not a conflict). Only the
+// (size, root) pair is compared — timestamp and signature differences are
+// expected and benign.
+//
+// This function does NOT verify signatures; callers MUST VerifySTH each
+// input against the pinned log key first (an unsigned or unpinned STH is
+// not admissible evidence). The dedicated DetectSplitView helper below does
+// the verify-then-compare in one call for callers that have the key.
+func VerifyWitnessConsistency(sths []STH) (*SplitViewConflict, error) {
+	// Group by (logID, treeSize) and look for a root disagreement. We keep
+	// the first head seen per (logID,size) and compare every subsequent
+	// head against it.
+	type key struct {
+		logID string
+		size  int
+	}
+	seen := make(map[key]STH, len(sths))
+
+	// Iterate in a deterministic order so the SAME input set always yields
+	// the SAME first-reported conflict (stable diagnostics).
+	idx := make([]int, len(sths))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.SliceStable(idx, func(a, b int) bool {
+		x, y := sths[idx[a]], sths[idx[b]]
+		if x.LogID != y.LogID {
+			return x.LogID < y.LogID
+		}
+		if x.TreeSize != y.TreeSize {
+			return x.TreeSize < y.TreeSize
+		}
+		return x.RootHash < y.RootHash
+	})
+
+	for _, i := range idx {
+		s := sths[i]
+		k := key{logID: s.LogID, size: s.TreeSize}
+		prev, ok := seen[k]
+		if !ok {
+			seen[k] = s
+			continue
+		}
+		if !prev.Equal(s) {
+			// Same log, same size, different root → equivocation.
+			c := &SplitViewConflict{
+				LogID:    s.LogID,
+				TreeSize: s.TreeSize,
+				RootA:    prev.RootHash,
+				RootB:    s.RootHash,
+				A:        prev,
+				B:        s,
+			}
+			return c, c
+		}
+	}
+	return nil, nil
+}
+
+// DetectSplitView is the verify-then-compare convenience: it first verifies
+// every STH against the pinned log public key (rejecting any unsigned /
+// unpinned / forged head), then runs VerifyWitnessConsistency. Use this at
+// the verifier boundary where the pinned key is available.
+func DetectSplitView(logPub PinnedLogKey, sths []STH) (*SplitViewConflict, error) {
+	for i, s := range sths {
+		pub, err := logPub.PublicKeyFor(s.LogID)
+		if err != nil {
+			return nil, fmt.Errorf("witness[%d] (log %q): %w", i, s.LogID, err)
+		}
+		if err := VerifySTH(pub, s); err != nil {
+			return nil, fmt.Errorf("witness[%d] (log %q): %w", i, s.LogID, err)
+		}
+	}
+	return VerifyWitnessConsistency(sths)
+}
+
+// CheckAppendConsistency verifies that a SET of witnessed STHs for the same
+// log are mutually append-consistent: for each pair (smaller, larger) the
+// caller supplies the consistency proof and we confirm the larger is a pure
+// append of the smaller. A failure means the log rewrote history between the
+// two heads → ErrWitnessInconsistent (a detected anti-rewrite violation).
+//
+// proofs is keyed by [smallerSize][largerSize]. Pairs with no proof are
+// skipped (the caller controls coverage); same-size pairs are checked for
+// root equality via the split-view path, not here.
+func CheckAppendConsistency(sths []STH, proofs map[int]map[int][][HashSize]byte) error {
+	// Sort by size ascending so we always pass (first <= second).
+	ordered := make([]STH, len(sths))
+	copy(ordered, sths)
+	sort.SliceStable(ordered, func(a, b int) bool { return ordered[a].TreeSize < ordered[b].TreeSize })
+
+	for i := 0; i < len(ordered); i++ {
+		for j := i + 1; j < len(ordered); j++ {
+			small, large := ordered[i], ordered[j]
+			if small.LogID != large.LogID {
+				continue
+			}
+			if small.TreeSize == large.TreeSize {
+				continue // handled by split-view detection
+			}
+			byLarge, ok := proofs[small.TreeSize]
+			if !ok {
+				continue
+			}
+			proof, ok := byLarge[large.TreeSize]
+			if !ok {
+				continue
+			}
+			sRoot, err := small.RootBytes()
+			if err != nil {
+				return fmt.Errorf("smaller STH (size %d): %w", small.TreeSize, err)
+			}
+			lRoot, err := large.RootBytes()
+			if err != nil {
+				return fmt.Errorf("larger STH (size %d): %w", large.TreeSize, err)
+			}
+			if err := VerifyConsistency(small.TreeSize, large.TreeSize, sRoot, lRoot, proof); err != nil {
+				return fmt.Errorf("%w: log %q between sizes %d and %d: %v",
+					ErrWitnessInconsistent, small.LogID, small.TreeSize, large.TreeSize, err)
+			}
+		}
+	}
+	return nil
+}
+
+// PinnedLogKey resolves a log_id to its pinned ed25519 public key. The
+// verify-layer trust-roots loader implements this so split-view detection
+// can verify each witnessed STH against the RIGHT pinned key.
+type PinnedLogKey interface {
+	PublicKeyFor(logID string) (ed25519PublicKey, error)
+}
+
+// ed25519PublicKey is a thin alias kept local so witness.go does not pull a
+// crypto import into a file that is otherwise pure comparison logic. It is
+// the same underlying type as crypto/ed25519.PublicKey.
+type ed25519PublicKey = []byte

--- a/pkg/skillctl/translog/witness_test.go
+++ b/pkg/skillctl/translog/witness_test.go
@@ -1,0 +1,182 @@
+package translog
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"testing"
+	"time"
+)
+
+// staticPinnedKey implements PinnedLogKey for one (or two) logs.
+type staticPinnedKey struct {
+	keys map[string]ed25519.PublicKey
+}
+
+func (s staticPinnedKey) PublicKeyFor(logID string) ([]byte, error) {
+	k, ok := s.keys[logID]
+	if !ok {
+		return nil, errors.New("no pinned key for log " + logID)
+	}
+	return k, nil
+}
+
+func sthAt(t *testing.T, priv ed25519.PrivateKey, logID string, size int, ts time.Time, leaves [][HashSize]byte) STH {
+	t.Helper()
+	root, err := MerkleTreeHash(leaves[:size])
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := STH{TreeSize: size, RootHash: hexOf(root), Timestamp: FormatSTHTimestamp(ts), LogID: logID}
+	signed, err := SignSTH(priv, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signed
+}
+
+// TestSplitView_Detected is the headline: two honestly-SIGNED STHs from the
+// same log at the SAME tree_size but with DIFFERENT roots is an
+// equivocation, and must be DETECTED.
+func TestSplitView_Detected(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+
+	// History 1: leaves[0:5]. History 2: a forked set of 5 leaves where
+	// leaf 2 differs. Both are size 5 → same tree_size, different root.
+	histA := leafHashes(5)
+	histB := leafHashes(5)
+	histB[2] = HashLeaf([]byte("FORKED-leaf-2"))
+
+	ts := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	sthA := sthAt(t, priv, "log-1", 5, ts, histA)
+	sthB := sthAt(t, priv, "log-1", 5, ts.Add(time.Minute), histB)
+
+	conflict, err := VerifyWitnessConsistency([]STH{sthA, sthB})
+	if !errors.Is(err, ErrSplitView) {
+		t.Fatalf("split view: want ErrSplitView, got %v", err)
+	}
+	if conflict == nil || conflict.TreeSize != 5 || conflict.LogID != "log-1" {
+		t.Fatalf("conflict not populated correctly: %+v", conflict)
+	}
+	if conflict.RootA == conflict.RootB {
+		t.Fatal("conflict roots should differ")
+	}
+}
+
+// TestSplitView_NoConflict_DifferentSizes: same log, different sizes is NOT
+// a split view (it's normal growth).
+func TestSplitView_NoConflict_DifferentSizes(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	leaves := leafHashes(8)
+	ts := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	s5 := sthAt(t, priv, "log-1", 5, ts, leaves)
+	s8 := sthAt(t, priv, "log-1", 8, ts, leaves)
+	conflict, err := VerifyWitnessConsistency([]STH{s5, s8})
+	if err != nil || conflict != nil {
+		t.Fatalf("different sizes must not conflict, got conflict=%v err=%v", conflict, err)
+	}
+}
+
+// TestSplitView_NoConflict_SameHead: two witnesses reporting the SAME head
+// (same size, same root, different timestamp) is consistent, not a split.
+func TestSplitView_NoConflict_SameHead(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	leaves := leafHashes(5)
+	a := sthAt(t, priv, "log-1", 5, time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC), leaves)
+	b := sthAt(t, priv, "log-1", 5, time.Date(2026, 6, 24, 13, 0, 0, 0, time.UTC), leaves)
+	conflict, err := VerifyWitnessConsistency([]STH{a, b})
+	if err != nil || conflict != nil {
+		t.Fatalf("identical heads must not conflict, got conflict=%v err=%v", conflict, err)
+	}
+}
+
+// TestSplitView_DifferentLogsNotCompared: same size collision across two
+// DIFFERENT logs is not a conflict.
+func TestSplitView_DifferentLogsNotCompared(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	a := sthAt(t, priv, "log-1", 5, time.Now(), leafHashes(5))
+	bLeaves := leafHashes(5)
+	bLeaves[0] = HashLeaf([]byte("x"))
+	b := sthAt(t, priv, "log-2", 5, time.Now(), bLeaves)
+	conflict, err := VerifyWitnessConsistency([]STH{a, b})
+	if err != nil || conflict != nil {
+		t.Fatalf("different logs must not conflict, got conflict=%v err=%v", conflict, err)
+	}
+}
+
+// TestDetectSplitView_VerifiesSignaturesFirst: an UNPINNED-key STH in the
+// witness set is rejected before the comparison — an attacker can't smuggle
+// an unsigned "head" to hide (or fabricate) an equivocation.
+func TestDetectSplitView_RejectsUnpinned(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	_, attacker, _ := ed25519.GenerateKey(nil)
+
+	pinned := staticPinnedKey{keys: map[string]ed25519.PublicKey{"log-1": pub}}
+
+	good := sthAt(t, priv, "log-1", 5, time.Now(), leafHashes(5))
+	forged := sthAt(t, attacker, "log-1", 5, time.Now(), leafHashes(5)) // wrong signer
+
+	if _, err := DetectSplitView(pinned, []STH{good, forged}); !errors.Is(err, ErrSTHSignatureInvalid) {
+		t.Fatalf("unpinned witness STH must be rejected, got %v", err)
+	}
+}
+
+// TestDetectSplitView_RealConflictWithValidSignatures: BOTH heads are
+// validly signed by the pinned key (the operator itself equivocated), and
+// the split view is detected.
+func TestDetectSplitView_RealConflict(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	pinned := staticPinnedKey{keys: map[string]ed25519.PublicKey{"log-1": pub}}
+
+	histA := leafHashes(6)
+	histB := leafHashes(6)
+	histB[4] = HashLeaf([]byte("forked"))
+	a := sthAt(t, priv, "log-1", 6, time.Now(), histA)
+	b := sthAt(t, priv, "log-1", 6, time.Now().Add(time.Second), histB)
+
+	conflict, err := DetectSplitView(pinned, []STH{a, b})
+	if !errors.Is(err, ErrSplitView) {
+		t.Fatalf("want ErrSplitView, got %v", err)
+	}
+	if conflict == nil {
+		t.Fatal("expected a populated conflict")
+	}
+}
+
+// TestCheckAppendConsistency_DetectsRewrite: a log that rewrote history
+// between two witnessed heads fails the consistency check (anti-rewrite).
+func TestCheckAppendConsistency_DetectsRewrite(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+
+	honest := leafHashes(8)
+	s4 := sthAt(t, priv, "log-1", 4, time.Now(), honest)
+
+	// Operator rewrote leaf 1 by size 8 — its size-8 STH commits a root
+	// that is NOT a pure append of the size-4 root.
+	rewritten := leafHashes(8)
+	rewritten[1] = HashLeaf([]byte("rewritten"))
+	s8 := sthAt(t, priv, "log-1", 8, time.Now(), rewritten)
+
+	// The proof is computed over the HONEST size-8 tree (the only one the
+	// operator could have published consistently); against the rewritten
+	// size-8 root it must fail.
+	proof, _ := ConsistencyProof(4, 8, honest)
+	proofs := map[int]map[int][][HashSize]byte{4: {8: proof}}
+
+	err := CheckAppendConsistency([]STH{s4, s8}, proofs)
+	if !errors.Is(err, ErrWitnessInconsistent) {
+		t.Fatalf("rewrite between witnessed heads: want ErrWitnessInconsistent, got %v", err)
+	}
+}
+
+// TestCheckAppendConsistency_HonestPasses: honest growth passes.
+func TestCheckAppendConsistency_HonestPasses(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	leaves := leafHashes(8)
+	s4 := sthAt(t, priv, "log-1", 4, time.Now(), leaves)
+	s8 := sthAt(t, priv, "log-1", 8, time.Now(), leaves)
+	proof, _ := ConsistencyProof(4, 8, leaves)
+	proofs := map[int]map[int][][HashSize]byte{4: {8: proof}}
+	if err := CheckAppendConsistency([]STH{s4, s8}, proofs); err != nil {
+		t.Fatalf("honest growth should pass: %v", err)
+	}
+}

--- a/pkg/skillctl/verify/errors.go
+++ b/pkg/skillctl/verify/errors.go
@@ -157,6 +157,20 @@ const (
 	// 21 is taken by agentid-expired (cmd/skillctl exitAgentIDExpired), so 22 is
 	// the next free code.
 	ExitRevocationStale = 22
+
+	// ExitLogInclusionMissing (23) — SPEC-0278 L1: the trust root sets
+	// `require_log_inclusion: true` but the event could not be shown INCLUDED
+	// under a pinned, signature-valid Signed Tree Head. The verifier fails
+	// closed: an event the operator demands be transparency-logged, but which
+	// no pinned head commits to, is refused.
+	//
+	// DISTINCT from the signature/governance codes (10-17) — the trust chain
+	// was fine but the event is not on the log — and from the freshness code
+	// (22). 20 (ExitSelfAttested), 21 (agentid-expired), and 22
+	// (ExitRevocationStale) are all taken, so 23 is the next free code. (The
+	// SPEC-0278 branch wrongly reused 20; it now lives at 23.) UX: surface the
+	// log_id + claimed tree_size so the operator can re-witness or pin a head.
+	ExitLogInclusionMissing = 23
 )
 
 // Sentinel errors so callers can `errors.Is(err, verify.ErrDigestMismatch)`
@@ -265,6 +279,18 @@ var (
 	//   fmt.Errorf("revocation snapshot is stale (epoch %d, %s old > max_staleness; risk=%s): %w",
 	//       epoch, age, risk, verify.ErrRevocationStale)
 	ErrRevocationStale = errors.New("revocation snapshot is stale (freshness fail-closed)")
+
+	// ErrLogInclusionMissing — SPEC-0278 L1: no valid inclusion proof was
+	// available for the event under any pinned, signature-valid STH, while
+	// the trust root sets require_log_inclusion: true. Exit code 23 (the
+	// next free code after 20/21/22). Whether this BLOCKS depends on the
+	// require_log_inclusion policy (hard) vs advisory (default); the hard
+	// path wraps this sentinel. Wrap with the log_id + tree_size so the
+	// operator can re-witness:
+	//
+	//   fmt.Errorf("event not included under pinned STH for log %q (size %d): %w",
+	//       logID, treeSize, verify.ErrLogInclusionMissing)
+	ErrLogInclusionMissing = errors.New("transparency-log inclusion proof missing or invalid")
 )
 
 // ExitCode maps a verifier error to its numeric process exit code.
@@ -326,6 +352,11 @@ func ExitCode(err error) int {
 		// denial only matters once the chain (digest/sig/trust/governance)
 		// otherwise passed, and it must not mask a more specific failure.
 		return ExitRevocationStale
+	case errors.Is(err, ErrLogInclusionMissing):
+		// SPEC-0278 L1 — require_log_inclusion fail-closed. Checked last: an
+		// inclusion-proof refusal only matters once the trust chain otherwise
+		// passed (the chain was fine but the event is not on a pinned log).
+		return ExitLogInclusionMissing
 	default:
 		return 1
 	}

--- a/pkg/skillctl/verify/translog_check.go
+++ b/pkg/skillctl/verify/translog_check.go
@@ -1,0 +1,191 @@
+package verify
+
+// SPEC-0278 L1 transparency-log integration for the verifier.
+//
+// This composes the translog primitives into the §7 verifier surface:
+// after the signature/governance chain passes, the verifier can ALSO
+// confirm that the event (identified by its digest) is INCLUDED under a
+// Signed Tree Head the machine trusts — entirely offline, against the STH
+// pinned in ~/.claude/skill-trust-roots.yaml. No network call to any single
+// company's server is made; that is the Round-A offline property preserved
+// across the cross-org boundary.
+//
+// Honesty: a passing inclusion check proves the event is COMMITTED to a log
+// whose head you trust. It makes a log that later tries to withhold or
+// equivocate about this event DETECTABLE (the head you pinned, plus a
+// cross-witnessed head, would diverge). It does NOT prove the log operator
+// is honest in general — only L2 (the deferred BFT consortium ledger) could
+// prevent a single operator from equivocating.
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/translog"
+)
+
+// ErrLogInclusionMissing and ExitLogInclusionMissing (23) are the canonical
+// SPEC-0278 L1 sentinel/exit-code pair; they are declared in errors.go
+// alongside the rest of the §7 verifier exit codes (20=ExitSelfAttested,
+// 21=agentid-expired, 22=ExitRevocationStale are taken — log inclusion is 23)
+// and wired into ExitCode(). This file consumes them.
+
+// LogInclusionInput is the material a caller hands the inclusion check: the
+// event's leaf (its LogEntry), the index it claims in the log, and the
+// inclusion proof. These come from the local log (translog.Log.ProveInclusion)
+// or are shipped alongside the bundle as a "log receipt."
+type LogInclusionInput struct {
+	// Entry is the logged event (its canonical leaf is recomputed here —
+	// we never trust a caller-supplied leaf hash).
+	Entry translog.LogEntry
+
+	// Index is the leaf position the proof claims.
+	Index int
+
+	// TreeSize is the tree size the proof was produced against. Must match
+	// (or be covered by) a pinned STH's tree_size.
+	TreeSize int
+
+	// Proof is the RFC-6962 inclusion (audit) path.
+	Proof [][translog.HashSize]byte
+
+	// LogID names which pinned log this receipt belongs to.
+	LogID string
+}
+
+// LogInclusionResult reports the outcome of the offline inclusion check.
+type LogInclusionResult struct {
+	// Included is true iff the event's leaf verified under a pinned,
+	// signature-valid STH.
+	Included bool
+
+	// STHTreeSize / STHRoot identify the pinned head the proof verified
+	// against (forensic breadcrumb).
+	STHTreeSize int
+	STHRoot     string
+
+	// Advisory carries a human-readable note when the check did not pass
+	// but the policy is advisory (so the caller can warn, not block).
+	Advisory string
+}
+
+// CheckLogInclusion verifies, OFFLINE, that the event in `in` is included
+// under a pinned STH for its log. It:
+//
+//  1. resolves the pinned LogTrust for in.LogID (must exist);
+//  2. recomputes the event's leaf hash from its canonical bytes (never
+//     trusting a supplied hash);
+//  3. finds a pinned STH whose tree_size == in.TreeSize and whose signature
+//     verifies under the pinned log key;
+//  4. verifies the inclusion proof against that STH's root.
+//
+// The boolean policy `requireInclusion` decides the FAILURE behaviour:
+//   - requireInclusion == true  → any failure returns a wrapped
+//     ErrLogInclusionMissing (fail-closed; the CLI maps this to exit 23).
+//   - requireInclusion == false → a failure returns (result, nil) with
+//     result.Included=false and an Advisory message (warn, don't block).
+//
+// A SUCCESSFUL check always returns (result{Included:true}, nil) regardless
+// of policy.
+func CheckLogInclusion(tr *TrustRoots, in LogInclusionInput, requireInclusion bool) (*LogInclusionResult, error) {
+	fail := func(reason string) (*LogInclusionResult, error) {
+		if requireInclusion {
+			return nil, fmt.Errorf("%w: %s", ErrLogInclusionMissing, reason)
+		}
+		return &LogInclusionResult{Included: false, Advisory: reason}, nil
+	}
+
+	if tr == nil {
+		return fail("no trust-roots loaded")
+	}
+	lt := tr.FindLog(in.LogID)
+	if lt == nil {
+		return fail(fmt.Sprintf("no pinned log %q in trust-roots", in.LogID))
+	}
+	if len(lt.PinnedSTHs) == 0 {
+		return fail(fmt.Sprintf("log %q has no pinned STH", in.LogID))
+	}
+
+	// (2) Recompute the leaf hash from the event itself. A caller cannot
+	// substitute a leaf hash for an event that was never logged.
+	leaf, err := in.Entry.LeafHash()
+	if err != nil {
+		return fail(fmt.Sprintf("event leaf is invalid: %v", err))
+	}
+
+	// (3) Find a pinned STH at exactly in.TreeSize whose signature verifies.
+	logPub := ed25519.PublicKey(lt.LogKey)
+	for _, ps := range lt.PinnedSTHs {
+		if ps.TreeSize != in.TreeSize {
+			continue
+		}
+		sth := translog.STH{
+			TreeSize:  ps.TreeSize,
+			RootHash:  ps.RootHash,
+			Timestamp: ps.Timestamp,
+			LogID:     ps.LogID,
+			Signature: ps.Signature,
+		}
+		if err := translog.VerifySTH(logPub, sth); err != nil {
+			// A pinned STH that doesn't verify under the pinned key is
+			// itself a red flag, but we keep scanning in case another
+			// pinned head at the same size is valid.
+			continue
+		}
+		root, err := sth.RootBytes()
+		if err != nil {
+			continue
+		}
+		// (4) Offline inclusion verification against the trusted root.
+		if err := translog.VerifyInclusion(leaf, in.Index, in.TreeSize, in.Proof, root); err != nil {
+			return fail(fmt.Sprintf("inclusion proof did not verify under pinned STH (size %d): %v", ps.TreeSize, err))
+		}
+		return &LogInclusionResult{
+			Included:    true,
+			STHTreeSize: ps.TreeSize,
+			STHRoot:     hex.EncodeToString(root[:]),
+		}, nil
+	}
+
+	return fail(fmt.Sprintf("no signature-valid pinned STH at tree_size %d for log %q", in.TreeSize, in.LogID))
+}
+
+// PinnedLogKeyResolver adapts the trust-roots `logs` block to the
+// translog.PinnedLogKey interface so split-view detection
+// (translog.DetectSplitView) can verify each witnessed STH against the
+// correct pinned key.
+type PinnedLogKeyResolver struct {
+	tr *TrustRoots
+}
+
+// LogKeys returns a resolver over the trust-roots' pinned logs.
+func (t *TrustRoots) LogKeys() PinnedLogKeyResolver {
+	return PinnedLogKeyResolver{tr: t}
+}
+
+// PublicKeyFor implements translog.PinnedLogKey. Returns the pinned raw
+// ed25519 public key for logID, or an error if the log is not pinned.
+func (r PinnedLogKeyResolver) PublicKeyFor(logID string) ([]byte, error) {
+	lt := r.tr.FindLog(logID)
+	if lt == nil {
+		return nil, fmt.Errorf("no pinned key for log %q", logID)
+	}
+	return lt.LogKey, nil
+}
+
+// ExitCodeForLog maps a transparency-log error to its process exit code,
+// layered on top of the §7 ExitCode. Returns 0 for nil, 23 for a missing/
+// invalid inclusion proof under require_log_inclusion, and falls through to
+// ExitCode for everything else. (ExitCode itself now also maps
+// ErrLogInclusionMissing → 23, so this layering is belt-and-braces.)
+func ExitCodeForLog(err error) int {
+	if err == nil {
+		return 0
+	}
+	if errors.Is(err, ErrLogInclusionMissing) {
+		return ExitLogInclusionMissing
+	}
+	return ExitCode(err)
+}

--- a/pkg/skillctl/verify/translog_check_test.go
+++ b/pkg/skillctl/verify/translog_check_test.go
@@ -1,0 +1,204 @@
+package verify
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/translog"
+)
+
+// buildPinnedLog creates a small log, signs a head, and returns a
+// *TrustRoots pinning that log + STH, plus the inclusion input for a chosen
+// entry. requireInclusion controls the policy field.
+func buildPinnedLog(t *testing.T, requireInclusion bool) (*TrustRoots, LogInclusionInput, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, _ := ed25519.GenerateKey(nil)
+
+	// Build a log of 5 entries.
+	logID := "skillctl-log-1"
+	entries := make([]translog.LogEntry, 5)
+	leaves := make([][translog.HashSize]byte, 5)
+	for i := 0; i < 5; i++ {
+		e := translog.LogEntry{
+			Type:      translog.EventAttest,
+			Digest:    "sha256:" + strings.Repeat("0", 63) + itoaLocal(i),
+			Timestamp: "2026-06-24T12:00:0" + itoaLocal(i) + "Z",
+			Subject:   "skill-" + itoaLocal(i),
+		}
+		entries[i] = e
+		h, err := e.LeafHash()
+		if err != nil {
+			t.Fatal(err)
+		}
+		leaves[i] = h
+	}
+	root, err := translog.MerkleTreeHash(leaves)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sth := translog.STH{
+		TreeSize:  5,
+		RootHash:  hexLocal(root),
+		Timestamp: translog.FormatSTHTimestamp(time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)),
+		LogID:     logID,
+	}
+	signed, err := translog.SignSTH(priv, sth)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := &TrustRoots{
+		RequireLogInclusion: requireInclusion,
+		Logs: []LogTrust{{
+			LogID:     logID,
+			LogKeyB64: base64.StdEncoding.EncodeToString(pub),
+			LogKey:    pub,
+			PinnedSTHs: []PinnedSTH{{
+				TreeSize:  signed.TreeSize,
+				RootHash:  signed.RootHash,
+				Timestamp: signed.Timestamp,
+				LogID:     signed.LogID,
+				Signature: signed.Signature,
+			}},
+		}},
+	}
+
+	// Inclusion input for entry index 2.
+	proof, err := translog.InclusionProof(2, 5, leaves)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := LogInclusionInput{
+		Entry:    entries[2],
+		Index:    2,
+		TreeSize: 5,
+		Proof:    proof,
+		LogID:    logID,
+	}
+	return tr, in, priv
+}
+
+func TestCheckLogInclusion_Success(t *testing.T) {
+	tr, in, _ := buildPinnedLog(t, true)
+	res, err := CheckLogInclusion(tr, in, true)
+	if err != nil {
+		t.Fatalf("inclusion should pass: %v", err)
+	}
+	if !res.Included || res.STHTreeSize != 5 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}
+
+// TestCheckLogInclusion_RequireFailsClosed: with require_log_inclusion the
+// absence of a valid proof is a HARD refusal (ErrLogInclusionMissing).
+func TestCheckLogInclusion_RequireFailsClosed_NoProof(t *testing.T) {
+	tr, in, _ := buildPinnedLog(t, true)
+	in.Proof = nil // drop the proof
+	_, err := CheckLogInclusion(tr, in, true)
+	if !errors.Is(err, ErrLogInclusionMissing) {
+		t.Fatalf("require + no proof: want ErrLogInclusionMissing, got %v", err)
+	}
+	if ExitCodeForLog(err) != ExitLogInclusionMissing {
+		t.Fatalf("exit code = %d, want %d", ExitCodeForLog(err), ExitLogInclusionMissing)
+	}
+}
+
+// TestCheckLogInclusion_RequireFailsClosed_ForgedEvent: an event that was
+// never logged (its leaf isn't in the tree) cannot be shown included →
+// fail-closed.
+func TestCheckLogInclusion_ForgedEvent(t *testing.T) {
+	tr, in, _ := buildPinnedLog(t, true)
+	// Swap in an event that was never logged but reuse a valid-shape proof.
+	in.Entry = translog.LogEntry{
+		Type:      translog.EventAttest,
+		Digest:    "sha256:" + strings.Repeat("a", 64),
+		Timestamp: "2026-06-24T12:00:00Z",
+		Subject:   "never-logged",
+	}
+	_, err := CheckLogInclusion(tr, in, true)
+	if !errors.Is(err, ErrLogInclusionMissing) {
+		t.Fatalf("forged event: want ErrLogInclusionMissing, got %v", err)
+	}
+}
+
+// TestCheckLogInclusion_AdvisoryDefault: without the policy, a missing proof
+// is advisory — returns Included=false, no error.
+func TestCheckLogInclusion_AdvisoryDefault(t *testing.T) {
+	tr, in, _ := buildPinnedLog(t, false)
+	in.Proof = nil
+	res, err := CheckLogInclusion(tr, in, false)
+	if err != nil {
+		t.Fatalf("advisory mode should not error: %v", err)
+	}
+	if res.Included {
+		t.Fatal("advisory: expected Included=false")
+	}
+	if res.Advisory == "" {
+		t.Fatal("advisory: expected a human-readable note")
+	}
+}
+
+// TestCheckLogInclusion_UnpinnedSTHKeyRefused: if the pinned STH is signed
+// by a key OTHER than the pinned log key, it is not a valid head and the
+// inclusion check cannot pass (fail-closed under require).
+func TestCheckLogInclusion_UnpinnedSTHKeyRefused(t *testing.T) {
+	tr, in, _ := buildPinnedLog(t, true)
+	// Re-sign the pinned STH with an ATTACKER key but keep the pinned
+	// (honest) public key in the trust-roots → VerifySTH fails → no valid
+	// head at this size.
+	_, attacker, _ := ed25519.GenerateKey(nil)
+	root, _ := translog.MerkleTreeHash(rebuildLeaves(t, in))
+	bad := translog.STH{TreeSize: 5, RootHash: hexLocal(root), Timestamp: tr.Logs[0].PinnedSTHs[0].Timestamp, LogID: in.LogID}
+	signedBad, _ := translog.SignSTH(attacker, bad)
+	tr.Logs[0].PinnedSTHs[0].Signature = signedBad.Signature
+
+	_, err := CheckLogInclusion(tr, in, true)
+	if !errors.Is(err, ErrLogInclusionMissing) {
+		t.Fatalf("unpinned STH key: want ErrLogInclusionMissing, got %v", err)
+	}
+}
+
+// TestCheckLogInclusion_NoPinnedLog: an event referencing an unpinned log
+// fails-closed under require.
+func TestCheckLogInclusion_NoPinnedLog(t *testing.T) {
+	tr, in, _ := buildPinnedLog(t, true)
+	in.LogID = "some-other-log"
+	if _, err := CheckLogInclusion(tr, in, true); !errors.Is(err, ErrLogInclusionMissing) {
+		t.Fatalf("unpinned log: want ErrLogInclusionMissing, got %v", err)
+	}
+}
+
+// rebuildLeaves reconstructs the 5 leaves used by buildPinnedLog so a test
+// can recompute the honest root. It mirrors the entry construction.
+func rebuildLeaves(t *testing.T, _ LogInclusionInput) [][translog.HashSize]byte {
+	t.Helper()
+	leaves := make([][translog.HashSize]byte, 5)
+	for i := 0; i < 5; i++ {
+		e := translog.LogEntry{
+			Type:      translog.EventAttest,
+			Digest:    "sha256:" + strings.Repeat("0", 63) + itoaLocal(i),
+			Timestamp: "2026-06-24T12:00:0" + itoaLocal(i) + "Z",
+			Subject:   "skill-" + itoaLocal(i),
+		}
+		h, _ := e.LeafHash()
+		leaves[i] = h
+	}
+	return leaves
+}
+
+func itoaLocal(i int) string {
+	return string(rune('0' + i))
+}
+
+func hexLocal(h [translog.HashSize]byte) string {
+	const hexdigits = "0123456789abcdef"
+	out := make([]byte, 0, len(h)*2)
+	for _, b := range h {
+		out = append(out, hexdigits[b>>4], hexdigits[b&0x0f])
+	}
+	return string(out)
+}

--- a/pkg/skillctl/verify/trustroots.go
+++ b/pkg/skillctl/verify/trustroots.go
@@ -351,9 +351,68 @@ type TrustRoots struct {
 	// metadata / tooling field rather than a trust-policy knob.
 	Environment string `yaml:"_environment,omitempty"`
 
+	// Logs pins the transparency log(s) this machine trusts for the
+	// SPEC-0278 L1 inclusion-proof check. Each entry pins a log's public
+	// key plus a recent (witnessed) STH set. Empty means "no log pinned"
+	// and the inclusion check is skipped entirely (unless a per-log policy
+	// demands it — which it cannot, since there is no log to demand it).
+	//
+	// L1 makes equivocation/withholding DETECTABLE, not impossible; pinning
+	// a recent STH here is what lets the offline verifier confirm an event
+	// is committed under a head it already trusts, and lets cross-witnessed
+	// heads surface a split view.
+	Logs []LogTrust `yaml:"logs,omitempty"`
+
+	// RequireLogInclusion, when true, makes the ABSENCE of a valid
+	// inclusion proof under a pinned STH a HARD refusal (fail-closed). When
+	// false (the default) the inclusion check is ADVISORY: a missing/invalid
+	// proof is surfaced as a warning but does not block. SPEC-0278 §3 makes
+	// this opt-in hard, advisory by default — a transparency log that is
+	// still being rolled out should not brick every install.
+	RequireLogInclusion bool `yaml:"require_log_inclusion,omitempty"`
+
 	// Path is the resolved absolute file path used by Load (and by
 	// Save() on round-trip). Not serialized to YAML.
 	Path string `yaml:"-"`
+}
+
+// LogTrust pins one transparency log: its identity, its signing public key,
+// and a set of STHs the machine has witnessed/accepted. The verifier checks
+// inclusion proofs against the pinned STH whose tree_size covers the proof,
+// entirely offline.
+type LogTrust struct {
+	// LogID identifies the log. Must be unique within the file and match
+	// the log_id carried in the STHs and in the log's own records.
+	LogID string `yaml:"log_id"`
+
+	// LogKeyB64 is the base64 of the raw 32-byte ed25519 LOG public key.
+	// Distinct from any registry/author/attestation key — the STH domain
+	// separator guarantees a signature over an STH can't be reused as any
+	// other envelope, but pinning a dedicated key is still the right
+	// hygiene. The loader hydrates LogKey (raw bytes) from this.
+	LogKeyB64 string `yaml:"log_key"`
+
+	// LogKey is the decoded raw 32-byte ed25519 public key. Populated by
+	// the loader; not serialized (the b64 form round-trips instead).
+	LogKey []byte `yaml:"-"`
+
+	// PinnedSTHs is the set of accepted STHs for this log (the witnessed
+	// heads). A verifier checks an inclusion proof against the pinned STH
+	// whose tree_size >= the proof size (and whose signature verifies under
+	// LogKey). Multiple heads support cross-witness split-view detection.
+	PinnedSTHs []PinnedSTH `yaml:"pinned_sths,omitempty"`
+}
+
+// PinnedSTH is one accepted Signed Tree Head, stored in the trust-roots
+// file. The fields mirror translog.STH but live here so the verify package
+// declares its own typed loader surface (strict YAML) without importing the
+// translog types into the YAML schema.
+type PinnedSTH struct {
+	TreeSize  int    `yaml:"tree_size"`
+	RootHash  string `yaml:"root_hash"`
+	Timestamp string `yaml:"timestamp"`
+	LogID     string `yaml:"log_id"`
+	Signature string `yaml:"signature"`
 }
 
 // DefaultPath returns the absolute path to the user's trust-roots file
@@ -775,6 +834,71 @@ func (t *TrustRoots) validate() error {
 			return fmt.Errorf("trust_roots[%d] %s: governance_minimum %q is not one of [green, yellow]", i, root.RegistryURL, root.GovernanceMinimum)
 		}
 		t.Roots[i].GovernanceMinimum = norm
+	}
+
+	// SPEC-0278 L1: validate + hydrate the pinned transparency logs.
+	if err := t.validateLogs(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateLogs runs strict validation over the SPEC-0278 `logs` block and
+// hydrates LogKey (raw bytes) from LogKeyB64 so callers don't re-decode.
+// Each log id must be unique; each log key must decode to a 32-byte ed25519
+// public key; each pinned STH must carry the SAME log_id, a 64-hex root, a
+// 128-hex signature, and tree_size >= 1.
+func (t *TrustRoots) validateLogs() error {
+	seenLogs := make(map[string]struct{}, len(t.Logs))
+	for i := range t.Logs {
+		lt := &t.Logs[i]
+		if lt.LogID == "" {
+			return fmt.Errorf("logs[%d]: log_id is required", i)
+		}
+		if _, dup := seenLogs[lt.LogID]; dup {
+			return fmt.Errorf("logs[%d]: duplicate log_id %q", i, lt.LogID)
+		}
+		seenLogs[lt.LogID] = struct{}{}
+
+		if lt.LogKeyB64 == "" {
+			return fmt.Errorf("logs[%d] %s: log_key is required", i, lt.LogID)
+		}
+		raw, err := base64.StdEncoding.DecodeString(lt.LogKeyB64)
+		if err != nil {
+			return fmt.Errorf("logs[%d] %s: log_key is not valid base64: %w", i, lt.LogID, err)
+		}
+		if len(raw) != pubkeyRawSize {
+			return fmt.Errorf("logs[%d] %s: log_key decodes to %d bytes, want %d", i, lt.LogID, len(raw), pubkeyRawSize)
+		}
+		lt.LogKey = raw
+
+		for j, s := range lt.PinnedSTHs {
+			if s.LogID != lt.LogID {
+				return fmt.Errorf("logs[%d].pinned_sths[%d]: log_id %q must match parent log %q", i, j, s.LogID, lt.LogID)
+			}
+			if s.TreeSize < 1 {
+				return fmt.Errorf("logs[%d].pinned_sths[%d]: tree_size must be >= 1", i, j)
+			}
+			if len(s.RootHash) != 64 {
+				return fmt.Errorf("logs[%d].pinned_sths[%d]: root_hash must be 64 hex chars", i, j)
+			}
+			if len(s.Signature) != 128 {
+				return fmt.Errorf("logs[%d].pinned_sths[%d]: signature must be 128 hex chars", i, j)
+			}
+		}
+	}
+	return nil
+}
+
+// FindLog returns the pinned LogTrust for logID, or nil if none is pinned.
+func (t *TrustRoots) FindLog(logID string) *LogTrust {
+	if t == nil {
+		return nil
+	}
+	for i := range t.Logs {
+		if t.Logs[i].LogID == logID {
+			return &t.Logs[i]
+		}
 	}
 	return nil
 }

--- a/pkg/skillctl/verify/trustroots_log_test.go
+++ b/pkg/skillctl/verify/trustroots_log_test.go
@@ -1,0 +1,136 @@
+package verify
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeRootsFile writes raw YAML to a temp trust-roots path and returns it.
+func writeRootsFile(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "skill-trust-roots.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// minimalRegistry is a valid trust_roots block we prepend so the file is
+// otherwise well-formed when we exercise the logs block.
+const minimalRegistry = `trust_roots:
+  - registry_url: https://aims.example.com/api/skills
+    registry_keys:
+      - id: k1
+        pubkey: %s
+        issued: 2026-06-24
+    identity_keys_authorized: from-registry
+    governance_minimum: green
+`
+
+func validPubkeyB64(t *testing.T) string {
+	t.Helper()
+	pub, _, _ := ed25519.GenerateKey(nil)
+	return base64.StdEncoding.EncodeToString(pub)
+}
+
+func TestLoad_LogsBlock_Valid(t *testing.T) {
+	regKey := validPubkeyB64(t)
+	logKey := validPubkeyB64(t)
+	body := strings_sprintf(minimalRegistry, regKey) + `require_log_inclusion: true
+logs:
+  - log_id: skillctl-log-1
+    log_key: ` + logKey + `
+    pinned_sths:
+      - tree_size: 5
+        root_hash: ` + strings.Repeat("ab", 32) + `
+        timestamp: 2026-06-24T12:00:00Z
+        log_id: skillctl-log-1
+        signature: ` + strings.Repeat("cd", 64) + `
+`
+	path := writeRootsFile(t, body)
+	tr, err := Load(path)
+	if err != nil {
+		t.Fatalf("valid logs block should load: %v", err)
+	}
+	if !tr.RequireLogInclusion {
+		t.Fatal("require_log_inclusion should be true")
+	}
+	lt := tr.FindLog("skillctl-log-1")
+	if lt == nil {
+		t.Fatal("FindLog should resolve the pinned log")
+	}
+	if len(lt.LogKey) != ed25519.PublicKeySize {
+		t.Fatalf("LogKey not hydrated: len=%d", len(lt.LogKey))
+	}
+	if len(lt.PinnedSTHs) != 1 || lt.PinnedSTHs[0].TreeSize != 5 {
+		t.Fatalf("pinned STH not parsed: %+v", lt.PinnedSTHs)
+	}
+}
+
+func TestLoad_LogsBlock_RejectsBadKey(t *testing.T) {
+	regKey := validPubkeyB64(t)
+	body := strings_sprintf(minimalRegistry, regKey) + `logs:
+  - log_id: log-1
+    log_key: not-base64!!!
+`
+	if _, err := Load(writeRootsFile(t, body)); err == nil {
+		t.Fatal("expected error for non-base64 log_key")
+	}
+}
+
+func TestLoad_LogsBlock_RejectsMismatchedSTHLogID(t *testing.T) {
+	regKey := validPubkeyB64(t)
+	logKey := validPubkeyB64(t)
+	body := strings_sprintf(minimalRegistry, regKey) + `logs:
+  - log_id: log-1
+    log_key: ` + logKey + `
+    pinned_sths:
+      - tree_size: 1
+        root_hash: ` + strings.Repeat("ab", 32) + `
+        timestamp: 2026-06-24T12:00:00Z
+        log_id: DIFFERENT-log
+        signature: ` + strings.Repeat("cd", 64) + `
+`
+	if _, err := Load(writeRootsFile(t, body)); err == nil {
+		t.Fatal("expected error when pinned STH log_id != parent log_id")
+	}
+}
+
+func TestLoad_LogsBlock_RejectsUnknownField(t *testing.T) {
+	// Strict loader: an unknown field under logs must be refused (a typo in
+	// a security policy field must fail loudly, not silently disable a key).
+	regKey := validPubkeyB64(t)
+	logKey := validPubkeyB64(t)
+	body := strings_sprintf(minimalRegistry, regKey) + `logs:
+  - log_id: log-1
+    log_key: ` + logKey + `
+    bogus_field: oops
+`
+	if _, err := Load(writeRootsFile(t, body)); err == nil {
+		t.Fatal("strict loader must reject unknown field under logs")
+	}
+}
+
+func TestLoad_NoLogsBlock_Backcompat(t *testing.T) {
+	// A trust-roots file with NO logs block must still load (the L1 feature
+	// is additive; existing files keep working).
+	regKey := validPubkeyB64(t)
+	body := strings_sprintf(minimalRegistry, regKey)
+	tr, err := Load(writeRootsFile(t, body))
+	if err != nil {
+		t.Fatalf("file without logs block should still load: %v", err)
+	}
+	if len(tr.Logs) != 0 || tr.RequireLogInclusion {
+		t.Fatal("absent logs block should yield empty Logs and require=false")
+	}
+}
+
+// strings_sprintf is a tiny local Sprintf-of-one-%s to avoid importing fmt
+// just for the test fixtures (and to keep the substitution obvious).
+func strings_sprintf(tmpl, a string) string {
+	return strings.Replace(tmpl, "%s", a, 1)
+}


### PR DESCRIPTION
## SPEC-0278 P5 — L1 transparency log (DETECTABLE, not impossible)

Implements **L1 only** of SPEC-0278 (the Sigstore/RFC-6962-style Merkle transparency log), built **stdlib-only** (`crypto/sha256`, `crypto/ed25519`) — no Trillian/Rekor, no blockchain, no Kafka.

**Honest scope, up front:** L1 makes equivocation / censorship / withholding **DETECTABLE** (via inclusion proofs + cross-witnessed STHs), **NOT impossible**. Only the **DEFERRED** L2 (no-single-operator BFT consortium ledger) could *prevent* a single operator from equivocating. L3 (public-chain anchoring) and the SPEC-0190/Kafka gossip **transport** are also **DEFERRED** (buyer-gated per §5/§6). This PR implements the STH-comparison/witness **logic** offline, not the wire transport. Per §5 (EU data sovereignty), **only event digests are logged — data stays off the log**.

### What's in it

**`pkg/skillctl/translog/` (new, pure stdlib):**
- **Merkle core** — RFC-6962 domain-prefixed hashing (`leaf = sha256(0x00 || bytes)`, `node = sha256(0x01 || left || right)`), `MerkleTreeHash` with the largest-power-of-two-less-than k-split.
- **Proofs** — `InclusionProof`/`VerifyInclusion` and `ConsistencyProof`/`VerifyConsistency` (the append-only / anti-rewrite property), verifying **offline** against a trusted root with constant-time compares and strict proof-length checks.
- **Signed Tree Head** — distinct domain separator `skillctl-sth-v1` (disjoint from attestation/revoke/etc.), `SignSTH`/`VerifySTH` against a pinned log key.
- **Event leaves** — canonical `LogEntry` for admit/attest/revoke/agentid-issue/agentid-revoke; commits the digest of the already-signed event.
- **Split-view detection** — `VerifyWitnessConsistency` flags two same-size STHs for one log with different roots (equivocation); `CheckAppendConsistency` catches a log that rewrote history between two witnessed heads.
- **Append-only log** — `~/.claude/skillctl/transparency-log.jsonl`, fsync'd appends, faithful reload, inclusion/consistency proof export, portable `Receipt`.

**`pkg/skillctl/verify/` integration:**
- New trust-roots fields: `logs` (per-log pinned `log_key` + `pinned_sths`) and `require_log_inclusion`; strict YAML loader → typed fields.
- `CheckLogInclusion` verifies offline that an event is included under a pinned, signature-valid STH (recomputes the leaf from the event; never trusts a supplied hash). `require_log_inclusion: true` **fails closed** (exit 20); default is **advisory** (warn, don't block).

**`cmd/skillctl translog`:** `append`, `sth`, `prove`, `verify`, `consistency`, `witness` — honest output throughout.

**Emit points:** best-effort logging at attest/revoke/awareness-sync success (opt-in `M3C_TRANSLOG=1`), never alters the primary decision (SPEC-0202 trail pattern).

### How split-view closes SPEC-0279 AC4

The cross-company STH freshness / split-view check that the P4 work deferred (SPEC-0279 AC4 / R4) is exactly `VerifyWitnessConsistency`: an STH cross-checked against a witness IS the SPEC-0279 R4 freshness checkpoint. Two independently-signed conflicting heads are non-repudiable evidence the log equivocated.

### Adversarial coverage (red-team vectors)

- forge an inclusion proof for a non-logged event → rejected (`TestInclusion_ForgedProofForNonLoggedLeaf`, `TestCheckLogInclusion_ForgedEvent`)
- second-preimage leaf/node confusion → blocked by domain prefixes (`TestSecondPreimage_LeafNodeConfusion`)
- STH by an unpinned key → refused (`TestSTH_UnpinnedKeyRefused`, `TestCheckLogInclusion_UnpinnedSTHKeyRefused`)
- hide an equivocation/split-view → detected (`TestSplitView_Detected`, `TestDetectSplitView_RejectsUnpinned`)
- rewrite the log past a consistency proof → detected (`TestConsistency_RewriteDetected`, `TestCheckAppendConsistency_DetectsRewrite`)
- cross-domain signature reuse (attestation ↔ STH) → refused (`TestSTH_CrossDomain_SignatureReuseRefused`)

### Gates

`go build ./...` + `go vet ./...` clean; `gofmt -l` empty on all changed files; `golangci-lint run` **0 issues** on `pkg/skillctl/translog`, `pkg/skillctl/verify`, `cmd/skillctl`; `go test` green (74 L1 tests; full changed-package suites pass; `-race` clean on the log mutex).

> Note: the first commit restores a compiling baseline — this worktree branched from an old HEAD (`0b227f7`) carrying three pre-existing merge collisions (`isStdoutTTY`, `writeTrustRoots`, `SetApplicationIcon`) that broke `go build ./...`. Those are mechanical dedups, unrelated to the feature. Pre-existing environmental failures in `e2e/` and `cmd/thinking-engine` (missing build artifacts / local `.env`) are out of scope and pre-date this work.

**L2/L3 + Kafka transport are DEFERRED. Do NOT merge — adversarial challenge gate expected.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
