### PR TITLE
feat(plaud): recording→ER1 doc_id visibility + click-to-open + sync-check

### DIFF
--- a/cmd/m3c-tools/commands_shared.go
+++ b/cmd/m3c-tools/commands_shared.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kamir/m3c-tools/pkg/config"
 	"github.com/kamir/m3c-tools/pkg/er1"
 	"github.com/kamir/m3c-tools/pkg/impression"
+	"github.com/kamir/m3c-tools/pkg/plaud"
 	"github.com/kamir/m3c-tools/pkg/tracking"
 	"github.com/kamir/m3c-tools/pkg/transcript"
 	"github.com/kamir/m3c-tools/pkg/whisper"
@@ -589,4 +590,123 @@ func validateVideoID(id string) error {
 		return fmt.Errorf("invalid video ID: %q (must be exactly 11 alphanumeric/dash/underscore chars)", id)
 	}
 	return nil
+}
+
+// --- Plaud sync visibility: recording -> ER1 doc_id mapping + coverage ------
+
+// plaudSyncState is the resolved ingestion state of one Plaud recording:
+// whether it reached ER1, under which doc_id, and the openable item URL.
+type plaudSyncState struct {
+	Status  string // "synced" | "new" | a local status (e.g. "failed")
+	DocID   string // ER1 doc_id, if known
+	ItemURL string // ER1 memory-viewer URL, if the doc_id is known
+}
+
+// resolvePlaudSyncStates returns, per Plaud recording ID, the ingestion state —
+// merging the LOCAL tracking DB (plaud://<id> -> UploadDocID/status) with the
+// SPEC-0117 SERVER-side sync check. The server is authoritative for
+// cross-machine visibility (an item synced from another Mac shows as synced
+// with its doc_id even when this machine's DB has no record); the local doc_id
+// is the fallback. The server check requires an ER1 API key.
+func resolvePlaudSyncStates(recIDs []string, plaudToken string) map[string]plaudSyncState {
+	out := make(map[string]plaudSyncState, len(recIDs))
+	er1Cfg := er1.LoadConfig()
+
+	// Local tracking DB.
+	if filesDB, err := tracking.OpenFilesDB(defaultFilesDBPath()); err == nil {
+		defer filesDB.Close()
+		for _, id := range recIDs {
+			if tracked, e := filesDB.GetByPath("plaud://" + id); e == nil && tracked != nil {
+				st := plaudSyncState{Status: tracked.Status, DocID: tracked.UploadDocID}
+				st.ItemURL = er1Cfg.MemoryItemURL(st.DocID)
+				out[id] = st
+			}
+		}
+	} else {
+		log.Printf("[plaud] warning: cannot open tracking DB: %v", err)
+	}
+
+	// Server-side sync check — authoritative, cross-machine (SPEC-0117).
+	if er1Cfg.APIKey != "" && plaudToken != "" {
+		syncAPI := plaud.NewSyncAPIClient(er1Cfg.APIURL, er1Cfg.APIKey, er1Cfg.ContextID, !er1Cfg.VerifySSL)
+		accountID := plaud.DeriveAccountID(plaudToken)
+		if res, err := syncAPI.CheckRecordings(accountID, recIDs); err == nil && res != nil {
+			for id, info := range res.Synced {
+				st := out[id]
+				st.Status = "synced"
+				if info.ER1DocID != "" {
+					st.DocID = info.ER1DocID
+					st.ItemURL = er1Cfg.MemoryItemURL(info.ER1DocID)
+				}
+				out[id] = st
+			}
+		} else if err != nil {
+			log.Printf("[plaud] server sync check failed (using local DB only): %v", err)
+		}
+	}
+	return out
+}
+
+// cmdPlaudCheck prints a read-only sync-coverage report: how many Plaud
+// recordings have been ingested into ER1 (with their doc_id) versus how many
+// are still unsynced. Authoritative across machines via the server sync check.
+func cmdPlaudCheck() {
+	cfg := plaud.LoadConfig()
+	session, err := plaud.LoadToken(cfg.TokenPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading token: %v\nRun: m3c-tools plaud auth --from-er1   (or: m3c-tools plaud auth login)\n", err)
+		os.Exit(1)
+	}
+	client := plaud.NewClient(cfg, session.Token)
+	recordings, err := client.ListRecordings()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing recordings: %v\n", err)
+		os.Exit(1)
+	}
+
+	ids := make([]string, len(recordings))
+	for i, r := range recordings {
+		ids[i] = r.ID
+	}
+	states := resolvePlaudSyncStates(ids, session.Token)
+
+	synced := 0
+	for _, r := range recordings {
+		if st, ok := states[r.ID]; ok && st.Status == "synced" {
+			synced++
+		}
+	}
+	unsynced := len(recordings) - synced
+
+	fmt.Printf("Plaud sync check — %d recordings: %d synced, %d unsynced\n", len(recordings), synced, unsynced)
+	if er1Cfg := er1.LoadConfig(); er1Cfg.APIKey == "" {
+		fmt.Println("(note: no ER1 API key — coverage is from the LOCAL tracking DB only, not server-authoritative)")
+	}
+
+	if unsynced > 0 {
+		fmt.Printf("\nUnsynced (%d) — run: m3c-tools plaud sync <#>   or   plaud sync --all\n", unsynced)
+		for i, r := range recordings {
+			st := states[r.ID]
+			if st.Status != "synced" {
+				fmt.Printf("  [%3d] %-6s  %-10s  %s\n",
+					i+1, plaud.FormatDuration(r.Duration), r.CreatedAt.Format("2006-01-02"), r.Title)
+			}
+		}
+	}
+	if synced > 0 {
+		fmt.Printf("\nSynced (%d) — recording -> ER1 item:\n", synced)
+		for i, r := range recordings {
+			st := states[r.ID]
+			if st.Status == "synced" {
+				docShown := st.DocID
+				if docShown == "" {
+					docShown = "(doc_id unknown — server-synced from another device)"
+				}
+				fmt.Printf("  [%3d] %-40s  doc_id=%s\n", i+1, r.Title, docShown)
+				if st.ItemURL != "" {
+					fmt.Printf("        %s\n", st.ItemURL)
+				}
+			}
+		}
+	}
 }

