### PR TITLE
fix(er1): PatchMemoryCurrentTime must send X-API-KEY (PATCH /memory enforces CSRF)

### DIFF
--- a/pkg/er1/upload.go
+++ b/pkg/er1/upload.go
@@ -225,8 +225,22 @@ func PatchMemoryCurrentTime(cfg *Config, docID, currentTime string) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	for k, v := range cfg.AuthHeaders() {
-		req.Header.Set(k, v)
+	// The /memory PATCH route enforces CSRF for a Bearer-only (session-style)
+	// request but exempts API-key clients — so send X-API-KEY (not just the
+	// device-token Bearer that AuthHeaders() prefers), else every PATCH 400s
+	// with "CSRF token missing". Both headers are safe; the server accepts the key.
+	if cfg.APIKey != "" {
+		req.Header.Set("X-API-KEY", cfg.APIKey)
+	}
+	if token := os.Getenv("ER1_DEVICE_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if cfg.APIKey == "" {
+		// No API key — fall back to the standard headers (may hit CSRF; the
+		// real fix is a server-side CSRF exemption for token auth on this route).
+		for k, v := range cfg.AuthHeaders() {
+			req.Header.Set(k, v)
+		}
 	}
 
 	client := &http.Client{Timeout: 30 * time.Second, CheckRedirect: httpsafe.NoCredentialRedirect}


### PR DESCRIPTION
`plaud fix-times --apply` 400'd on prod with **"CSRF token missing"**: the `/memory` PATCH route enforces CSRF for a Bearer-only (session-style) request but exempts API-key clients. `PatchMemoryCurrentTime` used `cfg.AuthHeaders()`, which prefers the device-token **Bearer** when present and omits X-API-KEY — so every PATCH was rejected before reaching the handler.

Fix: send **X-API-KEY** explicitly (plus the Bearer) when an API key is configured; fall back to `AuthHeaders()` only when there is no key.

**Verified live:** with the key header, `current_time` PATCH returns 200 and `fix-times` corrected **103 items, 0 failed** — the backfill is done.

Follow-up (server, aims-core, s-cew-owner): CSRF-exempt the `/memory` PATCH route for token auth so it works without an API key too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)