### PR TITLE
fix(plaud): 3 sync-panel bugs — deselect label, progress counter, doc_id back-fill

### DIFF
--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -5105,6 +5105,7 @@ func runPlaudSyncPipeline(client *plaud.Client, cfg *plaud.Config, recordingIDs 
 				Total: summary.Total, Outcome: "ok",
 				Done: i + 1, Success: summary.Success, Failed: summary.Failed,
 				CurrentFile: itemName, Phase: menubar.BulkPhaseDone,
+				DocID: resp.DocID, // back-fill the doc_id into the panel row
 			})
 		}
 	}
@@ -5280,31 +5281,51 @@ func menubarHandlePlaudSync(app *menubar.App) {
 			Active: true, Total: len(recordingIDs),
 		})
 
+		// The pipeline's events are inconsistent (ITEM_PHASE carries Total but
+		// Done=0; ITEM_START neither), which made the progress bar oscillate
+		// 0↔N and never show a real "N of M". Derive Done from evt.Index (1-based,
+		// present on every event) and keep success/failed monotonic so the
+		// counter never flickers back to 0.
+		er1Cfg := er1.LoadConfig()
+		total := len(recordingIDs)
+		lastSuccess, lastFailed := 0, 0
 		onProgress := func(evt menubar.BulkProgressEvent) {
-			state := menubar.BulkRunState{
+			if evt.Success > lastSuccess {
+				lastSuccess = evt.Success
+			}
+			if evt.Failed > lastFailed {
+				lastFailed = evt.Failed
+			}
+			done := evt.Index
+			if done < 1 {
+				done = 1
+			}
+			if done > total {
+				done = total
+			}
+			menubar.SetPlaudSyncProgress(menubar.BulkRunState{
 				Active:      true,
-				Total:       evt.Total,
-				Done:        evt.Done,
-				Success:     evt.Success,
-				Failed:      evt.Failed,
+				Total:       total,
+				Done:        done,
+				Success:     lastSuccess,
+				Failed:      lastFailed,
 				CurrentFile: evt.CurrentFile,
 				Phase:       evt.Phase,
-			}
-			menubar.SetPlaudSyncProgress(state)
+			})
 
 			if evt.Event == "ITEM_DONE" {
 				status := "synced"
 				if evt.Outcome == "failed" {
 					status = "failed"
 				}
-				// Update ONLY the row that actually finished. evt.Index is
-				// 1-based and matches the order runPlaudSyncPipeline iterates
-				// recordingIDs, so recordingIDs[Index-1] is this item. The old
-				// code looped over ALL recordingIDs and flipped every selected
-				// row to "synced" as soon as the FIRST item completed — the
-				// "upload already happened" illusion.
+				// Update ONLY the row that finished (evt.Index is 1-based).
 				if idx := evt.Index - 1; idx >= 0 && idx < len(recordingIDs) {
 					menubar.SetPlaudSyncStatus(recordingIDs[idx], status)
+					// Back-fill the ER1 doc_id + item URL so the row shows its
+					// doc_id (and double-click opens it) right after syncing.
+					if evt.DocID != "" {
+						menubar.SetPlaudSyncRowDoc(recordingIDs[idx], evt.DocID, er1Cfg.MemoryItemURL(evt.DocID))
+					}
 				}
 			}
 		}

--- a/pkg/bulkprogress/bulkprogress.go
+++ b/pkg/bulkprogress/bulkprogress.go
@@ -39,4 +39,5 @@ type Event struct {
 	Elapsed     time.Duration
 	Error       string
 	CurrentFile string
+	DocID       string // ER1 doc_id on a successful ITEM_DONE (for UI back-fill)
 }

--- a/pkg/menubar/plaud_sync.go
+++ b/pkg/menubar/plaud_sync.go
@@ -44,6 +44,9 @@ func GetPlaudCustomTags() string { return "" }
 // SetPlaudSyncStatus is a no-op on non-darwin platforms.
 func SetPlaudSyncStatus(recordingID, status string) {}
 
+// SetPlaudSyncRowDoc is a no-op on non-darwin platforms.
+func SetPlaudSyncRowDoc(recordingID, docID, itemURL string) {}
+
 // SetPlaudSyncProgress is a no-op on non-darwin platforms.
 func SetPlaudSyncProgress(state BulkRunState) {}
 

