### PR TITLE
chore(release): publish skillctl-demo artifacts (linux+windows)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,8 +127,10 @@ jobs:
           path: |
             dist/m3c-tools-linux-*.tar.gz
             dist/skillctl-linux-*.tar.gz
+            dist/skillctl-demo-linux-*.tar.gz
             dist/m3c-tools-windows-*.zip
             dist/skillctl-windows-*.zip
+            dist/skillctl-demo-windows-*.zip
 
   # -----------------------------------------------------------------------
   # Windows NSIS installer
@@ -210,5 +212,8 @@ jobs:
             artifacts/skillctl-linux-amd64.tar.gz
             artifacts/skillctl-linux-arm64.tar.gz
             artifacts/skillctl-windows-amd64.zip
+            artifacts/skillctl-demo-linux-amd64.tar.gz
+            artifacts/skillctl-demo-linux-arm64.tar.gz
+            artifacts/skillctl-demo-windows-amd64.zip
             artifacts/M3C-Tools-Setup.exe
             artifacts/checksums.txt


### PR DESCRIPTION
Pre-req for the **v2.8.0** release. `.goreleaser.yml` (added in #69) already **builds** the skillctl-demo archives, but `release.yml` didn't carry them to the GitHub Release — so the flagship demo would build but never ship.

- Add `dist/skillctl-demo-{linux-*.tar.gz,windows-*.zip}` to the *Upload GoReleaser artifacts* step.
- Add the three demo assets to the `softprops/action-gh-release` `files:` list.

**Validated locally** against the exact release commit (`35e06a9`): installed goreleaser, ran `goreleaser release --snapshot --skip=publish --clean` → succeeds in 40s and produces `skillctl-demo-linux-amd64.tar.gz`, `skillctl-demo-linux-arm64.tar.gz`, `skillctl-demo-windows-amd64.zip`. (`goreleaser check` also flags two *deprecated* archive keys — `archives.builds`, `format_overrides.format` — warnings only; `release` succeeds. Tracked as follow-up tech-debt, not touched here.)

After merge, v2.8.0 is tagged on the resulting master HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)