### PR TITLE
docs(readme): move skillctl hero to the top + fact-accurate illustration prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ that act on it. Two command-line tools, one repository, zero mandatory cloud mid
 [Full manuals](#-documentation) ·
 [Website](https://kamir.github.io/m3c-tools)
 
+<br>
+
+<img src="docs/assets/skillctl-hero.png" alt="skillctl — build, package, sign, share and run agent skills" width="880">
+
 </div>
 
 ---
@@ -104,10 +108,6 @@ thumbnail and the link.
 `setup`, `menubar`. See the [m3c-tools manual](docs/manual-m3c-tools.md).
 
 ## What `skillctl` governs
-
-<p align="center">
-  <img src="docs/assets/skillctl-hero.png" alt="skillctl — a CLI to build, package, sign, share and run agent skills" width="840">
-</p>
 
 `skillctl` is the trust-and-governance CLI for agent skills. It implements a full lifecycle
 so a skill can be trusted end to end:

--- a/docs/illustration-prompt.md
+++ b/docs/illustration-prompt.md
@@ -80,3 +80,37 @@ cheesy stock-photo people, no cluttered UI screenshots, not skeuomorphic, not ne
 - Ask for `16:9` for the site hero, `3:1` for the GitHub social/banner, `1:1` for the badge.
 - If the model renders garbled text, re-run with "no text" emphasized — labels should be
   added later in a vector editor, not baked into the image.
+
+---
+
+## 5. Fact-accurate "ecosystem" infographic (corrected variant)
+
+A first-pass "package manager" infographic looked great but baked in wrong facts
+(a `github.com/skillctl/skillctl` URL, a `get.skillctl.dev` installer, and invented
+`skillctl search` / `pdf-extract` commands). Use this prompt instead when you want an
+infographic that renders **real** text — so it can go in the repo without misleading anyone.
+
+> A polished dark-mode developer infographic for a CLI tool called **skillctl**, the
+> trust-and-governance CLI for AI-agent skills. Left column: four labeled feature rows with
+> line icons — **Sign** (a key + signature seal), **Verify** (a shield with a checkmark),
+> **Install** (a download arrow into a box), **Revoke** (a circular arrow with a stop). Center:
+> a realistic macOS-style terminal window titled `skillctl` showing the real command flow —
+> `skillctl keygen`, `skillctl pack`, `skillctl sign`, then `skillctl verify-sig ✓ ok (offline)`,
+> then `skillctl install my-skill@1.0.0 ✓ installed`. Right column: a small ecosystem diagram —
+> a "personal registry (ER1)" node and a "git repos" node feeding into the skillctl hexagon,
+> which fans out to "verify → install → use" with a small robot labeled "AI agent". Deep navy
+> background, electric teal + violet accents, green for the ✓ success states, single-weight line
+> icons, premium open-source aesthetic, generous spacing. **Aspect ratio 16:9.**
+
+**If the model bakes text into the image, it MUST use only these real strings** (everything
+else should be "no text"):
+
+- Tool name: `skillctl`  ·  Tagline: *the trust layer for agent skills*
+- Real commands only: `keygen`, `pack`, `sign`, `verify-sig`, `trust`, `install`, `verify`,
+  `publish`, `pull`, `registry`, `agentid`, `revoke` — **never** `search`, `init`, `build`, `run`.
+- Repo URL (footer): `github.com/kamir/m3c-tools`  — **not** `skillctl/skillctl`.
+- Install line (if shown): `curl -sL github.com/kamir/m3c-tools/releases/latest/download/skillctl-darwin-arm64.tar.gz | tar xz`
+  — **not** `get.skillctl.dev`.
+- License (footer, correct): `Apache-2.0`.
+- Trust phrasing: *offline-verifiable — no hosted CA in the verification path* (evidence-led, no overclaim).
+- Do **not** invent a public skill marketplace or named skills (no `pdf-extract`, `web-search`, `skillhub`).


### PR DESCRIPTION
- **README**: promotes the skillctl "Build · Package · Share · Run" banner from the skillctl section to the **top hero header** (under the title / badges / nav).
- **docs/illustration-prompt.md**: adds a **fact-accurate** "ecosystem" infographic prompt so a regenerated companion graphic renders REAL facts — `github.com/kamir/m3c-tools` (not `skillctl/skillctl`), install from GitHub Releases (not `get.skillctl.dev`), the real command set (`keygen`/`pack`/`sign`/`verify-sig`/`install`/…, never `search`/`init`/`build`/`run`), `Apache-2.0`.

Docs-only. No release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)