--- a/pkg/menubar/plaud_sync_darwin.go
+++ b/pkg/menubar/plaud_sync_darwin.go
@@ -132,6 +132,23 @@ static void setPlaudRowStatus(const char *recordingID, const char *status) {
 	reloadPlaudTable();
 }
 
+// Back-fill a row's ER1 doc_id + item URL after it syncs, so the "ER1 Doc"
+// column populates and double-click opens the item.
+static void setPlaudRowDoc(const char *recordingID, const char *docID, const char *itemURL) {
+	if (!recordingID) return;
+	for (int i = 0; i < g_plaudRowCount; i++) {
+		if (!g_plaudRecordingIDs[i]) continue;
+		if (strcmp(g_plaudRecordingIDs[i], recordingID) == 0) {
+			if (g_plaudDocIDs[i])   free(g_plaudDocIDs[i]);
+			g_plaudDocIDs[i]   = strdup(docID   ? docID   : "");
+			if (g_plaudItemURLs[i]) free(g_plaudItemURLs[i]);
+			g_plaudItemURLs[i] = strdup(itemURL ? itemURL : "");
+			break;
+		}
+	}
+	reloadPlaudTable();
+}
+
 static void setPlaudProgressState(int active, int total, int done, int success, int failed) {
 	g_plaudBulkActive = active ? YES : NO;
 	dispatch_async(dispatch_get_main_queue(), ^{
@@ -382,7 +399,7 @@ static void showPlaudSyncWindow(const char *accountInfo) {
 		[content addSubview:btnSelectAll];
 
 		NSButton *btnDeselectAll = [[NSButton alloc] initWithFrame:NSMakeRect(112, btnY, 96, 24)];
-		[btnDeselectAll setTitle:@"Select None"];
+		[btnDeselectAll setTitle:@"Deselect"];
 		[btnDeselectAll setBezelStyle:NSBezelStyleRounded];
 		[btnDeselectAll setAutoresizingMask:NSViewMaxXMargin | NSViewMinYMargin];
 		[content addSubview:btnDeselectAll];
@@ -583,6 +600,18 @@ func SetPlaudSyncStatus(recordingID, status string) {
 	C.setPlaudRowStatus(cID, cStatus)
 	C.free(unsafe.Pointer(cID))
 	C.free(unsafe.Pointer(cStatus))
+}
+
+// SetPlaudSyncRowDoc back-fills a row's ER1 doc_id + item URL after it syncs,
+// so the "ER1 Doc" column populates and double-click opens the item.
+func SetPlaudSyncRowDoc(recordingID, docID, itemURL string) {
+	cID := C.CString(recordingID)
+	cDoc := C.CString(docID)
+	cURL := C.CString(itemURL)
+	C.setPlaudRowDoc(cID, cDoc, cURL)
+	C.free(unsafe.Pointer(cID))
+	C.free(unsafe.Pointer(cDoc))
+	C.free(unsafe.Pointer(cURL))
 }
 
 // SetPlaudSyncProgress updates the progress bar and status label.


### PR DESCRIPTION
Three bugs reported on the rebuilt Plaud sync panel:

1. **Deselect label.** The second button ("Select None") truncated to "Select" and read like a duplicate → renamed to **"Deselect"**.
2. **Progress counter.** The bar only showed the first item and no "N of M" text. The pipeline's events are inconsistent (`ITEM_PHASE` carries `Total` but `Done=0`; `ITEM_START` neither), so the bar oscillated 0↔N. Fixed centrally in `onProgress`: derive `Done` from `evt.Index` (1-based, on every event) + keep success/failed monotonic → bar advances 1→N, status reads "Syncing N/total".
3. **doc_id after sync.** A freshly-synced row flipped to "synced" but its **ER1 Doc** column stayed empty. The success `ITEM_DONE` now carries `resp.DocID` (new `bulkprogress.Event.DocID`), and the callback back-fills the row via `SetPlaudSyncRowDoc` (doc_id + item URL, so double-click works too).

Darwin menubar (cgo) + one shared struct field. `go build ./...` + linux cross + `go vet` clean. Takes effect after a menubar rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)