--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -231,7 +231,8 @@ Commands:
     --compact              Machine-readable output (TSV: status, path, size, tags)
     --db <path>            Tracking DB path (default: ~/.m3c-tools/tracking.db)
 
-  plaud list             List Plaud recordings with sync status
+  plaud list             List Plaud recordings with sync status + ER1 doc_id
+  plaud check            Sync-coverage report: how many synced/unsynced + doc_id links
   plaud sync <id>        Sync a Plaud recording to ER1
   plaud sync --all       Sync all new Plaud recordings to ER1
   plaud auth login       Extract token from Chrome (web.plaud.ai)
@@ -4351,12 +4352,14 @@ func menubarWhisperTimeout() time.Duration {
 
 func cmdPlaud(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud <list|sync|auth> [args]")
+		fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud <list|check|sync|auth> [args]")
 		os.Exit(1)
 	}
 	switch args[0] {
 	case "list":
 		cmdPlaudList()
+	case "check":
+		cmdPlaudCheck()
 	case "sync":
 		if len(args) < 2 {
 			fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud sync <#|ID|--all> [flags]")
@@ -4645,30 +4648,23 @@ func cmdPlaudList() {
 		os.Exit(1)
 	}
 
-	// Check tracking DB for sync status.
-	dbPath := defaultFilesDBPath()
-	filesDB, dbErr := tracking.OpenFilesDB(dbPath)
-	if dbErr != nil {
-		log.Printf("[plaud] warning: cannot open tracking DB: %v", dbErr)
+	// Resolve sync status + ER1 doc_id: local tracking DB merged with the
+	// SPEC-0117 server sync check (so items synced from another Mac still show
+	// as synced with their doc_id, instead of a misleading "new").
+	ids := make([]string, len(recordings))
+	for i, rec := range recordings {
+		ids[i] = rec.ID
 	}
-	defer func() {
-		if filesDB != nil {
-			filesDB.Close()
-		}
-	}()
+	states := resolvePlaudSyncStates(ids, session.Token)
 
 	fmt.Printf("Plaud recordings (%d):\n\n", len(recordings))
 	fmt.Printf("  %3s  %-32s  %-40s  %6s  %s  %-10s  %s\n", "#", "ID", "Title", "Dur", "Date", "Status", "ER1 Doc")
 	fmt.Println("  ---  --------------------------------  ----------------------------------------  ------  ----------  ----------  --------")
 	for i, rec := range recordings {
-		status := "new"
-		docID := ""
-		if filesDB != nil {
-			plaudPath := "plaud://" + rec.ID
-			if tracked, lookupErr := filesDB.GetByPath(plaudPath); lookupErr == nil && tracked != nil {
-				status = tracked.Status
-				docID = tracked.UploadDocID
-			}
+		st := states[rec.ID]
+		status := st.Status
+		if status == "" {
+			status = "new"
 		}
 		fmt.Printf("  %3d  %-32s  %-40s  %6s  %s  [%-8s]  %s\n",
 			i+1,
@@ -4677,11 +4673,11 @@ func cmdPlaudList() {
 			plaud.FormatDuration(rec.Duration),
 			rec.CreatedAt.Format("2006-01-02"),
 			status,
-			docID,
+			st.DocID,
 		)
 	}
 	fmt.Println()
-	fmt.Println("  Use: m3c-tools plaud sync <#>   or   m3c-tools plaud sync <ID>")
+	fmt.Println("  Use: plaud sync <#>   ·   plaud check (coverage)   ·   double-click a synced row in the Sync panel to open it")
 }
 
 func cmdPlaudSync(recordingID string, force bool, customTags string, filter string, dryRun bool) {
@@ -5218,51 +5214,23 @@ func menubarHandlePlaudSync(app *menubar.App) {
 	}
 	log.Printf("[plaud] found %d recordings", len(recordings))
 
-	// Check each recording against tracking DB.
+	// Recording -> sync state (status + ER1 doc_id/URL): local tracking DB
+	// merged with the SPEC-0117 server sync check. dbPath is reused by the sync
+	// pipeline below; the ItemURL makes a synced row double-clickable to open
+	// the ER1 item in the browser.
 	dbPath := defaultFilesDBPath()
-	filesDB, dbErr := tracking.OpenFilesDB(dbPath)
-	if dbErr != nil {
-		log.Printf("[plaud] warning: cannot open tracking DB: %v", dbErr)
+	allIDs := make([]string, len(recordings))
+	for i, rec := range recordings {
+		allIDs[i] = rec.ID
 	}
-	defer func() {
-		if filesDB != nil {
-			filesDB.Close()
-		}
-	}()
-
-	// Server-side sync check for status display (SPEC-0117)
-	var serverSynced map[string]plaud.SyncedInfo
-	er1Cfg := er1.LoadConfig()
-	if er1Cfg.APIKey != "" {
-		syncAPI := plaud.NewSyncAPIClient(er1Cfg.APIURL, er1Cfg.APIKey, er1Cfg.ContextID, !er1Cfg.VerifySSL)
-		plaudAccountID := plaud.DeriveAccountID(session.Token)
-		allIDs := make([]string, len(recordings))
-		for i, rec := range recordings {
-			allIDs[i] = rec.ID
-		}
-		checkResult, checkErr := syncAPI.CheckRecordings(plaudAccountID, allIDs)
-		if checkErr == nil && checkResult != nil {
-			serverSynced = checkResult.Synced
-			if len(serverSynced) > 0 {
-				log.Printf("[plaud] server knows %d/%d recordings as synced", len(serverSynced), len(recordings))
-			}
-		}
-	}
+	states := resolvePlaudSyncStates(allIDs, session.Token)
 
 	var records []menubar.PlaudSyncRecord
 	for _, rec := range recordings {
-		status := "new"
-		if filesDB != nil {
-			plaudPath := "plaud://" + rec.ID
-			if tracked, lookupErr := filesDB.GetByPath(plaudPath); lookupErr == nil && tracked != nil {
-				status = tracked.Status
-			}
-		}
-		// Server-side check: mark as synced if server knows about it even when local DB doesn't (SPEC-0117)
-		if status == "new" && serverSynced != nil {
-			if _, ok := serverSynced[rec.ID]; ok {
-				status = "synced"
-			}
+		st := states[rec.ID]
+		status := st.Status
+		if status == "" {
+			status = "new"
 		}
 		records = append(records, menubar.PlaudSyncRecord{
 			Title:       rec.Title,
@@ -5270,6 +5238,7 @@ func menubarHandlePlaudSync(app *menubar.App) {
 			Date:        rec.CreatedAt.Format("2006-01-02 15:04"),
 			Status:      status,
 			RecordingID: rec.ID,
+			ItemURL:     st.ItemURL,
 		})
 	}
 

--- a/cmd/m3c-tools/main_other.go
+++ b/cmd/m3c-tools/main_other.go
@@ -384,7 +384,7 @@ func cmdTranscript(args []string) {
 // cmdPlaud handles plaud subcommands: auth, list, sync.
 func cmdPlaud(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud <auth|list|sync> [args...]")
+		fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud <auth|list|check|sync> [args...]")
 		os.Exit(1)
 	}
 
@@ -393,6 +393,8 @@ func cmdPlaud(args []string) {
 		cmdPlaudAuth(args[1:])
 	case "list":
 		cmdPlaudList()
+	case "check":
+		cmdPlaudCheck()
 	case "sync":
 		if len(args) < 2 {
 			fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud sync <#|ID|--all> [-f]")
@@ -547,17 +549,13 @@ func cmdPlaudList() {
 		return
 	}
 
-	// Check tracking DB for sync status + ER1 doc IDs.
-	dbPath := defaultFilesDBPath()
-	filesDB, dbErr := tracking.OpenFilesDB(dbPath)
-	if dbErr != nil {
-		log.Printf("[plaud] warning: cannot open tracking DB: %v", dbErr)
+	// Resolve sync status + ER1 doc_id: local tracking DB merged with the
+	// SPEC-0117 server sync check (cross-machine authoritative).
+	ids := make([]string, len(recordings))
+	for i, r := range recordings {
+		ids[i] = r.ID
 	}
-	defer func() {
-		if filesDB != nil {
-			filesDB.Close()
-		}
-	}()
+	states := resolvePlaudSyncStates(ids, session.Token)
 
 	fmt.Printf("  %3s  %-32s  %-40s  %6s  %s  %-10s  %s\n", "#", "ID", "Title", "Dur", "Date", "Status", "ER1 Doc")
 	fmt.Println("  ---  --------------------------------  ----------------------------------------  ------  ----------  ----------  --------")
@@ -566,22 +564,19 @@ func cmdPlaudList() {
 		if len(id) > 32 {
 			id = id[:32]
 		}
-		status := "new"
-		docID := ""
-		if filesDB != nil {
-			if tracked, lookupErr := filesDB.GetByPath("plaud://" + r.ID); lookupErr == nil && tracked != nil {
-				status = tracked.Status
-				docID = tracked.UploadDocID
-			}
+		st := states[r.ID]
+		status := st.Status
+		if status == "" {
+			status = "new"
 		}
 		title := r.Title
 		if len(title) > 40 {
 			title = title[:37] + "..."
 		}
-		fmt.Printf("  %3d  %-32s  %-40s  %6d  %s  [%-8s]  %s\n", i+1, id, title, r.Duration, r.CreatedAt.Format("2006-01-02"), status, docID)
+		fmt.Printf("  %3d  %-32s  %-40s  %6d  %s  [%-8s]  %s\n", i+1, id, title, r.Duration, r.CreatedAt.Format("2006-01-02"), status, st.DocID)
 	}
 	fmt.Printf("\nTotal: %d recordings\n", len(recordings))
-	fmt.Println("Use: m3c-tools plaud sync <#>   or   m3c-tools plaud sync <ID>")
+	fmt.Println("Use: plaud sync <#>   ·   plaud check (coverage)")
 }
 
 // cmdPlaudSync syncs a recording (or all) to ER1 with detailed statistics (FR-0009),

--- a/e2e/er1_itemurl_test.go
+++ b/e2e/er1_itemurl_test.go
@@ -1,0 +1,35 @@
+// Offline test for er1.Config.MemoryItemURL — the recording→ER1 item URL used
+// by `plaud list` / `plaud check` and the Plaud sync panel's click-to-open.
+package e2e
+
+import (
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/er1"
+)
+
+func TestMemoryItemURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		apiURL  string
+		ctx     string
+		docID   string
+		want    string
+	}{
+		{"upload_2 suffix stripped", "https://onboarding.guide/upload_2", "107677460544181387647___mft", "hzrCsrM0BGAThZ6lGd6y",
+			"https://onboarding.guide/memory/107677460544181387647___mft/hzrCsrM0BGAThZ6lGd6y"},
+		{"upload suffix stripped", "https://onboarding.guide/upload", "ctx", "d1",
+			"https://onboarding.guide/memory/ctx/d1"},
+		{"trailing slash stripped", "https://127.0.0.1:8081/", "ctx", "d1",
+			"https://127.0.0.1:8081/memory/ctx/d1"},
+		{"empty doc_id yields empty url", "https://onboarding.guide/upload_2", "ctx", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &er1.Config{APIURL: tt.apiURL, ContextID: tt.ctx}
+			if got := cfg.MemoryItemURL(tt.docID); got != tt.want {
+				t.Errorf("MemoryItemURL(%q) = %q; want %q", tt.docID, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/er1/config.go
+++ b/pkg/er1/config.go
@@ -144,6 +144,23 @@ func LoadConfig() *Config {
 	return cfg
 }
 
+// MemoryItemURL returns the ER1 memory-viewer URL for a document:
+//
+//	<base>/memory/<context_id>/<docID>
+//
+// where <base> is APIURL with the /upload_2 (or /upload) suffix stripped.
+// Returns "" when docID is empty. Used to make a synced item openable from the
+// Plaud sync panel and to print item links in `plaud list` / `plaud check`.
+func (c *Config) MemoryItemURL(docID string) string {
+	if docID == "" {
+		return ""
+	}
+	base := strings.TrimSuffix(c.APIURL, "/upload_2")
+	base = strings.TrimSuffix(base, "/upload")
+	base = strings.TrimSuffix(base, "/")
+	return fmt.Sprintf("%s/memory/%s/%s", base, c.ContextID, docID)
+}
+
 // AuthHeaders returns HTTP headers for ER1 authentication.
 // Prefers device token (Bearer) over API key (SPEC-0127).
 func (c *Config) AuthHeaders() map[string]string {

--- a/pkg/menubar/plaud_sync.go
+++ b/pkg/menubar/plaud_sync.go
@@ -31,6 +31,7 @@ type PlaudSyncRecord struct {
 	Date        string
 	Status      string
 	RecordingID string
+	ItemURL     string // ER1 memory-viewer URL (empty if not synced)
 }
 
 // ShowPlaudSyncWindow is a no-op on non-darwin platforms.

--- a/pkg/menubar/plaud_sync_darwin.go
+++ b/pkg/menubar/plaud_sync_darwin.go
@@ -39,6 +39,9 @@ static int   g_plaudRowCount = 0;
 // Recording IDs (parallel to rows).
 static char *g_plaudRecordingIDs[PLAUD_MAX_ROWS];
 
+// ER1 memory-viewer URLs (parallel to rows); empty for un-synced rows.
+static char *g_plaudItemURLs[PLAUD_MAX_ROWS];
+
 // ---------- Helpers ----------
 
 static void clearPlaudData(void) {
@@ -47,13 +50,15 @@ static void clearPlaudData(void) {
 			if (g_plaudData[r][c]) { free(g_plaudData[r][c]); g_plaudData[r][c] = NULL; }
 		}
 		if (g_plaudRecordingIDs[r]) { free(g_plaudRecordingIDs[r]); g_plaudRecordingIDs[r] = NULL; }
+		if (g_plaudItemURLs[r])    { free(g_plaudItemURLs[r]);    g_plaudItemURLs[r] = NULL; }
 	}
 	g_plaudRowCount = 0;
 	memset(g_plaudSelected, 0, sizeof(g_plaudSelected));
 }
 
 static void addPlaudRow(const char *num, const char *title, const char *duration,
-						const char *date, const char *status, const char *recordingID) {
+						const char *date, const char *status, const char *recordingID,
+						const char *itemURL) {
 	if (g_plaudRowCount >= PLAUD_MAX_ROWS) return;
 	int r = g_plaudRowCount++;
 	g_plaudData[r][0] = strdup(num       ? num       : "");
@@ -62,6 +67,7 @@ static void addPlaudRow(const char *num, const char *title, const char *duration
 	g_plaudData[r][3] = strdup(date      ? date      : "");
 	g_plaudData[r][4] = strdup(status    ? status    : "");
 	g_plaudRecordingIDs[r] = strdup(recordingID ? recordingID : "");
+	g_plaudItemURLs[r]     = strdup(itemURL     ? itemURL     : "");
 	g_plaudSelected[r] = NO;
 }
 
@@ -182,6 +188,7 @@ extern void goPlaudSyncAction(char* action);
 - (void)selectAllClicked:(id)sender;
 - (void)deselectAllClicked:(id)sender;
 - (void)syncSelectedClicked:(id)sender;
+- (void)rowDoubleClicked:(id)sender;
 @end
 
 @implementation PlaudSyncTableDataSource
@@ -285,6 +292,19 @@ extern void goPlaudSyncAction(char* action);
 - (void)syncSelectedClicked:(id)sender {
 	if (g_plaudBulkActive) return;
 	goPlaudSyncAction("sync");
+}
+
+// Double-click a synced row to open its ER1 memory item in the browser.
+// Rows without an item URL (un-synced) do nothing.
+- (void)rowDoubleClicked:(id)sender {
+	NSInteger row = [g_plaudTable clickedRow];
+	if (row < 0 || row >= g_plaudRowCount) return;
+	const char *u = g_plaudItemURLs[row];
+	if (!u || strlen(u) == 0) return;
+	NSString *us = [NSString stringWithUTF8String:u];
+	if (!us || [us length] == 0) return;
+	NSURL *url = [NSURL URLWithString:us];
+	if (url) [[NSWorkspace sharedWorkspace] openURL:url];
 }
 
 @end
@@ -450,6 +470,10 @@ static void showPlaudSyncWindow(const char *accountInfo) {
 		[g_plaudTable setDataSource:g_plaudDS];
 		[g_plaudTable setDelegate:g_plaudDS];
 
+		// Double-click a synced row → open its ER1 item in the browser.
+		[g_plaudTable setTarget:g_plaudDS];
+		[g_plaudTable setDoubleAction:@selector(rowDoubleClicked:)];
+
 		// Wire buttons
 		[btnSelectAll setTarget:g_plaudDS];
 		[btnSelectAll setAction:@selector(selectAllClicked:)];
@@ -482,6 +506,7 @@ type PlaudSyncRecord struct {
 	Date        string
 	Status      string
 	RecordingID string
+	ItemURL     string // ER1 memory-viewer URL (empty if not synced); double-click opens it
 }
 
 // ShowPlaudSyncWindow populates and displays the Plaud Sync window.
@@ -496,13 +521,15 @@ func ShowPlaudSyncWindow(records []PlaudSyncRecord, accountInfo string, defaultT
 		cDate := C.CString(rec.Date)
 		cStatus := C.CString(rec.Status)
 		cID := C.CString(rec.RecordingID)
-		C.addPlaudRow(cNum, cTitle, cDur, cDate, cStatus, cID)
+		cURL := C.CString(rec.ItemURL)
+		C.addPlaudRow(cNum, cTitle, cDur, cDate, cStatus, cID, cURL)
 		C.free(unsafe.Pointer(cNum))
 		C.free(unsafe.Pointer(cTitle))
 		C.free(unsafe.Pointer(cDur))
 		C.free(unsafe.Pointer(cDate))
 		C.free(unsafe.Pointer(cStatus))
 		C.free(unsafe.Pointer(cID))
+		C.free(unsafe.Pointer(cURL))
 	}
 
 	var cAccount *C.char


### PR DESCRIPTION
Answers three questions that were latent in the data but never surfaced: **which Plaud items are in ER1, under which item ID, and did we sync everything?**

## What's new
- **`plaud check`** — read-only sync-coverage report: *N synced / M unsynced*, the unsynced list, and the synced `recording → doc_id → ER1 URL` mapping. Wired on darwin + non-darwin.
- **Panel click-to-open** — the Plaud sync panel stores a per-row ER1 item URL; **double-clicking a synced row opens the ER1 item** in the browser (un-synced rows do nothing).
- **`plaud list` is now server-aware** — items synced from another machine show as `synced` with their `doc_id` instead of a misleading `new`.
- **`er1.Config.MemoryItemURL(docID)`** — reusable `<base>/memory/<ctx>/<docID>` builder (replaces the inlined version).
- **`resolvePlaudSyncStates()`** (shared) — merges the local tracking DB with the SPEC-0117 server sync check; single source of truth for status + doc_id + URL used by the panel and both CLIs.

## Verified live
`plaud check` on the real account → **209 recordings, 76 synced / 133 unsynced**, with correct `doc_id` and `https://onboarding.guide/memory/…` links. Offline `TestMemoryItemURL` added.

Note: the panel double-click is compile-verified; interactive click behavior can't be exercised headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)