### PR TITLE
feat(plaud): plaud fix-times — backfill real recording time onto synced items

### DIFF
--- a/cmd/m3c-tools/commands_shared.go
+++ b/cmd/m3c-tools/commands_shared.go
@@ -711,3 +711,94 @@ func cmdPlaudCheck() {
 		}
 	}
 }
+
+// cmdPlaudFixTimes backfills the real recording time onto already-synced Plaud
+// items: it PATCHes each synced item's ER1 current_time to its Plaud CreatedAt,
+// so they move from the import moment to their true position in the memory
+// viewer. Dry-run by default; pass apply=true to actually write.
+func cmdPlaudFixTimes(apply bool) {
+	cfg := plaud.LoadConfig()
+	session, err := plaud.LoadToken(cfg.TokenPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading token: %v\nRun: m3c-tools plaud auth --from-er1   (or: m3c-tools plaud auth login)\n", err)
+		os.Exit(1)
+	}
+	client := plaud.NewClient(cfg, session.Token)
+	recordings, err := client.ListRecordings()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing recordings: %v\n", err)
+		os.Exit(1)
+	}
+
+	ids := make([]string, len(recordings))
+	for i, r := range recordings {
+		ids[i] = r.ID
+	}
+	states := resolvePlaudSyncStates(ids, session.Token)
+	er1Cfg := er1.LoadConfig()
+
+	type fixItem struct {
+		title  string
+		docID  string
+		target string
+	}
+	var toFix []fixItem
+	var skippedNoDoc, skippedNoTime int
+	for _, r := range recordings {
+		st := states[r.ID]
+		if st.Status != "synced" {
+			continue
+		}
+		if st.DocID == "" {
+			skippedNoDoc++ // synced on another device; doc_id unknown here
+			continue
+		}
+		target := er1.FormatCaptureTime(r.CreatedAt)
+		if target == "" {
+			skippedNoTime++ // no recording time from Plaud
+			continue
+		}
+		toFix = append(toFix, fixItem{title: r.Title, docID: st.DocID, target: target})
+	}
+
+	fmt.Printf("Plaud fix-times — %d synced items to correct to their real recording time\n", len(toFix))
+	if skippedNoDoc > 0 {
+		fmt.Printf("  (%d synced items skipped: doc_id not known locally — run on the device that synced them)\n", skippedNoDoc)
+	}
+	if skippedNoTime > 0 {
+		fmt.Printf("  (%d skipped: no recording time from Plaud)\n", skippedNoTime)
+	}
+
+	if !apply {
+		fmt.Println("\nDRY-RUN — pass --apply to write. recording -> doc_id -> new current_time:")
+		for _, f := range toFix {
+			fmt.Printf("  %-40s  doc_id=%s  ->  %s\n", truncateStr(f.title, 40), f.docID, f.target)
+		}
+		fmt.Printf("\n%d item(s) would be updated. Re-run with: m3c-tools plaud fix-times --apply\n", len(toFix))
+		return
+	}
+
+	ok, failed := 0, 0
+	for _, f := range toFix {
+		if err := er1.PatchMemoryCurrentTime(er1Cfg, f.docID, f.target); err != nil {
+			failed++
+			log.Printf("[plaud] fix-times FAIL doc_id=%s: %v", f.docID, err)
+		} else {
+			ok++
+			log.Printf("[plaud] fix-times OK doc_id=%s -> %s", f.docID, f.target)
+		}
+	}
+	fmt.Printf("Done: %d updated, %d failed (of %d)\n", ok, failed, len(toFix))
+}
+
+// truncateStr shortens s to at most n runes with an ellipsis (portable; the
+// darwin build has its own truncate()).
+func truncateStr(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 3 {
+		return s[:n]
+	}
+	return s[:n-3] + "..."
+}

--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -233,6 +233,7 @@ Commands:
 
   plaud list             List Plaud recordings with sync status + ER1 doc_id
   plaud check            Sync-coverage report: how many synced/unsynced + doc_id links
+  plaud fix-times        Backfill real recording time onto synced items (--apply to write)
   plaud sync <id>        Sync a Plaud recording to ER1
   plaud sync --all       Sync all new Plaud recordings to ER1
   plaud auth login       Extract token from Chrome (web.plaud.ai)
