### PR TITLE
docs: refresh CLI surfaces + skillctl manual + new demo quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,20 @@ Capture → Preview + Record → Whisper transcribe → Tag editor → Store to 
 Each observation becomes a multimodal ER1 document — text + audio + image, with tags and
 metadata. On macOS this is a native menu-bar app; on Linux/Windows it's a full CLI.
 Even without a transcript (e.g. subtitles disabled), a YouTube capture still keeps the
-thumbnail and the link.
+thumbnail and the source link — the observation lands regardless.
+
+**Field recordings, positioned in real time.** `m3c-tools plaud` drains your Plaud.ai
+recordings — customer visits (*Kundenbesuche*), meetings and field notes — straight into
+ER1, and `m3c-tools pocket` does the same for a Pocket device. Synced items are placed at
+their **true recording time**, not the moment you synced them (`plaud fix-times` backfills
+earlier imports), so captures from multiple devices land on the timeline where they
+actually happened.
 
 **Command surface:** `transcript`, `upload`, `whisper`, `thumbnail`, `record`, `screenshot`,
-`import-audio`, `plaud`, `pocket`, `retry`, `schedule`, `status`, `doctor`, `login`,
-`setup`, `menubar`. See the [m3c-tools manual](docs/manual-m3c-tools.md).
+`import-audio` (capture); `plaud` (`list` · `check` · `sync` · `fix-times` · `auth`) and
+`pocket` (field-recording sync); `retry`, `cancel`, `schedule`, `status` (ER1 queue);
+`doctor`, `check-er1`, `config` (incl. `doctor`), `settings`, `token`, `devices`, `login`,
+`setup`, `menubar` (setup & diagnostics). See the [m3c-tools manual](docs/manual-m3c-tools.md).
 
 ## What `skillctl` governs
 
@@ -122,9 +131,11 @@ author → pack → sign → admit → attest → verify / install → use → a
 - **Auditable.** A local transparency log (`translog`) and a Claude Code trust gate
   (`verify-hook`) that fails closed.
 
-**Command surface:** `keygen`, `pack`, `sign`, `verify-sig`, `trust`, `install`, `verify`,
-`attest`, `revoke`, `audit`, `publish`, `pull`, `registry`, `agentid`, `translog`,
-`verify-hook`, `gate-stats`, `project`, `session`. See the [skillctl manual](docs/manual-skillctl.md).
+**Command surface** — *authoring:* `keygen`, `pack`, `sign`, `verify-sig`; *trust & install:*
+`trust`, `install`, `verify`, `verify-hook`; *governance:* `attest`, `revoke`, `agentid`,
+`publish`, `pull`, `registry`; *audit & transparency:* `audit`, `seal`, `scan`, `review`,
+`propose`, `translog`, `gate-stats`; plus `project`, `session`.
+See the [skillctl manual](docs/manual-skillctl.md).
 
 ---
 
@@ -134,6 +145,7 @@ author → pack → sign → admit → attest → verify / install → use → a
 |------|-----|
 | [**Quickstart: m3c-tools**](docs/quickstart-m3c-tools.md) | Capture your first memory in 5 minutes |
 | [**Quickstart: skillctl**](docs/quickstart-skillctl.md) | Sign, install and verify a skill in 5 minutes |
+| [**Quickstart: skillctl-demo**](docs/quickstart-skillctl-demo.md) | Run the skill-trust scenarios offline on your own machine — 3 run live with real exit codes (S1/S2A/S5); the remaining panels render their story but run nothing (S3 is a built-but-not-run PARTIAL, S2BC/S4 are ROADMAP) — plus Kata training (planned) |
 | [**Manual: m3c-tools**](docs/manual-m3c-tools.md) | Every command, flag and config variable |
 | [**Manual: skillctl**](docs/manual-skillctl.md) | The full trust lifecycle, command by command |
 | [Menu Bar App](docs/menubar-app.md) | Channels, Observation Window, menu items (macOS) |

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -86,17 +86,25 @@ automation can branch precisely. This is the authoritative table, sourced from
 
 Additional codes surface in specific commands:
 
