### PR TITLE
ci: run m3c-tools + skillctl-demo command packages under -race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,12 @@ jobs:
       # SPEC-0176 §3.1: every package under ./pkg/ now gates the build.
       # Race detector catches concurrency bugs in the retry queue, the
       # background scheduler, and the new pocket cloud-sync goroutines.
-      - name: Run unit tests (./pkg/...)
-        run: go test -race -count=1 ./pkg/...
+      # Also race the m3c-tools command package (menubar + plaud-sync
+      # goroutines, retry runner, bulk-progress) and the skillctl-demo
+      # command (SSE event bus) — previously only ./pkg/... and
+      # ./cmd/skillctl/... (skillctl-race job) were exercised under -race.
+      - name: Run unit tests (-race, ./pkg/... + m3c-tools/skillctl-demo cmds)
+        run: go test -race -count=1 ./pkg/... ./cmd/m3c-tools/... ./cmd/skillctl-demo/...
 
       - name: Run e2e tests (allow-list)
         run: go test -v -count=1 ./e2e/ -run "TestComposite|TestBuild|TestParseTagLine|TestER1Config|TestER1Queue|TestER1EnqueueFailure|TestUploadFailure|TestRecorderEncodeWAV|TestRecorderStats|TestExportsDB|TestFilesDB|TestHashFile|TestFormatterLoader|TestPrettyPrint|TestFormatTranscript|TestFormatSnippet|TestFormatKeyValue|TestFormatTable|TestFormatSection|TestFormatStatusLine|TestTranslateFlagParsing|TestTranslateNotTranslatable|TestTranslateTranslatable|TestRetryQueue|TestRetryBackoffTiming|TestRetryBackoffCustomBase|TestRetryProcessingOrder|TestRetryPartialFailure|TestRetryMaxRetriesDropsEntry|TestRetryDropCallback|TestRetryRespectsBackoffDelay|TestRetryProcessesAfterBackoffElapsed|TestRetryGracefulShutdownOnCancel|TestRetryRunStopsOnContextCancel|TestRetryRunProcessesMultipleCycles|TestRetryEmptyQueue|TestRetryOnRetryCallback|TestTranscriptFilter|TestProxy|TestRetryRunner|TestBackgroundRetry|TestTranscriptImport|TestTranscriptList|TestTranscriptExport|TestScheduleCommand|TestStatusCommand|TestCancelCommand|TestScheduleStatusCancelWorkflow|TestCLI|TestRepoRoot|TestWriteFixture|TestFixtureDir|TestTempDataDir|TestWithEnv|TestRunCLIWithEnv|TestImporter"


### PR DESCRIPTION
Answers the coverage question: **lint** already runs on every package (`golangci-lint run` in *Lint & Vet*), but **race** detection had a gap.

Before: `-race` covered `./pkg/...` (*Unit Tests*) and `./cmd/skillctl/...` + `./pkg/skillctl/...` (*skillctl-race*). **Not** covered: `./cmd/m3c-tools/...` — the command package with the most concurrency (menubar + plaud-sync goroutines, retry runner, bulk-progress; 5 test files) — and the new `./cmd/skillctl-demo/...` (SSE event bus).

Change: add both to the *Unit Tests* `-race` run.

**Verified locally** (macOS): `go test -race ./cmd/m3c-tools/... ./cmd/skillctl-demo/...` → `cmd/m3c-tools ok` (no data races), `cmd/skillctl-demo` compiles clean (no tests yet). So this adds coverage without turning the check red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)