### PR TITLE
feat(cli): ASCII-art + version banner on menu-bar / tray startup

### DIFF
--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -1770,6 +1770,7 @@ func cmdMenubar(args []string) {
 		log.SetFlags(log.Ldate | log.Ltime)
 	}
 
+	startupBanner()
 	// Fix 3 (BUG-0003): Print log file path on startup so user knows where to look.
 	fmt.Fprintf(os.Stderr, "m3c-tools menubar started. Logs: %s\n", cfg.LogPath)
 

--- a/cmd/m3c-tools/main_other.go
+++ b/cmd/m3c-tools/main_other.go
@@ -1443,6 +1443,7 @@ func cmdTrayApp(args []string) {
 		}
 		log.SetFlags(log.Ldate | log.Ltime)
 	}
+	startupBanner()
 	fmt.Fprintf(os.Stderr, "m3c-tools tray started. Logs: %s\n", logPath)
 
 	// Auto-configure from ~/m3c-tools.init.cfg if present (zero-touch onboarding).

--- a/cmd/m3c-tools/version.go
+++ b/cmd/m3c-tools/version.go
@@ -19,3 +19,20 @@ var (
 func printVersion() {
 	fmt.Printf("m3c-tools %s (commit=%s, built=%s)\n", version, commit, date)
 }
+
+// bannerArt is the "M3C" ANSI-shadow logo shown at menu-bar / tray startup.
+const bannerArt = `
+  ███╗   ███╗ ██████╗  ██████╗
+  ████╗ ████║ ╚════██╗██╔════╝
+  ██╔████╔██║  █████╔╝██║
+  ██║╚██╔╝██║  ╚═══██╗██║
+  ██║ ╚═╝ ██║ ██████╔╝╚██████╗
+  ╚═╝     ╚═╝ ╚═════╝  ╚═════╝
+`
+
+// startupBanner prints the logo, tagline, and build version when the app starts.
+func startupBanner() {
+	fmt.Print(bannerArt)
+	fmt.Println("  m3c-tools · Multi-Modal-Memory Capture")
+	fmt.Printf("  version %s  ·  commit %s  ·  built %s\n\n", version, commit, date)
+}


### PR DESCRIPTION
Startup printed only `m3c-tools menubar started. Logs: …`. Add a proper **banner** — an "M3C" ANSI-shadow logo, the tagline, and the ldflags-stamped build version (`version · commit · built`) — shown right before the started line on both the darwin menu-bar and the non-darwin tray.

```
  ███╗   ███╗ ██████╗  ██████╗
  ████╗ ████║ ╚════██╗██╔════╝
  ██╔████╔██║  █████╔╝██║
  ██║╚██╔╝██║  ╚═══██╗██║
  ██║ ╚═╝ ██║ ██████╔╝╚██████╗
  ╚═╝     ╚═╝ ╚═════╝  ╚═════╝

  m3c-tools · Multi-Modal-Memory Capture
  version v2.7.5  ·  commit … ·  built …
```

`version.go` gains `startupBanner()` (no build tags, shared by both entry points). `go build ./...` + linux cross-build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)