### PR TITLE
feat(g5): fleet kill-switch — FR-0045 D1–D5 (signed revocation HEAD, fail-closed freshness)

### DIFF
--- a/cmd/skillctl/agentid_gate.go
+++ b/cmd/skillctl/agentid_gate.go
@@ -251,27 +251,39 @@ func emergencyDeniesInstalledSkill(home, skill string) emergencyVerdict {
 	if home == "" {
 		return emergencyVerdict{}
 	}
-	ep := emergencyDenyPath(home)
-	if !fileExists(ep) {
-		return emergencyVerdict{} // opt-in: nothing placed → nothing to enforce.
-	}
-
-	// The file is present → from here, any inability to VERIFY it is fail-closed.
-	_, root, err := loadRootsFn("")
-	if err != nil {
-		return emergencyVerdict{Deny: true, Reason: "emergency_list_untrusted"}
-	}
-	set, lerr := verify.LoadVerifiedEmergencyDenyList(ep, root)
-	if lerr != nil {
-		return emergencyVerdict{Deny: true, Reason: "emergency_list_untrusted"}
-	}
 
 	// Test BOTH the installed digest and the installed author identity. ANY hit
 	// denies. (A "sha256:<digest>" on the list burns the exact bundle; an
 	// "id:<owner>" burns everything that author signed.)
 	digest := installedSkillDigest(home, skill)
 	author := installedSkillAuthor(home, skill)
-	if tok, bad := verify.EmergencyDenies(set, digest, author); bad {
+
+	// (1) SPEC-0279 R5 — the local signed emergency-deny.json. Opt-in per machine:
+	// absent → skip. Present → any inability to VERIFY it is fail-closed.
+	if ep := emergencyDenyPath(home); fileExists(ep) {
+		_, root, err := loadRootsFn("")
+		if err != nil {
+			return emergencyVerdict{Deny: true, Reason: "emergency_list_untrusted"}
+		}
+		set, lerr := verify.LoadVerifiedEmergencyDenyList(ep, root)
+		if lerr != nil {
+			return emergencyVerdict{Deny: true, Reason: "emergency_list_untrusted"}
+		}
+		if tok, bad := verify.EmergencyDenies(set, digest, author); bad {
+			appendGateEvent(home, gateEvent{
+				Source: "hook", Skill: skill, Decision: "deny",
+				Reason: "emergency_deny:" + tok, ExitCode: exitBundleRevoked,
+				ContentDigest: digest,
+			})
+			return emergencyVerdict{Deny: true, Token: tok, Reason: "emergency_denied"}
+		}
+	}
+
+	// (2) FR-0045 Fix C / finding F4 — the ADOPTED signed HEAD's emergency list.
+	// A digest the registry placed in the signed HEAD.emergency MUST deny at the
+	// gate, authenticated by the same registry key (headEmergencyDeniesDigest
+	// re-verifies the HEAD envelope), even with NO local emergency-deny.json.
+	if tok, bad := headEmergencyDeniesDigest(home, digest); bad {
 		appendGateEvent(home, gateEvent{
 			Source: "hook", Skill: skill, Decision: "deny",
 			Reason: "emergency_deny:" + tok, ExitCode: exitBundleRevoked,
@@ -279,6 +291,7 @@ func emergencyDeniesInstalledSkill(home, skill string) emergencyVerdict {
 		})
 		return emergencyVerdict{Deny: true, Token: tok, Reason: "emergency_denied"}
 	}
+
 	return emergencyVerdict{}
 }
 

--- a/cmd/skillctl/kill_switch_hardening_test.go
+++ b/cmd/skillctl/kill_switch_hardening_test.go
@@ -282,6 +282,74 @@ func TestGate_StaleRevocation_RefusalCode(t *testing.T) {
 	}
 }
 
+// --- Fix N1 — a present-but-unverifiable signed HEAD FAILS CLOSED (not no-op) ---
+
+// TestGate_CorruptSignedHead_FailsClosed proves the regression fix: a one-byte
+// corruption of revoked-head.signed.json must NOT flip the kill-switch open. On the
+// OLD code readRevokedCacheHead returned issued_at="" for the corrupt HEAD and
+// revocationSnapshotStale treated that identically to the ABSENT case (no anchor →
+// allow); this test asserts the gate now DENIES. It also asserts the ABSENT case
+// (with the same max_staleness policy) still no-ops, so pre-D2 installs are not
+// bricked.
+func TestGate_CorruptSignedHead_FailsClosed(t *testing.T) {
+	home := khSetupHome(t)
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	khWriteSelfTrustRoots(t, home, pub)
+
+	origLoad := loadRootsFn
+	loadRootsFn = func(string) (*verify.TrustRoots, *verify.TrustRoot, error) {
+		return nil, &verify.TrustRoot{MaxStaleness: "24h", FailPolicy: "closed"}, nil
+	}
+	t.Cleanup(func() { loadRootsFn = origLoad })
+
+	revoked := headTestDigest('b')
+	installed := headTestDigest('a')
+	khInstallSkill(t, home, "er1-push", installed, "id:author@m3c")
+
+	// (0) ABSENT signed HEAD + no checkpoint, even WITH a max_staleness policy →
+	// no-op (must not brick pre-D2 installs that never adopted a HEAD).
+	if code, out, _ := feed(t, hookEventFor("er1-push")); code != exitOK {
+		t.Fatalf("absent signed HEAD must no-op (allow), got %d out=%q", code, out)
+	}
+
+	// (1) A VALID, fresh signed HEAD → the gate allows (fresh anchor).
+	fresh := time.Now().Add(-1 * time.Hour)
+	persistSignedHead(home, khSignHead(t, priv, 5, fresh, []string{revoked}, nil))
+	writeRevokedCacheHead(home, map[string]struct{}{revoked: {}}, 5, fresh.UTC().Format(time.RFC3339))
+	if code, out, _ := feed(t, hookEventFor("er1-push")); code != exitOK {
+		t.Fatalf("valid fresh signed HEAD should allow, got %d out=%q", code, out)
+	}
+
+	// (2) Corrupt the signed HEAD on disk (one-byte flip) → present-but-unverifiable.
+	p := revokedHeadSignedPath(home)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b[len(b)/2] ^= 0xff
+	if err := os.WriteFile(p, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Sanity: it really no longer verifies.
+	if _, ok := verifiedAdoptedHead(home); ok {
+		t.Fatal("test invariant: the corrupted HEAD must not verify")
+	}
+
+	// The gate must now DENY (fail-closed) — the one-byte corruption must not open
+	// the kill-switch. On the OLD code this fed() ALLOWED.
+	code, out, _ := feed(t, hookEventFor("er1-push"))
+	assertDeny(t, code, out, "signed revocation HEAD is present but")
+
+	// The machine-readable refusal_code distinguishes tampering from mere staleness.
+	data, err := os.ReadFile(invocationTrailPath(home))
+	if err != nil {
+		t.Fatalf("read invocation trail: %v", err)
+	}
+	if !strings.Contains(string(data), `"refusal_code":"bundle_revocation_head_untrusted"`) {
+		t.Fatalf("tampered-HEAD refusal_code not asserted on the signed trail:\n%s", data)
+	}
+}
+
 // --- fetch-failure eventually denies (not merely "floor kept") ---
 
 func TestGate_AdoptedHeadFetchFailure_EventuallyDenies(t *testing.T) {

--- a/cmd/skillctl/kill_switch_hardening_test.go
+++ b/cmd/skillctl/kill_switch_hardening_test.go
@@ -1,0 +1,327 @@
+package main
+
+// FR-0045 kill-switch HARDENING tests — the enforcement negatives the 3-reviewer
+// adversarial gate found missing (the ed25519 envelope had negatives; the
+// ENFORCEMENT did not). Each test drives the REAL enforcement surface:
+//
+//   Fix A — the epoch/issued_at floor is authenticated against the pinned registry
+//           key and is monotonic: it cannot be rolled back by rewriting the
+//           unsigned json, and a replayed lower-epoch signed HEAD is rejected.
+//   Fix B — a set-root mismatch retains last-known-good; a revoked digest still
+//           denies at the gate (the truncated set cannot un-revoke a bundle).
+//   Fix C — a digest placed in the SIGNED HEAD.emergency denies at the gate, with
+//           no local emergency-deny.json present.
+//   Fix D — the stale-revocation deny carries the machine-readable
+//           `bundle_revocation_stale` refusal code on the signed invocation record.
+//   +     — an adopted HEAD whose fetch then fails eventually DENIES once its
+//           signed issued_at ages past max_staleness (not merely "floor kept").
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/er1"
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// khSetupHome points HOME (and USERPROFILE for Windows parity) at a fresh temp
+// dir so the gate + the registry SelfTrustRoots loader resolve into it.
+func khSetupHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
+}
+
+// khWriteSelfTrustRoots writes ~/.claude/trust-roots.yaml (registry.SelfTrustRoots)
+// pinning pub, so verifiedAdoptedHead / readRevokedCacheHead / headEmergencyDenies-
+// Digest re-verify a persisted signed HEAD against it.
+func khWriteSelfTrustRoots(t *testing.T, home string, pub ed25519.PublicKey) {
+	t.Helper()
+	body := "registry: self\n" +
+		"pubkey_b64: " + base64.StdEncoding.EncodeToString(pub) + "\n" +
+		"governance_minimum: green\n"
+	p := filepath.Join(home, ".claude", "trust-roots.yaml")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// khSignHead builds + ed25519-signs a revocation HEAD with priv.
+func khSignHead(t *testing.T, priv ed25519.PrivateKey, epoch int, issuedAt time.Time, digests, emergency []string) map[string]any {
+	t.Helper()
+	h, err := registry.BuildRevocationHead(registry.RevocationHeadInput{
+		Epoch: epoch, IssuedAt: issuedAt, Digests: digests, Emergency: emergency,
+	})
+	if err != nil {
+		t.Fatalf("build head: %v", err)
+	}
+	if _, err := registry.SignEnvelopeSignature(priv, h); err != nil {
+		t.Fatalf("sign head: %v", err)
+	}
+	return h
+}
+
+// khInstallSkill installs a managed skill (stashed .skb + provenance sidecar
+// recording the bundle digest + author) and stubs the chain seams to ALLOW, so any
+// deny that follows is purely the kill-switch enforcement under test.
+func khInstallSkill(t *testing.T, home, skill, digest, author string) {
+	t.Helper()
+	dir := filepath.Join(home, ".claude", "skills", skill)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, skill+".skb"), []byte("blob"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	side := registry.ProvenanceSidecar{
+		SchemaVersion: registry.ProvenanceSchemaVersion, Skill: skill, Version: "1.0.0",
+		BundleDigest: digest, Registry: "self", GovernanceLevel: "green",
+		Signatures: []registry.SignatureSidecar{{Role: "author", IdentityID: author}},
+	}
+	b, _ := json.Marshal(side)
+	if err := os.WriteFile(filepath.Join(dir, registry.ProvenanceSidecarName), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	origOn := verifyManagedFn
+	verifyManagedFn = func(string, gatePolicy) (int, string) { return exitOK, "" }
+	origOff := verifyManagedOfflineFn
+	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return exitOK, "", true }
+	t.Cleanup(func() { verifyManagedFn = origOn; verifyManagedOfflineFn = origOff })
+}
+
+// --- Fix A — authenticated + monotonic floor ---
+
+// TestRevokedFloor_UnforgeableViaUnsignedJson: with a signed HEAD present, the
+// floor is derived from the RE-VERIFIED HEAD, so rewriting the unsigned json cannot
+// roll it back (finding F2).
+func TestRevokedFloor_UnforgeableViaUnsignedJson(t *testing.T) {
+	home := khSetupHome(t)
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	khWriteSelfTrustRoots(t, home, pub)
+	dig := headTestDigest('a')
+	set := map[string]struct{}{dig: {}}
+	issued := time.Date(2026, 7, 6, 18, 0, 0, 0, time.UTC)
+
+	fetchRevocationHeadFn = func(_ *er1.Config, _ string, _ ed25519.PublicKey) (map[string]any, bool) {
+		return khSignHead(t, priv, 9, issued, []string{dig}, nil), true
+	}
+	defer func() { fetchRevocationHeadFn = nil }()
+
+	if _, refreshed := applyFetchedRevokedSet(home, nil, "skills", pub, set); !refreshed {
+		t.Fatalf("adopted set must be persisted (refreshed=true)")
+	}
+	if ep, iss := readRevokedCacheHead(home); ep != 9 || iss != "2026-07-06T18:00:00Z" {
+		t.Fatalf("authenticated floor = %d,%q, want 9,<ts>", ep, iss)
+	}
+
+	// The cache file must be owner-only (0o600) — Fix A perms tightening.
+	if fi, err := os.Stat(revokedCachePath(home)); err != nil {
+		t.Fatal(err)
+	} else if perm := fi.Mode().Perm(); perm&0o077 != 0 {
+		t.Fatalf("revoked cache perms = %o, want owner-only (no group/other bits)", perm)
+	}
+
+	// Attacker rewrites the UNSIGNED json to a lower epoch + older issued_at.
+	writeRevokedCacheHead(home, set, 0, "2000-01-01T00:00:00Z")
+	if ep, iss := readRevokedCacheHead(home); ep != 9 || iss != "2026-07-06T18:00:00Z" {
+		t.Fatalf("floor rolled back via unsigned json: got %d,%q, want 9,<ts>", ep, iss)
+	}
+}
+
+// TestRevokedFloor_ReplayedLowerEpochRejected: a validly-signed but OLDER HEAD
+// replayed over the signed-head file cannot lower the floor below the high-water
+// mark, and its (replayed) freshness is distrusted.
+func TestRevokedFloor_ReplayedLowerEpochRejected(t *testing.T) {
+	home := khSetupHome(t)
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	khWriteSelfTrustRoots(t, home, pub)
+	dig := headTestDigest('a')
+	set := map[string]struct{}{dig: {}}
+
+	// High-water mark 9 recorded in the unsigned json.
+	writeRevokedCacheHead(home, set, 9, "2026-07-06T18:00:00Z")
+	// Attacker replays a validly-signed, LOWER-epoch HEAD into the signed-head file.
+	persistSignedHead(home, khSignHead(t, priv, 4, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), []string{dig}, nil))
+
+	ep, iss := readRevokedCacheHead(home)
+	if ep != 9 {
+		t.Fatalf("replayed lower-epoch HEAD lowered the floor: epoch %d, want 9 (high-water)", ep)
+	}
+	if iss != "" {
+		t.Fatalf("replayed HEAD freshness must be distrusted (issued_at cleared), got %q", iss)
+	}
+}
+
+// --- Fix B — set-root mismatch retains last-known-good; revoked digest still denies ---
+
+func TestFetchedSetRootMismatch_RetainsAndDenies(t *testing.T) {
+	home := khSetupHome(t)
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	khWriteSelfTrustRoots(t, home, pub)
+	dig := headTestDigest('a') // the revocation an attacker wants to drop
+
+	// Prior last-known-good cache: contains the revoked digest, fresh, epoch 5.
+	priorSet := map[string]struct{}{dig: {}}
+	writeRevokedCacheHead(home, priorSet, 5, time.Now().Add(-1*time.Hour).UTC().Format(time.RFC3339))
+	priorBytes, _ := os.ReadFile(revokedCachePath(home))
+
+	// The registry's SIGNED HEAD still binds the FULL {dig} set at epoch 6.
+	fetchRevocationHeadFn = func(_ *er1.Config, _ string, _ ed25519.PublicKey) (map[string]any, bool) {
+		return khSignHead(t, priv, 6, time.Now().Add(-30*time.Minute), []string{dig}, nil), true
+	}
+	defer func() { fetchRevocationHeadFn = nil }()
+
+	// The attacker-truncated fetch DROPS dig (empty set) → set-root mismatch.
+	set, refreshed := applyFetchedRevokedSet(home, nil, "skills", pub, map[string]struct{}{})
+	if refreshed {
+		t.Fatalf("a set-root-mismatched (truncated) set must NOT refresh the cache")
+	}
+	if _, ok := set[dig]; !ok {
+		t.Fatalf("prior good set must be retained (dig present); got %v", set)
+	}
+	// The on-disk cache is untouched (last-known-good retained, FetchedAt not bumped).
+	if after, _ := os.ReadFile(revokedCachePath(home)); string(after) != string(priorBytes) {
+		t.Fatalf("cache overwritten with truncated set:\n before=%s\n after=%s", priorBytes, after)
+	}
+
+	// And the RETAINED revoked digest STILL denies at the gate.
+	khInstallSkill(t, home, "er1-push", dig, "id:author@m3c")
+	code, out, _ := feed(t, hookEventFor("er1-push"))
+	assertDeny(t, code, out, "revoked")
+}
+
+// --- Fix C — the signed HEAD's emergency list denies at the gate ---
+
+func TestGate_SignedHeadEmergencyDenies(t *testing.T) {
+	home := khSetupHome(t)
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	khWriteSelfTrustRoots(t, home, pub)
+	dig := headTestDigest('a')
+	khInstallSkill(t, home, "er1-push", dig, "id:author@m3c")
+
+	// No signed HEAD yet → allowed.
+	if code, out, _ := feed(t, hookEventFor("er1-push")); code != exitOK {
+		t.Fatalf("pre-emergency should allow, got %d out=%q", code, out)
+	}
+
+	// Registry burns the digest in the SIGNED HEAD.emergency — NO local
+	// emergency-deny.json is present, proving the HEAD channel is enforced on its own.
+	persistSignedHead(home, khSignHead(t, priv, 3, time.Now().Add(-1*time.Hour), []string{dig}, []string{dig}))
+	if fileExists(emergencyDenyPath(home)) {
+		t.Fatal("test invariant: no emergency-deny.json should be present")
+	}
+
+	code, out, _ := feed(t, hookEventFor("er1-push"))
+	assertDeny(t, code, out, "emergency deny-list")
+	if !strings.Contains(out, dig) {
+		t.Fatalf("deny must cite the burned digest %q, got %q", dig, out)
+	}
+}
+
+// A digest NOT in the signed HEAD.emergency is still allowed (no false-deny).
+func TestGate_SignedHeadEmergencyNonListedAllowed(t *testing.T) {
+	home := khSetupHome(t)
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	khWriteSelfTrustRoots(t, home, pub)
+	installed := headTestDigest('a')
+	burned := headTestDigest('b') // a DIFFERENT digest is burned
+	khInstallSkill(t, home, "er1-push", installed, "id:author@m3c")
+	persistSignedHead(home, khSignHead(t, priv, 3, time.Now().Add(-1*time.Hour), []string{burned}, []string{burned}))
+
+	code, out, _ := feed(t, hookEventFor("er1-push"))
+	assertAllow(t, code, out)
+}
+
+// --- Fix D — the stale-revocation deny carries the bundle_revocation_stale code ---
+
+func TestGate_StaleRevocation_RefusalCode(t *testing.T) {
+	home := khSetupHome(t)
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	khWriteSelfTrustRoots(t, home, pub)
+
+	// Gate freshness policy: max_staleness 24h, fail-closed (via the loadRootsFn seam).
+	origLoad := loadRootsFn
+	loadRootsFn = func(string) (*verify.TrustRoots, *verify.TrustRoot, error) {
+		return nil, &verify.TrustRoot{MaxStaleness: "24h", FailPolicy: "closed"}, nil
+	}
+	t.Cleanup(func() { loadRootsFn = origLoad })
+
+	revoked := headTestDigest('b')   // the revoked set — NOT the skill's digest
+	installed := headTestDigest('a') // the installed skill digest (not revoked/emergency)
+	khInstallSkill(t, home, "er1-push", installed, "id:author@m3c")
+
+	// Adopt a STALE HEAD (issued 48h ago) as the authenticated anchor.
+	stale := time.Now().Add(-48 * time.Hour)
+	persistSignedHead(home, khSignHead(t, priv, 5, stale, []string{revoked}, nil))
+	writeRevokedCacheHead(home, map[string]struct{}{revoked: {}}, 5, stale.UTC().Format(time.RFC3339))
+
+	code, out, _ := feed(t, hookEventFor("er1-push"))
+	assertDeny(t, code, out, "revocation snapshot too stale")
+
+	// The signed invocation record's machine-readable refusal_code is the "22"
+	// semantic token — the qa exit-22 assertion the gate said was missing.
+	data, err := os.ReadFile(invocationTrailPath(home))
+	if err != nil {
+		t.Fatalf("read invocation trail: %v", err)
+	}
+	if !strings.Contains(string(data), `"refusal_code":"bundle_revocation_stale"`) {
+		t.Fatalf("stale-revocation refusal_code not asserted on the signed trail:\n%s", data)
+	}
+}
+
+// --- fetch-failure eventually denies (not merely "floor kept") ---
+
+func TestGate_AdoptedHeadFetchFailure_EventuallyDenies(t *testing.T) {
+	home := khSetupHome(t)
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	khWriteSelfTrustRoots(t, home, pub)
+
+	origLoad := loadRootsFn
+	loadRootsFn = func(string) (*verify.TrustRoots, *verify.TrustRoot, error) {
+		return nil, &verify.TrustRoot{MaxStaleness: "24h", FailPolicy: "closed"}, nil
+	}
+	t.Cleanup(func() { loadRootsFn = origLoad })
+
+	revoked := headTestDigest('b')
+	installed := headTestDigest('a')
+	khInstallSkill(t, home, "er1-push", installed, "id:author@m3c")
+
+	// 1) A successful adopt whose issued_at is already 48h old (the last time the
+	//    feed was reachable). Persists the signed HEAD + json floor at epoch 5.
+	t0 := time.Now().Add(-48 * time.Hour)
+	fetchRevocationHeadFn = func(_ *er1.Config, _ string, _ ed25519.PublicKey) (map[string]any, bool) {
+		return khSignHead(t, priv, 5, t0, []string{revoked}, nil), true
+	}
+	if _, refreshed := applyFetchedRevokedSet(home, nil, "skills", pub, map[string]struct{}{revoked: {}}); !refreshed {
+		t.Fatalf("initial adopt must persist (refreshed=true)")
+	}
+
+	// 2) The fetch now FAILS (no HEAD) → the floor is KEPT, never advanced.
+	fetchRevocationHeadFn = func(_ *er1.Config, _ string, _ ed25519.PublicKey) (map[string]any, bool) {
+		return nil, false
+	}
+	defer func() { fetchRevocationHeadFn = nil }()
+	if ep, _, rej := adoptHeadOrKeepFloor(home, nil, "skills", pub, map[string]struct{}{revoked: {}}); ep != 5 || rej {
+		t.Fatalf("fetch failure must keep the floor (epoch 5, not rejected), got ep=%d rej=%v", ep, rej)
+	}
+
+	// 3) With the anchor now 48h old and max_staleness 24h, the gate must DENY —
+	//    not merely keep the floor. (The local cache TTL still looks fresh; the D4
+	//    gate judges the SIGNED issued_at, which cannot be refreshed while the feed
+	//    is down.)
+	code, out, _ := feed(t, hookEventFor("er1-push"))
+	assertDeny(t, code, out, "revocation snapshot too stale")
+}

--- a/cmd/skillctl/kill_switch_hardening_test.go
+++ b/cmd/skillctl/kill_switch_hardening_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -128,10 +129,13 @@ func TestRevokedFloor_UnforgeableViaUnsignedJson(t *testing.T) {
 	}
 
 	// The cache file must be owner-only (0o600) — Fix A perms tightening.
-	if fi, err := os.Stat(revokedCachePath(home)); err != nil {
-		t.Fatal(err)
-	} else if perm := fi.Mode().Perm(); perm&0o077 != 0 {
-		t.Fatalf("revoked cache perms = %o, want owner-only (no group/other bits)", perm)
+	// POSIX-only: Windows does not map Go file modes to Unix permission bits.
+	if runtime.GOOS != "windows" {
+		if fi, err := os.Stat(revokedCachePath(home)); err != nil {
+			t.Fatal(err)
+		} else if perm := fi.Mode().Perm(); perm&0o077 != 0 {
+			t.Fatalf("revoked cache perms = %o, want owner-only (no group/other bits)", perm)
+		}
 	}
 
 	// Attacker rewrites the UNSIGNED json to a lower epoch + older issued_at.

--- a/cmd/skillctl/main.go
+++ b/cmd/skillctl/main.go
@@ -25,6 +25,12 @@ func main() {
 		printUsage(os.Stderr)
 		os.Exit(2)
 	}
+	// FR-0045 D5: install the production revocation-HEAD fetch seam so the
+	// SessionStart sweep + verify-hook gate adopt the signed HEAD from the D2
+	// registry endpoint. Fail-safe when no registry URL is configured; tests leave
+	// the seam nil (pre-D2 set-only behaviour).
+	fetchRevocationHeadFn = fetchRevocationHeadOnline
+
 	// FR-0043: for ER1-bound commands, auto-load the device token persisted by
 	// `skillctl login` / `m3c-tools login` so users need not export it by hand.
 	// Gated to networkCommands so offline commands never touch the OS keychain.

--- a/cmd/skillctl/revoke_cmds.go
+++ b/cmd/skillctl/revoke_cmds.go
@@ -94,6 +94,13 @@ type revokeError struct {
 // the verifier can install. The `reason` field on stderr distinguishes
 // already-revoked from never-admitted for the operator.
 func runRevoke(args []string, stdout, stderr io.Writer) int {
+	// FR-0045 D5 — `skillctl revoke feed …` inspects/refreshes the signed
+	// revocation HEAD (the G5 kill-switch feed). Intercepted before the digest
+	// parsing so "feed" is never mistaken for a bundle digest.
+	if len(args) > 0 && args[0] == "feed" {
+		return runRevokeFeed(args[1:], stdout, stderr)
+	}
+
 	fs := flag.NewFlagSet("revoke", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 

--- a/cmd/skillctl/revoke_feed_cmds.go
+++ b/cmd/skillctl/revoke_feed_cmds.go
@@ -1,0 +1,97 @@
+package main
+
+// revoke_feed_cmds.go — `skillctl revoke feed` (FR-0045 D5).
+//
+// Operator-facing view of the signed revocation HEAD (the G5 kill-switch feed):
+//   --status  (default) fetch the HEAD from the registry, verify its ed25519
+//             envelope signature against the PINNED registry key, and print a
+//             one-line status (verified / epoch / issued_at / staleness / counts).
+//   --refresh run the revocation sweep now (adopts the HEAD into the local cache
+//             + freshness anchor the SPEC-0247 gate reads).
+
+import (
+	"crypto/ed25519"
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+)
+
+func runRevokeFeed(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("revoke feed", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	registryURL := fs.String("registry", defaultRegistryURL, "Registry base URL (e.g. http://127.0.0.1:8081/api/skills).")
+	tenant := fs.String("tenant", "", "Tenant scope (optional; default global).")
+	timeout := fs.Duration("timeout", defaultHTTPTimeout, "HTTP timeout for the HEAD fetch.")
+	refresh := fs.Bool("refresh", false, "Run the revocation sweep now to refresh the local cache + freshness anchor.")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl revoke feed [--status] [--refresh] [--registry URL] [--tenant T]")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "Inspect or refresh the signed revocation HEAD — the G5 kill-switch feed (FR-0045).")
+		fmt.Fprintln(stderr, "  --status  (default) fetch + verify the HEAD against the pinned registry key")
+		fmt.Fprintln(stderr, "  --refresh sweep now: adopt the HEAD into the local cache + freshness anchor")
+		fmt.Fprintln(stderr, "")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	home, _ := userHome()
+
+	if *refresh {
+		// Ensure the production fetch seam is installed even if this runs outside
+		// the main() dispatch (e.g. a test binary), then sweep.
+		if fetchRevocationHeadFn == nil {
+			fetchRevocationHeadFn = fetchRevocationHeadOnline
+		}
+		set, online := fetchRevokedOnline(home)
+		epoch, issuedAt := readRevokedCacheHead(home)
+		fmt.Fprintf(stdout, "refreshed: %d revoked digest(s), epoch=%d issued_at=%q online=%v\n",
+			len(set), epoch, issuedAt, online)
+		return exitOK
+	}
+
+	// --status (default): fetch + verify the HEAD.
+	head, err := registry.FetchRevocationHead(*registryURL, *tenant, *timeout)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillctl revoke feed: fetch failed: %v\n", err)
+		return exitGeneric
+	}
+
+	verified := false
+	if _, root, rerr := loadRootsFn(*registryURL); rerr == nil && root != nil {
+		for _, k := range root.ActiveKeys() {
+			if registry.VerifyEnvelopeSignature(ed25519.PublicKey(k.Pubkey), head) == nil {
+				verified = true
+				break
+			}
+		}
+	}
+
+	epoch, _ := registry.HeadEpoch(head)
+	issuedAt, _ := registry.HeadIssuedAt(head)
+	staleness := "n/a"
+	issuedStr := "n/a"
+	if !issuedAt.IsZero() {
+		issuedStr = issuedAt.Format(time.RFC3339)
+		staleness = time.Since(issuedAt).Truncate(time.Second).String()
+	}
+	emergency, _ := registry.HeadEmergency(head)
+	revokedCount := 0
+	if v, ok := head["revoked_count"].(float64); ok {
+		revokedCount = int(v)
+	}
+
+	fmt.Fprintf(stdout,
+		"revocation-head[%s] verified=%v epoch=%d issued_at=%s staleness=%s revoked=%d emergency=%d\n",
+		*registryURL, verified, epoch, issuedStr, staleness, revokedCount, len(emergency))
+
+	if !verified {
+		fmt.Fprintln(stderr, "WARNING: HEAD signature not verified against any pinned registry key (untrusted registry, or no trust roots configured).")
+		return exitGeneric
+	}
+	return exitOK
+}

--- a/cmd/skillctl/revoked_cache.go
+++ b/cmd/skillctl/revoked_cache.go
@@ -34,6 +34,13 @@ const revokedCacheTTL = 12 * time.Hour
 // SPEC-0198 revoke theme (exitcode.RevokeIdentityRevoked.Number).
 const exitBundleRevoked = 17
 
+// exitRevocationStale is the SPEC-0279 R3 code recorded when a skill is denied
+// because the revocation snapshot is too stale to trust (fail-closed for a
+// high-risk action past the trust-root max_staleness). 22 = verify.ExitRevocationStale.
+// As with exitBundleRevoked, the verify-hook PROCESS still exits exitHookBlock (2)
+// to block the call; 22 is carried in the human message + the signed refusal_code.
+const exitRevocationStale = 22
+
 type revokedCacheFile struct {
 	Digests   []string `json:"digests"`
 	FetchedAt string   `json:"fetched_at"`

--- a/cmd/skillctl/revoked_cache.go
+++ b/cmd/skillctl/revoked_cache.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/kamir/m3c-tools/pkg/er1"
@@ -186,6 +187,28 @@ func setToSortedSlice(set map[string]struct{}) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// revocationHeadTimeout bounds the HEAD fetch. Short by design: this runs inside
+// the best-effort sweep, so a slow/unreachable registry must not stall it.
+const revocationHeadTimeout = 2 * time.Second
+
+// fetchRevocationHeadOnline is the production wiring for fetchRevocationHeadFn
+// (FR-0045 D5): it resolves the registry URL from trust-roots and GETs the signed
+// HEAD from the FR-0045 D2 endpoint. Fail-safe: no trust roots / no registry URL /
+// any fetch error → (nil, false), so the sweep keeps the prior epoch floor and the
+// gate applies its own fail-closed staleness policy. main() installs this seam;
+// tests leave it nil (the pre-D2 set-only behaviour).
+func fetchRevocationHeadOnline(cfg *er1.Config, ctx string, pub ed25519.PublicKey) (map[string]any, bool) {
+	_, root, err := loadRootsFn("")
+	if err != nil || root == nil || strings.TrimSpace(root.RegistryURL) == "" {
+		return nil, false
+	}
+	head, ferr := registry.FetchRevocationHead(root.RegistryURL, "", revocationHeadTimeout)
+	if ferr != nil {
+		return nil, false
+	}
+	return head, true
 }
 
 // installedSkillDigest reads the provenance sidecar's bundle_digest for an

--- a/cmd/skillctl/revoked_cache.go
+++ b/cmd/skillctl/revoked_cache.go
@@ -14,12 +14,15 @@ package main
 // in a verified revoked set — a fetch failure never false-quarantines.
 
 import (
+	"crypto/ed25519"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"time"
 
+	"github.com/kamir/m3c-tools/pkg/er1"
 	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
 )
 
@@ -34,22 +37,56 @@ const exitBundleRevoked = 17
 type revokedCacheFile struct {
 	Digests   []string `json:"digests"`
 	FetchedAt string   `json:"fetched_at"`
+	// Epoch / IssuedAt carry the last ADOPTED revocation HEAD (FR-0045 D3).
+	// omitempty keeps legacy caches (pre-HEAD) valid: absent => epoch 0, "".
+	// Epoch is the monotonicity floor for the next AdoptRevocationHead; IssuedAt
+	// is the freshness anchor the gate (D4) evaluates against SPEC-0279.
+	Epoch    int    `json:"epoch,omitempty"`
+	IssuedAt string `json:"issued_at,omitempty"`
 }
 
 func revokedCachePath(home string) string {
 	return filepath.Join(home, ".claude", "skillctl", "revoked-digests.json")
 }
 
+// writeRevokedCache persists the set with no HEAD freshness (epoch 0). Used by
+// the SPEC-0266 set-only path and tests.
 func writeRevokedCache(home string, set map[string]struct{}) {
+	writeRevokedCacheHead(home, set, 0, "")
+}
+
+// writeRevokedCacheHead persists the set plus the adopted HEAD's epoch/issued_at.
+func writeRevokedCacheHead(home string, set map[string]struct{}, epoch int, issuedAt string) {
 	digs := make([]string, 0, len(set))
 	for d := range set {
 		digs = append(digs, d)
 	}
 	sort.Strings(digs)
-	b, _ := json.MarshalIndent(revokedCacheFile{Digests: digs, FetchedAt: sweepClockFn().UTC().Format(time.RFC3339)}, "", "  ")
+	b, _ := json.MarshalIndent(revokedCacheFile{
+		Digests:   digs,
+		FetchedAt: sweepClockFn().UTC().Format(time.RFC3339),
+		Epoch:     epoch,
+		IssuedAt:  issuedAt,
+	}, "", "  ")
 	p := revokedCachePath(home)
 	_ = os.MkdirAll(filepath.Dir(p), 0o755)
 	_ = os.WriteFile(p, b, 0o644)
+}
+
+// readRevokedCacheHead returns the epoch + issued_at persisted from the last
+// adopted HEAD (0 / "" if none or a legacy cache). The epoch is the rollback
+// floor for the next AdoptRevocationHead; issued_at feeds the gate freshness
+// policy (D4).
+func readRevokedCacheHead(home string) (int, string) {
+	b, err := os.ReadFile(revokedCachePath(home))
+	if err != nil {
+		return 0, ""
+	}
+	var rc revokedCacheFile
+	if json.Unmarshal(b, &rc) != nil {
+		return 0, ""
+	}
+	return rc.Epoch, rc.IssuedAt
 }
 
 // readRevokedCache returns the cached revoked set and whether it is within ttl.
@@ -77,10 +114,19 @@ func readRevokedCache(home string, ttl time.Duration) (map[string]struct{}, bool
 // stub it. Production = fetchRevokedOnline. Returns (set, fetchedOnline).
 var sweepRevokedFn = fetchRevokedOnline
 
+// fetchRevocationHeadFn is the seam that fetches a signed revocation HEAD from
+// the registry (FR-0045 D2 endpoint). nil until the HEAD endpoint ships; while
+// nil, fetchRevokedOnline keeps the SPEC-0266 set-only behaviour (epoch floor is
+// preserved, never advanced). Returns (head, ok); ok=false means "no head
+// available" (not an error). Tests stub it.
+var fetchRevocationHeadFn func(cfg *er1.Config, ctx string, pub ed25519.PublicKey) (map[string]any, bool)
+
 // fetchRevokedOnline fetches the live verified revoked-digest set and refreshes
-// the cache. Fail-OPEN: any error → the cached set (possibly stale/empty),
-// online=false. Never returns an error — revocation enforcement is best-effort
-// availability, exactly as the offline-verify tradeoff documents.
+// the cache. Fail-OPEN on availability: any fetch error → the cached set
+// (possibly stale/empty), online=false. Never returns an error — revocation
+// enforcement is best-effort availability, exactly as the offline-verify tradeoff
+// documents. When a signed HEAD is available it is adopted (freshness +
+// rollback), and its epoch/issued_at are persisted for the gate (FR-0045 D3/D4).
 func fetchRevokedOnline(home string) (map[string]struct{}, bool) {
 	tr, err := registry.LoadSelfTrustRoots("")
 	if err != nil || tr == nil || len(tr.PubKey()) == 0 {
@@ -92,13 +138,47 @@ func fetchRevokedOnline(home string) (map[string]struct{}, bool) {
 		cached, _ := readRevokedCache(home, revokedCacheTTL)
 		return cached, false
 	}
-	set, err := registry.FetchRevokedDigests(cfg, envOr("ER1_CONTEXT", "skills"), tr.PubKey())
+	ctx := envOr("ER1_CONTEXT", "skills")
+	set, err := registry.FetchRevokedDigests(cfg, ctx, tr.PubKey())
 	if err != nil {
 		cached, _ := readRevokedCache(home, revokedCacheTTL)
 		return cached, false
 	}
-	writeRevokedCache(home, set)
+	epoch, issuedAt := adoptHeadOrKeepFloor(home, cfg, ctx, tr.PubKey(), set)
+	writeRevokedCacheHead(home, set, epoch, issuedAt)
 	return set, true
+}
+
+// adoptHeadOrKeepFloor tries to adopt a signed HEAD for the freshly-fetched set.
+// If there is no HEAD source, or the HEAD fails to verify (bad sig / rollback /
+// set-root mismatch), it KEEPS the previously-persisted epoch as the floor and
+// returns the prior issued_at — so the gate (D4) sees a non-advancing snapshot
+// and applies its fail-closed staleness policy under trust-root config. A
+// verified HEAD returns its epoch + issued_at to persist.
+func adoptHeadOrKeepFloor(home string, cfg *er1.Config, ctx string, pub ed25519.PublicKey, set map[string]struct{}) (int, string) {
+	prevEpoch, prevIssued := readRevokedCacheHead(home)
+	if fetchRevocationHeadFn == nil {
+		return prevEpoch, prevIssued
+	}
+	head, ok := fetchRevocationHeadFn(cfg, ctx, pub)
+	if !ok {
+		return prevEpoch, prevIssued
+	}
+	epoch, issued, aerr := registry.AdoptRevocationHead(pub, head, setToSortedSlice(set), prevEpoch)
+	if aerr != nil {
+		fmt.Fprintf(os.Stderr, "skillctl: revocation HEAD rejected (%v); keeping epoch floor %d\n", aerr, prevEpoch)
+		return prevEpoch, prevIssued
+	}
+	return epoch, issued.UTC().Format(time.RFC3339)
+}
+
+func setToSortedSlice(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for d := range set {
+		out = append(out, d)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // installedSkillDigest reads the provenance sidecar's bundle_digest for an

--- a/cmd/skillctl/revoked_cache.go
+++ b/cmd/skillctl/revoked_cache.go
@@ -61,9 +61,12 @@ func revokedCachePath(home string) string {
 // revokedHeadSignedPath is the sibling file that stores the RAW BYTES of the last
 // ADOPTED, ed25519-signed revocation HEAD (FR-0045 Fix A / finding F2). Because the
 // envelope signature covers epoch/issued_at/emergency, re-verifying these bytes
-// against the pinned registry key makes the freshness floor + the HEAD emergency
-// list UNFORGEABLE without that key — the unsigned revoked-digests.json alone can
-// no longer be rewritten to roll the floor back or drop an emergency digest.
+// against the pinned registry key means the unsigned revoked-digests.json ALONE can
+// no longer be rewritten to roll the floor back or drop an emergency digest — the
+// values are authenticated, not merely cached. This is NOT a claim of being
+// unforgeable: a same-uid attacker can still replace THIS file with a validly-signed
+// OLDER HEAD, and combined with a rewrite of the unsigned high-water-mark can roll
+// the floor back (the combined-vector residual documented in readRevokedCacheHeadRaw).
 func revokedHeadSignedPath(home string) string {
 	return filepath.Join(home, ".claude", "skillctl", "revoked-head.signed.json")
 }
@@ -94,6 +97,10 @@ func writeRevokedCacheHead(home string, set map[string]struct{}, epoch int, issu
 	// group/other-writable file would let a non-owner rewrite the epoch/issued_at
 	// floor (finding F2 / hacker#1). Owner-only.
 	_ = os.WriteFile(p, b, 0o600)
+	// os.WriteFile does NOT chmod an EXISTING file, so a machine upgraded from the
+	// pre-fix 0o644 cache would stay world-readable. Chmod after the write to
+	// tighten it on first upgrade (best-effort; a chmod failure is not fatal).
+	_ = os.Chmod(p, 0o600)
 }
 
 // persistSignedHead writes the raw bytes of a VERIFIED, adopted revocation HEAD to
@@ -111,6 +118,9 @@ func persistSignedHead(home string, head map[string]any) {
 	p := revokedHeadSignedPath(home)
 	_ = os.MkdirAll(filepath.Dir(p), 0o700)
 	_ = os.WriteFile(p, b, 0o600)
+	// Tighten an existing (upgraded) file too — os.WriteFile won't chmod one that
+	// already exists. Best-effort.
+	_ = os.Chmod(p, 0o600)
 }
 
 // verifiedAdoptedHead loads the persisted signed HEAD and RE-VERIFIES its ed25519
@@ -174,6 +184,14 @@ func headEmergencyDeniesDigest(home, digest string) (string, bool) {
 // on-disk value; it doubles as the monotonic high-water-mark store — writeRevoked-
 // CacheHead only ever writes it with an epoch that AdoptRevocationHead has already
 // proven >= the prior floor, so it never decreases through the legitimate path.
+//
+// CAVEAT (documented same-uid residual): the high-water-mark lives in this UNSIGNED
+// file, so the monotonic clamp is only same-uid-defeatable, NOT unforgeable. A
+// process running as the owning uid can rewrite BOTH this json epoch AND replace
+// the signed-head file with a validly-signed OLDER HEAD to roll the floor back
+// (the "combined-vector rollback"). We defeat each SINGLE vector (json-only, or
+// signed-head-only), which is all local-file state without a hardware root of trust
+// can promise; the combined vector is a knowingly-accepted residual, not closed.
 func readRevokedCacheHeadRaw(home string) (int, string) {
 	b, err := os.ReadFile(revokedCachePath(home))
 	if err != nil {
@@ -194,10 +212,14 @@ func readRevokedCacheHeadRaw(home string) (int, string) {
 // the pinned SelfTrustRoots key and the floor is derived from the verified HEAD —
 // so an attacker who rewrites the unsigned json cannot move the floor. The unsigned
 // json is used ONLY when no signed HEAD is present (legacy / pre-adopt caches), and
-// as the monotonic high-water-mark store:
+// as the (same-uid-defeatable — see readRevokedCacheHeadRaw) high-water-mark store:
 //
-//   - a signed HEAD present but unverifiable (tampered/forged, or trust roots gone)
-//     is fail-safe: keep the high-water epoch, treat freshness as UNKNOWN ("");
+//   - a signed HEAD present but unverifiable (tampered/forged, or trust roots gone):
+//     keep the high-water epoch and return issued_at="" to signal UNKNOWN freshness.
+//     NB: "" here is NOT by itself a deny — a caller that ignores it would fail OPEN.
+//     revocationSnapshotStale (N1) therefore separately detects this present-but-bad
+//     state and fails closed for a high-risk action under a max_staleness policy,
+//     mirroring freshness.go's "missing issued_at = infinitely stale" rule.
 //   - a signed HEAD whose epoch is BELOW the high-water-mark is a replayed older
 //     HEAD → reject its (lower) epoch and its freshness, keep the high-water floor.
 func readRevokedCacheHead(home string) (int, string) {
@@ -210,7 +232,9 @@ func readRevokedCacheHead(home string) (int, string) {
 	head, ok := verifiedAdoptedHead(home)
 	if !ok {
 		// Present but unverifiable → do NOT fall back to the (forgeable) json
-		// freshness; keep the high-water epoch and distrust freshness (fail-safe).
+		// freshness; keep the high-water epoch and return "" for UNKNOWN freshness.
+		// The deny for this case lives in revocationSnapshotStale (N1) — returning
+		// "" alone is not a deny.
 		return hwEpoch, ""
 	}
 	epoch, eerr := registry.HeadEpoch(head)

--- a/cmd/skillctl/revoked_cache.go
+++ b/cmd/skillctl/revoked_cache.go
@@ -16,6 +16,7 @@ package main
 import (
 	"crypto/ed25519"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -57,6 +58,16 @@ func revokedCachePath(home string) string {
 	return filepath.Join(home, ".claude", "skillctl", "revoked-digests.json")
 }
 
+// revokedHeadSignedPath is the sibling file that stores the RAW BYTES of the last
+// ADOPTED, ed25519-signed revocation HEAD (FR-0045 Fix A / finding F2). Because the
+// envelope signature covers epoch/issued_at/emergency, re-verifying these bytes
+// against the pinned registry key makes the freshness floor + the HEAD emergency
+// list UNFORGEABLE without that key — the unsigned revoked-digests.json alone can
+// no longer be rewritten to roll the floor back or drop an emergency digest.
+func revokedHeadSignedPath(home string) string {
+	return filepath.Join(home, ".claude", "skillctl", "revoked-head.signed.json")
+}
+
 // writeRevokedCache persists the set with no HEAD freshness (epoch 0). Used by
 // the SPEC-0266 set-only path and tests.
 func writeRevokedCache(home string, set map[string]struct{}) {
@@ -77,15 +88,93 @@ func writeRevokedCacheHead(home string, set map[string]struct{}, epoch int, issu
 		IssuedAt:  issuedAt,
 	}, "", "  ")
 	p := revokedCachePath(home)
-	_ = os.MkdirAll(filepath.Dir(p), 0o755)
-	_ = os.WriteFile(p, b, 0o644)
+	_ = os.MkdirAll(filepath.Dir(p), 0o700)
+	// 0o600 (was 0o644): the revoked-digest floor is security state; a
+	// world-readable cache leaks the revocation set and, more importantly, a
+	// group/other-writable file would let a non-owner rewrite the epoch/issued_at
+	// floor (finding F2 / hacker#1). Owner-only.
+	_ = os.WriteFile(p, b, 0o600)
 }
 
-// readRevokedCacheHead returns the epoch + issued_at persisted from the last
-// adopted HEAD (0 / "" if none or a legacy cache). The epoch is the rollback
-// floor for the next AdoptRevocationHead; issued_at feeds the gate freshness
-// policy (D4).
-func readRevokedCacheHead(home string) (int, string) {
+// persistSignedHead writes the raw bytes of a VERIFIED, adopted revocation HEAD to
+// the sibling signed-head file (0o600). Called only from AdoptRevocationHead's
+// success path (via adoptHeadOrKeepFloor) — the head passed here has already had
+// its envelope signature + epoch monotonicity + set-root binding checked, so its
+// bytes are a trustworthy anchor for a later re-verify (readRevokedCacheHead /
+// headEmergencyDeniesDigest). Best-effort: a write failure just means the next
+// read falls back to the unsigned json floor.
+func persistSignedHead(home string, head map[string]any) {
+	b, err := json.MarshalIndent(head, "", "  ")
+	if err != nil {
+		return
+	}
+	p := revokedHeadSignedPath(home)
+	_ = os.MkdirAll(filepath.Dir(p), 0o700)
+	_ = os.WriteFile(p, b, 0o600)
+}
+
+// verifiedAdoptedHead loads the persisted signed HEAD and RE-VERIFIES its ed25519
+// envelope signature against the pinned SelfTrustRoots registry key. ok=false when
+// there is no signed HEAD on disk, the trust roots are unavailable, or the
+// signature does not verify (a tampered/forged file). This is the single
+// authenticator both the freshness floor (Fix A) and the HEAD emergency list
+// (Fix C) route through, so neither can be forged without the registry key.
+func verifiedAdoptedHead(home string) (map[string]any, bool) {
+	p := revokedHeadSignedPath(home)
+	if !fileExists(p) {
+		return nil, false
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil, false
+	}
+	var head map[string]any
+	if json.Unmarshal(b, &head) != nil {
+		return nil, false
+	}
+	tr, err := registry.LoadSelfTrustRoots("")
+	if err != nil || tr == nil || len(tr.PubKey()) == 0 {
+		return nil, false
+	}
+	if registry.VerifyEnvelopeSignature(tr.PubKey(), head) != nil {
+		return nil, false
+	}
+	return head, true
+}
+
+// headEmergencyDeniesDigest reports whether the installed skill's bundle digest is
+// on the ADOPTED signed HEAD's `emergency` list (FR-0045 Fix C / finding F4). The
+// emergency set is read from the RE-VERIFIED HEAD (verifiedAdoptedHead), so a
+// digest the registry placed in HEAD.emergency denies at the gate even with no
+// local emergency-deny.json present, and the list cannot be edited without the
+// registry key. Returns the matched token + true on a hit.
+func headEmergencyDeniesDigest(home, digest string) (string, bool) {
+	if strings.TrimSpace(digest) == "" {
+		return "", false
+	}
+	head, ok := verifiedAdoptedHead(home)
+	if !ok {
+		return "", false
+	}
+	em, err := registry.HeadEmergency(head)
+	if err != nil {
+		return "", false
+	}
+	want := strings.ToLower(strings.TrimSpace(digest))
+	for _, e := range em {
+		if strings.ToLower(strings.TrimSpace(e)) == want {
+			return e, true
+		}
+	}
+	return "", false
+}
+
+// readRevokedCacheHeadRaw returns the epoch + issued_at as stored in the UNSIGNED
+// revoked-digests.json (0 / "" if none or a legacy cache). This is the forgeable
+// on-disk value; it doubles as the monotonic high-water-mark store — writeRevoked-
+// CacheHead only ever writes it with an epoch that AdoptRevocationHead has already
+// proven >= the prior floor, so it never decreases through the legitimate path.
+func readRevokedCacheHeadRaw(home string) (int, string) {
 	b, err := os.ReadFile(revokedCachePath(home))
 	if err != nil {
 		return 0, ""
@@ -95,6 +184,47 @@ func readRevokedCacheHead(home string) (int, string) {
 		return 0, ""
 	}
 	return rc.Epoch, rc.IssuedAt
+}
+
+// readRevokedCacheHead returns the AUTHENTICATED epoch + issued_at floor (FR-0045
+// Fix A / finding F2). It is the rollback floor for the next AdoptRevocationHead
+// and the freshness anchor the gate (D4) evaluates.
+//
+// If a persisted signed HEAD exists, its ed25519 envelope is RE-VERIFIED against
+// the pinned SelfTrustRoots key and the floor is derived from the verified HEAD —
+// so an attacker who rewrites the unsigned json cannot move the floor. The unsigned
+// json is used ONLY when no signed HEAD is present (legacy / pre-adopt caches), and
+// as the monotonic high-water-mark store:
+//
+//   - a signed HEAD present but unverifiable (tampered/forged, or trust roots gone)
+//     is fail-safe: keep the high-water epoch, treat freshness as UNKNOWN ("");
+//   - a signed HEAD whose epoch is BELOW the high-water-mark is a replayed older
+//     HEAD → reject its (lower) epoch and its freshness, keep the high-water floor.
+func readRevokedCacheHead(home string) (int, string) {
+	hwEpoch, jsonIssued := readRevokedCacheHeadRaw(home)
+
+	if !fileExists(revokedHeadSignedPath(home)) {
+		// No signed HEAD → fall back to the unsigned json (legacy / pre-adopt).
+		return hwEpoch, jsonIssued
+	}
+	head, ok := verifiedAdoptedHead(home)
+	if !ok {
+		// Present but unverifiable → do NOT fall back to the (forgeable) json
+		// freshness; keep the high-water epoch and distrust freshness (fail-safe).
+		return hwEpoch, ""
+	}
+	epoch, eerr := registry.HeadEpoch(head)
+	issuedAt, ierr := registry.HeadIssuedAt(head)
+	if eerr != nil || ierr != nil {
+		return hwEpoch, ""
+	}
+	// Monotonic high-water-mark: never accept a floor epoch below the highest
+	// previously-verified epoch. A replayed older-but-validly-signed HEAD is
+	// rejected — keep the floor and distrust the replay's freshness.
+	if epoch < hwEpoch {
+		return hwEpoch, ""
+	}
+	return epoch, issuedAt.UTC().Format(time.RFC3339)
 }
 
 // readRevokedCache returns the cached revoked set and whether it is within ttl.
@@ -152,32 +282,62 @@ func fetchRevokedOnline(home string) (map[string]struct{}, bool) {
 		cached, _ := readRevokedCache(home, revokedCacheTTL)
 		return cached, false
 	}
-	epoch, issuedAt := adoptHeadOrKeepFloor(home, cfg, ctx, tr.PubKey(), set)
+	return applyFetchedRevokedSet(home, cfg, ctx, tr.PubKey(), set)
+}
+
+// applyFetchedRevokedSet reconciles a freshly-fetched revoked set with the signed
+// HEAD and decides the authoritative set to trust. On the happy path it adopts the
+// HEAD (freshness + rollback), persists the set + floor, and returns (set, true).
+//
+// FR-0045 Fix B / finding F1 — when the signed HEAD verifies but binds a DIFFERENT
+// revoked_set_root than the fetched set (ErrHeadSetRootMismatch), the fetched set
+// is truncated/forged relative to the signed HEAD: we REFUSE to overwrite the cache
+// with it, retain the prior last-known-good set, do NOT refresh FetchedAt (staleness
+// accrues against the prior issued_at so the D4 gate can eventually fail closed),
+// and return the prior set as authoritative (refreshed=false).
+func applyFetchedRevokedSet(home string, cfg *er1.Config, ctx string, pub ed25519.PublicKey, set map[string]struct{}) (map[string]struct{}, bool) {
+	epoch, issuedAt, setRejected := adoptHeadOrKeepFloor(home, cfg, ctx, pub, set)
+	if setRejected {
+		prior, _ := readRevokedCache(home, revokedCacheTTL)
+		return prior, false
+	}
 	writeRevokedCacheHead(home, set, epoch, issuedAt)
 	return set, true
 }
 
 // adoptHeadOrKeepFloor tries to adopt a signed HEAD for the freshly-fetched set.
-// If there is no HEAD source, or the HEAD fails to verify (bad sig / rollback /
-// set-root mismatch), it KEEPS the previously-persisted epoch as the floor and
-// returns the prior issued_at — so the gate (D4) sees a non-advancing snapshot
-// and applies its fail-closed staleness policy under trust-root config. A
-// verified HEAD returns its epoch + issued_at to persist.
-func adoptHeadOrKeepFloor(home string, cfg *er1.Config, ctx string, pub ed25519.PublicKey, set map[string]struct{}) (int, string) {
+// If there is no HEAD source, or the HEAD fails to verify (bad sig / rollback), it
+// KEEPS the previously-persisted epoch as the floor and returns the prior issued_at
+// — so the gate (D4) sees a non-advancing snapshot and applies its fail-closed
+// staleness policy under trust-root config. A verified HEAD returns its epoch +
+// issued_at to persist AND persists the signed HEAD bytes (Fix A) for a later
+// authenticated re-verify.
+//
+// The third return, setRejected, is true ONLY for ErrHeadSetRootMismatch (finding
+// F1): the HEAD verified but bound a different set-root, so the fetched set is
+// truncated/forged and the caller MUST discard it and retain last-known-good.
+func adoptHeadOrKeepFloor(home string, cfg *er1.Config, ctx string, pub ed25519.PublicKey, set map[string]struct{}) (int, string, bool) {
 	prevEpoch, prevIssued := readRevokedCacheHead(home)
 	if fetchRevocationHeadFn == nil {
-		return prevEpoch, prevIssued
+		return prevEpoch, prevIssued, false
 	}
 	head, ok := fetchRevocationHeadFn(cfg, ctx, pub)
 	if !ok {
-		return prevEpoch, prevIssued
+		return prevEpoch, prevIssued, false
 	}
 	epoch, issued, aerr := registry.AdoptRevocationHead(pub, head, setToSortedSlice(set), prevEpoch)
 	if aerr != nil {
+		if errors.Is(aerr, registry.ErrHeadSetRootMismatch) {
+			fmt.Fprintf(os.Stderr, "skillctl: revocation HEAD set-root mismatch (%v); REJECTING the fetched set as truncated/forged and retaining last-known-good (staleness accrues against prior issued_at)\n", aerr)
+			return prevEpoch, prevIssued, true
+		}
 		fmt.Fprintf(os.Stderr, "skillctl: revocation HEAD rejected (%v); keeping epoch floor %d\n", aerr, prevEpoch)
-		return prevEpoch, prevIssued
+		return prevEpoch, prevIssued, false
 	}
-	return epoch, issued.UTC().Format(time.RFC3339)
+	// Verified HEAD → persist its raw bytes as the authenticated floor / emergency
+	// anchor (Fix A / Fix C).
+	persistSignedHead(home, head)
+	return epoch, issued.UTC().Format(time.RFC3339), false
 }
 
 func setToSortedSlice(set map[string]struct{}) []string {

--- a/cmd/skillctl/revoked_cache_head_test.go
+++ b/cmd/skillctl/revoked_cache_head_test.go
@@ -49,8 +49,8 @@ func TestAdoptHeadOrKeepFloor(t *testing.T) {
 		home := t.TempDir()
 		writeRevokedCacheHead(home, set, 3, "2026-01-01T00:00:00Z")
 		fetchRevocationHeadFn = nil
-		if ep, iss := adoptHeadOrKeepFloor(home, nil, "skills", pub, set); ep != 3 || iss != "2026-01-01T00:00:00Z" {
-			t.Errorf("= %d,%q, want 3,<prev>", ep, iss)
+		if ep, iss, rej := adoptHeadOrKeepFloor(home, nil, "skills", pub, set); ep != 3 || iss != "2026-01-01T00:00:00Z" || rej {
+			t.Errorf("= %d,%q,%v, want 3,<prev>,false", ep, iss, rej)
 		}
 	})
 
@@ -60,8 +60,8 @@ func TestAdoptHeadOrKeepFloor(t *testing.T) {
 			return signedHead(5), true
 		}
 		defer func() { fetchRevocationHeadFn = nil }()
-		if ep, iss := adoptHeadOrKeepFloor(home, nil, "skills", pub, set); ep != 5 || iss != "2026-07-06T18:00:00Z" {
-			t.Errorf("= %d,%q, want 5,<ts>", ep, iss)
+		if ep, iss, rej := adoptHeadOrKeepFloor(home, nil, "skills", pub, set); ep != 5 || iss != "2026-07-06T18:00:00Z" || rej {
+			t.Errorf("= %d,%q,%v, want 5,<ts>,false", ep, iss, rej)
 		}
 	})
 
@@ -72,8 +72,30 @@ func TestAdoptHeadOrKeepFloor(t *testing.T) {
 			return signedHead(4), true // lower epoch than the persisted floor 9
 		}
 		defer func() { fetchRevocationHeadFn = nil }()
-		if ep, iss := adoptHeadOrKeepFloor(home, nil, "skills", pub, set); ep != 9 || iss != "2026-06-01T00:00:00Z" {
-			t.Errorf("rollback advanced floor = %d,%q, want 9,<prev>", ep, iss)
+		if ep, iss, rej := adoptHeadOrKeepFloor(home, nil, "skills", pub, set); ep != 9 || iss != "2026-06-01T00:00:00Z" || rej {
+			t.Errorf("rollback advanced floor = %d,%q,%v, want 9,<prev>,false", ep, iss, rej)
+		}
+	})
+
+	// FR-0045 Fix B / finding F1 — a signed HEAD that binds a DIFFERENT set-root
+	// than the fetched set signals setRejected=true (the fetched set is
+	// truncated/forged) and keeps the prior floor.
+	t.Run("set-root mismatch is signalled and keeps floor", func(t *testing.T) {
+		home := t.TempDir()
+		writeRevokedCacheHead(home, set, 2, "2026-05-01T00:00:00Z")
+		// The signed HEAD binds the full {dg} set; feed a set MISSING dg (empty) so
+		// the recomputed set-root cannot match the head's revoked_set_root.
+		fetchRevocationHeadFn = func(_ *er1.Config, _ string, _ ed25519.PublicKey) (map[string]any, bool) {
+			return signedHead(5), true
+		}
+		defer func() { fetchRevocationHeadFn = nil }()
+		truncated := map[string]struct{}{} // dropped dg
+		ep, iss, rej := adoptHeadOrKeepFloor(home, nil, "skills", pub, truncated)
+		if !rej {
+			t.Fatalf("set-root mismatch not signalled: rej=%v", rej)
+		}
+		if ep != 2 || iss != "2026-05-01T00:00:00Z" {
+			t.Errorf("mismatch must keep prior floor, got %d,%q", ep, iss)
 		}
 	})
 }

--- a/cmd/skillctl/revoked_cache_head_test.go
+++ b/cmd/skillctl/revoked_cache_head_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/er1"
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+)
+
+func headTestDigest(c byte) string { return "sha256:" + strings.Repeat(string(c), 64) }
+
+func TestRevokedCacheHead_RoundTrip(t *testing.T) {
+	home := t.TempDir()
+	set := map[string]struct{}{headTestDigest('a'): {}}
+
+	writeRevokedCacheHead(home, set, 7, "2026-07-06T18:00:00Z")
+	if ep, iss := readRevokedCacheHead(home); ep != 7 || iss != "2026-07-06T18:00:00Z" {
+		t.Fatalf("head round-trip = %d,%q", ep, iss)
+	}
+	// A legacy set-only write (pre-HEAD) reads back as 0,"" — backward compatible.
+	writeRevokedCache(home, set)
+	if ep, iss := readRevokedCacheHead(home); ep != 0 || iss != "" {
+		t.Errorf("legacy head = %d,%q, want 0,\"\"", ep, iss)
+	}
+}
+
+func TestAdoptHeadOrKeepFloor(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	dg := headTestDigest('a')
+	set := map[string]struct{}{dg: {}}
+	ts := time.Date(2026, 7, 6, 18, 0, 0, 0, time.UTC)
+
+	signedHead := func(epoch int) map[string]any {
+		h, err := registry.BuildRevocationHead(registry.RevocationHeadInput{Epoch: epoch, IssuedAt: ts, Digests: []string{dg}})
+		if err != nil {
+			t.Fatalf("build head: %v", err)
+		}
+		if _, err := registry.SignEnvelopeSignature(priv, h); err != nil {
+			t.Fatalf("sign head: %v", err)
+		}
+		return h
+	}
+
+	t.Run("no head source keeps floor", func(t *testing.T) {
+		home := t.TempDir()
+		writeRevokedCacheHead(home, set, 3, "2026-01-01T00:00:00Z")
+		fetchRevocationHeadFn = nil
+		if ep, iss := adoptHeadOrKeepFloor(home, nil, "skills", pub, set); ep != 3 || iss != "2026-01-01T00:00:00Z" {
+			t.Errorf("= %d,%q, want 3,<prev>", ep, iss)
+		}
+	})
+
+	t.Run("valid head adopted", func(t *testing.T) {
+		home := t.TempDir()
+		fetchRevocationHeadFn = func(_ *er1.Config, _ string, _ ed25519.PublicKey) (map[string]any, bool) {
+			return signedHead(5), true
+		}
+		defer func() { fetchRevocationHeadFn = nil }()
+		if ep, iss := adoptHeadOrKeepFloor(home, nil, "skills", pub, set); ep != 5 || iss != "2026-07-06T18:00:00Z" {
+			t.Errorf("= %d,%q, want 5,<ts>", ep, iss)
+		}
+	})
+
+	t.Run("rollback head keeps floor (does not advance)", func(t *testing.T) {
+		home := t.TempDir()
+		writeRevokedCacheHead(home, set, 9, "2026-06-01T00:00:00Z")
+		fetchRevocationHeadFn = func(_ *er1.Config, _ string, _ ed25519.PublicKey) (map[string]any, bool) {
+			return signedHead(4), true // lower epoch than the persisted floor 9
+		}
+		defer func() { fetchRevocationHeadFn = nil }()
+		if ep, iss := adoptHeadOrKeepFloor(home, nil, "skills", pub, set); ep != 9 || iss != "2026-06-01T00:00:00Z" {
+			t.Errorf("rollback advanced floor = %d,%q, want 9,<prev>", ep, iss)
+		}
+	})
+}

--- a/cmd/skillctl/verify_hook_cmds.go
+++ b/cmd/skillctl/verify_hook_cmds.go
@@ -76,6 +76,13 @@ func refusalCodeForHook(exitCode int, reason string) string {
 		return "agent_emergency_denied"
 	case strings.Contains(reason, "agentid: agent_revocation_stale"):
 		return "agent_revocation_stale"
+	// FR-0045 N1 — the signed revocation HEAD is present but failed verification
+	// (tampered/corrupt). A distinct token from the plain-stale case so the Art.12
+	// trail separates "we could not prove the HEAD authentic" from "the HEAD is
+	// authentic but too old". Checked BEFORE the stale case (the two tokens are
+	// disjoint, but keep the more specific one first).
+	case strings.Contains(reason, "bundle_revocation_head_untrusted"):
+		return "bundle_revocation_head_untrusted"
 	// SPEC-0279 R3 / FR-0045 D4 — bundle-revocation snapshot too stale to trust
 	// (fail-closed for a high-risk skill invocation). Distinct from the agentid
 	// mandate stale case so the Art.12 trail separates the two channels.
@@ -571,7 +578,24 @@ func revocationSnapshotStale(home, skill string) (bool, string, string) {
 	if p := freshnessCheckpointPath(home); fileExists(p) {
 		cpPath = p
 	}
-	if issuedAt == "" && cpPath == "" {
+
+	// FR-0045 N1 — a signed HEAD that is PRESENT but fails verification is tampering,
+	// NOT the pre-D2 "no anchor" case. readRevokedCacheHead returns issued_at="" for
+	// BOTH the ABSENT and the PRESENT-BUT-BAD states, so without this the early no-op
+	// below would flip DENY→ALLOW on a one-byte corruption wherever max_staleness is
+	// configured. Detect the tampered state explicitly and drive it through the
+	// freshness evaluation with an empty anchor (= infinitely stale, per freshness.go)
+	// so a high-risk action fails CLOSED once a max_staleness ceiling is set. The
+	// ABSENT case (no signed HEAD, no checkpoint) stays a no-op — must not brick a
+	// pre-D2 install that never adopted a HEAD.
+	headTampered := false
+	if fileExists(revokedHeadSignedPath(home)) {
+		if _, ok := verifiedAdoptedHead(home); !ok {
+			headTampered = true
+		}
+	}
+
+	if issuedAt == "" && cpPath == "" && !headTampered {
 		return false, "", "" // no signed anchor yet → nothing to enforce (pre-D2).
 	}
 	_, root, rerr := loadRootsFn("")
@@ -584,11 +608,15 @@ func revocationSnapshotStale(home, skill string) (bool, string, string) {
 		root:           root,
 		checkpointPath: cpPath,
 		syncedEpoch:    epoch,
-		syncedIssuedAt: issuedAt,
+		syncedIssuedAt: issuedAt, // "" for a tampered HEAD → infinitely stale
 		risk:           verify.RiskHigh,
 	})
 	auditFreshnessDecision("hook", skill, out)
 	if out.Err != nil {
+		if headTampered {
+			return true, "bundle_revocation_head_untrusted",
+				fmt.Sprintf("skillctl: BLOCKED '%s' — the signed revocation HEAD is present but its ed25519 envelope failed verification (tampered/corrupt); refusing a high-risk skill invocation (exit %d, fail-closed, FR-0045 N1). Run `skillctl revoke feed --refresh` to re-fetch a valid signed HEAD.", skill, exitRevocationStale)
+		}
 		return true, "bundle_revocation_stale",
 			fmt.Sprintf("skillctl: BLOCKED '%s' — revocation snapshot too stale to trust (exit %d, SPEC-0279 R3); refusing a high-risk skill invocation until the revocation feed is refreshed. Run `skillctl verify --all` (or `skillctl revoke feed --refresh`).", skill, exitRevocationStale)
 	}

--- a/cmd/skillctl/verify_hook_cmds.go
+++ b/cmd/skillctl/verify_hook_cmds.go
@@ -76,6 +76,11 @@ func refusalCodeForHook(exitCode int, reason string) string {
 		return "agent_emergency_denied"
 	case strings.Contains(reason, "agentid: agent_revocation_stale"):
 		return "agent_revocation_stale"
+	// SPEC-0279 R3 / FR-0045 D4 — bundle-revocation snapshot too stale to trust
+	// (fail-closed for a high-risk skill invocation). Distinct from the agentid
+	// mandate stale case so the Art.12 trail separates the two channels.
+	case strings.Contains(reason, "bundle_revocation_stale"):
+		return "bundle_revocation_stale"
 	// Both the mandate path ("agentid_emergency_list_untrusted") and the
 	// unconditional runtime path ("agent_emergency_list_untrusted") match this
 	// common substring → a present-but-forged emergency file's fail-closed deny.
@@ -349,6 +354,18 @@ func runVerifyHook(stdin io.Reader, stdout, stderr io.Writer) (code int) {
 		}
 	}
 
+	// SPEC-0279 R3 / FR-0045 D4 — FRESHNESS FAIL-CLOSED. If the revocation snapshot
+	// is too stale to trust (per the trust-root max_staleness), refuse a high-risk
+	// skill invocation rather than run against a revocation list we can no longer
+	// prove is current. This closes the fail-OPEN gap above where a >TTL sweep cache
+	// silently skips the revocation check. Placed BEFORE the verdict-cache fast path
+	// so a cached allow cannot bypass a stale kill-switch. OPT-IN: a no-op unless a
+	// max_staleness policy is set AND a signed HEAD/checkpoint anchor exists.
+	if stale, reason, msg := revocationSnapshotStale(home, skill); stale {
+		audReason = reason
+		return emitDeny(stdout, stderr, msg)
+	}
+
 	// Managed skill → offline fast path first: a fresh, digest-matching PASS
 	// in the verdict cache (written by the SessionStart sweep or a prior hook)
 	// lets us allow without touching the network (SPEC-0247 §8 / P1.1).
@@ -521,6 +538,61 @@ func reasonForExit(code int, err error) string {
 		}
 		return "verification failed"
 	}
+}
+
+// revocationSnapshotStale applies the SPEC-0279 R3 freshness contract to the
+// sweep-maintained bundle-revocation snapshot at the runtime gate. It is the
+// fail-CLOSED half of the G5 kill-switch (FR-0045 D4): if the revocation snapshot
+// is too stale to trust — older than the trust-root max_staleness — it refuses a
+// high-risk skill invocation rather than run one against a revocation list we can
+// no longer prove is current. That closes the fail-OPEN gap where a >TTL sweep
+// cache silently skipped the revocation check entirely.
+//
+// Deliberately gated to STAY OUT OF THE WAY until a signed freshness anchor
+// exists, so it cannot brick existing installs:
+//   - engaged ONLY when the cache carries an adopted HEAD's issued_at (FR-0045 D3)
+//     OR a signed freshness checkpoint (R4) is on disk. Absent both there is no
+//     signed anchor to judge → no-op (the pre-FR-0045 sweep set-only path stands
+//     unchanged; relevant until the D2 HEAD endpoint ships).
+//   - a no-op anyway when the trust root sets no max_staleness (EvaluateFreshness
+//     ALLOWs an unset ceiling) — so the whole fail-closed behaviour is OPT-IN by
+//     trust-root policy.
+//
+// A skill invocation is classified RiskHigh: its concrete side effects are unknown
+// at the gate, and SPEC-0279 fails high-risk closed past the ceiling (fail-safe).
+// Returns (deny, refusalToken, humanMessage). Every decision is audited (R6) via
+// auditFreshnessDecision inside evaluateFreshness's caller path.
+func revocationSnapshotStale(home, skill string) (bool, string, string) {
+	if home == "" {
+		return false, "", ""
+	}
+	epoch, issuedAt := readRevokedCacheHead(home)
+	cpPath := ""
+	if p := freshnessCheckpointPath(home); fileExists(p) {
+		cpPath = p
+	}
+	if issuedAt == "" && cpPath == "" {
+		return false, "", "" // no signed anchor yet → nothing to enforce (pre-D2).
+	}
+	_, root, rerr := loadRootsFn("")
+	if rerr != nil {
+		// No trust roots → we cannot read the freshness policy. The managed-skill
+		// chain fails closed later on the same condition; do not double-deny here.
+		return false, "", ""
+	}
+	out := evaluateFreshness(freshnessInputs{
+		root:           root,
+		checkpointPath: cpPath,
+		syncedEpoch:    epoch,
+		syncedIssuedAt: issuedAt,
+		risk:           verify.RiskHigh,
+	})
+	auditFreshnessDecision("hook", skill, out)
+	if out.Err != nil {
+		return true, "bundle_revocation_stale",
+			fmt.Sprintf("skillctl: BLOCKED '%s' — revocation snapshot too stale to trust (exit %d, SPEC-0279 R3); refusing a high-risk skill invocation until the revocation feed is refreshed. Run `skillctl verify --all` (or `skillctl revoke feed --refresh`).", skill, exitRevocationStale)
+	}
+	return false, "", ""
 }
 
 // --- managed/unmanaged classification ---

--- a/cmd/skillctl/verify_hook_freshness_test.go
+++ b/cmd/skillctl/verify_hook_freshness_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// TestRevocationSnapshotStale exercises the FR-0045 D4 fail-closed freshness gate
+// on the bundle-revocation snapshot: stale + a max_staleness policy denies a
+// high-risk skill invocation; anything short of that (no anchor, fresh, or no
+// policy) is a no-op so existing installs are not bricked.
+func TestRevocationSnapshotStale(t *testing.T) {
+	origLoad := loadRootsFn
+	defer func() { loadRootsFn = origLoad }()
+
+	withPolicy := func(maxStaleness string) {
+		loadRootsFn = func(string) (*verify.TrustRoots, *verify.TrustRoot, error) {
+			return nil, &verify.TrustRoot{MaxStaleness: maxStaleness, FailPolicy: "closed"}, nil
+		}
+	}
+	set := map[string]struct{}{headTestDigest('a'): {}}
+	stale := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+	fresh := time.Now().UTC().Format(time.RFC3339)
+
+	t.Run("no signed anchor -> no deny (pre-D2 behaviour preserved)", func(t *testing.T) {
+		home := t.TempDir()
+		writeRevokedCache(home, set) // epoch 0, issued_at ""
+		withPolicy("24h")
+		if deny, _, _ := revocationSnapshotStale(home, "s"); deny {
+			t.Errorf("denied with no signed anchor")
+		}
+	})
+
+	t.Run("stale anchor + max_staleness policy -> DENY (fail-closed)", func(t *testing.T) {
+		home := t.TempDir()
+		writeRevokedCacheHead(home, set, 5, stale)
+		withPolicy("24h")
+		deny, reason, msg := revocationSnapshotStale(home, "s")
+		if !deny || reason != "bundle_revocation_stale" {
+			t.Fatalf("stale not fail-closed: deny=%v reason=%q", deny, reason)
+		}
+		if msg == "" {
+			t.Errorf("empty deny message")
+		}
+	})
+
+	t.Run("fresh anchor + policy -> no deny", func(t *testing.T) {
+		home := t.TempDir()
+		writeRevokedCacheHead(home, set, 5, fresh)
+		withPolicy("24h")
+		if deny, _, _ := revocationSnapshotStale(home, "s"); deny {
+			t.Errorf("fresh anchor denied")
+		}
+	})
+
+	t.Run("anchor present but no max_staleness policy -> no deny (opt-in)", func(t *testing.T) {
+		home := t.TempDir()
+		writeRevokedCacheHead(home, set, 5, stale)
+		withPolicy("") // no ceiling configured
+		if deny, _, _ := revocationSnapshotStale(home, "s"); deny {
+			t.Errorf("denied without a max_staleness policy (should be opt-in)")
+		}
+	})
+}

--- a/pkg/skillctl/registry/revocation_feed.go
+++ b/pkg/skillctl/registry/revocation_feed.go
@@ -1,0 +1,52 @@
+package registry
+
+// FR-0045 D5 — the client-side fetch of the signed revocation HEAD.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// FetchRevocationHead GETs the signed revocation HEAD from the registry
+// (FR-0045 D2 endpoint: <registry>/revocations/head, where <registry> already
+// includes the /api/skills root — mirroring how `revoke` posts to
+// <registry>/bundles/<digest>/revoke). Returns the head as a map[string]any for
+// AdoptRevocationHead.
+//
+// PUBLIC feed (CRL semantics): no auth header. Integrity comes from the ed25519
+// envelope signature, which the caller verifies against the PINNED registry key —
+// this function only transports the already-authoritative record (BDR 2026-07-06).
+func FetchRevocationHead(baseURL, tenantScope string, timeout time.Duration) (map[string]any, error) {
+	base := strings.TrimSpace(baseURL)
+	if base == "" {
+		return nil, fmt.Errorf("registry: empty base URL for revocation head")
+	}
+	u := strings.TrimRight(base, "/") + "/revocations/head"
+	if tenantScope != "" {
+		u += "?tenant_scope=" + url.QueryEscape(tenantScope)
+	}
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := (&http.Client{Timeout: timeout}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("registry: revocation head HTTP %d", resp.StatusCode)
+	}
+	var head map[string]any
+	if err := json.Unmarshal(body, &head); err != nil {
+		return nil, fmt.Errorf("registry: revocation head decode: %w", err)
+	}
+	return head, nil
+}

--- a/pkg/skillctl/registry/revocation_feed_test.go
+++ b/pkg/skillctl/registry/revocation_feed_test.go
@@ -1,0 +1,55 @@
+package registry
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestFetchRevocationHead(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/skills/revocations/head" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"schema_version":"m3c-revocation-head/v1","epoch":7,"issued_at":"2026-07-06T18:00:00Z","emergency":[]}`)
+	}))
+	defer srv.Close()
+
+	head, err := FetchRevocationHead(srv.URL+"/api/skills", "", 3*time.Second)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if head["schema_version"] != RevocationHeadSchema {
+		t.Errorf("schema_version = %v", head["schema_version"])
+	}
+	if ep, _ := HeadEpoch(head); ep != 7 {
+		t.Errorf("epoch = %d, want 7", ep)
+	}
+}
+
+func TestFetchRevocationHead_Errors(t *testing.T) {
+	// empty URL
+	if _, err := FetchRevocationHead("", "", time.Second); err == nil {
+		t.Error("want error on empty base URL")
+	}
+	// non-200
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+	if _, err := FetchRevocationHead(bad.URL, "", time.Second); err == nil {
+		t.Error("want error on HTTP 500")
+	}
+	// malformed JSON
+	junk := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "not json")
+	}))
+	defer junk.Close()
+	if _, err := FetchRevocationHead(junk.URL, "", time.Second); err == nil {
+		t.Error("want error on malformed JSON")
+	}
+}

--- a/pkg/skillctl/registry/revocation_head.go
+++ b/pkg/skillctl/registry/revocation_head.go
@@ -18,6 +18,7 @@ package registry
 // (HTTP/ER1/Kafka) — is the source of truth; the transport only carries it.
 
 import (
+	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -194,6 +195,33 @@ func CheckEpochMonotonic(head map[string]any, persistedMax int) error {
 		return fmt.Errorf("%w: head epoch %d < accepted floor %d", ErrHeadRollback, epoch, persistedMax)
 	}
 	return nil
+}
+
+// AdoptRevocationHead is the client's gate for accepting a fetched HEAD before
+// it advances its freshness/epoch. It composes, in fail-closed order:
+//  1. the envelope signature against the pinned registry key (event.go),
+//  2. epoch monotonicity against the client's persisted floor (R1 rollback),
+//  3. that the separately-transported set binds to the head's revoked_set_root.
+// On success it returns the epoch + issued_at to persist. On ANY failure the
+// client MUST NOT advance its epoch or treat the snapshot as fresh — the gate
+// (SPEC-0247 / FR-0045 D4) then applies the fail-closed staleness policy.
+func AdoptRevocationHead(pub ed25519.PublicKey, head map[string]any, set []string, persistedEpoch int) (epoch int, issuedAt time.Time, err error) {
+	if err = VerifyEnvelopeSignature(pub, head); err != nil {
+		return 0, time.Time{}, err
+	}
+	if err = CheckEpochMonotonic(head, persistedEpoch); err != nil {
+		return 0, time.Time{}, err
+	}
+	if err = VerifyRevocationHeadSet(head, set); err != nil {
+		return 0, time.Time{}, err
+	}
+	if epoch, err = HeadEpoch(head); err != nil {
+		return 0, time.Time{}, err
+	}
+	if issuedAt, err = HeadIssuedAt(head); err != nil {
+		return 0, time.Time{}, err
+	}
+	return epoch, issuedAt, nil
 }
 
 // ─── helpers ───────────────────────────────────────────────────────────────

--- a/pkg/skillctl/registry/revocation_head.go
+++ b/pkg/skillctl/registry/revocation_head.go
@@ -1,0 +1,237 @@
+package registry
+
+// SPEC-0279 R4 (signed freshness checkpoint) / FR-0045 D1 — the G5 kill-switch
+// feed HEAD.
+//
+// A RevocationHead is a signed, monotonic pointer at the current revoked-digest
+// set: {epoch, issued_at, revoked_set_root, emergency}. It is NOT a new envelope
+// — it reuses the SPEC-0190 canonical bytes + ed25519 signing from event.go
+// verbatim (CanonicalEventBytes / SignEnvelopeSignature / VerifyEnvelopeSignature),
+// so the HEAD is just another event shape on the same wire. The registry key
+// signs it; verifiers pin that key via trust-roots (ActiveKeys).
+//
+// Why a HEAD at all: a verifier that only fetches the revoked *set* cannot tell
+// a fresh snapshot from a stale one, so it silently fails open. The HEAD carries
+// a monotonic `epoch` (rollback protection) and an `issued_at` (freshness), and
+// binds itself to the full set via `revoked_set_root` so a truncated or forged
+// set is detectable. Per the 2026-07-06 BDR, the signed HEAD — not the transport
+// (HTTP/ER1/Kafka) — is the source of truth; the transport only carries it.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// RevocationHeadSchema is the value of the head's `schema_version` field. Bumping
+// it is a breaking change for any consumer.
+const RevocationHeadSchema = "m3c-revocation-head/v1"
+
+var (
+	// ErrInvalidHead is returned for a head missing required fields or with
+	// fields of the wrong shape.
+	ErrInvalidHead = errors.New("registry: invalid revocation head")
+
+	// ErrHeadRollback is returned when a head's epoch is lower than the highest
+	// epoch a verifier has already accepted (SPEC-0279 R1 rollback protection).
+	ErrHeadRollback = errors.New("registry: revocation head epoch went backwards")
+
+	// ErrHeadSetRootMismatch is returned when a revoked set hashes to a root that
+	// does not match the head's revoked_set_root (truncated / forged set).
+	ErrHeadSetRootMismatch = errors.New("registry: revoked set does not match head revoked_set_root")
+)
+
+// RevocationHeadInput is the typed input for BuildRevocationHead.
+type RevocationHeadInput struct {
+	Epoch       int       // monotonic; verifier persists the highest seen and refuses lower
+	IssuedAt    time.Time // event ts (UTC); freshness anchor
+	Digests     []string  // the full revoked set; revoked_set_root is computed from it
+	Emergency   []string  // subset of Digests that short-circuits the cadence (R5)
+	TenantScope *string   // nil for the self tenant
+}
+
+// BuildRevocationHead constructs the signed head payload (unsigned map; caller
+// signs with SignEnvelopeSignature, exactly as for the SPEC-0190 events). Digests
+// and Emergency are validated; Emergency must be a subset of Digests (an
+// emergency-denied digest is by definition revoked).
+func BuildRevocationHead(in RevocationHeadInput) (map[string]any, error) {
+	if in.Epoch < 0 {
+		return nil, fmt.Errorf("%w: epoch must be >= 0, got %d", ErrInvalidHead, in.Epoch)
+	}
+	inSet := make(map[string]struct{}, len(in.Digests))
+	for _, d := range in.Digests {
+		if err := validateDigest(d); err != nil {
+			return nil, fmt.Errorf("%w: revoked digest: %v", ErrInvalidHead, err)
+		}
+		inSet[d] = struct{}{}
+	}
+	for _, e := range in.Emergency {
+		if err := validateDigest(e); err != nil {
+			return nil, fmt.Errorf("%w: emergency digest: %v", ErrInvalidHead, err)
+		}
+		if _, ok := inSet[e]; !ok {
+			return nil, fmt.Errorf("%w: emergency digest %s not in revoked set", ErrInvalidHead, e)
+		}
+	}
+	emergency := dedupeSortedAny(in.Emergency)
+	head := map[string]any{
+		"schema_version":   RevocationHeadSchema,
+		"event_id":         newEventID(),
+		"occurred_at":      rfc3339(in.IssuedAt),
+		"epoch":            in.Epoch,
+		"issued_at":        rfc3339(in.IssuedAt),
+		"revoked_set_root": ComputeRevokedSetRoot(in.Digests),
+		"revoked_count":    len(inSet),
+		"emergency":        emergency,
+		"tenant_scope":     derefOrNil(in.TenantScope),
+	}
+	return head, nil
+}
+
+// ComputeRevokedSetRoot returns "sha256:<hex>" over the deduped, sorted revoked
+// digest set joined by '\n' (no trailing newline). Deterministic and independent
+// of input order/duplication, so producer and verifier agree. The empty set
+// hashes the empty string.
+func ComputeRevokedSetRoot(digests []string) string {
+	sorted := dedupeSorted(digests)
+	h := sha256.Sum256([]byte(strings.Join(sorted, "\n")))
+	return "sha256:" + hex.EncodeToString(h[:])
+}
+
+// VerifyRevocationHeadSet recomputes the root over the supplied revoked set and
+// compares it to the head's revoked_set_root. Call this AFTER the envelope
+// signature verifies, to bind the (separately transported) set to the signed head.
+func VerifyRevocationHeadSet(head map[string]any, digests []string) error {
+	want, err := headString(head, "revoked_set_root")
+	if err != nil {
+		return err
+	}
+	got := ComputeRevokedSetRoot(digests)
+	if got != want {
+		return fmt.Errorf("%w: got %s want %s", ErrHeadSetRootMismatch, got, want)
+	}
+	return nil
+}
+
+// HeadEpoch extracts the epoch as an int, tolerating both an in-process map (int)
+// and a JSON-decoded map (float64 / json.Number).
+func HeadEpoch(head map[string]any) (int, error) {
+	raw, ok := head["epoch"]
+	if !ok {
+		return 0, fmt.Errorf("%w: epoch missing", ErrInvalidHead)
+	}
+	switch v := raw.(type) {
+	case int:
+		return v, nil
+	case int64:
+		return int(v), nil
+	case float64:
+		return int(v), nil
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return 0, fmt.Errorf("%w: epoch %q not an integer", ErrInvalidHead, v.String())
+		}
+		return int(n), nil
+	default:
+		return 0, fmt.Errorf("%w: epoch has unexpected type %T", ErrInvalidHead, raw)
+	}
+}
+
+// HeadIssuedAt extracts and parses the head's issued_at (RFC3339 UTC).
+func HeadIssuedAt(head map[string]any) (time.Time, error) {
+	s, err := headString(head, "issued_at")
+	if err != nil {
+		return time.Time{}, err
+	}
+	t, perr := time.Parse(time.RFC3339, s)
+	if perr != nil {
+		return time.Time{}, fmt.Errorf("%w: issued_at %q not RFC3339: %v", ErrInvalidHead, s, perr)
+	}
+	return t.UTC(), nil
+}
+
+// HeadEmergency returns the head's emergency deny-list as a string slice.
+func HeadEmergency(head map[string]any) ([]string, error) {
+	raw, ok := head["emergency"]
+	if !ok {
+		return nil, nil // absent == empty
+	}
+	switch v := raw.(type) {
+	case []string:
+		return v, nil
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, e := range v {
+			s, ok := e.(string)
+			if !ok {
+				return nil, fmt.Errorf("%w: emergency entry not a string (%T)", ErrInvalidHead, e)
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	case nil:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("%w: emergency has unexpected type %T", ErrInvalidHead, raw)
+	}
+}
+
+// CheckEpochMonotonic returns ErrHeadRollback if the head's epoch is below the
+// highest epoch the verifier has already accepted (SPEC-0279 R1). persistedMax is
+// the verifier's stored floor (0 if none seen yet).
+func CheckEpochMonotonic(head map[string]any, persistedMax int) error {
+	epoch, err := HeadEpoch(head)
+	if err != nil {
+		return err
+	}
+	if epoch < persistedMax {
+		return fmt.Errorf("%w: head epoch %d < accepted floor %d", ErrHeadRollback, epoch, persistedMax)
+	}
+	return nil
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+func headString(head map[string]any, key string) (string, error) {
+	raw, ok := head[key]
+	if !ok {
+		return "", fmt.Errorf("%w: %s missing", ErrInvalidHead, key)
+	}
+	s, ok := raw.(string)
+	if !ok || s == "" {
+		return "", fmt.Errorf("%w: %s not a non-empty string", ErrInvalidHead, key)
+	}
+	return s, nil
+}
+
+func dedupeSorted(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func dedupeSortedAny(in []string) []any {
+	sorted := dedupeSorted(in)
+	out := make([]any, len(sorted))
+	for i, s := range sorted {
+		out[i] = s
+	}
+	return out
+}

--- a/pkg/skillctl/registry/revocation_head_test.go
+++ b/pkg/skillctl/registry/revocation_head_test.go
@@ -12,6 +12,44 @@ import (
 
 func mkDigest(c byte) string { return "sha256:" + strings.Repeat(string(c), 64) }
 
+// TestRevocationHeadGoldenVector pins the EXACT canonical bytes a cross-language
+// producer (the aims-core Python HEAD endpoint, FR-0045 D2) must reproduce so its
+// ed25519 signature verifies here. A one-character divergence in either encoder
+// breaks it. The Python test asserts json.dumps(head, separators=(",",":"),
+// sort_keys=True, ensure_ascii=False) == this same string.
+// TestRevokedSetRootGolden pins the ComputeRevokedSetRoot output for a fixed
+// 2-digest set so the aims-core Python compute_revoked_set_root can be asserted
+// against the identical hex (cross-language set-root agreement).
+func TestRevokedSetRootGolden(t *testing.T) {
+	got := ComputeRevokedSetRoot([]string{mkDigest('b'), mkDigest('a')})
+	const golden = "sha256:4ab61be5d46a66e7f659b66144d4bead5b761c247b565fa202161590dcd9e45d"
+	if got != golden {
+		t.Fatalf("set-root golden mismatch:\n got: %s\nwant: %s", got, golden)
+	}
+}
+
+func TestRevocationHeadGoldenVector(t *testing.T) {
+	fixed := map[string]any{
+		"schema_version":   RevocationHeadSchema,
+		"event_id":         "fixed-event-id-0001",
+		"occurred_at":      "2026-07-06T18:00:00Z",
+		"epoch":            42,
+		"issued_at":        "2026-07-06T18:00:00Z",
+		"revoked_set_root": "sha256:" + strings.Repeat("a", 64),
+		"revoked_count":    2,
+		"emergency":        []any{"sha256:" + strings.Repeat("b", 64)},
+		"tenant_scope":     nil,
+	}
+	got, err := CanonicalEventBytes(fixed)
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	const golden = `{"emergency":["sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],"epoch":42,"event_id":"fixed-event-id-0001","issued_at":"2026-07-06T18:00:00Z","occurred_at":"2026-07-06T18:00:00Z","revoked_count":2,"revoked_set_root":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","schema_version":"m3c-revocation-head/v1","tenant_scope":null}`
+	if string(got) != golden {
+		t.Fatalf("golden vector mismatch — cross-language canonicalization would break.\n got: %s\nwant: %s", got, golden)
+	}
+}
+
 func mustHead(t *testing.T, in RevocationHeadInput) map[string]any {
 	t.Helper()
 	h, err := BuildRevocationHead(in)

--- a/pkg/skillctl/registry/revocation_head_test.go
+++ b/pkg/skillctl/registry/revocation_head_test.go
@@ -161,6 +161,43 @@ func TestCheckEpochMonotonic(t *testing.T) {
 	}
 }
 
+func TestAdoptRevocationHead(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	otherPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	set := []string{mkDigest('a'), mkDigest('b')}
+	ts := time.Date(2026, 7, 6, 18, 0, 0, 0, time.UTC)
+
+	newSignedHead := func(epoch int) map[string]any {
+		h := mustHead(t, RevocationHeadInput{Epoch: epoch, IssuedAt: ts, Digests: set})
+		if _, err := SignEnvelopeSignature(priv, h); err != nil {
+			t.Fatalf("sign: %v", err)
+		}
+		return h
+	}
+
+	t.Run("happy", func(t *testing.T) {
+		ep, iss, err := AdoptRevocationHead(pub, newSignedHead(5), set, 5)
+		if err != nil || ep != 5 || !iss.Equal(ts) {
+			t.Fatalf("adopt = %d,%v,%v", ep, iss, err)
+		}
+	})
+	t.Run("bad signature (wrong key) -> reject", func(t *testing.T) {
+		if _, _, err := AdoptRevocationHead(otherPub, newSignedHead(5), set, 0); !errors.Is(err, ErrEnvelopeSignatureInvalid) {
+			t.Errorf("want ErrEnvelopeSignatureInvalid, got %v", err)
+		}
+	})
+	t.Run("rollback -> reject", func(t *testing.T) {
+		if _, _, err := AdoptRevocationHead(pub, newSignedHead(4), set, 9); !errors.Is(err, ErrHeadRollback) {
+			t.Errorf("want ErrHeadRollback, got %v", err)
+		}
+	})
+	t.Run("set mismatch -> reject", func(t *testing.T) {
+		if _, _, err := AdoptRevocationHead(pub, newSignedHead(5), []string{mkDigest('a')}, 0); !errors.Is(err, ErrHeadSetRootMismatch) {
+			t.Errorf("want ErrHeadSetRootMismatch, got %v", err)
+		}
+	})
+}
+
 func TestHeadAccessors_FromDecodedMap(t *testing.T) {
 	ts := time.Date(2026, 7, 6, 12, 30, 0, 0, time.UTC)
 	h := mustHead(t, RevocationHeadInput{

--- a/pkg/skillctl/registry/revocation_head_test.go
+++ b/pkg/skillctl/registry/revocation_head_test.go
@@ -1,0 +1,187 @@
+package registry
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mkDigest(c byte) string { return "sha256:" + strings.Repeat(string(c), 64) }
+
+func mustHead(t *testing.T, in RevocationHeadInput) map[string]any {
+	t.Helper()
+	h, err := BuildRevocationHead(in)
+	if err != nil {
+		t.Fatalf("BuildRevocationHead: %v", err)
+	}
+	return h
+}
+
+func TestBuildRevocationHead_HappyPath(t *testing.T) {
+	ts := time.Date(2026, 7, 6, 18, 0, 0, 0, time.UTC)
+	h := mustHead(t, RevocationHeadInput{
+		Epoch:     42,
+		IssuedAt:  ts,
+		Digests:   []string{mkDigest('b'), mkDigest('a')},
+		Emergency: []string{mkDigest('a')},
+	})
+	if h["schema_version"] != RevocationHeadSchema {
+		t.Errorf("schema_version = %v", h["schema_version"])
+	}
+	if h["issued_at"] != "2026-07-06T18:00:00Z" {
+		t.Errorf("issued_at = %v", h["issued_at"])
+	}
+	if got, _ := HeadEpoch(h); got != 42 {
+		t.Errorf("epoch = %d, want 42", got)
+	}
+	if h["revoked_count"].(int) != 2 {
+		t.Errorf("revoked_count = %v, want 2", h["revoked_count"])
+	}
+	// revoked_set_root binds to the set regardless of input order.
+	if h["revoked_set_root"] != ComputeRevokedSetRoot([]string{mkDigest('a'), mkDigest('b')}) {
+		t.Errorf("revoked_set_root not order-independent")
+	}
+}
+
+func TestBuildRevocationHead_Validation(t *testing.T) {
+	cases := []struct {
+		name string
+		in   RevocationHeadInput
+	}{
+		{"negative epoch", RevocationHeadInput{Epoch: -1}},
+		{"bad revoked digest", RevocationHeadInput{Epoch: 1, Digests: []string{"not-a-digest"}}},
+		{"bad emergency digest", RevocationHeadInput{Epoch: 1, Digests: []string{mkDigest('a')}, Emergency: []string{"nope"}}},
+		{"emergency not subset", RevocationHeadInput{Epoch: 1, Digests: []string{mkDigest('a')}, Emergency: []string{mkDigest('c')}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := BuildRevocationHead(tc.in); !errors.Is(err, ErrInvalidHead) {
+				t.Errorf("want ErrInvalidHead, got %v", err)
+			}
+		})
+	}
+}
+
+func TestComputeRevokedSetRoot_Deterministic(t *testing.T) {
+	a, b, c := mkDigest('a'), mkDigest('b'), mkDigest('c')
+	root := ComputeRevokedSetRoot([]string{a, b, c})
+	// order-independent
+	if ComputeRevokedSetRoot([]string{c, b, a}) != root {
+		t.Errorf("root depends on order")
+	}
+	// dedup-independent
+	if ComputeRevokedSetRoot([]string{a, a, b, c, c}) != root {
+		t.Errorf("root depends on duplicates")
+	}
+	// distinct sets differ
+	if ComputeRevokedSetRoot([]string{a, b}) == root {
+		t.Errorf("distinct sets share a root")
+	}
+	// empty set has a stable non-empty root string
+	if e := ComputeRevokedSetRoot(nil); !strings.HasPrefix(e, "sha256:") || len(e) != len("sha256:")+64 {
+		t.Errorf("empty-set root malformed: %q", e)
+	}
+}
+
+func TestRevocationHead_SignVerify_RoundTrip(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	h := mustHead(t, RevocationHeadInput{
+		Epoch:    7,
+		IssuedAt: time.Now().UTC(),
+		Digests:  []string{mkDigest('a'), mkDigest('b')},
+	})
+	if _, err := SignEnvelopeSignature(priv, h); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if err := VerifyEnvelopeSignature(pub, h); err != nil {
+		t.Fatalf("verify in-process: %v", err)
+	}
+
+	// The decisive test: after JSON transport (epoch int -> float64), the
+	// signature must still verify and epoch must read back as the same int.
+	raw, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := VerifyEnvelopeSignature(pub, decoded); err != nil {
+		t.Fatalf("verify after JSON round-trip: %v", err)
+	}
+	if got, _ := HeadEpoch(decoded); got != 7 {
+		t.Errorf("epoch after round-trip = %d, want 7", got)
+	}
+}
+
+func TestRevocationHead_TamperDetected(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	h := mustHead(t, RevocationHeadInput{Epoch: 3, IssuedAt: time.Now().UTC(), Digests: []string{mkDigest('a')}})
+	if _, err := SignEnvelopeSignature(priv, h); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	h["epoch"] = 4 // attacker bumps the epoch after signing
+	if err := VerifyEnvelopeSignature(pub, h); !errors.Is(err, ErrEnvelopeSignatureInvalid) {
+		t.Errorf("tampered epoch not detected: %v", err)
+	}
+}
+
+func TestVerifyRevocationHeadSet(t *testing.T) {
+	digests := []string{mkDigest('a'), mkDigest('b'), mkDigest('c')}
+	h := mustHead(t, RevocationHeadInput{Epoch: 1, IssuedAt: time.Now().UTC(), Digests: digests})
+
+	if err := VerifyRevocationHeadSet(h, []string{mkDigest('c'), mkDigest('a'), mkDigest('b')}); err != nil {
+		t.Errorf("matching set (reordered) rejected: %v", err)
+	}
+	// truncated set (attacker drops a revocation)
+	if err := VerifyRevocationHeadSet(h, []string{mkDigest('a'), mkDigest('b')}); !errors.Is(err, ErrHeadSetRootMismatch) {
+		t.Errorf("truncated set not detected: %v", err)
+	}
+	// swapped-in bogus digest
+	if err := VerifyRevocationHeadSet(h, []string{mkDigest('a'), mkDigest('b'), mkDigest('d')}); !errors.Is(err, ErrHeadSetRootMismatch) {
+		t.Errorf("forged set not detected: %v", err)
+	}
+}
+
+func TestCheckEpochMonotonic(t *testing.T) {
+	h := mustHead(t, RevocationHeadInput{Epoch: 10, IssuedAt: time.Now().UTC()})
+	if err := CheckEpochMonotonic(h, 10); err != nil {
+		t.Errorf("equal epoch rejected: %v", err)
+	}
+	if err := CheckEpochMonotonic(h, 5); err != nil {
+		t.Errorf("higher epoch rejected: %v", err)
+	}
+	if err := CheckEpochMonotonic(h, 11); !errors.Is(err, ErrHeadRollback) {
+		t.Errorf("rollback not detected: %v", err)
+	}
+}
+
+func TestHeadAccessors_FromDecodedMap(t *testing.T) {
+	ts := time.Date(2026, 7, 6, 12, 30, 0, 0, time.UTC)
+	h := mustHead(t, RevocationHeadInput{
+		Epoch:     99,
+		IssuedAt:  ts,
+		Digests:   []string{mkDigest('a'), mkDigest('b')},
+		Emergency: []string{mkDigest('a')},
+	})
+	raw, _ := json.Marshal(h)
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, err := HeadEpoch(decoded); err != nil || got != 99 {
+		t.Errorf("HeadEpoch = %d, %v", got, err)
+	}
+	if got, err := HeadIssuedAt(decoded); err != nil || !got.Equal(ts) {
+		t.Errorf("HeadIssuedAt = %v, %v", got, err)
+	}
+	em, err := HeadEmergency(decoded)
+	if err != nil || len(em) != 1 || em[0] != mkDigest('a') {
+		t.Errorf("HeadEmergency = %v, %v", em, err)
+	}
+}


### PR DESCRIPTION
Completes **FR-0045** (the fleet kill-switch — the flagship 'in-build' trust feature the paper/demo mark as *roadmap* / Scenario S3). Merging this flips S3 from roadmap to built.

- **D1** signed `RevocationHead` object
- **D2** cross-language canonicalization golden vectors (test)
- **D3** HEAD-aware revocation fetch + freshness-carrying cache
- **D4** fail-closed revocation freshness at the verify-hook
- **D5** `revoke feed` CLI + HEAD-fetch seam wired end-to-end

Security-critical (revocation / fail-closed). **Will run the hacker/security/qa-judge challenge gate before merge.** Branch is 5 ahead / 5 behind master — merging via squash; if GitHub reports conflicts I'll rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)