### PR TITLE
feat(er1): position captures at real recording time, not import time

### DIFF
--- a/cmd/m3c-tools/commands_shared.go
+++ b/cmd/m3c-tools/commands_shared.go
@@ -85,6 +85,7 @@ func cmdRetry(args []string) {
 			AudioFilename:      entry.AudioPath,
 			ImageFilename:      entry.ImagePath,
 			Tags:               entry.Tags,
+			CurrentTime:        entry.CurrentTime, // keep the real capture time on retry
 		}
 		if entry.TranscriptPath != "" {
 			if data, readErr := os.ReadFile(entry.TranscriptPath); readErr == nil {

--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -1232,9 +1232,15 @@ func runAudioImportPipeline(sourceDir, dbPath, onlySourcePath string, app *menub
 		_ = filesDB.RecordTranscript(imp.Hash, "audio", strings.TrimSpace(text), lang)
 
 		now := time.Now()
+		// Real capture time = the source file's mtime, so the item is positioned
+		// at when it was recorded rather than the import moment.
+		captureTime := now
+		if fi, statErr := os.Stat(imp.Source); statErr == nil {
+			captureTime = fi.ModTime()
+		}
 		doc := (&impression.CompositeDoc{
 			ObsType:        impression.Import,
-			Timestamp:      now,
+			Timestamp:      captureTime,
 			TranscriptText: strings.TrimSpace(text),
 			ImpressionText: fmt.Sprintf("Imported audio file: %s\nSource: %s\nTags: %s", filepath.Base(imp.Dest), imp.Source, imp.Tags),
 		}).Build()
@@ -1248,6 +1254,7 @@ func runAudioImportPipeline(sourceDir, dbPath, onlySourcePath string, app *menub
 			ImageFilename:      "placeholder-logo.png",
 			Tags:               imp.Tags,
 			ContentType:        cfg.ContentType,
+			CurrentTime:        er1.FormatCaptureTime(captureTime),
 		}
 
 		if onProgress != nil {
@@ -1476,6 +1483,7 @@ func reprocessAudioFile(srcPath, dbPath string, app *menubar.App, onProgress fun
 		Tags:               tags,
 		ContentType:        cfg.ContentType,
 		DocID:              existingDocID, // Reuse existing doc_id if available.
+		CurrentTime:        er1.FormatCaptureTime(info.ModTime()), // position at real file time
 	}
 
 	if existingDocID != "" {
@@ -5010,6 +5018,7 @@ func runPlaudSyncPipeline(client *plaud.Client, cfg *plaud.Config, recordingIDs 
 			Tags:          tags,
 			ContentType:   cfg.ContentType,
 			DoTranscribe:  doTranscribe,
+			CurrentTime:   er1.FormatCaptureTime(rec.CreatedAt), // position at real recording time
 		}
 		// Only send transcript when Plaud provided one.
 		if hasPlaudTranscript {
@@ -5492,6 +5501,7 @@ func pocketCloudSyncSelected(
 			Tags:               tagsStr,
 			ContentType:        pcfg.ContentType,
 			DoTranscribe:       false,
+			CurrentTime:        er1.FormatCaptureTime(full.RecordingAt), // position at real recording time
 		}
 		resp, err := er1.Upload(er1Cfg, payload)
 		if err != nil {
@@ -5794,6 +5804,7 @@ func pocketSyncSelected(selected []pocket.Recording, tags []string, cfg *pocket.
 			AudioFilename:      filepath.Base(stagedPath),
 			ContentType:        cfg.ContentType,
 			Tags:               strings.Join(tags, ","),
+			CurrentTime:        er1.FormatCaptureTime(selected[i].Timestamp), // position at real capture time
 		}
 		resp, uploadErr := er1.Upload(er1Cfg, payload)
 		if uploadErr != nil {

--- a/cmd/m3c-tools/main_other.go
+++ b/cmd/m3c-tools/main_other.go
@@ -833,6 +833,7 @@ func runPlaudSyncPipeline(client *plaud.Client, cfg *plaud.Config, recordingIDs 
 			ImageFilename:      "plaud-logo.png",
 			Tags:               tags,
 			ContentType:        cfg.ContentType,
+			CurrentTime:        er1.FormatCaptureTime(rec.CreatedAt), // position at real recording time
 		}
 
 		resp, upErr := er1.Upload(er1Cfg, payload)

--- a/e2e/er1_itemurl_test.go
+++ b/e2e/er1_itemurl_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
 	"github.com/kamir/m3c-tools/pkg/er1"
 )
@@ -31,5 +32,15 @@ func TestMemoryItemURL(t *testing.T) {
 				t.Errorf("MemoryItemURL(%q) = %q; want %q", tt.docID, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFormatCaptureTime(t *testing.T) {
+	if got := er1.FormatCaptureTime(time.Time{}); got != "" {
+		t.Errorf("zero time should format to empty, got %q", got)
+	}
+	ts := time.Date(2026, 5, 19, 14, 3, 49, 0, time.UTC)
+	if got, want := er1.FormatCaptureTime(ts), "2026-05-19 14:03:49"; got != want {
+		t.Errorf("FormatCaptureTime = %q; want %q", got, want)
 	}
 }

--- a/pkg/er1/queue.go
+++ b/pkg/er1/queue.go
@@ -28,6 +28,7 @@ type QueueEntry struct {
 	AudioPath      string    `json:"audio_path,omitempty"`
 	ImagePath      string    `json:"image_path,omitempty"`
 	Tags           string    `json:"tags"`
+	CurrentTime    string    `json:"current_time,omitempty"` // real capture time; preserved across retries
 	QueuedAt       time.Time `json:"queued_at"`
 	LastRetry      time.Time `json:"last_retry,omitempty"`
 	RetryCount     int       `json:"retry_count"`
@@ -132,6 +133,7 @@ func EnqueueFailure(queuePath string, videoID string, payload *UploadPayload, ta
 		AudioPath:      payload.AudioFilename,
 		ImagePath:      payload.ImageFilename,
 		Tags:           tags,
+		CurrentTime:    payload.CurrentTime, // preserve real capture time across retries
 	}
 	if uploadErr != nil {
 		entry.LastError = uploadErr.Error()

--- a/pkg/er1/upload.go
+++ b/pkg/er1/upload.go
@@ -27,6 +27,9 @@ type UploadPayload struct {
 	ContentType        string // per-observation content type (overrides cfg.ContentType if set)
 	DocID              string // if set, request ER1 to overwrite this existing document
 	DoTranscribe       bool   // if true, send DO_TRANSCRIBE=true — server transcribes audio
+	CurrentTime        string // real capture time "2006-01-02 15:04:05"; empty → server stamps now.
+	// Positions the item at its true creation time in the memory viewer instead
+	// of the import time — important for multi-device capture (SPEC-0117).
 }
 
 // UploadResponse is the parsed response from ER1 on success.
@@ -66,6 +69,10 @@ func Upload(cfg *Config, payload *UploadPayload) (*UploadResponse, error) {
 	}
 	if payload.DoTranscribe {
 		_ = writer.WriteField("DO_TRANSCRIBE", "true")
+	}
+	if payload.CurrentTime != "" {
+		// Real capture time — the server positions the item here instead of "now".
+		_ = writer.WriteField("current_time", payload.CurrentTime)
 	}
 
 	// Transcript (optional — omit to let server handle transcription)
@@ -190,6 +197,19 @@ func truncate(s string, n int) string {
 		return s[:n] + "..."
 	}
 	return s
+}
+
+// CaptureTimeLayout is the timestamp format ER1 stores in `current_time` and
+// sorts the memory viewer by ("YYYY-MM-DD HH:MM:SS").
+const CaptureTimeLayout = "2006-01-02 15:04:05"
+
+// FormatCaptureTime formats a capture time for UploadPayload.CurrentTime.
+// A zero time yields "" so the caller omits the field and the server stamps now.
+func FormatCaptureTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(CaptureTimeLayout)
 }
 
 func isAudioImportPayload(contentType, tags string) bool {


### PR DESCRIPTION
The ER1 memory viewer sorts by `current_time`. m3c-tools sent none, so aims-core stamped the **import moment** — old Plaud/Pocket recordings imported today all piled up at "today", and the same item landed at different positions depending on which device/when it was imported (bad for multi-device work).

## Change
Every capture source now sends its **real capture time** as `current_time`:
- `pkg/er1`: `UploadPayload.CurrentTime` + `Upload` writes the field; `FormatCaptureTime(t)` (zero → `""` so the server keeps "now").
- `pkg/er1`: `QueueEntry.CurrentTime` — preserved across retries.
- **Plaud** (darwin + non-darwin): `rec.CreatedAt`.
- **Pocket** (cloud + menubar): recording `Timestamp` / `RecordingAt`.
- **Audio import**: source file mtime (import + reprocess).

Pairs with the aims-core change that **honors** a client `current_time` (BUG-0170, separate PR). Both are needed — without the server change this is inert. Offline `TestFormatCaptureTime` added; `go build ./...` + linux cross-build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)