### PR TITLE
fix(timetracking): honor device token in PLM gate + surface why Projects is empty

### DIFF
--- a/cmd/m3c-tools/healthcheck_classifier_test.go
+++ b/cmd/m3c-tools/healthcheck_classifier_test.go
@@ -114,3 +114,28 @@ func TestClassifyPLMHealthCheckError_ConsistentWithPLMClient(t *testing.T) {
 		}
 	}
 }
+// TestPLMDisabledReason verifies the Projects-submenu diagnostic shown when
+// PLM sync can't start at all — so the menu never sits on "Loading projects..."
+// forever. Regression guard for the placeholder-key shadowing bug (active
+// profile carried ER1_API_KEY=minimal-key, silently disabling PLM).
+func TestPLMDisabledReason(t *testing.T) {
+	tests := []struct {
+		name    string
+		plmBase string
+		rawKey  string
+		want    string
+	}{
+		{"placeholder key on prod", "https://onboarding.guide", "minimal-key", "placeholder"},
+		{"empty key placeholder", "https://onboarding.guide", "", "placeholder"},
+		{"no base url", "", "e25creal", "ER1 URL not set"},
+		{"real key, no other issue", "https://onboarding.guide", "e25crealkey", "Not signed in"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := plmDisabledReason(tt.plmBase, tt.rawKey)
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("plmDisabledReason(%q, <key>) = %q; want substring %q", tt.plmBase, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -1982,7 +1982,13 @@ func cmdMenubar(args []string) {
 		if plmBase == "" {
 			plmBase = er1BaseURL(er1Cfg.APIURL)
 		}
-		if plmBase != "" && er1Cfg.APIKey != "" {
+		// PLM needs an ER1 credential. The API key OR a device token is
+		// sufficient — plmclient.doRequest sends whichever is present (Bearer
+		// device-token preferred, X-API-KEY fallback). Gating on APIKey alone
+		// silently disabled PLM for device-token-only logins (e.g. a fresh
+		// `m3c-tools login` whose profile still holds a placeholder key).
+		deviceToken := os.Getenv("ER1_DEVICE_TOKEN")
+		if plmBase != "" && (er1Cfg.APIKey != "" || deviceToken != "") {
 			log.Printf("[timetracking] PLM connection: base=%s context=%s ssl=%v",
 				plmBase, truncateForLog(er1Cfg.ContextID, 32), er1Cfg.VerifySSL)
 			// Strip ___mft suffix from context ID — PLM uses the raw Google UID.
@@ -1997,7 +2003,7 @@ func cmdMenubar(args []string) {
 				VerifySSL: er1Cfg.VerifySSL,
 			})
 
-			// Health check: validate API key before starting background services.
+			// Health check: validate credentials before starting background services.
 			if err := plmClient.HealthCheck(); err != nil {
 				log.Printf("[healthcheck] PLM auth check FAILED: %v", err)
 				log.Printf("[healthcheck] PLM sync and time tracking will be disabled until key is fixed")
@@ -2019,7 +2025,12 @@ func cmdMenubar(args []string) {
 				startTimeTrackingProjectRefresher(plmClient, ttStore)
 			}
 		} else {
-			log.Printf("[timetracking] PLM sync disabled (base=%q key_set=%v)", plmBase, er1Cfg.APIKey != "")
+			log.Printf("[timetracking] PLM sync disabled (base=%q key_set=%v device_token=%v)",
+				plmBase, er1Cfg.APIKey != "", deviceToken != "")
+			// Don't leave the Projects submenu stuck on "Loading projects..."
+			// forever — tell the user why it's empty. LoadConfig blanks a
+			// placeholder API key, so inspect the raw env value for the reason.
+			menubar.SetTimeTrackingError(plmDisabledReason(plmBase, os.Getenv("ER1_API_KEY")))
 		}
 
 		log.Printf("[timetracking] engine ready db=%s", timetracking.DefaultDBPath())
@@ -2293,6 +2304,22 @@ func classifyPLMHealthCheckError(err error) string {
 	}
 }
 
+// plmDisabledReason returns a short, user-facing diagnostic for the Projects
+// submenu when PLM sync can't start at all, so the menu never sits on
+// "Loading projects..." forever. rawKey is the pre-sanitization ER1_API_KEY
+// env value — LoadConfig blanks placeholders, so the reason must be derived
+// from the raw value here, not from the sanitized Config.APIKey.
+func plmDisabledReason(plmBase, rawKey string) string {
+	switch {
+	case plmBase == "":
+		return "ER1 URL not set — configure ER1_API_URL"
+	case config.IsPlaceholderKey(rawKey):
+		return "ER1_API_KEY is a placeholder — fix the active profile"
+	default:
+		return "Not signed in — run 'm3c-tools login' or set ER1_API_KEY"
+	}
+}
+
 // startTimeTrackingProjectRefresher fetches the PLM project list periodically
 // and updates the menubar cache and time tracking store (for reverse tracking tag matching).
 func startTimeTrackingProjectRefresher(plmClient *timetracking.PLMClient, ttStore *timetracking.Store) {
@@ -2300,8 +2327,14 @@ func startTimeTrackingProjectRefresher(plmClient *timetracking.PLMClient, ttStor
 		projects, err := plmClient.FetchProjects()
 		if err != nil {
 			log.Printf("[timetracking] project refresh failed: %v", err)
+			// Surface the cause in the Projects submenu instead of leaving it
+			// stuck on "Loading projects...".
+			menubar.SetTimeTrackingError(classifyPLMHealthCheckError(err))
 			return
 		}
+		// A successful fetch clears any prior diagnostic — even for an empty
+		// account (SetTimeTrackingProjects only clears on a non-empty list).
+		menubar.SetTimeTrackingError("")
 		var ttProjects []menubar.TimeTrackingProject
 		var cacheProjects []timetracking.CachedProject
 		for _, p := range projects {


### PR DESCRIPTION
## Symptom

The menubar **Projects** submenu sits on **"Loading projects…"** forever (greyed/inactive), empty. Field log:

```
[timetracking] PLM sync disabled (base="https://onboarding.guide" key_set=false)
```

## Root cause (two independent bugs, same symptom)

1. **The PLM enable-gate ignored the device token.** It required `er1Cfg.APIKey != ""`, but `plmclient.doRequest` is explicitly built to auth with a `Bearer` device token (BUG-0124 server fix). So a device-token-only login — or a profile whose `ER1_API_KEY` is a placeholder that `LoadConfig` blanks — got PLM **silently disabled** despite valid credentials.
2. **Both dead-end paths left the menu "loading" forever.** The disabled branch and a `FetchProjects` error in the periodic refresher left `ttError==""` and `ttLastRefresh` zero → the menu renders that as "Loading projects…" indefinitely, with no cause shown.

The field trigger: the active profile carried `ER1_API_KEY=minimal-key` (a known placeholder in `placeholderKeys`), shadowing the real key in `preferences.env` — the *"#1 cause of silent menubar failure"* the doctor already warns about.

## Fix

- Gate enables PLM when **`APIKey` OR `ER1_DEVICE_TOKEN`** is present.
- Both dead-ends now call `SetTimeTrackingError(...)`; new `plmDisabledReason` classifies the disabled case (placeholder key / no URL / not signed in).
- A successful refresh clears any stale diagnostic, even for an empty account.

## Files
- `cmd/m3c-tools/main.go` — device-token-aware gate; diagnostics on both dead-ends; `plmDisabledReason`
- `cmd/m3c-tools/healthcheck_classifier_test.go` — `TestPLMDisabledReason`

## Verification
`make vet` clean · `go build ./...` OK · `make test-unit` green (incl. new `TestPLMDisabledReason`). Runtime `doctor`/`check-er1` confirm ER1 auth healthy after the profile-key repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)