-| Code | Command | Meaning |
-|-----:|---------|---------|
-| `18` | `intent declare` | intent inconsistent with `data_dependencies` (SPEC-0196 §3.3) |
-| `20` | `agentid verify` | approver-floor not met |
-| `21` | `agentid verify` | mandate expired |
-| `22` | `agentid verify` | revocation stale (SPEC-0279 freshness) |
-| `23` | `translog verify` | not included in the log |
-| `24` | `translog witness` | split-view (equivocation) detected |
+| Code | Command(s) | Meaning |
+|-----:|------------|---------|
+| `3` | `audit` | at least one skill is `BROKEN`. |
+| `4` | `import-public` | pin required (input validation). |
+| `5` | `import-public` | scanner refuse (scanner / policy hit). |
+| `6` | `import-public` | bodyscan refuse. |
+| `18` | `intent declare`, `import-public` | intent inconsistent with `data_dependencies` (SPEC-0196 §3.3); also intent-capped on import. |
+| `19` | `awareness reset`, `import-public` | identity mismatch — `client_identity` ≠ `admitted_by_identity`; also source-blocked on import. |
+| `20` | `agentid verify` | self-attested / approver-floor not met (reviewer_id == author_id; SPEC-0246 §5.2). |
+| `21` | `agentid verify` | AgentID mandate expired. |
+| `22` | `agentid verify`, `verify --bundle` | revocation snapshot stale — freshness fail-closed (SPEC-0279 R3). |
+| `23` | `translog verify`, `verify` | transparency-log inclusion missing / receipt not included (SPEC-0278 L1). |
+| `24` | `translog witness` | split-view (equivocation) detected. |
+| `25` | `translog consistency` | consistency / append-only rewrite violation detected. |
+| `32` | *(ROADMAP — not implemented)* | runtime capability-envelope (egress) violation. Appears **only** in the demo's ROADMAP scenario; **no** current `skillctl` subcommand emits it (the Go-native OS-level cage is FR-0044, pending). |
 
-`audit` uses its own scale: `0` all OK · `2` at least one `UNVERIFIED`/`BELOW_MIN` · `3` at
-least one `BROKEN`. `propose` uses `0` pass / `2` fail.
+`audit` uses its own scale: `0` all OK · `2` at least one `UNVERIFIED`/`BELOW_MIN` (or a
+G-23 confirm-delete precondition refusal on drift) · `3` at least one `BROKEN`. `propose` uses
+`0` pass / `2` gate failed.
 
 > Some commands print flags with a **single dash** in their own help output (e.g. `-key`,
 > `-out`). Both `-flag` and `--flag` are accepted. This manual reproduces flag names as the
@@ -365,12 +373,37 @@ Exit: `0` ok · `1` generic/network/non-2xx · `2` usage.
 
 ---
 
-### `revoke`
+### `revoke` — revoke an admitted bundle
 
