### PR TITLE
feat(menubar): capture thumbnail + link when a video has no transcript

### DIFF
--- a/e2e/transcript_test.go
+++ b/e2e/transcript_test.go
@@ -256,3 +256,35 @@ func TestTranscriptFetchNMSHcSq8nMs(t *testing.T) {
 	}
 	t.Logf("NMSHcSq8nMs: %d snippets, %s", len(fetched.Snippets), fetched.Language)
 }
+
+// TestIsTranscriptUnavailable verifies the degrade-vs-fail classification used
+// by the menu bar to decide whether to proceed with thumbnail + link when a
+// transcript can't be fetched. Offline — constructs error values directly.
+func TestIsTranscriptUnavailable(t *testing.T) {
+	vid := "VLUfEWN0NY8"
+
+	// Degrade gracefully: the video exists but has no usable transcript.
+	degrade := []error{
+		transcript.NewTranscriptsDisabledError(vid),
+		transcript.NewNoTranscriptFoundError(vid, []string{"en"}, nil),
+		transcript.NewTranscriptNotAvailableError(vid),
+	}
+	for _, err := range degrade {
+		if !transcript.IsTranscriptUnavailable(err) {
+			t.Errorf("expected IsTranscriptUnavailable(true) for %T", err)
+		}
+	}
+
+	// Hard-fail: the video itself is inaccessible or rate limited.
+	fail := []error{
+		transcript.NewTooManyRequestsError(vid),
+		transcript.NewVideoUnavailableError(vid),
+		transcript.NewInvalidVideoIDError(vid),
+		nil,
+	}
+	for _, err := range fail {
+		if transcript.IsTranscriptUnavailable(err) {
+			t.Errorf("expected IsTranscriptUnavailable(false) for %T", err)
+		}
+	}
+}

--- a/pkg/menubar/fetch.go
+++ b/pkg/menubar/fetch.go
@@ -45,6 +45,8 @@ type FetchResult struct {
 	Text         string `json:"text"`
 	Flag         string `json:"flag"`
 	RateLimited  bool   `json:"rate_limited,omitempty"`
+	NoTranscript bool   `json:"no_transcript,omitempty"`
+	Reason       string `json:"reason,omitempty"`
 	FromCache    bool   `json:"from_cache,omitempty"`
 }
 
@@ -137,6 +139,19 @@ func (tf *TranscriptFetcher) Fetch(videoID string) (*FetchResult, error) {
 			}, nil
 		}
 
+		// Graceful degradation: the video exists but has no usable transcript
+		// (subtitles disabled / none in requested languages / none at all).
+		// Proceed so we still capture the thumbnail and link.
+		if transcript.IsTranscriptUnavailable(err) {
+			log.Printf("[menubar] no transcript available — proceeding with thumbnail + link for video=%s", videoID)
+			return &FetchResult{
+				VideoID:      videoID,
+				NoTranscript: true,
+				Reason:       err.Error(),
+				Flag:         "📄",
+			}, nil
+		}
+
 		return nil, fmt.Errorf("fetch transcript: %w", err)
 	}
 
@@ -185,6 +200,12 @@ func (tf *TranscriptFetcher) FetchAndDisplay(app *App, videoID string) {
 		app.notify("Rate Limited", fmt.Sprintf("YouTube rate limit for %s — proceeding without transcript", videoID))
 	}
 