@@ -4360,7 +4361,7 @@ func menubarWhisperTimeout() time.Duration {
 
 func cmdPlaud(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud <list|check|sync|auth> [args]")
+		fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud <list|check|sync|fix-times|auth> [args]")
 		os.Exit(1)
 	}
 	switch args[0] {
@@ -4368,6 +4369,14 @@ func cmdPlaud(args []string) {
 		cmdPlaudList()
 	case "check":
 		cmdPlaudCheck()
+	case "fix-times":
+		apply := false
+		for _, a := range args[1:] {
+			if a == "--apply" {
+				apply = true
+			}
+		}
+		cmdPlaudFixTimes(apply)
 	case "sync":
 		if len(args) < 2 {
 			fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud sync <#|ID|--all> [flags]")

--- a/cmd/m3c-tools/main_other.go
+++ b/cmd/m3c-tools/main_other.go
@@ -384,7 +384,7 @@ func cmdTranscript(args []string) {
 // cmdPlaud handles plaud subcommands: auth, list, sync.
 func cmdPlaud(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud <auth|list|check|sync> [args...]")
+		fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud <auth|list|check|sync|fix-times> [args...]")
 		os.Exit(1)
 	}
 
@@ -395,6 +395,14 @@ func cmdPlaud(args []string) {
 		cmdPlaudList()
 	case "check":
 		cmdPlaudCheck()
+	case "fix-times":
+		apply := false
+		for _, a := range args[1:] {
+			if a == "--apply" {
+				apply = true
+			}
+		}
+		cmdPlaudFixTimes(apply)
 	case "sync":
 		if len(args) < 2 {
 			fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud sync <#|ID|--all> [-f]")

--- a/pkg/er1/upload.go
+++ b/pkg/er1/upload.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"os"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -197,6 +198,51 @@ func truncate(s string, n int) string {
 		return s[:n] + "..."
 	}
 	return s
+}
+
+// PatchMemoryCurrentTime updates an already-stored ER1 memory item's
+// `current_time` (the memory-viewer sort position) via
+// PATCH /memory/<ctx>/<docID>. Used by `plaud fix-times` to backfill the real
+// recording time onto items that were synced before capture-time support —
+// no audio re-upload, no transcription disruption. currentTime must be
+// "2006-01-02 15:04:05".
+func PatchMemoryCurrentTime(cfg *Config, docID, currentTime string) error {
+	if docID == "" || currentTime == "" {
+		return fmt.Errorf("doc_id and current_time are required")
+	}
+	if cfg.APIKey == "" && os.Getenv("ER1_DEVICE_TOKEN") == "" {
+		return fmt.Errorf("no authentication configured")
+	}
+	base := strings.TrimSuffix(cfg.APIURL, "/upload_2")
+	base = strings.TrimSuffix(base, "/upload")
+	base = strings.TrimSuffix(base, "/")
+	endpoint := fmt.Sprintf("%s/memory/%s/%s", base, cfg.ContextID, docID)
+
+	form := url.Values{}
+	form.Set("current_time", currentTime)
+	req, err := http.NewRequest("PATCH", endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for k, v := range cfg.AuthHeaders() {
+		req.Header.Set(k, v)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second, CheckRedirect: httpsafe.NoCredentialRedirect}
+	if !cfg.VerifySSL {
+		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("PATCH current_time HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+	return nil
 }
 
 // CaptureTimeLayout is the timestamp format ER1 stores in `current_time` and


### PR DESCRIPTION
Corrects the memory-viewer position of **already-synced** Plaud items (which carry the *import* time) to their **true recording time** — no re-upload, no transcription disruption. **Dry-run by default**; `--apply` writes.

- `pkg/er1`: `PatchMemoryCurrentTime()` → `PATCH /memory/<ctx>/<docID>` with `current_time` (uses the extended aims-core endpoint, my-ai-X #67).
- `cmd` (shared): `cmdPlaudFixTimes(apply)` — resolves synced recording→doc_id via the server sync check, PATCHes each to `rec.CreatedAt`. Wired on darwin + non-darwin; help/usage updated.

Verified dry-run against the live account: **76 synced items** resolved to their Plaud recording times. Needs the aims-core PATCH extension deployed (bundle with BUG-0170).

🤖 Generated with [Claude Code](https://claude.com/claude-code)