-Revocation of skill bundles is issued through `publish --revoke` (see below); AgentID
-revocation is issued through `agentid revoke`. Both produce **signed, offline-verifiable**
-revocation lists that the verifier enforces with freshness contracts (SPEC-0279), failing
-closed on a stale or rolled-back list.
+```bash
+skillctl revoke <bundle-digest> --reason <code> [--registry <url>] [--timeout <duration>]
+```
+
+Revokes an admitted bundle (SPEC-0188 §4.5) by publishing a **signed, offline-verifiable**
+`BundleRevokedEvent` to the registry. The verifier then enforces it with freshness contracts
+(SPEC-0279), failing **closed** on a stale or rolled-back list. `<bundle-digest>` is the
+`sha256:<hex>` digest to revoke.
+
+| Flag | Purpose |
+|------|---------|
+| `-reason key_compromise\|vulnerability\|governance_retraction\|author_request\|duplicate` | Reason code. **Required.** |
+| `-actor-identity` | Revoke as a `governance_reviewer` (rather than the default `original_author`); pair with `--key`. |
+| `-key` | Signing key for the revocation event. Required for the `original_author` (default) and `governance_reviewer` roles. |
+| `-registry` | Registry base URL. |
+| `-timeout` | HTTP request timeout. |
+
+Three actor roles: **`original_author`** (the default — signs with the author key),
+**`governance_reviewer`** (`--actor-identity` + `--key`), and **`registry_operator`**
+(unsigned, operator-authenticated).
+
+```bash
+skillctl revoke sha256:<hex> --reason key_compromise --registry https://aims.example.com/api/skills
+```
+
+Related paths: `publish --revoke` posts the same `BundleRevokedEvent` to your personal ER1
+`self` registry (see [`publish`](#publish--admit--attest--revoke-via-er1-self-registry)), and
+`agentid revoke` adds `agent:<id>` to a signed AgentID revocation list. All three produce
+signed, offline-verifiable lists the verifier honours fail-closed.
 
 ---
 
@@ -381,27 +414,39 @@ skillctl audit [flags]
 ```
 
 Prints a per-skill verdict: `OK | UNVERIFIED | BROKEN | BELOW_MIN`. Cleanup is a G-23
-destructive-op **two-step** (dry-run token, then confirm).
+destructive-op **two-step** (a signed dry-run token, then a confirm that re-checks the live
+set). There is **no `--force`.**
 
 | Flag | Purpose |
 |------|---------|
 | `-minimum-governance green\|yellow\|red` | Floor below which a skill is flagged. Defaults to trust-roots `governance_minimum`, else green. |
 | `-format table\|json` | Output format (default: table on TTY, json on pipe). |
+| `-source claude\|user\|plugins\|all` | Skill source scope. |
 | `-include-shadowed` | Include shadowed skills (lower-tier names hidden by a higher-tier winner). |
 | `-cleanup` | After listing, delete affected skills (gated; requires `--dry-run-cleanup` or `--confirm-delete`). |
-| `-dry-run-cleanup` | Step 1: print the affected list + a signature token; no deletion. |
-| `-confirm-delete` | Step 2: actually delete; requires a fresh `--dry-run-cleanup-token`. |
-| `-dry-run-cleanup-token` | Token from a prior `--dry-run-cleanup`. |
+| `-dry-run-cleanup` | **Step 1**: print the affected set + a signed 5-minute token; **no deletion**. |
+| `-confirm-delete` | **Step 2**: actually delete; requires a fresh `--dry-run-cleanup-token`. |
+| `-dry-run-cleanup-token <sig>` | The token from a prior `--dry-run-cleanup`. |
 | `-keep-unverified` | Don't auto-clean `UNVERIFIED` skills under `--cleanup`. |
-| `-source` | Skill source scope. |
 
 ```bash
 skillctl audit
-skillctl audit --cleanup --dry-run-cleanup
-skillctl audit --cleanup --confirm-delete --dry-run-cleanup-token <sig>
+skillctl audit --cleanup --dry-run-cleanup                                  # step 1: plan + token
+skillctl audit --cleanup --confirm-delete --dry-run-cleanup-token <sig>     # step 2: re-check + delete
 ```
 
-Exit: `0` all OK · `2` ≥1 `UNVERIFIED`/`BELOW_MIN` · `3` ≥1 `BROKEN`.
+**The G-23 two-step contract.** Step 1 (`--cleanup --dry-run-cleanup`) computes the affected
+set and prints a **signed token** (an HMAC bound to the hostname, the sorted affected skill
+paths, and an issued-at timestamp) with a **5-minute** lifetime. It deletes nothing. Step 2
+(`--cleanup --confirm-delete --dry-run-cleanup-token <sig>`) **re-computes the live affected
+set and re-verifies the token against it.** If the set has **drifted** (a skill appeared,
+disappeared, or changed) — or the token expired or was tampered — the confirm **refuses** and
+exits `2` (a usage / precondition refusal), deleting nothing. Both the plan and the refusal
+are auditable, and there is **no `--force`** to bypass the re-check: a destructive op that no
+longer matches its approved plan simply does not run.
+
+Exit: `0` all OK · `2` ≥1 `UNVERIFIED`/`BELOW_MIN`, **or** a confirm-delete precondition
+refusal (drift/expiry/tamper) · `3` ≥1 `BROKEN`.
 
 ---
 

--- a/docs/quickstart-skillctl-demo.md
+++ b/docs/quickstart-skillctl-demo.md
@@ -1,0 +1,184 @@
+---
+layout: default
+title: Quickstart — skillctl-demo
+---
+
+# Quickstart: skillctl-demo
+
+Show a CISO the trust plane **containing a live attack** — a poisoned bundle refused with
+exit `10`, a governance action that refuses to be forced with exit `2` — in about five
+minutes, on a locked-down, **offline** laptop. No install, no admin, no server.
+
+> **What is skillctl-demo?** One self-contained, offline binary that **bundles the real
+> `skillctl`** and drives it through real trust scenarios in a hermetic sandbox. Every LIVE
+> verdict you see is a **real `skillctl` exit code** — nothing is simulated. A browser opens
+> to a live mirror (scenario graphics + a streaming terminal); the CLI runs the same deck.
+> For every underlying command and flag, see the [skillctl manual](manual-skillctl.md).
+
+> **Honesty rule (non-negotiable).** LIVE scenarios run the real `skillctl` and show its real
+> exit code. ROADMAP / PARTIAL panels **run nothing** and are labelled as such — the demo
+> never dresses a simulated output as a real verdict.
+
+---
+
+## 1. Run it
+
+The demo ships as a zip with two files: `skillctl-demo` and `skillctl` (plus embedded web
+assets). It is **offline, no admin, no install** — double-click or run it, and a browser
+opens.
+
+```bash
+./skillctl-demo
+```
+
+On launch it builds a hermetic sandbox (a throwaway `HOME` with its own keys, sample skills,
+a file-based registry and pinned trust-roots), locates the real `skillctl`, starts a web
+mirror on `127.0.0.1`, and opens your browser. It prints the sandbox `HOME`, the resolved
+`skillctl` path, and the mirror URL.
+
+### Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--mode guided\|kiosk` | `guided` (default): Enter advances each step; one pass, then it holds so the web mirror stays up. `kiosk`: timed auto-loop for a booth / screen-share. **These are the only two modes** — any other value is forced back to `guided`. |
+| `--kiosk-delay <dur>` | Auto-advance delay in kiosk mode (default `3s`). |
+| `--port <n>` | Web-mirror port on `127.0.0.1` (default `8765`). |
+| `--no-browser` | Do not auto-open the browser (print the URL only). |
+| `--no-web` | CLI only; do not start the web mirror. |
+| `--no-color` | Disable ANSI colour in the terminal. |
+| `--skillctl <path>` | Path to the real `skillctl` binary. Default search: `./build/skillctl` → next to this binary → `$PATH`. |
+| `--selftest` | Run the LIVE scenarios non-interactively and assert the real exit codes (see §4). |
+
+```bash
+./skillctl-demo --mode kiosk --kiosk-delay 5s      # booth loop
+./skillctl-demo --no-browser --port 9000           # headless / custom port
+./skillctl-demo --skillctl /usr/local/bin/skillctl # point at a specific skillctl
+```
+
+---
+
+## 2. The LIVE scenarios (real exit codes)
+
+These three run the real `skillctl` in the sandbox. Watch the exit-code badge flip.
+
+### S1 — Poisoned script → the signature prevents the run
+
+A signed `.skb` skill bundle is verified **offline** against a pinned key. An attacker edits a
+script *inside* the bundle to exfiltrate `~/.ssh` and reships it — one changed byte breaks the
+signed digest.
+
+```
+verify --bundle  →  0 (clean)  →  10 (digest mismatch, refused)
+```
+
+The signature does not *describe* the risk — it **prevents the run**. Nothing is written to
+`~/.claude/skills/`.
+
+### S2A — Post-install tamper → re-verify catches it
+
+An installed, green skill is edited on disk to smuggle a prompt-injection into `SKILL.md`. The
+load-time `PreToolUse(Skill)` gate re-runs the trust chain **before** Claude Code can load it,
+then a sweep quarantines it.
+
+```
+verify-hook  →  0 (allow)  →  2 (gate BLOCKS the tampered load)
+verify --all →  per-skill verdict 10 (digest mismatch)  →  quarantined
+```
+
+### S5 — Reversible governance / no-force (drift refuses)
+
+`skillctl`'s own destructive op — a cache cleanup — is a **G-23 two-step**: a signed dry-run
+plan with a short-lived token, then a confirm that **re-checks the live affected-set**. When
+the set drifts before you confirm, the confirm **refuses**.
+
+```
+audit --cleanup --dry-run-cleanup   →  0 (plan + signed 5-minute token)
+audit --cleanup --confirm-delete …  →  2 (confirm REFUSES on drift)
+```
+
+Exit `2` is a usage / precondition refusal — the token no longer matches the live set. **There
+is no `--force`**; both the plan and the refusal are auditable.
+
+---
+
+## 3. The roadmap panels (nothing is run)
+
+The deck also shows three scenarios the demo does **not** run — each renders its story and the
+*closest built surface*, honestly labelled. They are never presented as live verdicts.
+
+| Scenario | Tier | Documented exit | Why it isn't run here |
+|----------|------|-----------------|-----------------------|
+| **S2BC** — runtime envelope violation + fleet kill | `ROADMAP` | `envelope 32 · revoke 17` | The Go-native OS-level egress cage is FR-0044 (pending); the block point exists only as a Python reference (`pkg/skillgate`, SPEC-0202). Exit `32` is shown as roadmap — no `skillctl` subcommand emits it today. |
+| **S3** — fleet kill-switch under live compromise | `PARTIAL` | `17 (revoked) / 22 (offline fail-closed)` | The **offline freshness contract IS built** — `verify --bundle --revocations/--emergency` returns `17` (revoked) and `22` (stale + high-risk, fail-closed), proven by SPEC-0279 tests. The signed-HEAD fleet-propagation endpoint (FR-0045) is the remaining work, and this offline demo stands up no registry — so S3 is shown as a built surface, not run live. |
+| **S4** — untrusted internet import → airlock | `ROADMAP` | `1 (refused on critical-rule hit)` | A static import scanner exists (`import_public_cmds.go`, SPEC-0201), but the airlock flow isn't wired for the offline demo — so S4 stays a labelled roadmap panel. |
+
+---
+
+## 4. Prove it in CI — `--selftest`
+
+`--selftest` runs the three LIVE scenarios non-interactively, asserts each observed exit code
+against its expectation, prints a PASS/FAIL table, and exits non-zero if any assertion fails —
+the CI-friendly proof that the honest core actually blocks.
+
+```bash
+./skillctl-demo --selftest
+```
+
+```
+──────── selftest summary ────────
+  1. allowed  exit=0  expected=0   [PASS]
+  2. blocked  exit=10 expected=10  [PASS]
+  ...
+  ✔ all N exit-code assertions passed (real skillctl).
+```
+
+---
+
+## 5. Training mode (Kata) — **planned**, not shipped
+
+> **Status: PLANNED (P4 in `DEMO-TOOL-design.md`).** The binary today accepts **only** `--mode
+> guided` and `--mode kiosk`; there is no Kata flag, code path, or scenario in the shipped
+> tool. The section below describes the *designed* onboarding mode — treat it as a preview,
+> not a runnable command.
+
+Where the demo modes *sell* (a buyer watches containment happen), the designed **Kata** mode
+*onboards* — it turns "watched a demo" into "can operate `skillctl`" through **deliberate
+practice with a coach**, not a click-through. It reuses the CEW Kata vocabulary (SPEC-0303:
+the 3-state machine, the **N/3 chip**, *sitzt* / *rust*) so tool-onboarding reinforces the
+same coaching model. Nothing is self-reported — **a "pass" is a real exit code.**
+
+**The five planned Katas** (target condition → practised with → green when):
+
+| Kata | The learner can… | Practised with | Green when |
+|------|------------------|----------------|-----------|
+| **K1 Seal & prove** | seal a skill and prove authorship offline | `keygen → pack → sign → verify --bundle` | 3 distinct clean reps |
+| **K2 Detect tamper** | catch a modified skill before it runs | edit on disk → `verify --all` → exit `10` | 3 reps |
+| **K3 Govern reversibly** | run a destructive op that refuses to be forced | `audit --cleanup --dry-run-cleanup` → `--cleanup --confirm-delete` on a drifted set → exit `2` | 3 reps |
+| **K4 Trust roots & install** | pin a registry and install only what's admitted | `trust add → install → verify` | 3 reps |
+| **K5 Revoke & fail-closed** *(concept + roadmap)* | reason about fleet revocation & offline deny | `revoke` live + the S3 roadmap panel | 1 rep + read |
+
+**The coach loop (the tool plays the coach — 5 questions per cycle):**
+
+1. **Target** — the capability you should be able to demonstrate.
+2. **Actual** — "Where are you now? Run it and observe." (the learner runs the real command)
+3. **Obstacle** — "What blocked you?" (the tool maps the real exit code `10`/`11`/`12`/`2` to a
+   plain-language obstacle).
+4. **Next experiment + expectation** — the learner predicts the exit code, then acts.
+5. **Go & see** — the learner runs it; the tool shows the **real** result and records a *beat*.
+
+**Mastery.** A clean distinct rep is a beat toward **N/3 → *sitzt* (green)**; a Kata *rusts* if
+unpractised past a stall window (identical to CEW's 3-state machine). Progress would persist
+locally (`~/.skillctl-demo/kata-progress.json`), with a later bridge to `cew_kata_events`
+(SPEC-0303) and the `skillprofile` aware→practiced→fluent ladder (SPEC-0121). The browser would
+show a **Kata board** — one card per Kata with a rot/gelb/grün state and the N/3 chip.
+
+Again: this is the **design** (P4). Today, run `--mode guided` or `--mode kiosk`.
+
+---
+
+## Next steps
+
+- **Every `skillctl` command, flag and exit code:** [skillctl manual](manual-skillctl.md)
+- **Author, sign and verify your own skill in five minutes:** [Quickstart: skillctl](quickstart-skillctl.md)
+- **The scenarios' exit-code contracts** (`10` digest mismatch, `2` G-23 drift refusal, `17`
+  revoked, `22` freshness fail-closed) are the [manual's exit-code table](manual-skillctl.md#exit-codes).


### PR DESCRIPTION
Brings the docs up to date with everything shipped through **v2.8.0**. Produced by a 10-agent workflow (inventory the real `--help` surfaces → draft → adversarial accuracy/honesty review → fix).

**README.md** — expanded the stale command surfaces (m3c-tools: `plaud` sub-verbs, `check-er1`, `cancel`, `config`/`doctor`, `settings`, `token`, `devices`; skillctl: regrouped by phase + added `seal`/`scan`/`review`/`propose`); added a *Field recordings, positioned in real time* paragraph (Plaud/pocket capture-time, multi-device, no-transcript fallback); added a **Quickstart: skillctl-demo** doc row.

**docs/manual-skillctl.md** — documented the trust-lifecycle commands: `audit` (the G-23 two-step — dry-run token → `confirm-delete` that **refuses on drift with exit 2**, no `--force`), `revoke`, `agentid`, `attest`, `translog`, `publish`/`seal`/`scan`/`review`/`propose`; accurate exit-code table.

**docs/quickstart-skillctl-demo.md** (new) — how to run the offline demo (`--mode guided|kiosk`, `--selftest`); scenarios with honesty tiers (S1→10, S2A→2, S5→2 **live**; S3/S2BC/S4 **roadmap**); **Kata training marked PLANNED** (no shipped flag — only `guided`/`kiosk` exist).

Honesty verified: no invented commands/flags, Kata is planned-not-shipped, S3/S4 roadmap, S5=exit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)