+	// Handle no-transcript result (graceful degradation): the video exists but
+	// has no usable subtitles. We still capture the thumbnail and link.
+	if result.NoTranscript {
+		app.notify("No Transcript", fmt.Sprintf("No subtitles for %s — capturing thumbnail + link", videoID))
+	}
+
 	// Copy transcript text to clipboard (skip if rate-limited/empty).
 	if result.Text != "" {
 		if err := CopyToClipboard(result.Text); err != nil {
@@ -208,9 +229,17 @@ func (tf *TranscriptFetcher) FetchAndDisplay(app *App, videoID string) {
 		Date:         time.Now().Format("2006-01-02 15:04:05"),
 	}
 
+	videoURL := "https://www.youtube.com/watch?v=" + result.VideoID
+
 	transcriptText := result.Text
-	if result.RateLimited {
-		transcriptText = "[Transcript unavailable — YouTube rate limit (429). Try again later or configure YT_PROXY_URL in .env]"
+	switch {
+	case result.RateLimited:
+		transcriptText = "[Transcript unavailable — YouTube rate limit (429). Try again later or configure YT_PROXY_URL in .env]\n\nSource: " + videoURL
+	case result.NoTranscript:
+		transcriptText = fmt.Sprintf(
+			"[No transcript available — %s]\n\nThe video has no usable subtitles, but the thumbnail and link were captured. Add your own notes above.\n\nSource: %s",
+			result.Reason, videoURL)
+		meta.Source = "YouTube (no transcript)"
 	}
 
 	if result.FromCache {
@@ -228,6 +257,9 @@ func (tf *TranscriptFetcher) FetchAndDisplay(app *App, videoID string) {
 	if result.RateLimited {
 		app.notify("Observation Ready",
 			fmt.Sprintf("⚠️ %s — rate limited, no transcript", result.VideoID))
+	} else if result.NoTranscript {
+		app.notify("Observation Ready",
+			fmt.Sprintf("📄 %s — no transcript, captured thumbnail + link", result.VideoID))
 	} else {
 		source := ""
 		if result.FromCache {

--- a/pkg/transcript/errors.go
+++ b/pkg/transcript/errors.go
@@ -1,6 +1,7 @@
 package transcript
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -30,6 +31,20 @@ func NewTranscriptsDisabledError(videoID string) *TranscriptsDisabledError {
 	return &TranscriptsDisabledError{
 		TranscriptError{VideoID: videoID, Msg: "subtitles are disabled for this video"},
 	}
+}
+
+// IsTranscriptUnavailable reports whether err means the video exists but has
+// no usable transcript: subtitles disabled, none in the requested languages,
+// or none at all. Callers use this to degrade gracefully — proceeding with the
+// thumbnail and link instead of failing — as opposed to errors that mean the
+// video itself is inaccessible (invalid ID, unavailable, rate limit).
+func IsTranscriptUnavailable(err error) bool {
+	var disabled *TranscriptsDisabledError
+	var notFound *NoTranscriptFoundError
+	var notAvailable *TranscriptNotAvailableError
+	return errors.As(err, &disabled) ||
+		errors.As(err, &notFound) ||
+		errors.As(err, &notAvailable)
 }
 
 // NoTranscriptFoundError indicates no transcript was found for the requested languages.


### PR DESCRIPTION
## Problem

A `subtitles are disabled` failure (and the whole no-transcript family) made `TranscriptFetcher.Fetch` return a hard error, so `FetchAndDisplay` bailed **before** fetching the thumbnail — the observation window never opened. Observed in the field:

```
[transcript] FAIL video=VLUfEWN0NY8 error=[VLUfEWN0NY8] subtitles are disabled for this video
[menubar] transcript fetch FAIL video=VLUfEWN0NY8 ...
```

## Change

Extend the **existing rate-limit graceful-degradation pattern** to the "video exists but no usable transcript" family — subtitles disabled / none in requested languages / none at all. These now return a partial `FetchResult` (`NoTranscript=true`) instead of an error, so the flow proceeds to:

- fetch and show the **thumbnail** (Record tab),
- pre-fill tags (`youtube, <id>`),
- put the **video link** + reason in the Review tab so the user can add their own notes.

Errors that mean the video itself is inaccessible (invalid ID, video unavailable, 429 — already handled) still hard-fail.

## Files
- `pkg/transcript/errors.go` — reusable classifier `IsTranscriptUnavailable(err)`
- `pkg/menubar/fetch.go` — `FetchResult.NoTranscript/Reason`; degrade branch in `Fetch`; link in body; new notification path
- `e2e/transcript_test.go` — offline test locking the degrade-vs-fail boundary

## Verification
`make vet` clean · `make build` OK · `make test-unit` green (incl. new `TestIsTranscriptUnavailable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)