### PR TITLE
fix(plaud): panel marked ALL rows synced when the first item finished

### DIFF
--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -5277,11 +5277,14 @@ func menubarHandlePlaudSync(app *menubar.App) {
 				if evt.Outcome == "failed" {
 					status = "failed"
 				}
-				// Find the recording ID for this item.
-				for _, id := range recordingIDs {
-					if evt.Item != "" {
-						menubar.SetPlaudSyncStatus(id, status)
-					}
+				// Update ONLY the row that actually finished. evt.Index is
+				// 1-based and matches the order runPlaudSyncPipeline iterates
+				// recordingIDs, so recordingIDs[Index-1] is this item. The old
+				// code looped over ALL recordingIDs and flipped every selected
+				// row to "synced" as soon as the FIRST item completed — the
+				// "upload already happened" illusion.
+				if idx := evt.Index - 1; idx >= 0 && idx < len(recordingIDs) {
+					menubar.SetPlaudSyncStatus(recordingIDs[idx], status)
 				}
 			}
 		}


### PR DESCRIPTION
## Symptom (field report)

Syncing in the Plaud panel gave "the illusion the upload had already happened" — the progress/status was wrong even though the actual upload worked.

## Root cause

In the sync callback's `onProgress`, the `ITEM_DONE` handler looped over **all** selected `recordingIDs` and set each to `synced`:

```go
for _, id := range recordingIDs {
    if evt.Item != "" {          // evt.Item is the TITLE — never compared to id
        menubar.SetPlaudSyncStatus(id, status)
    }
}
```

So when **item #1** finished, **every** selected row flipped green at once.

## Fix

`evt.Index` is 1-based and matches the order `runPlaudSyncPipeline` iterates `recordingIDs`, so `recordingIDs[Index-1]` is exactly the item that finished. Update only that row, with its real outcome (synced/failed).

Darwin-only (menubar callback). `go build ./...` + `go vet` clean.

Follow-up noted (not in this PR): a failed ER1 upload that falls back to a local save still counts as `Success`/`synced` — worth a distinct "saved-local" status later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)