### PR TITLE
docs: rewrite README + add quickstarts, manuals & illustration kit (m3c-tools + skillctl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,147 @@
+<div align="center">
+
 # m3c-tools
 
-**Multi-Modal-Memory-Capturing Tools** — a macOS menu bar app and CLI for capturing observations (text + audio + image) and uploading them to an [ER1](https://er1.io) personal knowledge server.
+### Give your agents a memory — and proof of what they're allowed to do.
+
+**Multi-Modal-Memory Tools** is a personal, sovereign toolkit for turning everything you
+see, hear and decide into durable, structured memory — and for governing the agent skills
+that act on it. Two command-line tools, one repository, zero mandatory cloud middleman.
+
+[![Latest release](https://img.shields.io/github/v/release/kamir/m3c-tools?sort=semver)](https://github.com/kamir/m3c-tools/releases/latest)
+[![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-blue)](#install)
+[![Made with Go](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go)](https://go.dev)
+
+[Quickstart: m3c-tools](docs/quickstart-m3c-tools.md) ·
+[Quickstart: skillctl](docs/quickstart-skillctl.md) ·
+[Full manuals](#-documentation) ·
+[Website](https://kamir.github.io/m3c-tools)
+
+</div>
 
 ---
 
-## Install (one-liner)
+## Why this exists
+
+Autonomous agents need two things you can't buy off the shelf:
+
+1. **A memory of what actually happened** — not a chat log, but structured, multimodal,
+   replayable observations that live on infrastructure *you* control.
+2. **Proof of what they're allowed to do** — every skill an agent runs should carry a
+   verifiable identity, be revocable on demand, and be checkable **offline**, with no
+   external authority in the verification path.
+
+This repository ships one focused tool for each half.
+
+| Tool | The one-liner | You use it to… |
+|------|---------------|----------------|
+| **`m3c-tools`** | *The capture pipeline.* | Turn YouTube videos, audio, screenshots and voice notes into multimodal memory on your own [ER1](https://er1.io) knowledge server. |
+| **`skillctl`** | *The capability plane.* | Sign, admit, verify and revoke the agent skills that read that memory and act — so nothing runs unless it's authorized and provable. |
+
+`m3c-tools` fills the memory. `skillctl` governs the hands. Together they're the
+personal-scale foundation for running agents you can actually trust in production.
+
+---
+
+## 60-second start
+
+Pick the tool you came for. Both ship as single static binaries in every
+[release](https://github.com/kamir/m3c-tools/releases/latest).
+
+### `m3c-tools` — capture your first memory
+
+```bash
+# macOS (Apple Silicon) — see Install below for Intel / Linux / Windows
+curl -sL https://github.com/kamir/m3c-tools/releases/latest/download/m3c-tools-darwin-arm64.tar.gz | tar xz \
+  && sudo mv m3c-tools-darwin-arm64 /usr/local/bin/m3c-tools
+
+m3c-tools setup                         # guided onboarding (ER1 URL, login, key)
+m3c-tools transcript dQw4w9WgXcQ        # fetch a YouTube transcript, right now
+m3c-tools doctor                        # verify connectivity & config
+```
+
+→ **Full walkthrough:** [Quickstart: m3c-tools](docs/quickstart-m3c-tools.md)
+
+### `skillctl` — sign and verify your first skill
+
+```bash
+# macOS (Apple Silicon)
+curl -sL https://github.com/kamir/m3c-tools/releases/latest/download/skillctl-darwin-arm64.tar.gz | tar xz \
+  && sudo mv skillctl-darwin-arm64 /usr/local/bin/skillctl
+
+skillctl keygen --out ~/.config/m3c/skill-keys/mykey            # ed25519 → mykey.priv + mykey.pub
+skillctl pack --skill ./my-skill -o my-skill.skb --name my-skill --version 1.0.0
+skillctl sign my-skill.skb --key ~/.config/m3c/skill-keys/mykey.priv
+skillctl verify-sig my-skill.skb --pubkey ~/.config/m3c/skill-keys/mykey.pub   # offline, no server
+```
+
+→ **Full walkthrough:** [Quickstart: skillctl](docs/quickstart-skillctl.md)
+
+---
+
+## What `m3c-tools` captures
+
+Four capture channels flow through one shared pipeline:
+
+```
+Capture → Preview + Record → Whisper transcribe → Tag editor → Store to ER1
+```
+
+| Channel | Trigger | What it captures |
+|---------|---------|------------------|
+| **A — YouTube** | Paste a video URL/ID | Transcript + thumbnail + your voice comment |
+| **B — Screenshot** | Menu item | Screenshot + voice note (uses clipboard image if present) |
+| **C — Impulse** | Menu item | Interactive region capture + quick voice note |
+| **D — Audio Import** | Menu item / CLI | Batch audio from a folder (e.g. a voice recorder or Plaud/Pocket sync) |
+
+Each observation becomes a multimodal ER1 document — text + audio + image, with tags and
+metadata. On macOS this is a native menu-bar app; on Linux/Windows it's a full CLI.
+Even without a transcript (e.g. subtitles disabled), a YouTube capture still keeps the
+thumbnail and the link.
+
+**Command surface:** `transcript`, `upload`, `whisper`, `thumbnail`, `record`, `screenshot`,
+`import-audio`, `plaud`, `pocket`, `retry`, `schedule`, `status`, `doctor`, `login`,
+`setup`, `menubar`. See the [m3c-tools manual](docs/manual-m3c-tools.md).
+
+## What `skillctl` governs
+
+`skillctl` is the trust-and-governance CLI for agent skills. It implements a full lifecycle
+so a skill can be trusted end to end:
+
+```
+author → pack → sign → admit → attest → verify / install → use → audit → revoke
+```
+
+- **Offline-verifiable.** The trust-chain check needs no hosted CA in the verification path.
+- **Revocable on demand.** Signed, offline revocation lists; freshness contracts, fail-closed.
+- **Provable identity for agents.** `agentid` issues owner-signed mandates that verify offline.
+- **Auditable.** A local transparency log (`translog`) and a Claude Code trust gate
+  (`verify-hook`) that fails closed.
+
+**Command surface:** `keygen`, `pack`, `sign`, `verify-sig`, `trust`, `install`, `verify`,
+`attest`, `revoke`, `audit`, `publish`, `pull`, `registry`, `agentid`, `translog`,
+`verify-hook`, `gate-stats`, `project`, `session`. See the [skillctl manual](docs/manual-skillctl.md).
+
+---
+
+## 📚 Documentation
+
+| Page | For |
+|------|-----|
+| [**Quickstart: m3c-tools**](docs/quickstart-m3c-tools.md) | Capture your first memory in 5 minutes |
+| [**Quickstart: skillctl**](docs/quickstart-skillctl.md) | Sign, install and verify a skill in 5 minutes |
+| [**Manual: m3c-tools**](docs/manual-m3c-tools.md) | Every command, flag and config variable |
+| [**Manual: skillctl**](docs/manual-skillctl.md) | The full trust lifecycle, command by command |
+| [Menu Bar App](docs/menubar-app.md) | Channels, Observation Window, menu items (macOS) |
+| [Platform differences](docs/PLATFORM-DIFFERENCES.md) | What works where |
+| [Website](https://kamir.github.io/m3c-tools) | The rendered docs site |
+
+---
+
+## Install
+
+Both binaries are attached to every [release](https://github.com/kamir/m3c-tools/releases/latest).
+Swap `m3c-tools` ↔ `skillctl` in any one-liner below to install the other tool.
 
 **macOS (Apple Silicon):**
 ```bash
@@ -16,344 +153,79 @@ curl -sL https://github.com/kamir/m3c-tools/releases/latest/download/m3c-tools-d
 curl -sL https://github.com/kamir/m3c-tools/releases/latest/download/m3c-tools-darwin-amd64.tar.gz | tar xz && sudo mv m3c-tools-darwin-amd64 /usr/local/bin/m3c-tools
 ```
 
-**Linux (Ubuntu/Debian):**
+**Linux (amd64):**
 ```bash
 curl -sL https://github.com/kamir/m3c-tools/releases/latest/download/m3c-tools-linux-amd64.tar.gz | tar xz && sudo mv m3c-tools-linux-amd64 /usr/local/bin/m3c-tools
 ```
 
-**Windows (PowerShell — run as Administrator):**
-```powershell
-# Download and install to C:\m3c-tools
-New-Item -ItemType Directory -Force -Path C:\m3c-tools
-Invoke-WebRequest -Uri https://github.com/kamir/m3c-tools/releases/latest/download/m3c-tools-windows-amd64.zip -OutFile "$env:TEMP\m3c-tools.zip"
-Expand-Archive -Path "$env:TEMP\m3c-tools.zip" -DestinationPath C:\m3c-tools -Force
-Rename-Item C:\m3c-tools\m3c-tools-windows-amd64.exe C:\m3c-tools\m3c-tools.exe -Force
-
-# Add to system PATH (requires restart of terminal)
-$oldPath = [Environment]::GetEnvironmentVariable("PATH", "Machine")
-if ($oldPath -notlike "*C:\m3c-tools*") {
-    [Environment]::SetEnvironmentVariable("PATH", "$oldPath;C:\m3c-tools", "Machine")
-}
-```
-
-After installation, **open a new PowerShell window** and verify: `m3c-tools help`
+**Windows:** download `m3c-tools-windows-amd64.zip` (or the `M3C-Tools-Setup.exe` installer)
+from the [latest release](https://github.com/kamir/m3c-tools/releases/latest) and add it to your `PATH`.
+See [Quickstart: m3c-tools](docs/quickstart-m3c-tools.md) for the PowerShell one-liner.
 
 ### Platform support
 
-| Platform | Install | CLI | Menu Bar | Audio Recording | Bridge Mode |
-|----------|---------|-----|----------|-----------------|-------------|
-| macOS arm64 (Apple Silicon) | one-liner | full | full GUI | full | yes |
-| macOS amd64 (Intel/iMac) | one-liner | full | full GUI | full | yes |
-| Linux amd64 (Ubuntu) | one-liner | full | — | — | yes |
-| Linux arm64 (Jetson) | one-liner | full | — | — | yes (relay) |
-| Windows amd64 | one-liner | full | — | — | — |
+| Platform | CLI | Menu Bar | Audio Recording | Bridge Mode |
+|----------|-----|----------|-----------------|-------------|
+| macOS arm64 (Apple Silicon) | full | full GUI | full | yes |
+| macOS amd64 (Intel) | full | full GUI | full | yes |
+| Linux amd64 (Ubuntu) | full | — | — | yes |
+| Linux arm64 (Jetson) | full | — | — | yes (relay) |
+| Windows amd64 | full | — | — | — |
+
+`skillctl` is CLI-only and runs identically on all five platforms.
 
 ---
 
-## Quickstart (5 minutes)
+## Build from source
 
-### 1. Install prerequisites (macOS full build from source)
-
-```bash
-brew install pkg-config portaudio ffmpeg    # build tools + audio
-python3 -m pip install openai-whisper       # speech-to-text
-```
-
-Or: `make deps` (after cloning) to install everything at once.
-
-Requires **Go 1.25+** and **macOS** (Cocoa UI via cgo).
-
-> **First-run note:** Whisper downloads its language model on first use (~150 MB for `base`, ~1.5 GB for `medium`). This requires internet access.
-
-> **Windows/Linux users:** Use the one-liner install above — no build from source needed.
-
-### 2. Build and install
+Requires **Go 1.25+**. The macOS menu-bar GUI additionally needs `portaudio` + `ffmpeg` (cgo).
 
 ```bash
-git clone https://github.com/kamir/m3c-tools.git
-cd m3c-tools
-make install
+git clone https://github.com/kamir/m3c-tools.git && cd m3c-tools
+
+make build          # build the m3c-tools CLI → ./build/m3c-tools
+make build-all      # build the CLI + POC binaries
+go build -o build/skillctl ./cmd/skillctl   # build skillctl
+
+make install        # macOS: CLI + M3C-Tools.app + data dir + permission setup
+make menubar        # macOS: build + launch the menu bar app (dev mode)
+
+make test-unit      # offline unit tests
+make vet            # go vet ./...
+make help           # show all targets
 ```
-
-This builds the binary, creates `M3C-Tools.app`, installs both to `/usr/local/bin` and `/Applications`, and walks you through macOS permission setup (Microphone, Screen Recording).
-
-### 3. Configure
-
-**Guided setup (recommended):**
-
-```bash
-m3c-tools setup
-```
-
-The wizard walks you through:
-1. ER1 server URL (defaults to `https://onboarding.guide/upload_2`)
-2. Browser login — opens Chrome, captures your User ID automatically
-3. API key — you'll need an ER1 API key (get one from your ER1 admin)
-4. Default tags for Plaud sync
-
-This writes `~/.m3c-tools.env` with all required settings.
-
-**Manual setup** (if you prefer):
-
-```bash
-cp .env.example ~/.m3c-tools.env
-```
-
-Edit `~/.m3c-tools.env`:
-
-```
-ER1_API_URL=https://onboarding.guide/upload_2
-ER1_API_KEY=your-api-key
-ER1_CONTEXT_ID=your-context-id
-```
-
-> **Note:** An API key is required for uploads. The browser login flow captures your User ID (context), but all API calls (upload, project list) authenticate via `X-API-KEY` header. You cannot use Google login alone — ask your ER1 admin for an API key.
-
-### 4. Launch
-
-```bash
-make menubar
-```
-
-Or open `/Applications/M3C-Tools.app`. A menu bar icon appears — you're ready to capture.
-
-### 5. Try it
-
-- **Fetch a transcript**: click the menu bar icon → *Fetch Transcript...* → paste a YouTube URL
-- **Screenshot observation**: click *Capture Screenshot* → record a voice note → Store to ER1
-- **CLI only**: `m3c-tools transcript dQw4w9WgXcQ --format srt`
-
----
-
-## What does m3c-tools do?
-
-m3c-tools captures four types of observations, each flowing through a shared pipeline:
-
-```
-Capture → Preview + Record → Whisper Transcribe → Tag Editor → Store to ER1
-```
-
-| Channel | Trigger | What it captures |
-|---------|---------|------------------|
-| **A — YouTube** | Paste video URL | Transcript + thumbnail + your voice comment |
-| **B — Screenshot** | Menu item | Screenshot + voice note (uses clipboard image if present) |
-| **C — Impulse** | Menu item | Interactive region capture + quick voice note |
-| **D — Audio Import** | Menu item | Batch audio files from a folder (e.g. voice recorder sync) |
-
-Each observation becomes a multimodal ER1 document: text transcript + audio recording + image, with tags and metadata.
-
----
-
-## Configuration Reference
-
-Settings are loaded from `.env` in the project root or `~/.m3c-tools.env`. See [`.env.example`](.env.example) for all options.
-
-### Required for ER1 upload
-
-| Variable | Description |
-|----------|-------------|
-| `ER1_API_URL` | ER1 upload endpoint URL |
-| `ER1_API_KEY` | API key (sent as `X-API-KEY` header) |
-| `ER1_CONTEXT_ID` | Your ER1 context/user identifier |
-
-### Whisper (speech-to-text)
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `M3C_WHISPER_MODEL` | `base` | Model size: `tiny`, `base`, `small`, `medium`, `large` |
-| `M3C_WHISPER_TIMEOUT` | `7200` | Transcription timeout in seconds |
-| `YT_WHISPER_LANGUAGE` | `de` | Language code (ISO 639-1) |
-| `M3C_WHISPER_PRELOAD` | `true` | Preload model at startup |
-
-### Screenshot capture
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `M3C_SCREENSHOT_MODE` | `clipboard-first` | `clipboard-first` or `interactive` |
-| `M3C_SCREENSHOT_CLIPBOARD_TIMEOUT_SEC` | `20` | Wait time for clipboard image |
-
-### Audio import (Channel D)
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `IMPORT_AUDIO_SOURCE` | — | Source folder for audio files |
-| `IMPORT_AUDIO_DEST` | `~/ER1` | Destination for MEMORY folders |
-| `IMPORT_CONTENT_TYPE` | — | ER1 content-type label |
-
-### ER1 tuning
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `ER1_UPLOAD_TIMEOUT` | `600` | HTTP timeout in seconds |
-| `ER1_VERIFY_SSL` | `false` | TLS certificate verification |
-| `ER1_RETRY_INTERVAL` | `300` | Seconds between retry cycles |
-| `ER1_MAX_RETRIES` | `10` | Max retries before dropping |
-
----
-
-## macOS App Bundle
-
-m3c-tools ships as a native macOS `.app` bundle (`M3C-Tools.app`) that runs as a menu bar agent. The bundle includes:
-
-- Go binary compiled with cgo (native Cocoa UI)
-- App icon (`.icns` generated from `maindset_icon.png`)
-- `Info.plist` with microphone and screen capture usage descriptions
-- `LSUIElement = true` (menu bar agent — no Dock icon)
-
-### Build the app bundle only
-
-```bash
-make build-app
-# Result: build/M3C-Tools.app
-```
-
-### Install to /Applications
-
-```bash
-make install
-```
-
-This runs `build-app` and then:
-1. Copies the CLI binary to `/usr/local/bin/m3c-tools`
-2. Copies `M3C-Tools.app` to `/Applications/`
-3. Creates `~/.m3c-tools/` data directory
-
-### Grant macOS permissions
-
-After installing, run:
-
-```bash
-make permissions
-```
-
-This opens each System Settings pane one at a time:
-
-| Permission | Why |
-|------------|-----|
-| **Screen Recording** | Screenshot capture (Channels B & C) |
-| **Microphone** | Voice recording for observations |
-| **Accessibility** | Clipboard monitoring for screenshot detection |
-| **Input Monitoring** | Keystroke capture for hotkey support |
-
-Toggle **M3C-Tools** ON in each pane (click `+` to add if not listed).
-
-### Launch
-
-Double-click `/Applications/M3C-Tools.app`, or:
-
-```bash
-open /Applications/M3C-Tools.app
-```
-
-Or for development:
-
-```bash
-make menubar    # builds + launches directly (no install needed)
-```
-
-### Uninstall
-
-```bash
-make uninstall
-```
-
-Removes `/usr/local/bin/m3c-tools` and `/Applications/M3C-Tools.app`. Data at `~/.m3c-tools/` is preserved.
-
----
-
-## Build & Test
-
-```bash
-make build          # Build CLI binary → ./build/m3c-tools
-make build-app      # Build macOS .app bundle → ./build/M3C-Tools.app
-make menubar        # Build + launch menu bar app (dev mode)
-make install        # Full install: CLI + .app + data dir
-
-make test-unit      # Offline unit tests
-make ci             # Full CI: vet + lint + test + build
-make test-network   # YouTube API tests (requires internet)
-make test-er1       # ER1 integration tests (requires server)
-
-make help           # Show all targets
-```
-
-Run a single test:
-
-```bash
-go test -v -count=1 ./e2e/ -run TestTranscriptFetch
-```
-
----
-
-## Cross-Platform CLI (Windows, Linux, Jetson)
-
-On non-macOS platforms, m3c-tools runs in CLI-only mode (no menu bar GUI):
-
-```bash
-m3c-tools setup                  # Interactive onboarding wizard
-m3c-tools plaud auth login       # Authenticate with Plaud (auto-launches Chrome)
-m3c-tools plaud list             # List all Plaud recordings
-m3c-tools plaud sync all         # Sync all recordings to ER1
-m3c-tools transcript <video_id>  # Fetch YouTube transcript
-m3c-tools check-er1              # Verify ER1 connectivity
-```
-
-### Plaud auth (all platforms)
-
-`plaud auth login` works on macOS, Windows, and Linux. It auto-launches Chrome (or Edge) with remote debugging, opens `app.plaud.ai`, and extracts the auth token after you log in. No manual Chrome flags needed. On macOS, it can also extract the token directly from a running Chrome via AppleScript (no debug port needed).
-
-### Context Processor Bridge (macOS / Ubuntu only)
-
-An iMac or Ubuntu box can serve as a dedicated batch processing node for transcription and bulk ingestion. Windows is **desktop interaction mode only** — no bridge mode.
-
-```bash
-# One-command bridge setup (macOS or Ubuntu):
-curl -sL https://raw.githubusercontent.com/kamir/m3c-tools-maintenance/master/scripts/setup-bridge.sh | bash
-
-# Then:
-m3c-tools import-audio ~/m3c-inbox/ --run    # Batch-transcribe
-m3c-tools import-audio retry                  # Retry failed uploads
-m3c-tools plaud sync all                      # Sync all Plaud recordings
-```
-
-Setup details: [scripts/setup-bridge.sh](https://github.com/kamir/m3c-tools-maintenance/blob/master/scripts/setup-bridge.sh) | Hardware planning: [SPEC-0018](https://github.com/kamir/m3c-tools-maintenance/blob/master/SPEC/SPEC-0018-jetson-nano-whisper.md)
 
 ---
 
 ## Architecture
 
 ```
-cmd/m3c-tools/       CLI + menu bar app entry point
-  main.go            macOS: full GUI + CLI
-  main_other.go      Windows/Linux: CLI only
+cmd/m3c-tools/       m3c-tools CLI + macOS menu-bar app entry point
+cmd/skillctl/        skillctl trust-&-governance CLI entry point
 pkg/transcript/      YouTube InnerTube API client (pure Go, no API key)
 pkg/er1/             ER1 upload client + retry queue + health check
 pkg/impression/      Composite document builder + tag system
-pkg/whisper/         Whisper CLI subprocess wrapper (heartbeat, progress)
-pkg/recorder/        PortAudio microphone recording (cgo, macOS only)
+pkg/whisper/         Whisper CLI subprocess wrapper
+pkg/recorder/        PortAudio microphone recording (cgo, macOS)
 pkg/screenshot/      macOS screenshot capture + clipboard detection
-pkg/menubar/         Native Cocoa UI via cgo (NSWindow, NSTabView, etc.)
+pkg/menubar/         Native Cocoa UI via cgo (NSWindow, NSTabView, …)
 pkg/importer/        Batch audio import pipeline
-pkg/tracking/        SQLite tracking database
 pkg/plaud/           Plaud.ai client + Chrome CDP auth
-pkg/timetracking/    Project time tracking + Gantt chart
+pkg/pocket/          Pocket capture-device sync
+pkg/timetracking/    Project time tracking + Gantt chart + PLM client
 ```
 
-## Documentation
+Core logic (transcript, er1, impression) depends only on the Go standard library.
 
-Full documentation: **[kamir.github.io/m3c-tools](https://kamir.github.io/m3c-tools)**
+---
 
-- [Getting Started](https://kamir.github.io/m3c-tools/getting-started)
-- [Menu Bar App](https://kamir.github.io/m3c-tools/menubar-app)
-- [Roadmap](https://kamir.github.io/m3c-tools/roadmap)
+## The bigger picture
 
-## Uninstalling
-
-```bash
-make uninstall
-```
-
-Data at `~/.m3c-tools/` is preserved — remove manually if desired.
+`skillctl` is the reference implementation of what we call the **capability plane** — one
+plane of a *Sovereign Decision Fabric*: an architecture for running autonomous agents where
+every decision is recorded and replayable, and every capability an agent holds is itself
+authorized, provable, and revocable. This repo is the "ur-version" where that machinery is
+built and battle-tested in the open.
 
 ## License
 

--- a/docs/illustration-prompt.md
+++ b/docs/illustration-prompt.md
@@ -1,0 +1,82 @@
+---
+layout: default
+title: Illustration Prompt — m3c-tools
+---
+
+# Illustration prompt kit
+
+Paste one of these into your image model of choice (Midjourney, DALL·E, Ideogram, Flux,
+Nano Banana, etc.) to generate a hero/cover illustration for the README and docs site.
+The **story to convey**: two halves of one system — a pipeline that turns the messy world
+(video, audio, screenshots, voice) into structured *memory*, and a *trust plane* that
+signs and governs the agent skills acting on that memory. Sovereign, offline, yours.
+
+---
+
+## 1. Primary hero image (recommended)
+
+> A sleek, modern technical illustration in a clean isometric style. On the **left**, a
+> "capture pipeline": stylized streams of raw signals — a YouTube play button, a sound
+> waveform, a screenshot frame, a microphone — flowing rightward and being distilled into
+> neat, glowing memory cards stacked in a personal vault. On the **right**, a "capability
+> plane": a translucent horizontal layer where small autonomous agent figures reach toward
+> the memory vault, but each agent's hand passes through a glowing verification gate marked
+> with a **checkmark, a key, and a signature seal** — some pass (green), one is stopped
+> (amber). A thin luminous line connects both halves, labeled implicitly by flow, not text.
+> Palette: deep indigo and slate background, electric teal and cyan accents, warm amber for
+> the "denied" gate, soft white highlights. Subtle grid floor, faint circuit textures,
+> volumetric glow. Confident, trustworthy, high-tech but human-scale — not corporate stock.
+> Crisp vector-adjacent shading, 4k, generous negative space at top for a title.
+> **Aspect ratio 16:9. No text, no logos, no watermarks.**
+
+---
+
+## 2. Minimalist emblem (for a badge / favicon / social card)
+
+> A minimalist emblem combining two motifs into one mark: a **memory node** (a rounded
+> square containing three stacked cards or layers) fused with a **shield-and-key** for
+> trust. Single-weight linework, geometric, balanced, suitable at small sizes. Two-tone:
+> teal on deep navy, or monochrome line art on transparent. Modern open-source project vibe.
+> **1:1 square. No text.**
+
+---
+
+## 3. Conceptual "planes" diagram (for the docs / pillar page)
+
+> A calm, editorial isometric diagram of horizontal translucent planes stacked in depth,
+> like glass shelves floating in dark space. From bottom to top: an **event stream** plane
+> (flowing ordered dots), a **memory** plane (glowing cards), a **reasoning** plane (small
+> agent glyphs), a **provenance/audit** plane (an immutable ledger ribbon), and a
+> **capability** plane at the front (signed keys and verification checkmarks gating access).
+> Compute arrows point *down toward the data*, not up. Thin cyan connective light between
+> planes. Muted, sophisticated palette: charcoal, indigo, teal, a single warm accent.
+> Editorial infographic quality, lots of breathing room. **Aspect ratio 16:9. No text labels.**
+
+---
+
+## 4. Dark-mode README banner (wide)
+
+> A wide, cinematic banner: on a near-black background, a horizontal river of luminous data
+> particles flows left-to-right, gradually condensing from chaotic raw signals into orderly
+> glowing memory blocks, then passing through a single elegant **verification gate** (a ring
+> with a keyhole and a checkmark) before reaching a serene personal "vault" on the right.
+> Electric teal and cyan light, deep shadows, subtle lens bloom, a sense of calm control.
+> Minimal, premium, developer-tool aesthetic. **Aspect ratio 3:1 (wide banner). No text.**
+
+---
+
+## Style & negative-prompt cheatsheet
+
+**Add for consistency:** `isometric, clean vector shading, volumetric glow, deep indigo +
+teal + cyan palette, subtle circuit texture, premium developer-tool aesthetic, high detail,
+4k`
+
+**Negative / avoid:** `no text, no lettering, no logos, no watermark, no busy clutter, no
+cheesy stock-photo people, no cluttered UI screenshots, not skeuomorphic, not neon-overload`
+
+**Tips**
+- Keep **negative space at the top** if you'll overlay the project title.
+- Generate the emblem (#2) on a transparent background for reuse.
+- Ask for `16:9` for the site hero, `3:1` for the GitHub social/banner, `1:1` for the badge.
+- If the model renders garbled text, re-run with "no text" emphasized — labels should be
+  added later in a vector editor, not baked into the image.

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,10 +58,19 @@ ER1_CONTEXT_ID=your-context-id
 
 See the [Getting Started](getting-started) guide for the full configuration reference.
 
+## Two tools, one repo
+
+This repository ships two CLIs. **`m3c-tools`** fills the memory; **`skillctl`** governs the
+agent skills that act on it (sign, admit, verify, revoke — offline-verifiable).
+
 ---
 
 **Documentation:**
 
-- [Getting Started](getting-started) — install, configure, first use
+- [Quickstart: m3c-tools](quickstart-m3c-tools) — capture your first memory in 5 minutes
+- [Quickstart: skillctl](quickstart-skillctl) — sign, install and verify a skill in 5 minutes
+- [Manual: m3c-tools](manual-m3c-tools) — every command, flag and config variable
+- [Manual: skillctl](manual-skillctl) — the full trust lifecycle, command by command
 - [Menu Bar App](menubar-app) — channels, Observation Window, menu items
+- [Platform differences](PLATFORM-DIFFERENCES) — what works where
 - [Roadmap](roadmap) — current state, future work, ideas

--- a/docs/manual-m3c-tools.md
+++ b/docs/manual-m3c-tools.md
@@ -1,0 +1,588 @@
+---
+layout: default
+title: Manual — m3c-tools
+---
+
+# Manual: m3c-tools
+
+`m3c-tools` (Multi-Modal-Memory Tools) is a capture pipeline: it turns YouTube videos,
+audio, screenshots and voice notes into structured, **multimodal observations** (text +
+audio + image) uploaded to *your* [ER1](https://er1.io) personal knowledge server. On
+macOS it ships as a native menu-bar app **and** a full CLI; on Linux and Windows it is
+CLI-only. The core packages (`transcript`, `er1`, `impression`) use only the Go standard
+library. If you just want the 5-minute path, start with the
+[Quickstart](quickstart-m3c-tools.md) — **this page is the exhaustive reference** for
+every command, flag and configuration variable.
+
+---
+
+## Installation & build
+
+Grab the single binary from the
+[latest release](https://github.com/kamir/m3c-tools/releases/latest), or use the
+platform one-liners in the [Quickstart](quickstart-m3c-tools.md#1-install) and the
+[README](../README.md#build-from-source). To build from source (Go 1.25+):
+
+```bash
+go build -o m3c-tools ./cmd/m3c-tools   # plain Go build
+make build                              # → ./build/m3c-tools
+make install                            # build + install CLI (and the macOS app)
+make menubar                            # build & launch the menu-bar app (macOS, dev)
+```
+
+On macOS the menu-bar GUI additionally needs `brew install pkg-config portaudio ffmpeg`
+and `python3 -m pip install openai-whisper`. See the
+[README](../README.md#build-from-source) for the full install matrix.
+
+---
+
+## Usage & conventions
+
+```bash
+m3c-tools <command> [args] [flags]
+```
+
+- Flags use the `--flag <value>` form and follow their command.
+- Run `m3c-tools help` for the top-level listing, or `m3c-tools <command> --help` for a
+  single command. When in doubt about a flag, trust `--help` over any doc.
+- Every run prints two informational log lines first (`[config] profile: …` and
+  `[auth] …`) — these are diagnostics, not command output.
+
+**Where configuration comes from.** Settings load from `~/.m3c-tools.env` (the global
+config), from a project-local `.env`, and from named **profiles** managed by
+`m3c-tools config`. See [Configuration reference](#configuration-reference) for the full
+variable list and copy `.env.example` as a starting template.
+
+**Authentication.** Uploads to ER1 authenticate with an **API key** (sent as the
+`X-API-KEY` header, from `ER1_API_KEY`) **and/or** a **device token** (paired via
+`m3c-tools login`). Set up at least one. Check what the tool sees with
+`m3c-tools token` and `m3c-tools doctor`.
+
+---
+
+## Command reference
+
+Fetching a YouTube transcript needs **no ER1 credential and no API key** (it uses
+YouTube's InnerTube API). Everything that touches ER1 (`upload`, `import-audio`, `plaud
+sync`, `pocket sync`, the retry/queue commands) needs a working ER1 config.
+
+### Capture
+
+#### `transcript` — fetch a YouTube transcript
+
+```bash
+m3c-tools transcript <video_id> [flags]
+```
+
+Fetches a video's transcript via YouTube's InnerTube API and prints it in the chosen
+format. Also lists available transcript tracks and can translate to another language.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--lang` | `<code>` | `en` | Language code of the transcript to fetch |
+| `--format` | `<fmt>` | `text` | Output format: `text`, `srt`, `json`, `webvtt` |
+| `--translate` | `<code>` | — | Translate the transcript to this language code |
+| `--list` | — | — | List available transcripts only (no fetch) |
+| `--exclude-generated` | — | — | With `--list`: exclude auto-generated transcripts |
+| `--exclude-manually-created` | — | — | With `--list`: exclude manually created transcripts |
+| `--proxy-url` | `<url>` | — | HTTP/SOCKS5 proxy URL, e.g. `http://host:port` |
+| `--proxy-auth` | `<creds>` | — | Proxy credentials as `user:password` |
+
+```bash
+m3c-tools transcript dQw4w9WgXcQ --format srt
+m3c-tools transcript dQw4w9WgXcQ --list --exclude-generated
+```
+
+#### `upload` — capture a full observation to ER1
+
+```bash
+m3c-tools upload <video_id> [flags]
+```
+
+Fetches the transcript **and** the thumbnail, builds a composite document, and uploads it
+to ER1. If subtitles are disabled the capture still keeps the thumbnail and the link, so
+the observation is never empty.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--audio` | `<file>` | — | Include an audio file with the observation |
+| `--impression` | `<text>` | — | Add your own impression / commentary text |
+
+```bash
+m3c-tools upload dQw4w9WgXcQ --impression "Great intro to the topic"
+m3c-tools upload dQw4w9WgXcQ --audio note.wav --impression "My take"
+```
+
+#### `whisper` — transcribe local audio
+
+```bash
+m3c-tools whisper <audio_file> [flags]
+```
+
+Transcribes an audio file by invoking your local `whisper` binary as a subprocess.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--model` | `<model>` | `base` | Whisper model (`tiny`, `base`, `small`, `medium`, `large`) |
+| `--language` | `<lang>` | — | Language hint for transcription |
+
+```bash
+m3c-tools whisper meeting.wav --model base --language en
+```
+
+#### `thumbnail` — download a video thumbnail
+
+```bash
+m3c-tools thumbnail <video_id> [flags]
+```
+
+Downloads the highest-available thumbnail for a video (with size fallback).
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--output` | `<file>` | `<video_id>_thumbnail.jpg` | Output file path |
+
+```bash
+m3c-tools thumbnail dQw4w9WgXcQ --output cover.jpg
+```
+
+#### `record` — record from the microphone
+
+```bash
+m3c-tools record [output.wav] [flags]
+```
+
+Records from the default microphone to a WAV file (16 kHz / 16-bit PCM mono,
+whisper-compatible). Requires PortAudio and a microphone.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--duration` | `<secs>` | `5` | Recording duration in seconds |
+
+```bash
+m3c-tools record note.wav --duration 15
+```
+
+#### `screenshot` — capture a screenshot (macOS only)
+
+```bash
+m3c-tools screenshot [flags]
+```
+
+Captures the screen, a window, or a selected region and writes an image file. macOS only.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--mode` | `<mode>` | `full` | Capture mode: `full`, `window`, `region` |
+| `--output` | `<dir>` | current dir | Output directory |
+| `--filename` | `<name>` | timestamped | Output filename |
+| `--silent` | — | — | Suppress the capture sound |
+| `--hide-cursor` | — | — | Hide the cursor in the capture |
+
+```bash
+m3c-tools screenshot --mode region --output ~/shots --silent
+```
+
+#### `import-audio` — scan / import a folder of audio
+
+```bash
+m3c-tools import-audio <dir> [flags]
+```
+
+Scans a directory for audio files. With `--run` it transcribes, uploads and tags each new
+file end-to-end. Progress is tracked in a local SQLite DB so re-runs skip what's done.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--run` | — | — | Import, transcribe, upload and tag end-to-end |
+| `--extensions` | — | — | List supported audio extensions |
+| `--compact` | — | — | Machine-readable TSV output (status, path, size, tags) |
+| `--db` | `<path>` | `~/.m3c-tools/tracking.db` | Tracking DB path |
+
+```bash
+m3c-tools import-audio ~/m3c-inbox/ --run
+m3c-tools import-audio --extensions
+```
+
+### Capture devices
+
+#### `plaud` — Plaud recorder integration
+
+```bash
+m3c-tools plaud <subcommand>
+```
+
+Syncs recordings from a Plaud.ai device into ER1.
+
+| Subcommand | Meaning |
+|------------|---------|
+| `plaud list` | List Plaud recordings with sync status |
+| `plaud sync <id>` | Sync one Plaud recording to ER1 |
+| `plaud sync --all` | Sync all new Plaud recordings to ER1 |
+| `plaud auth login` | Extract the API token from Chrome (`web.plaud.ai`) |
+| `plaud auth --token-file <path>` | Save the Plaud token from a file (secure) |
+| `plaud auth` | Save the token from `$M3C_PLAUD_TOKEN` (secure) |
+| `plaud auth <token>` | Save the token from argv — **deprecated** (leaks via `ps`) |
+
+```bash
+m3c-tools plaud auth login
+m3c-tools plaud sync --all
+```
+
+#### `pocket` — Pocket recorder integration
+
+```bash
+m3c-tools pocket <subcommand> [flags]
+```
+
+Syncs recordings from a Pocket device into ER1.
+
+| Subcommand / flag | Argument | Meaning |
+|-------------------|----------|---------|
+| `pocket list` | — | List Pocket recordings with sync status |
+| `pocket sync --all` | — | Sync all new Pocket recordings to ER1 |
+| `--path` | `<dir>` | Override the device recording path (either subcommand) |
+
+```bash
+m3c-tools pocket list
+m3c-tools pocket sync --all --path /Volumes/POCKET
+```
+
+#### `devices` — list audio input devices
+
+```bash
+m3c-tools devices
+```
+
+Lists the available audio input devices (useful before `record`). No flags.
+
+### ER1 & queue
+
+#### `check-er1` — test ER1 reachability
+
+```bash
+m3c-tools check-er1
+```
+
+A quick reachability check against the ER1 server. For a full diagnostic use `doctor`.
+No flags.
+
+#### `doctor` — connectivity & config diagnostics
+
+```bash
+m3c-tools doctor
+```
+
+Runs the full diagnostic: active profile, authentication (API key and/or device token),
+DNS, TLS, and the ER1 health/auth endpoints. Run this first when uploads fail. No flags.
+
+#### `token` — show device-token status
+
+```bash
+m3c-tools token [--print]
+```
+
+Shows whether a device token is loaded.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--print` | — | — | Emit the Bearer token to stdout (for shell capture) |
+
+```bash
+m3c-tools token
+export TOKEN=$(m3c-tools token --print)
+```
+
+#### `retry` — run the retry loop for queued uploads
+
+```bash
+m3c-tools retry [flags]
+```
+
+Processes the local retry queue of failed uploads, polling on an interval.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--interval` | `<secs>` | `30` | Poll interval in seconds |
+| `--max-retries` | `<n>` | `10` | Max retries per entry |
+| `--queue` | `<path>` | `~/.m3c-tools/queue.json` | Queue file path |
+
+```bash
+m3c-tools retry --interval 60 --max-retries 5
+```
+
+#### `schedule` — schedule a retry entry in the tracking DB
+
+```bash
+m3c-tools schedule <entry_id> --transcript <path> [flags]
+```
+
+Registers an ER1 retry entry in the SQLite tracking DB. `--transcript` is required.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--transcript` | `<path>` | — (required) | Transcript file path |
+| `--audio` | `<path>` | — | Audio file path |
+| `--image` | `<path>` | — | Image file path |
+| `--tags` | `<tags>` | — | Comma-separated tags |
+| `--max-attempts` | `<n>` | `10` | Max retry attempts |
+| `--db` | `<path>` | `~/.m3c-tools/exports.db` | SQLite DB path |
+
+```bash
+m3c-tools schedule vid-001 --transcript out.txt --tags progress,youtube
+```
+
+#### `status` — show retry entry status
+
+```bash
+m3c-tools status [flags]
+```
+
+Shows the status of ER1 retry entries in the tracking DB.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--entry` | `<id>` | — | Show a specific entry only |
+| `--db` | `<path>` | `~/.m3c-tools/exports.db` | SQLite DB path |
+
+```bash
+m3c-tools status
+m3c-tools status --entry vid-001
+```
+
+#### `cancel` — cancel a pending retry entry
+
+```bash
+m3c-tools cancel <entry_id> [flags]
+```
+
+Cancels a pending ER1 retry entry.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--db` | `<path>` | `~/.m3c-tools/exports.db` | SQLite DB path |
+
+```bash
+m3c-tools cancel vid-001
+```
+
+### Config & app
+
+#### `setup` — set up the Python venv + whisper
+
+```bash
+m3c-tools setup [flags]
+```
+
+Sets up the Python virtual environment and installs whisper for local transcription.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--force` | — | — | Recreate the venv from scratch |
+| `--check` | — | — | Check setup status without installing |
+
+```bash
+m3c-tools setup --check
+m3c-tools setup --force
+```
+
+#### `config` — configuration profile management
+
+```bash
+m3c-tools config <list|show|switch|create|test|import>
+```
+
+Manages named configuration profiles.
+
+| Subcommand | Meaning |
+|------------|---------|
+| `config list` | List available profiles |
+| `config show` | Show the active profile's settings |
+| `config switch` | Switch the active profile |
+| `config create` | Create a new profile |
+| `config test` | Test a profile's ER1 connectivity |
+| `config import` | Import a profile |
+
+```bash
+m3c-tools config list
+m3c-tools config switch cloud
+```
+
+#### `settings` — open the profile settings editor
+
+```bash
+m3c-tools settings
+```
+
+Opens the profile settings editor in your browser. No flags.
+
+#### `login` — pair this device via the browser
+
+```bash
+m3c-tools login
+```
+
+Opens the browser to sign in to ER1 and links this device (captures your context and can
+store a device token). Run any time to re-pair. No flags.
+
+#### `menubar` — launch the macOS menu-bar app
+
+```bash
+m3c-tools menubar [flags]
+```
+
+Launches the native menu-bar app (macOS only). See the
+[Menu Bar App guide](menubar-app.md) for every menu item.
+
+| Flag | Argument | Default | Meaning |
+|------|----------|---------|---------|
+| `--title` | `<text>` | `M3C` | Menu-bar title text |
+| `--icon` | `<path>` | — | Menu-bar icon PNG path |
+| `--log` | `<path>` | `~/.m3c-tools/m3c-tools.log` | Log file path |
+
+```bash
+m3c-tools menubar --title "M3C" --icon ~/icons/m3c.png
+```
+
+#### `version` — print the version
+
+```bash
+m3c-tools version
+```
+
+Prints the build version. No flags.
+
+#### `help` — show the command listing
+
+```bash
+m3c-tools help
+```
+
+Prints the full command + flag listing. No flags.
+
+---
+
+## Configuration reference
+
+Variables are read from `~/.m3c-tools.env`, a project `.env`, or the active profile. Copy
+`.env.example` as a template. All examples below show the documented defaults; commented
+lines in `.env.example` mean the value is optional.
+
+### ER1 connection (required for uploads)
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `ER1_API_URL` | — | ER1 upload endpoint URL, e.g. `https://onboarding.guide/upload_2` |
+| `ER1_API_KEY` | — | API key sent as the `X-API-KEY` header |
+| `ER1_CONTEXT_ID` | — | Context identifier for uploads |
+| `ER1_VERIFY_SSL` | `false` | SSL verification: `true` \| `false` (use `false` for self-signed local dev) |
+| `ER1_CONTENT_TYPE` | `YouTube-Video-Impression` | Content-type label in the upload form payload |
+
+### ER1 tuning
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `ER1_UPLOAD_TIMEOUT` | `600` | HTTP timeout (seconds) for upload requests |
+| `ER1_RETRY_INTERVAL` | `300` | Seconds between automatic retry-queue cycles |
+| `ER1_MAX_RETRIES` | `10` | Max retry attempts before dropping a failed upload |
+| `M3C_ER1_SESSION_PERSIST` | `false` | Persist login-linked context across app restarts |
+| `M3C_ER1_SESSION_FILE` | `~/.m3c-tools/er1_session.json` | Custom path for the persisted ER1 session JSON |
+
+> Retry backoff itself is hardcoded in `pkg/er1/retry.go` — the former
+> `ER1_RETRY_BASE_DELAY` / `ER1_RETRY_MAX_DELAY` variables were removed and have no effect.
+
+### YouTube rate-limit mitigation
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `YT_PROXY_URL` | — | HTTP/SOCKS5 proxy to avoid YouTube 429 rate limits |
+| `YT_PROXY_AUTH` | — | Proxy credentials as `user:password` |
+
+> Transcripts are also cached at `~/.m3c-tools/cache/transcripts/` (7-day TTL). On a 429,
+> the app proceeds without the transcript (graceful degradation).
+
+### Whisper transcription
+
+Used for menu-bar voice recording, audio import, and local speech-to-text (**not** for
+YouTube transcripts, which are fetched directly).
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `M3C_WHISPER_MODEL` | `large` | Model size: `tiny` \| `base` \| `small` \| `medium` \| `large` |
+| `M3C_WHISPER_FALLBACK` | `medium,base,tiny` | Comma-separated fallback chain if the primary model fails |
+| `M3C_WHISPER_TIMEOUT` | `7200` | Transcription timeout in seconds (`0` = no timeout) |
+| `M3C_WHISPER_LANGUAGE` | `de` | Transcription language (ISO 639-1 code) |
+| `M3C_WHISPER_PRELOAD` | `true` | Preload the model at menu-bar startup (lower first-run latency) |
+
+### Screenshot capture
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `M3C_SCREENSHOT_MODE` | `clipboard-first` | `clipboard-first` \| `interactive` \| `screencapture-legacy` |
+| `M3C_SCREENSHOT_CLIPBOARD_TIMEOUT_SEC` | `20` | Seconds to wait for a clipboard screenshot in clipboard-first mode |
+| `M3C_SCREENSHOT_FOCUS_DELAY_MS` | `700` | Delay (ms) before an interactive capture from menu-bar actions (`0` to disable) |
+| `YT_MEMORY_DIR` | `~/Library/Application Support/YTTranscript/MEMORY` | Root directory for MEMORY folders (impression storage) |
+
+> Interactive capture also requires Screen Recording permission for `m3c-tools`.
+
+### Audio import
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `IMPORT_AUDIO_SOURCE` | — | Source folder for audio files (e.g. a GDrive mirror) |
+| `IMPORT_AUDIO_DEST` | `~/ER1` | Destination base folder for imported MEMORY folders |
+| `IMPORT_CONTENT_TYPE` | `Audio-Track vom Diktiergerät` | Content-type label for audio imports |
+| `IMPORT_TRACKER_FILE` | `~/.m3c-tools/transcript_tracker.md` | Tracks which files have been imported |
+
+### Plaud integration
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `PLAUD_API_URL` | `https://api.plaud.ai` | Plaud API base URL |
+| `PLAUD_TOKEN_FILE` | `~/.m3c-tools/plaud-session.json` | Path to the Plaud session token file |
+| `PLAUD_CONTENT_TYPE` | `Plaud-Fieldnote` | Content-type label for Plaud fieldnote uploads |
+| `M3C_PLAUD_TOKEN` | — | Plaud API token consumed by `plaud auth` (secure, avoids argv leaks) |
+
+---
+
+## Exit behavior & the retry queue
+
+Uploads that fail (network error, ER1 unreachable, auth problem) are **not lost** — they
+are queued locally and can be retried later.
+
+- **Where.** The JSON retry queue lives at `~/.m3c-tools/queue.json`. The `schedule`,
+  `status` and `cancel` commands use a separate SQLite tracking DB at
+  `~/.m3c-tools/exports.db`.
+- **Retry.** Run `m3c-tools retry` to process the queue on an interval (`--interval`,
+  `--max-retries`, `--queue`). Automatic cycles are governed by `ER1_RETRY_INTERVAL` and
+  `ER1_MAX_RETRIES`; the backoff itself is hardcoded in `pkg/er1/retry.go`.
+- **Inspect / cancel.** `m3c-tools status` lists tracked entries (`--entry <id>` for one);
+  `m3c-tools cancel <entry_id>` drops a pending entry.
+
+```bash
+m3c-tools status
+m3c-tools retry --interval 60
+m3c-tools cancel vid-001
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Uploads fail / auth failing (`key_set=false`) | Run `m3c-tools doctor`. The active profile likely has a placeholder key — re-run `setup` or `login`, and make sure `ER1_API_KEY` is real. |
+| `whisper` command not found | Install it: `python3 -m pip install openai-whisper` (needs `ffmpeg`). Or run `m3c-tools setup`. |
+| `subtitles are disabled for this video` | Expected. The capture still keeps the **thumbnail + link** — add a voice note or `--impression`. |
+| "Projects" menu stuck on *Loading…* | No ER1 credential reached the app. Fix the active profile's key or run `login`, then **restart the menu-bar app**. |
+| Upload fails, then retries | Failed uploads queue at `~/.m3c-tools/queue.json`. Run `m3c-tools retry`, check `m3c-tools status`. |
+| YouTube 429 / rate limited | Set `YT_PROXY_URL`; transcripts are cached for 7 days and the app degrades gracefully without them. |
+
+---
+
+## See also
+
+- [Quickstart: m3c-tools](quickstart-m3c-tools.md) — the 5-minute path
+- [Manual: skillctl](manual-skillctl.md) — the agent-skill trust lifecycle, command by command
+- [Menu Bar App](menubar-app.md) — every menu item and the Observation Window
+- [Platform differences](PLATFORM-DIFFERENCES.md) — macOS vs Linux vs Windows behavior

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -1,0 +1,949 @@
+---
+layout: default
+title: Manual — skillctl
+---
+
+# Manual: skillctl
+
+`skillctl` is the trust-and-governance CLI for agent skills. Every skill gets a verifiable
+identity and a full lifecycle — **author → pack → sign → admit → attest → verify / install →
+use → audit → revoke** — so nothing an agent runs is unauthorized or unprovable. The
+trust-chain check is **offline-verifiable: no external authority sits in the verification
+path.** A hosted registry, ledger, or transparency log is *complementary*, not required to
+prove a bundle authentic.
+
+> **New here?** The [Quickstart: skillctl](quickstart-skillctl.md) walks the happy path in
+> about five minutes. This manual is the exhaustive reference — every command, every flag,
+> every exit code, derived from `skillctl help` and each command's `--help`.
+
+`skillctl` ships in the same repository as `m3c-tools` and reuses its ER1 device login
+(`skillctl login`) for any command that talks to a registry.
+
+---
+
+## Installation
+
+`skillctl` is a single, dependency-light CLI binary. It runs identically on macOS, Linux and
+Windows. Grab the platform binary from a
+[release](https://github.com/kamir/m3c-tools/releases/latest), or build from source:
+
+```bash
+go build -o build/skillctl ./cmd/skillctl
+```
+
+See the [Quickstart](quickstart-skillctl.md#1-install) for one-line install commands per
+platform.
+
+```bash
+skillctl version          # print the build version
+skillctl help             # the full command map, grouped by capability
+```
+
+`skillctl help` groups commands by the SPEC that introduced them: **S1** signing, **device
+login**, **S7** trust roots, **S8** install/verify, **SPEC-0247** the Claude Code trust gate,
+**SPEC-0277** AgentID, **SPEC-0195** the awareness bridge, **SPEC-0214** PLM project context,
+**SPEC-0225** the personal registry, **SPEC-0213** session-state, and **SPEC-0278** the L1
+transparency log. Run any command with `--help` for its flags.
+
+---
+
+## Concepts
+
+| Term | Meaning |
+|------|---------|
+| **`.skb` bundle** | A sealed skill bundle: a `SKILL.md`-bearing skill directory packed with a signed manifest (`bundle.json`). Its SHA-256 digest is the bundle's stable identity. |
+| **Author signature (detached)** | An ed25519 signature over the bundle's 32-byte digest, written *next to* the bundle as `<bundle>.<digest_hex>.author.sig`. Anyone with the author's public key can verify it offline. |
+| **Trust roots** | `~/.claude/skill-trust-roots.yaml`: the registry public keys *you* have pinned. The verifier trusts only these. Multiple keys per registry support rotation overlap windows. |
+| **Registry** | Where admitted bundles and their governance events live. Can be a `self` ER1 registry (personal) or an HTTP registry. The registry is a *distribution + audit* surface — it is **not** in the cryptographic verification path. |
+| **Admit / attest** | *Admit* publishes a bundle to a registry. *Attest* posts a signed governance verdict on an admitted digest. Attestations — not author intent — are what bind governance. |
+| **Governance level (green/yellow/red)** | The verdict carried by an attestation. Install/verify enforce a configurable minimum (default green). Author *intent* is advisory; the verifier ignores it. |
+| **Revocation + freshness** | A signed, offline-verifiable revocation list. Freshness contracts (SPEC-0279) fail **closed**: a stale, rolled-back, or forged revocation list is rejected rather than silently trusted. A signed checkpoint can reset the staleness clock; a signed emergency deny-list denies a named digest immediately. |
+| **AgentID** | An owner-signed *mandate* stating that a specific agent instance may use these skills for these intents. It verifies **offline** against pinned owner/approver keys — no authority in the path. |
+| **Transparency log (translog)** | A local RFC-6962 Merkle log (SPEC-0278, "L1"). It makes equivocation and withholding **detectable**, and emits offline inclusion receipts. It does not gate installs; L2 (BFT ledger) and L3 (public anchoring) are deferred. |
+| **The fail-closed gate** | `verify-hook` is a Claude Code `PreToolUse(Skill)` hook. It verifies the trust chain before any skill runs and emits allow/deny. If it cannot read or verify, it **denies** — fail-closed. |
+
+---
+
+## Exit codes
+
+The verifier (`install`, `verify`, and the gate) returns **numbered** exit codes so
+automation can branch precisely. This is the authoritative table, sourced from
+`skillctl trust --help` / `install --help` / `verify --help`.
+
+| Code | Meaning |
+|-----:|---------|
+| `0` | ok |
+| `1` | generic error (including network / non-2xx) |
+| `2` | usage / flag error |
+| `10` | digest mismatch |
+| `11` | author signature invalid |
+| `12` | registry not in trust roots |
+| `13` | governance below minimum |
+| `14` | `depends_on` unsatisfied |
+| `15` | blob missing |
+| `16` | tenant blocked (CISO console verdict) |
+| `17` | revoked / emergency deny (from a signed revocation or emergency list) |
+
+Additional codes surface in specific commands:
+
+| Code | Command | Meaning |
+|-----:|---------|---------|
+| `18` | `intent declare` | intent inconsistent with `data_dependencies` (SPEC-0196 §3.3) |
+| `20` | `agentid verify` | approver-floor not met |
+| `21` | `agentid verify` | mandate expired |
+| `22` | `agentid verify` | revocation stale (SPEC-0279 freshness) |
+| `23` | `translog verify` | not included in the log |
+| `24` | `translog witness` | split-view (equivocation) detected |
+
+`audit` uses its own scale: `0` all OK · `2` at least one `UNVERIFIED`/`BELOW_MIN` · `3` at
+least one `BROKEN`. `propose` uses `0` pass / `2` fail.
+
+> Some commands print flags with a **single dash** in their own help output (e.g. `-key`,
+> `-out`). Both `-flag` and `--flag` are accepted. This manual reproduces flag names as the
+> command prints them, and shows examples in the common `--flag` form.
+
+---
+
+## Command reference
+
+### Lifecycle at a glance
+
+```
+keygen → pack → sign → verify-sig      # author, locally, fully offline
+  → publish (admit) → attest           # governed distribution (registry)
+  → trust add → install / verify       # consumer: pin, pull, verify offline
+  → verify-hook (gate) → use           # runtime enforcement
+  → audit → revoke                     # ongoing governance
+```
+
+---
+
+### `keygen` — generate an author keypair
+
+```bash
+skillctl keygen --out PATH
+```
+
+Writes `<PATH>.priv` (mode `0600`) and `<PATH>.pub` (mode `0644`), both PEM-wrapped ed25519
+(PKCS#8 private / SPKI public). Suggested location: `~/.config/m3c/skill-keys/<name>`.
+
+| Flag | Purpose |
+|------|---------|
+| `-out` | Output keypair stem; produces `<out>.priv` and `<out>.pub`. **Required.** |
+
+```bash
+skillctl keygen --out ~/.config/m3c/skill-keys/mykey
+```
+
+Exit: `0` ok · `2` usage.
+
+---
+
+### `pack` — build a `.skb` bundle
+
+```bash
+skillctl pack --skill <dir> -o <out.skb> --name <n> --version <v> [options]
+```
+
+Packs a skill directory (which must contain `SKILL.md`) into a sealed `.skb` bundle with a
+manifest. Data-scopes are validated **fail-closed at pack time**, before the digest is
+computed, so the author signature covers them.
+
+> `pack` does not implement `--help`; it prints `Unknown flag: --help` and then its usage.
+
+| Flag | Purpose |
+|------|---------|
+| `--skill <dir>` | Skill directory containing `SKILL.md`. **Required.** |
+| `-o, --output <path>` | Output `.skb` file. **Required.** |
+| `--name <s>` | Skill name (manifest field). **Required.** |
+| `--version <s>` | Skill version (manifest field). **Required.** |
+| `--summary <s>` | One-line description. |
+| `--source-repo <s>` / `--source-commit <sha>` / `--source-path <s>` | Provenance: where the skill came from. |
+| `--author-intent green\|yellow\|red` | Advisory governance hint — **the verifier ignores it**; signed attestations bind. |
+| `--author-intent-rationale <s>` | Free-text rationale for the intent. |
+| `--compatibility <s>` | Compatibility note. |
+| `--depends-on kind:name:constraint` | Declare a dependency, e.g. `python:requests:>=2.31`. Repeatable. |
+| `--data-scopes <json>` | Typed SPEC-0196 data-scope, bound *into* `bundle.json`. Repeatable. Validated fail-closed. |
+| `--data-dep <json>` | **Deprecated** alias for `--data-scopes`. |
+| `--side-effects <list>` | Comma-separated SPEC-0196 §5 side-effect tokens (signed into intent). |
+| `--destructive true\|false` | Author claim: irreversible changes (§3.3 cross-rule input). |
+| `--network true\|false` | Author claim: outbound network (§3.3 cross-rule input). |
+
+```bash
+skillctl pack \
+  --skill ./my-skill -o my-skill.skb \
+  --name my-skill --version 1.0.0 \
+  --summary "What this skill does" \
+  --data-scopes '{"id":"ds:fs/cwd","kind":"local_fs","access":"write","scope":"<cwd>/decks/**","reason":"write deck"}'
+```
+
+Exit: `0` ok · `2` usage / validation error.
+
+---
+
+### `sign` — sign a bundle
+
+```bash
+skillctl sign BUNDLE.skb --key PATH.priv [--identity-id ID]
+```
+
+Computes the bundle's SHA-256 digest, signs the 32 raw digest bytes with ed25519, and writes
+a **detached** signature: `<BUNDLE.skb>.<digest_hex>.author.sig` (64 raw bytes, mode `0644`).
+
+| Flag | Purpose |
+|------|---------|
+| `-key` | Path to PEM PKCS#8 ed25519 private key (mode `0600`). **Required.** |
+| `-identity-id` | Author identity ID (advisory; reserved for future use). |
+
+```bash
+skillctl sign my-skill.skb --key ~/.config/m3c/skill-keys/mykey.priv
+```
+
+Exit: `0` ok · `2` usage.
+
+---
+
+### `verify-sig` — verify a detached signature (offline)
+
+```bash
+skillctl verify-sig BUNDLE.skb --pubkey PATH.pub
+```
+
+Recomputes the bundle's digest, locates the matching `.author.sig`, and verifies it. **No
+network, no CA.**
+
+| Flag | Purpose |
+|------|---------|
+| `-pubkey` | Path to PEM SPKI ed25519 public key. **Required.** |
+
+```bash
+skillctl verify-sig my-skill.skb --pubkey ~/.config/m3c/skill-keys/mykey.pub
+```
+
+Exit: `0` ok · `11` signature invalid · `1` other error · `2` usage.
+
+---
+
+### `trust` — manage trust roots
+
+```bash
+skillctl trust <list|add|remove> [flags]
+```
+
+Manages `~/.claude/skill-trust-roots.yaml` (SPEC-0188 §4.4) — the registry keys you pin.
+Multiple keys per registry are supported for rotation overlap windows. `rm` is an alias for
+`remove`.
+
+**`trust list`** — print configured registries and their pinned keys.
+
+**`trust add`** — pin a registry public key.
+
+| Flag | Purpose |
+|------|---------|
+| `-registry` | Registry URL (e.g. `https://aims.example.com/api/skills`). **Required.** |
+| `-pubkey` | Path to PEM SPKI ed25519 public key file. **Required.** |
+| `-id` | Optional key-id label (defaults to a short fingerprint-derived id). |
+
+**`trust remove`** — unpin a registry (including all its keys).
+
+| Flag | Purpose |
+|------|---------|
+| `-registry` | Registry URL to remove. **Required.** |
+
+```bash
+skillctl trust add --registry https://aims.example.com/api/skills --pubkey registry.pub
+skillctl trust list
+skillctl trust remove --registry https://aims.example.com/api/skills
+```
+
+`trust --help` also prints the shared verifier exit-code table (see [Exit codes](#exit-codes)).
+
+---
+
+### `install` — pull, verify, and install
+
+```bash
+skillctl install <name>[@<version>] [flags]
+```
+
+Pulls a bundle from the registry, runs the SPEC-0188 §7 verifier, and **atomically** installs
+it under `~/.claude/skills/<name>/`. Refuses if *any* trust-chain step fails. `<version>` may
+be a human version string (`1.0.0`) or a digest pin (`sha256:<hex>`); omit it to install the
+newest admitted version.
+
+| Flag | Purpose |
+|------|---------|
+| `-allow-yellow` | Lower the gate from green to yellow for this install (audited). |
+| `-governance-min green\|yellow` | Override the trust-root's `governance_minimum`. Empty = use trust-root. |
+| `-home` | Override the install root (advanced; defaults to `$HOME`). |
+| `-ignore-deps` | Skip `depends_on` resolution (audited). |
+| `-registry` | Registry base URL. Required only when trust-roots pins multiple registries. |
+| `-tenant` | Pin this install to a tenant scope (§7 step 5.5). Overrides trust-roots `tenant_scope`. |
+| `-timeout` | HTTP timeout for registry calls (default `30s`). |
+| `-verbose` | Print structured per-step log lines to stderr. |
+
+```bash
+skillctl install my-skill@1.0.0
+skillctl install my-skill@sha256:<hex> --verbose
+```
+
+Exit: `0`, `1`, `2`, `10`–`16` (see [Exit codes](#exit-codes)).
+
+---
+
+### `verify` — re-run the trust chain
+
+```bash
+skillctl verify <name> [flags]
+skillctl verify --all [--quarantine]
+skillctl verify --bundle <file.skb> [--trust-roots <file>] [--json]
+```
+
+Re-runs the SPEC-0188 §7 trust-chain check against an already-installed skill — useful for
+catching post-install revocations or trust-root rotations. `--all` re-verifies everything.
+`--bundle` verifies a **standalone `.skb` file** with no install state and no network, against
+locally pinned trust-roots — the trustless third-party path (requires a `<file>.skbmeta.json`
+sidecar or `--meta`).
+
+| Flag | Purpose |
+|------|---------|
+| `-bundle` | Verify a standalone `.skb` file, fully offline against pinned trust-roots (SPEC-0276 R4.2). |
+| `-meta` | Path to the BundleMeta envelope JSON for `--bundle` (default: the sidecar `.skbmeta.json`). |
+| `-trust-roots` | Trust-roots YAML to use instead of the default. Pair with `--bundle` for a portable kit. |
+| `-offline` | Network-free verify: use stashed metadata + bind on-disk content to the signed `.skb`. No registry calls. |
+| `-revocations` | Signed revocation list to enforce offline for `--bundle`. Revoked digest → `17`; forged list → `12`. |
+| `-checkpoint` | Signed freshness checkpoint (SPEC-0279 R4) to reset the `--revocations` staleness clock. Forged/stale → `12`. |
+| `-emergency` | Signed emergency deny-list (SPEC-0279 R5). Named digest → `17`; forged list → `12`. |
+| `-allow-yellow` | Permit a yellow result against a green-required trust root (does not re-audit). |
+| `-governance-min green\|yellow` | Override the trust-root's `governance_minimum`. |
+| `-home` | Override the install root. |
+| `-json` | Emit the verification result as JSON (`--bundle` mode). |
+| `-registry` | Registry base URL. Required only when trust-roots pins multiple registries. |
+| `-tenant` | Pin this verify to a tenant scope (§7 step 5.5). |
+| `-timeout` | HTTP timeout for registry calls (default `30s`). |
+| `-verbose` | Print structured per-step log lines to stderr. |
+
+```bash
+skillctl verify my-skill
+skillctl verify --all
+skillctl verify --bundle my-skill.skb --trust-roots ./roots.yaml --json
+```
+
+Exit: same as `install` (see [Exit codes](#exit-codes)).
+
+---
+
+### `attest` — post a governance attestation
+
+```bash
+skillctl attest <bundle-digest> --level <green|yellow|red> \
+  --rationale "<text>" --reviewer-id <id> --key <path> \
+  [--registry <url>] [--timeout <duration>]
+```
+
+Composes the canonical attestation message
+(`attestation\n<digest>\n<level>\n<attested_at>\n<reviewer_id>\n`), signs it with the given
+ed25519 key, and POSTs it to `<registry>/attestations`.
+
+| Flag | Purpose |
+|------|---------|
+| `-level green\|yellow\|red` | Governance verdict. **Required.** |
+| `-rationale` | Free-text rationale (audit metadata; **not** folded into the signed bytes). **Required.** |
+| `-reviewer-id` | Reviewer identity ID (e.g. `id:reviewer@m3c`). **Required.** |
+| `-key` | PEM PKCS#8 ed25519 private key (mode `0600`). **Required.** |
+| `-author-id` | Bundle author ID, for the SPEC-0246 §5 reviewer≠author check when the admit record is unavailable (offline). Optional. |
+| `-registry` | Registry base URL (default `http://localhost:8080/api/skills`). |
+| `-timeout` | HTTP request timeout (default `30s`). |
+
+```bash
+skillctl attest sha256:<hex> --level green --rationale "reviewed" \
+  --reviewer-id id:reviewer@m3c --key ~/.config/m3c/skill-keys/reviewer.priv \
+  --registry https://aims.example.com/api/skills
+```
+
+Exit: `0` ok · `1` generic/network/non-2xx · `2` usage.
+
+---
+
+### `revoke`
+
+Revocation of skill bundles is issued through `publish --revoke` (see below); AgentID
+revocation is issued through `agentid revoke`. Both produce **signed, offline-verifiable**
+revocation lists that the verifier enforces with freshness contracts (SPEC-0279), failing
+closed on a stale or rolled-back list.
+
+---
+
+### `audit` — antivirus-style verdict per skill
+
+```bash
+skillctl audit [flags]
+```
+
+Prints a per-skill verdict: `OK | UNVERIFIED | BROKEN | BELOW_MIN`. Cleanup is a G-23
+destructive-op **two-step** (dry-run token, then confirm).
+
+| Flag | Purpose |
+|------|---------|
+| `-minimum-governance green\|yellow\|red` | Floor below which a skill is flagged. Defaults to trust-roots `governance_minimum`, else green. |
+| `-format table\|json` | Output format (default: table on TTY, json on pipe). |
+| `-include-shadowed` | Include shadowed skills (lower-tier names hidden by a higher-tier winner). |
+| `-cleanup` | After listing, delete affected skills (gated; requires `--dry-run-cleanup` or `--confirm-delete`). |
+| `-dry-run-cleanup` | Step 1: print the affected list + a signature token; no deletion. |
+| `-confirm-delete` | Step 2: actually delete; requires a fresh `--dry-run-cleanup-token`. |
+| `-dry-run-cleanup-token` | Token from a prior `--dry-run-cleanup`. |
+| `-keep-unverified` | Don't auto-clean `UNVERIFIED` skills under `--cleanup`. |
+| `-source` | Skill source scope. |
+
+```bash
+skillctl audit
+skillctl audit --cleanup --dry-run-cleanup
+skillctl audit --cleanup --confirm-delete --dry-run-cleanup-token <sig>
+```
+
+Exit: `0` all OK · `2` ≥1 `UNVERIFIED`/`BELOW_MIN` · `3` ≥1 `BROKEN`.
+
+---
+
+### `publish` — admit / attest / revoke via ER1 (`self` registry)
+
+```bash
+skillctl publish <name[@ver]> [flags]
+skillctl publish --attest <name[@ver]> --level green --rationale '<why>' [flags]
+skillctl publish --revoke <name> --digest sha256:<hex> --reason '<code>' [flags]
+```
+
+Publishes to your personal ER1 `self` registry (SPEC-0225). Three modes: admit a bundle
+(default), post a governance attestation (`--attest`), or post a `BundleRevokedEvent`
+(`--revoke`). `--all` batches an admit+attest for every entry in the publish manifest.
+
+| Flag | Purpose |
+|------|---------|
+| `-attest` | Mode: publish an `AttestationPublishedEvent` instead of admitting. |
+| `-revoke` | Mode: publish a `BundleRevokedEvent`. Requires `--digest` and `--reason`. |
+| `-all` | Publish every entry in `--manifest` (admit + attest as one batch). |
+| `-bundle` | Path to a pre-built `.skb`. If empty, the skill dir is packed in place. |
+| `-skill-dir` | Skill directory. Default: `~/.claude/skills/<name>`. |
+| `-version` | Skill version (overrides SKILL.md frontmatter). Required for admit. |
+| `-digest` | `[--attest\|--revoke]` existing bundle digest (`sha256:<hex>`). Derived from `--bundle` if empty. |
+| `-level green\|yellow\|red` | `[--attest]` governance level (default `green`). |
+| `-rationale` | `[--attest\|--revoke]` one-line rationale. |
+| `-reason` | `[--revoke]` short reason code (e.g. `key-compromise`, `deprecated`). |
+| `-registry` | Registry spec: `self` (recommended) or `er1://…`. HTTP registries route through `install`. Default `self`. |
+| `-er1-target prod\|stage\|local` | ER1 target (default `prod`). |
+| `-er1-context` | ER1 context (default `skills`). |
+| `-identity` | Author/registry identity id stamped into the event and tags. |
+| `-key` | ed25519 private key (PEM PKCS#8). Default `$SIGNING_KEY_LOCATION` or `~/.config/m3c/skill-registry-self.key`. |
+| `-manifest` | Publish manifest (with `--all`; default `INFRA/skill-registry/self/publish-manifest.txt`). |
+| `-share-room <label>` | Map the bundle into a SPEC-0096 co-learning room. Repeatable. |
+| `-inline-max` | Inline base64 cap; larger bundles need a claim-check (default `262144`). |
+| `-no-checkpoint` | Don't append a checkpoint to the open SPEC-0213 session. |
+| `-no-runbook-publish` | Don't auto-register the skill's runbook into the THOH catalog (SPEC-0275). |
+| `-dry-run` | Print the plan + rendered item body; don't POST or pack. |
+| `-yes` | Skip the 🟡 confirm pause (scripted runs). |
+
+```bash
+skillctl publish my-skill --bundle my-skill.skb --version 1.0.0
+skillctl publish --attest my-skill --level green --rationale "reviewed"
+skillctl publish --revoke my-skill --digest sha256:<hex> --reason superseded
+```
+
+Exit: `0` ok · `2` usage.
+
+---
+
+### `pull` — the 5-gate gauntlet against `self`
+
+```bash
+skillctl pull [flags]
+```
+
+Runs the 5-gate trust gauntlet against your `self` registry and stages verified bundles.
+`--install` writes them under `~/.claude/skills/<name>/` (with a provenance sidecar);
+installing is a G-23 two-step (`--dry-run-install` → `--confirm-install`).
+
+| Flag | Purpose |
+|------|---------|
+| `-install` | Install verified bundles into `~/.claude/skills/<name>/` with a provenance sidecar. |
+| `-trust-mode` | Required for `--install`: re-affirm the trust-mode path (writes `.m3c-provenance.json`). |
+| `-dry-run-install` | G-23 step 1: print the create/overwrite plan + a token; do not write. |
+| `-confirm-install` | G-23 step 2: consume `--dry-run-install-token` and write. |
+| `-dry-run-install-token` | Token returned by `--dry-run-install`; required if any skill would be overwritten. |
+| `-allow-downgrade` | Allow installing an older version over a newer one. |
+| `-skill` | Filter: only this skill name. |
+| `-digest` | Filter: only this exact bundle digest (`sha256:<hex>`). |
+| `-since` | Best-effort lower bound on `occurred_at` (RFC3339). |
+| `-skills-dir` | Where to install skills. Default `~/.claude/skills`. |
+| `-trust-roots` | SPEC-0225 trust-roots YAML. Default `~/.claude/trust-roots.yaml`. |
+| `-registry self` | Registry spec. Only `self` / `er1://…` here; HTTP routes through `install`. |
+| `-er1-target prod\|stage\|local` / `-er1-context` | ER1 target/context (defaults `prod` / `skills`). |
+| `-emit-installed` | After install, POST a `BundleInstalledEvent` so the other machine sees it. |
+| `-identity` / `-key` | `[--emit-installed]` identity + signing key for the install event. |
+| `-no-checkpoint` | Don't append a SPEC-0213 session checkpoint after install. |
+| `-verbose` | Print one line per per-gate decision. |
+
+```bash
+skillctl pull --verbose
+skillctl pull --install --trust-mode --dry-run-install
+skillctl pull --install --trust-mode --confirm-install --dry-run-install-token <sig>
+```
+
+Exit: `0` ok · `2` usage.
+
+---
+
+### `registry` — inspect the `self` registry
+
+```bash
+skillctl registry <ls|show> [flags]
+```
+
+**`registry ls`** — list bundles in the `self` registry, grouped by skill.
+Flags: `[--latest] [--skill <name>] [--er1-target …] [--er1-context …]`.
+
+**`registry show`** — show the full event timeline (admit / attest / revoke / install) for
+one skill or one digest.
+Usage: `registry show <name | sha256:<hex>> [--er1-target …] [--er1-context …]`.
+
+```bash
+skillctl registry ls --latest
+skillctl registry show my-skill
+skillctl registry show sha256:<hex>
+```
+
+---
+
+### `verify-hook` — the fail-closed Claude Code gate
+
+```bash
+skillctl verify-hook
+```
+
+A `PreToolUse(Skill)` hook: it reads a hook event on **stdin**, verifies the SPEC-0188 §7
+chain, and emits an allow/deny decision as JSON on stdout. **Fail-closed** — if it cannot read
+or verify the event, it denies. Wire it in your Claude Code settings as a hook; do **not** run
+it by hand. Running it interactively prints a fail-closed deny (unreadable stdin) and exits
+`2`.
+
+```json
+// settings.json (excerpt) — wire it as a PreToolUse(Skill) hook
+{ "hooks": { "PreToolUse": [ { "matcher": "Skill", "hooks": [ { "type": "command", "command": "skillctl verify-hook" } ] } ] } }
+```
+
+---
+
+### `gate-stats` — summarise gate decisions
+
+```bash
+skillctl gate-stats [--since <168h|YYYY-MM-DD>] [--json]
+```
+
+Summarises `gate-audit.jsonl`: decisions, top blocks, cache-hit rate.
+
+| Flag | Purpose |
+|------|---------|
+| `-since` | Only events newer than this — a Go duration (e.g. `168h`) or a date (`YYYY-MM-DD`). |
+| `-json` | Emit the summary as stable JSON. |
+
+```bash
+skillctl gate-stats --since 168h
+skillctl gate-stats --since 2026-06-01 --json
+```
+
+---
+
+### `agentid` — offline-verifiable agent identity
+
+```bash
+skillctl agentid <issue|verify|show|revoke> [flags]
+```
+
+An **AgentID** is an owner-signed mandate (SPEC-0277): *this agent may use these skills for
+these intents*. It verifies **offline** against pinned owner/approver keys.
+
+**`agentid issue`** — build + owner-sign a mandate.
+
+| Flag | Purpose |
+|------|---------|
+| `--owner <plm-id>` / `--owner-key <path>` | Owner identity and signing key. |
+| `--for-agent <ref>` | The agent instance the mandate is issued to. |
+| `--skills a,b` | Granted skills. |
+| `--intents x,y` | Granted intents. |
+| `--data-scopes s,t` | Optional granted data-scopes. |
+| `--approver <id>` / `--approver-key <path>` | Optional co-signing approver (raises the approver floor). |
+| `--limit k=v` | Repeatable grant limits. |
+| `--display-name N` / `--agent-id <id>` / `--trust-root URL` | Optional metadata. |
+| `--expires <RFC3339>` | Expiry (e.g. `2026-12-31T00:00:00Z`). |
+| `--out <file>` | Write the mandate JSON (e.g. `agentid.json`). |
+
+**`agentid verify`** — verify a mandate offline.
+
+| Flag | Purpose |
+|------|---------|
+| `--bundle <agentid.json>` | The mandate to verify. |
+| `--offline` | Network-free verification. |
+| `--trust-roots <file>` / `--registry <url>` | Pinned keys / registry disambiguation. |
+| `--revocations <file>` / `--checkpoint <file>` / `--emergency <file>` | Signed lists enforcing SPEC-0279 freshness. |
+| `--json` | Emit the result as JSON. |
+
+**`agentid show`** — print owner, grant, expiry, fingerprints, signatures:
+`skillctl agentid show <agentid.json>`.
+
+**`agentid revoke`** — add `agent:<id>` to a signed, offline revocation list (SPEC-0276):
+`skillctl agentid revoke <agent-id> --reason <text> --registry <url> [--key <path>] [--out <list.json>] [--epoch N]`.
+
+```bash
+skillctl agentid issue --owner id:you@m3c --owner-key mykey.priv \
+  --for-agent agent-42 --skills my-skill --intents summarize --out agentid.json
+skillctl agentid verify --bundle agentid.json --offline
+skillctl agentid show agentid.json
+skillctl agentid revoke agent-42 --reason compromised --registry https://aims.example.com/api/skills
+```
+
+Exit (`verify`): `0` ok · `11` owner-sig/not-pinned · `20` approver-floor · `21` expired ·
+`17` revoked/emergency · `12` registry-not-pinned · `22` revocation-stale · `1` other.
+
+---
+
+### `translog` — L1 transparency log
+
+```bash
+skillctl translog <append|sth|prove|verify|consistency|witness> [flags]
+```
+
+A local RFC-6962 Merkle log (SPEC-0278, stdlib-only). L1 makes equivocation/withholding
+**detectable**, not impossible. Event *data stays off the log* — only the signed event's
+digest is appended. The default log file is `~/.claude/skillctl/transparency-log.jsonl`
+(`--log` to override; `--log-id` default `skillctl-local`).
+
+**`translog append`** — append an event.
+`skillctl translog append <type> <digest> [--subject S] [--log PATH] [--log-id ID]`
+where `type` ∈ `admit | attest | revoke | agentid-issue | agentid-revoke` and `digest` is
+`sha256:<64 lowercase hex>` of the already-signed event.
+
+**`translog sth`** — show / sign the current tree head.
+
+| Flag | Purpose |
+|------|---------|
+| `-key` | Log ed25519 private key (PEM). If set, sign the head into an STH. |
+| `-log` / `-log-id` | Log path / id. |
+
+**`translog prove`** — emit an offline inclusion receipt.
+`skillctl translog prove <digest> --key PATH.priv [--out FILE]` (`-key` **required**; `-out`
+defaults to stdout).
+
+**`translog verify`** — offline inclusion check.
+`skillctl translog verify --receipt FILE --log-pubkey PATH.pub` (both **required**).
+
+**`translog consistency`** — verify append-only between two heads.
+
+**`translog witness`** — cross-witness STHs for a split view.
+`skillctl translog witness --sths FILE --log-pubkey PATH.pub` (both **required**).
+
+```bash
+skillctl translog append admit sha256:<hex> --subject my-skill
+skillctl translog sth --key ~/.config/m3c/skill-keys/log.priv
+skillctl translog prove sha256:<hex> --key ~/.config/m3c/skill-keys/log.priv --out receipt.json
+skillctl translog verify --receipt receipt.json --log-pubkey log.pub
+skillctl translog witness --sths sths.json --log-pubkey log.pub
+```
+
+Exit: `translog verify` → `0` ok · `23` not-included · `1` other · `2` usage.
+`translog witness` → `0` consistent · `24` split-view-detected · `1` other · `2` usage.
+
+---
+
+### `session` — session-state in ER1 (SPEC-0213)
+
+```bash
+skillctl session <open|checkpoint|close|resume|list|show> [flags]
+```
+
+Persists the working session as an ER1 item and appends checkpoints; resume it on any machine.
+All verbs share one flag-set (only some flags apply per verb).
+
+| Verb | Purpose |
+|------|---------|
+| `open` | Create the session-state item for this session (idempotent). |
+| `checkpoint` | Append a checkpoint child item (`--auto` for a git/todo snapshot). |
+| `close` | Write a final close-checkpoint (`--summary` verbatim, or `--distill`). |
+| `list` | List session-state items (`--project` / `--host` / `--open-only`). |
+| `show` | Show a session-state item by `session_id` or `doc_id`. |
+| `resume` | Print a resume hint for a prior session. |
+
+| Flag | Purpose |
+|------|---------|
+| `-session` | Session id (the harness `session_id`; required for checkpoint/close). |
+| `-C` | Resolve the project context relative to this directory. |
+| `-project` | PLM project id override (default: from `.m3c/project.yaml`). |
+| `-er1-target prod\|local\|stage\|<url>` / `-er1-context` | ER1 target / context override. |
+| `-intent` | Session intent (open only). |
+| `-continues <ctx>/<doc_id>` | Thread the chain to a prior session-state item (open only). |
+| `-model` | Agent/model recorded as `opened_by` (default `skillctl`). |
+| `-auto` | Checkpoint: build a git-diff/todo snapshot rather than prose (skips if nothing changed). |
+| `-note` | Checkpoint note prose. |
+| `-todos` | Open-items text for the checkpoint body. |
+| `-summary` | Close summary (verbatim — your words). |
+| `-distill` | Close: mark the close-checkpoint `auto:generated` (agent-authored summary, SPEC-0210). |
+| `-host` | Filter by host (list/resume). |
+| `-open-only` | List: exclude closed sessions. |
+| `-latest` | Resume: pick the newest session (default true when only one matches). |
+
+```bash
+skillctl session open --intent "port whisper"
+skillctl session checkpoint --session <id> --auto
+skillctl session close --session <id> --summary "shipped v0.4.0"
+skillctl session list --open-only
+skillctl session resume --latest
+```
+
+---
+
+### `project` — PLM project context (SPEC-0214)
+
+```bash
+skillctl project <show|resolve|channels|path> [-C dir] [--field name] [--kind kind]
+```
+
+Resolves the PLM project context for the current directory from `.m3c/project.yaml` (falling
+back to a directory-slug when there is no descriptor).
+
+| Verb | Purpose |
+|------|---------|
+| `show` | Print the resolved context (project id, ER1 target/context, descriptor source). |
+| `resolve` | Print one field: `--field project_id\|er1-target\|er1-context\|channel:<kind>\|…`. |
+| `channels` | List the v2 `channels:` block (`--kind` to filter). |
+| `path` | Print the descriptor file path, or `(none)`. |
+
+```bash
+skillctl project show
+skillctl project resolve --field project_id
+skillctl project channels --kind repo
+skillctl project path
+```
+
+---
+
+### `awareness` — the admission bridge (SPEC-0195)
+
+```bash
+skillctl awareness <sync|verify|reset> [flags]
+```
+
+**`awareness sync`** — admit local skills to a registry by scanning (or reading a saved scan).
+Default is dry-run; pass `--confirm` to actually POST. Registry resolution:
+`--registry` > trust-roots `default_registry` > `$M3C_REGISTRY_URL`.
+
+| Flag | Purpose |
+|------|---------|
+| `-confirm` | Required to actually push to the registry (defends against accidental writes). |
+| `-dry-run` | Build the envelope; do not POST. |
+| `-source claude\|user\|plugins\|all` | Scan source (default `claude`; ignored if `--inventory` is set). |
+| `-inventory <file\|->` | Read scan JSON from FILE; `-` reads stdin. |
+| `-registry` | Registry URL override. |
+| `-key` | Author key path (PEM PKCS#8). Default `~/.claude/skillctl-keys/author.key`. |
+| `-author-identity` | Override the author identity. |
+| `-require-intent` | Refuse entries with no intent or the SPEC-0196 `UNKNOWN` sentinel. |
+| `-default-intent yellow\|green` | Stamp this level on entries with no/UNKNOWN intent (empty = off). |
+| `-default-attest yellow\|green\|none` | After admission, request a default attestation (default `none`). |
+| `-session` | Session tag (default `skill-awareness/<host>/<YYYY-MM-DD>`). |
+| `-help-advanced` | Print advanced flags (e.g. `--allow-overwrite`). |
+
+**`awareness verify`** — read back per-session admissions.
+Usage: `skillctl awareness verify [--session TAG] [--registry URL]`.
+
+**`awareness reset`** — delete admit-from-scan docs scoped to a `session_tag` (G-23 two-step).
+
+```bash
+skillctl awareness sync --source claude --dry-run
+skillctl awareness sync --confirm --require-intent
+skillctl awareness verify --session skill-awareness/host/2026-07-02
+```
+
+---
+
+### `intent` — declare / show a bundle's SPEC-0196 intent
+
+```bash
+skillctl intent <declare|show> [flags]
+```
+
+**`intent declare <skill-name|@digest>`** — patch the `intent` block of a previously-admitted
+bundle, replacing the awareness `UNKNOWN` sentinel with a real declaration. Requires
+`--confirm` to issue the PATCH; typed data-scope via `--data-scopes` (repeatable JSON).
+Exit codes: `0` ok · `1` generic/network · `2` usage · `18` intent inconsistent with
+`data_dependencies` (SPEC-0196 §3.3).
+
+**`intent show <skill-name|@digest> --registry URL`** — print the declared intent +
+`data_dependencies`. A scope is shown as **AUTHORITATIVE** only when the local `.skb`'s author
+signature is verified against a **pinned** trust-root key (`--bundle` + the full verify
+chain); a bare digest match is `UNVERIFIED`. `--json` for machine output.
+
+```bash
+skillctl intent show my-skill --registry https://aims.example.com/api/skills
+skillctl intent declare my-skill --data-scopes '{"id":"…","kind":"local_fs","access":"read","scope":"…","reason":"…"}' --confirm
+```
+
+---
+
+### `propose` — the ready-to-promote gate (SPEC-0194)
+
+```bash
+skillctl propose <skill-name> [flags]
+```
+
+Runs the SPEC-0194 §6 ready-to-promote gate against a local skill and, on pass, registers a
+proposal record so the post-admission hook can flip `pending → admitted` when the bundle is
+admitted.
+
+| Flag | Purpose |
+|------|---------|
+| `-intent green\|yellow\|red` | Author governance intent. |
+| `-rationale` | Required for yellow/red intent. |
+| `-dry-run` | Run the gate only; do not POST a proposal record. |
+| `-bug-reports-dir` | Enable gate check #8 (open BUG-NNNN against this skill). |
+| `-last-admitted-version` | Enable gate check #10 (proposed version > last admitted). |
+| `-skip-smoke` | Skip gate check #9 (smoke-test marker). |
+| `-bodyscan-rationale` | Justify a 🟡 bodyscan verdict (check #11); a 🔴 verdict cannot be overridden. |
+| `-proposal-id` | Client-generated proposal id (ULID). Default: locally generated. |
+| `-registry` | Registry base URL (default `http://localhost:8080/api/skills`). |
+
+Exit: `0` gate passed (or `--dry-run`) · `2` gate failed (one or more rows print `FAIL`).
+
+---
+
+### `export-verification-kit` — portable, trust-nothing kit (SPEC-0276)
+
+```bash
+skillctl export-verification-kit --bundle <file.skb> --out <dir> [flags]
+```
+
+Builds a portable, offline verification kit that a third party can check with no network and
+no trust in you.
+
+| Flag | Purpose |
+|------|---------|
+| `-bundle` | Signed `.skb` to package. **Required.** |
+| `-out` | Output directory for the kit. **Required.** |
+| `-meta` | BundleMeta envelope JSON (default: sidecar `.skbmeta.json`). |
+| `-trust-roots` | Trust-roots YAML to source pinned keys from. Must be pinned mode. |
+| `-revocations` | Optional signed revocation list to include (validated against the pinned key before inclusion). |
+| `-registry` | Registry URL to disambiguate when trust-roots pins multiple. |
+| `-zip` | Also produce `<out>.zip`. |
+
+```bash
+skillctl export-verification-kit --bundle my-skill.skb --out ./kit --zip
+```
+
+---
+
+### `compliance` — offline evidence aid (SPEC-0276)
+
+```bash
+skillctl compliance report --framework <eu-ai-act|nist-ai-rmf|soc2> [--format md|json] [--out file]
+```
+
+Generates an **offline evidence aid** mapping your installed skills' trust posture to a
+framework's controls. This produces *evidence*, **not** a certification.
+
+| Flag | Purpose |
+|------|---------|
+| `-framework eu-ai-act\|nist-ai-rmf\|soc2` | Framework. **Required.** |
+| `-format md\|json` | Output format (default `md`). |
+| `-out` | Write to file instead of stdout. |
+| `-skills-dir` / `-home` | Skills directory / home override. |
+| `-offline` | Offline mode (default and only mode in v1). |
+
+```bash
+skillctl compliance report --framework eu-ai-act --format md --out evidence.md
+```
+
+---
+
+### `login` — ER1 device pairing (FR-0043)
+
+```bash
+skillctl login [--no-browser] [--timeout 5m] [--base-url URL]
+skillctl login --status | --logout
+```
+
+Browser device-pairing against ER1; saves a token `skillctl` uses automatically for
+registry-backed commands. Shares the ER1 login with `m3c-tools`.
+
+| Flag | Purpose |
+|------|---------|
+| `-base-url` | ER1 server base URL. Default: public SaaS (`https://onboarding.guide`), or `ER1_API_URL` if set. |
+| `-no-browser` | Print the login URL but do not open a browser (headless/SSH). |
+| `-timeout` | How long to wait for the browser callback (default `5m0s`). |
+| `-status` | Report whether a (non-expired) device token is stored, and exit. |
+| `-logout` | Remove the stored device token and exit. |
+
+```bash
+skillctl login
+skillctl login --status
+skillctl login --logout
+```
+
+---
+
+### `version` / `help`
+
+```bash
+skillctl version     # print the build version
+skillctl help        # the grouped command map
+```
+
+Any command accepts `--help` (some sub-verbed groups print usage on the bare parent, e.g.
+`skillctl agentid --help`, `skillctl translog`).
+
+---
+
+### Other commands (one-line synopsis)
+
+Derived from each command's own usage output.
+
+| Command | Synopsis |
+|---------|----------|
+| `scan` | Scan skill directories (`~/.claude/skills`, plugin skill dirs, …) and emit a JSON inventory. |
+| `report` | Render a scan into a report. `skillctl report [--format html\|md] --input <scan.json> [--out <file>]`. |
+| `diff` | Diff two scans. `skillctl diff <scan1.json> <scan2.json> [--output json\|md\|html\|text] [--out <file>]`. |
+| `seal` | Snapshot all installed skills into a signed inventory seal (under `~/.m3c-tools/skill-seals/`). |
+| `import` | Import a scan into a remote target. `skillctl import --target <url> [--api-key <key>] [--input <scan.json>] [--dry-run]`. |
+| `menubar` | Launch the macOS menu-bar app surface (interactive; long-running). |
+| `review` | Review installed / scanned skills. |
+| `browse` | Build a local skill graph and serve an interactive browser at `http://127.0.0.1:<port>/?token=…`. |
+| `consolidate` | Report duplicate / orphan / drifted / missing-frontmatter skills across projects. |
+| `sync-usage` | Sync local skill-usage counters to ER1 (needs `--api-key`, `M3C_API_KEY`, or `~/.m3c-tools/er1_session.json`). |
+| `runbook` | `skillctl runbook publish <runbook.html> --tag <tag> [flags]` — publish an onboarding runbook into the THOH catalog (SPEC-0272/0275). |
+| `room` | `skillctl room <share\|unshare> <skill> --room <label> [flags]` — share/unshare a skill into a SPEC-0096 co-learning room. |
+
+> `scan`, `report`, `diff`, `seal`, `import`, `menubar`, `review`, `browse`, `consolidate`,
+> `sync-usage` do not implement `-h`/`--help`; run them with no arguments to see their usage,
+> or consult the flags shown above. Run `skillctl <cmd> --help` for the current flags on the
+> other commands.
+
+---
+
+## Files & locations
+
+| Path | Contents |
+|------|----------|
+| `~/.claude/skill-trust-roots.yaml` | Pinned registry public keys (managed by `trust`). The root of the offline verification chain. |
+| `~/.claude/skills/<name>/` | Installed skills (`install`, `pull --install`). Installs are atomic. |
+| `<stem>.priv` (mode `0600`) / `<stem>.pub` (mode `0644`) | ed25519 keypair written by `keygen`, PEM PKCS#8 / SPKI. |
+| `<bundle>.<digest_hex>.author.sig` | Detached author signature written by `sign` (64 raw bytes, mode `0644`). |
+| `~/.claude/skillctl/transparency-log.jsonl` | Default L1 transparency log (`translog`; `--log` to override). |
+| `gate-audit.jsonl` | Append-only audit log of `verify-hook` decisions, summarised by `gate-stats`. |
+| `~/.m3c-tools/skill-seals/` | Inventory seals written by `seal`. |
+| `.m3c/project.yaml` | SPEC-0214 PLM project descriptor resolved by `project` (and by `publish`/`session`). |
+| `~/.config/m3c/skill-registry-self.key` | Default `self`-registry signing key for `publish` / `pull` (or `$SIGNING_KEY_LOCATION`). |
+
+ER1 credentials for registry-backed commands resolve via Keychain → Secret Manager → env
+(ADR-0003), keyed by the ER1 target.
+
+---
+
+## See also
+
+- **[Quickstart: skillctl](quickstart-skillctl.md)** — the happy path in five minutes.
+- **[Manual: m3c-tools](manual-m3c-tools.md)** — the memory-capture toolkit `skillctl` ships alongside.

--- a/docs/quickstart-m3c-tools.md
+++ b/docs/quickstart-m3c-tools.md
@@ -1,0 +1,202 @@
+---
+layout: default
+title: Quickstart — m3c-tools
+---
+
+# Quickstart: m3c-tools
+
+Capture your first multimodal memory in about five minutes. By the end you'll have
+`m3c-tools` installed, connected to an [ER1](https://er1.io) knowledge server, and a
+YouTube transcript fetched and (optionally) uploaded.
+
+> **What is m3c-tools?** A capture pipeline: it turns YouTube videos, audio, screenshots
+> and voice notes into structured, multimodal observations stored on *your* ER1 server.
+> On macOS it's a native menu-bar app; on Linux/Windows it's a full CLI. For the exhaustive
+> command reference, see the [m3c-tools manual](manual-m3c-tools.md).
+
+---
+
+## 1. Install
+
+You only need the single binary. Grab it from the
+[latest release](https://github.com/kamir/m3c-tools/releases/latest).
+
+**macOS (Apple Silicon):**
+```bash
+curl -sL https://github.com/kamir/m3c-tools/releases/latest/download/m3c-tools-darwin-arm64.tar.gz | tar xz \
+  && sudo mv m3c-tools-darwin-arm64 /usr/local/bin/m3c-tools
+```
+
+**macOS (Intel):**
+```bash
+curl -sL https://github.com/kamir/m3c-tools/releases/latest/download/m3c-tools-darwin-amd64.tar.gz | tar xz \
+  && sudo mv m3c-tools-darwin-amd64 /usr/local/bin/m3c-tools
+```
+
+**Linux (amd64):**
+```bash
+curl -sL https://github.com/kamir/m3c-tools/releases/latest/download/m3c-tools-linux-amd64.tar.gz | tar xz \
+  && sudo mv m3c-tools-linux-amd64 /usr/local/bin/m3c-tools
+```
+
+**Windows (PowerShell, as Administrator):**
+```powershell
+New-Item -ItemType Directory -Force -Path C:\m3c-tools
+Invoke-WebRequest -Uri https://github.com/kamir/m3c-tools/releases/latest/download/m3c-tools-windows-amd64.zip -OutFile "$env:TEMP\m3c-tools.zip"
+Expand-Archive -Path "$env:TEMP\m3c-tools.zip" -DestinationPath C:\m3c-tools -Force
+Rename-Item C:\m3c-tools\m3c-tools-windows-amd64.exe C:\m3c-tools\m3c-tools.exe -Force
+$oldPath = [Environment]::GetEnvironmentVariable("PATH", "Machine")
+if ($oldPath -notlike "*C:\m3c-tools*") { [Environment]::SetEnvironmentVariable("PATH", "$oldPath;C:\m3c-tools", "Machine") }
+```
+Open a **new** terminal, then verify anywhere:
+
+```bash
+m3c-tools version
+m3c-tools help
+```
+
+> **Prefer to build from source?** You need Go 1.25+. On macOS the menu-bar GUI also needs
+> `brew install pkg-config portaudio ffmpeg` and `python3 -m pip install openai-whisper`.
+> Then `make install`. See [Build from source](../README.md#build-from-source).
+
+---
+
+## 2. Connect to ER1 (guided setup)
+
+```bash
+m3c-tools setup
+```
+
+The wizard walks you through:
+
+1. **ER1 server URL** — defaults to `https://onboarding.guide/upload_2`.
+2. **Browser login** — opens Chrome and captures your User ID (context) automatically.
+3. **API key** — required for uploads (sent as the `X-API-KEY` header). Ask your ER1 admin.
+4. **Default tags** — used for capture-device sync.
+
+It writes everything to `~/.m3c-tools.env`.
+
+> **Login vs. API key.** The browser login captures your *context* and can also store a
+> device token. Uploads authenticate with an API key **or** a device token — set up at
+> least one. Run `m3c-tools login` any time to (re-)pair via the browser.
+
+**Prefer manual config?** Copy the template and edit it:
+
+```bash
+cp .env.example ~/.m3c-tools.env
+```
+
+```ini
+ER1_API_URL=https://onboarding.guide/upload_2
+ER1_API_KEY=your-api-key
+ER1_CONTEXT_ID=your-context-id
+```
+
+Full variable reference: [m3c-tools manual → Configuration](manual-m3c-tools.md#configuration).
+
+---
+
+## 3. Verify
+
+```bash
+m3c-tools doctor
+```
+
+`doctor` checks the active profile, authentication (API key and/or device token), DNS, TLS,
+and the ER1 `/health` and auth endpoints. Green across the board means you're ready.
+For a quick reachability-only check, use `m3c-tools check-er1`.
+
+---
+
+## 4. Your first capture
+
+### Fetch a YouTube transcript (no ER1 needed)
+
+```bash
+m3c-tools transcript dQw4w9WgXcQ                 # plain text
+m3c-tools transcript dQw4w9WgXcQ --format srt    # SubRip
+m3c-tools transcript dQw4w9WgXcQ --list          # list available languages
+m3c-tools transcript dQw4w9WgXcQ --translate de  # translate to German
+```
+
+Uses YouTube's InnerTube API — **no API key required**. Supports `text`, `srt`, `json`,
+`webvtt`, proxies (`--proxy-url`), and translation.
+
+### Capture a full observation to ER1
+
+```bash
+m3c-tools upload dQw4w9WgXcQ --impression "Great intro to the topic"
+```
+
+This fetches the transcript **and** the thumbnail, builds a composite document, and uploads
+it to ER1. If subtitles are disabled, it still captures the **thumbnail and the link** so
+the observation is never empty. Add your own audio with `--audio note.wav`.
+
+### Transcribe local audio
+
+```bash
+m3c-tools whisper meeting.wav --model base --language en
+```
+
+Runs your local `whisper` binary. The first run downloads the model (~150 MB for `base`).
+
+### Batch-import a folder of audio
+
+```bash
+m3c-tools import-audio ~/m3c-inbox/ --run     # transcribe + upload + tag, end-to-end
+m3c-tools import-audio --extensions           # show supported formats
+```
+
+Progress is tracked in a local SQLite DB, so re-runs skip what's already done.
+
+---
+
+## 5. Launch the menu-bar app (macOS)
+
+```bash
+open /Applications/M3C-Tools.app     # after `make install`
+# or, in dev:
+make menubar
+```
+
+A menu-bar icon appears. From there:
+
+- **Fetch Transcript…** → paste a YouTube URL.
+- **Capture Screenshot** → annotate + voice note → Store to ER1.
+- **Projects** → your PLM project list (time tracking).
+
+See the [Menu Bar App guide](menubar-app.md) for every menu item and the Observation Window.
+
+---
+
+## 6. Capture devices (optional)
+
+If you use a **Plaud** recorder or a **Pocket** device:
+
+```bash
+m3c-tools plaud auth login      # pair (auto-launches Chrome) — macOS/Windows/Linux
+m3c-tools plaud list            # list recordings + sync status
+m3c-tools plaud sync all        # sync everything to ER1
+
+m3c-tools pocket ...            # see: m3c-tools pocket --help
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `doctor` shows `key_set=false` / auth failing | Your active profile has no real key. Re-run `m3c-tools setup` or `m3c-tools login`; ensure `ER1_API_KEY` isn't a placeholder. |
+| "Projects" menu stuck on *Loading projects…* | No ER1 credential reached the app. Fix the active profile's key or run `login`, then restart the menu-bar app. |
+| `subtitles are disabled for this video` | Expected — the capture still keeps the thumbnail + link. Add a voice note. |
+| Whisper "command not found" | Install it: `python3 -m pip install openai-whisper` (needs `ffmpeg`). |
+| Upload fails, then retries | Failed uploads queue locally; run `m3c-tools retry` or check `m3c-tools status`. |
+
+---
+
+## Next steps
+
+- **Every command and flag:** [m3c-tools manual](manual-m3c-tools.md)
+- **Govern the skills your agents run:** [Quickstart: skillctl](quickstart-skillctl.md)
+- **Platform-specific behavior:** [Platform differences](PLATFORM-DIFFERENCES.md)

--- a/docs/quickstart-skillctl.md
+++ b/docs/quickstart-skillctl.md
@@ -1,0 +1,195 @@
+---
+layout: default
+title: Quickstart — skillctl
+---
+
+# Quickstart: skillctl
+
+Package, sign and verify your first agent skill in about five minutes — entirely offline,
+no server required. Then see how the same bundle flows through admit → install → revoke.
+
+> **What is skillctl?** The trust-and-governance CLI for agent skills. It gives every skill
+> a verifiable identity and a full lifecycle — **author → pack → sign → admit → attest →
+> verify / install → use → audit → revoke** — so nothing an agent runs is unauthorized or
+> unprovable. The trust-chain check is **offline-verifiable**: no hosted CA sits in the
+> verification path. For every command and flag, see the [skillctl manual](manual-skillctl.md).
+
+---
+
+## 1. Install
+
+`skillctl` is a single CLI binary, attached to every
+[release](https://github.com/kamir/m3c-tools/releases/latest). It runs identically on
+macOS, Linux and Windows.
+
+**macOS (Apple Silicon):**
+```bash
+curl -sL https://github.com/kamir/m3c-tools/releases/latest/download/skillctl-darwin-arm64.tar.gz | tar xz \
+  && sudo mv skillctl-darwin-arm64 /usr/local/bin/skillctl
+```
+
+Swap `darwin-arm64` for `darwin-amd64`, `linux-amd64`, `linux-arm64`, or use the
+`skillctl-windows-amd64.zip`. Or build from source: `go build -o build/skillctl ./cmd/skillctl`.
+
+```bash
+skillctl version
+skillctl help        # the full command map, grouped by capability
+```
+
+---
+
+## 2. Create your author identity
+
+A skill is trusted because it's **signed**. Generate your ed25519 keypair once:
+
+```bash
+skillctl keygen --out ~/.config/m3c/skill-keys/mykey
+```
+
+This writes:
+
+- `~/.config/m3c/skill-keys/mykey.priv` — your **private** key (mode `0600`, keep it secret)
+- `~/.config/m3c/skill-keys/mykey.pub` — your **public** key (share this so others can verify)
+
+Both are PEM-wrapped ed25519 (PKCS#8 / SPKI).
+
+---
+
+## 3. Pack a skill into a sealed bundle
+
+A skill directory just needs a `SKILL.md`. Package it into a `.skb` bundle with a manifest:
+
+```bash
+skillctl pack \
+  --skill ./my-skill \
+  -o my-skill.skb \
+  --name my-skill \
+  --version 1.0.0 \
+  --summary "What this skill does"
+```
+
+Useful optional manifest fields:
+
+| Flag | Purpose |
+|------|---------|
+| `--source-repo` / `--source-commit` / `--source-path` | Provenance: where the skill came from |
+| `--depends-on kind:name:constraint` | Declare dependencies, e.g. `python:requests:>=2.31` (repeatable) |
+| `--author-intent green\|yellow\|red` | Advisory governance hint (the verifier ignores it — signed **attestations** are what bind) |
+| `--data-scopes <json>` | Author-signed declared data-scope, bound into the bundle |
+
+---
+
+## 4. Sign it
+
+```bash
+skillctl sign my-skill.skb --key ~/.config/m3c/skill-keys/mykey.priv
+```
+
+This computes the bundle's SHA-256 digest, signs it with ed25519, and writes a **detached**
+signature next to the bundle: `my-skill.skb.<digest>.author.sig`.
+
+---
+
+## 5. Verify it — offline
+
+```bash
+skillctl verify-sig my-skill.skb --pubkey ~/.config/m3c/skill-keys/mykey.pub
+```
+
+It recomputes the digest, finds the matching signature, and checks it. **No network, no CA.**
+
+```
+Exit codes:  0 ok  ·  11 signature invalid  ·  1 other error  ·  2 usage
+```
+
+That's the core loop: **anyone with your public key can prove a bundle is authentic and
+unmodified, with nothing but the two files in front of them.**
+
+---
+
+## 6. Trust a registry, then install
+
+To pull and install skills from a registry, first **pin** that registry's public key in your
+trust roots (`~/.claude/skill-trust-roots.yaml`):
+
+```bash
+skillctl trust add   <registry> --pubkey <registry.pub>   # pin a key
+skillctl trust list                                        # show pinned registries
+```
+
+Then install — this pulls the bundle, runs the full trust-chain verifier, and installs
+atomically under `~/.claude/skills/<name>/`, refusing if **any** step fails:
+
+```bash
+skillctl install my-skill@1.0.0        # or a digest pin: my-skill@sha256:<hex>
+skillctl verify  my-skill              # re-run the trust check on an installed skill
+skillctl verify  --all                 # re-verify everything (catches new revocations)
+```
+
+The verifier returns **numbered exit codes** so automation can branch precisely:
+
+| Code | Meaning | Code | Meaning |
+|-----:|---------|-----:|---------|
+| `0` | ok | `13` | governance below minimum |
+| `10` | digest mismatch | `14` | `depends_on` unsatisfied |
+| `11` | author signature invalid | `15` | blob missing |
+| `12` | registry not in trust roots | `16` | tenant blocked (CISO verdict) |
+
+---
+
+## 7. Publish, attest, revoke (the governed path)
+
+Once you run your own registry (via ER1), the lifecycle extends:
+
+```bash
+skillctl login                                     # device-pair against ER1 (browser)
+skillctl publish my-skill --bundle my-skill.skb    # admit the bundle to your `self` registry
+skillctl publish --attest my-skill --level green --rationale "reviewed"   # governance attestation
+skillctl pull                                      # run the 5-gate gauntlet; stage verified bundles
+skillctl registry ls                               # list admitted bundles
+skillctl publish --revoke my-skill --digest sha256:… --reason "superseded"   # revoke on demand
+skillctl audit  <name>                             # inspect a skill's trust timeline
+```
+
+Revocation is **signed and offline-verifiable**, with freshness contracts (fail-closed) so a
+stale or rolled-back revocation list is rejected rather than silently trusted.
+
+---
+
+## 8. Wire the Claude Code trust gate (optional, powerful)
+
+`skillctl` can gate every skill invocation in Claude Code, failing **closed**:
+
+```bash
+# As a PreToolUse(Skill) hook — reads the hook event on stdin, verifies the chain,
+# and emits allow/deny. Wire it in settings, don't run it by hand:
+skillctl verify-hook
+
+skillctl gate-stats --since 168h        # decisions, top blocks, cache-hit rate
+```
+
+Now an agent literally cannot invoke a skill that isn't authorized and provable.
+
+---
+
+## Bonus: give an agent a provable identity
+
+```bash
+skillctl agentid issue  --owner <you> --owner-key mykey.priv \
+                        --for-agent <agent-id> --skills my-skill --intents summarize
+skillctl agentid verify --bundle agent.mandate --offline    # verify offline against pinned keys
+skillctl agentid show   --bundle agent.mandate              # owner, grant, expiry, fingerprints
+```
+
+An **AgentID** is an owner-signed mandate that says *this agent may use these skills for these
+intents* — and it verifies offline, no authority in the path.
+
+---
+
+## Next steps
+
+- **Every command, flag and exit code:** [skillctl manual](manual-skillctl.md)
+- **Capture the memory your agents reason over:** [Quickstart: m3c-tools](quickstart-m3c-tools.md)
+- **The full lifecycle & governance model** lives behind `skillctl help` — it groups commands
+  by capability (signing, trust roots, install, agent identity, registry, transparency log,
+  sessions, PLM project context).


### PR DESCRIPTION
## Why

The README was macOS/developer-centric and never mentioned **skillctl** or the *why*. Alexander (and any newcomer) bounced off it. This reframes the repo as **two tools** and adds the missing onboarding + reference docs.

## What's in it

- **`README.md` — rewritten.** Hook ("Give your agents a memory — and proof of what they're allowed to do"), two-tool framing (**m3c-tools** = the capture pipeline · **skillctl** = the capability plane), a 60-second start per tool, install matrix, architecture, and a Sovereign Decision Fabric positioning footer.
- **`docs/quickstart-m3c-tools.md`** — install → `setup` → `doctor` → first captures → menu bar → troubleshooting.
- **`docs/quickstart-skillctl.md`** — `keygen` → `pack` → `sign` → `verify-sig` (offline) → `trust`/`install` → `publish`/`revoke` → `verify-hook` gate → `agentid`.
- **`docs/manual-m3c-tools.md`** — full command reference (25 commands).
- **`docs/manual-skillctl.md`** — full trust-lifecycle reference + authoritative exit-code table.
- **`docs/illustration-prompt.md`** — ready-to-paste image prompts (hero / emblem / planes / banner).
- **`docs/index.md`** — Pages nav wired to the new pages.

## Accuracy

Every flag, default and exit code in the manuals and quickstarts was derived from the **live `--help` output of the built binaries** — no invented behavior. An incorrect skillctl example in the old draft (`keygen`/`pack`/`verify-sig` flags) was corrected. skillctl trust claims kept **evidence-led**: offline-verifiable, no hosted CA in the verification path; audit framed as *evidence, not certification*.

All internal `.md` links verified to resolve. Docs-only — no code or binary change, so no release needed; GitHub Pages refreshes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)