### PR TITLE
SPEC-0247 §7.3 P1.3: managed-settings pinning (skillctl pin)

### DIFF
--- a/cmd/skillctl/main.go
+++ b/cmd/skillctl/main.go
@@ -110,6 +110,10 @@ func main() {
 	case "gate-stats":
 		os.Exit(runGateStats(os.Args[2:], os.Stdout, os.Stderr))
 	// === END SPEC-0255 ===
+	// === SPEC-0247 §7.3 P1.3: managed-settings pinning (make the gate un-deletable). ===
+	case "pin":
+		os.Exit(runPin(os.Args[2:], os.Stdout, os.Stderr))
+	// === END SPEC-0247 P1.3 ===
 	// === SPEC-0189 S0a: scanner family dispatchers (imported from
 	// feature/thinking-engine-phase1; pre-SPEC-0189 behaviour preserved). ===
 	case "scan":
@@ -217,6 +221,9 @@ func printUsage(w *os.File) {
 	fmt.Fprintln(w, "               §7 chain, and emits allow/deny. Fail-closed. Wire as a hook, not by hand.")
 	fmt.Fprintln(w, "  gate-stats   Summarise the gate-audit.jsonl (decisions, top blocks, cache-hit rate).")
 	fmt.Fprintln(w, "               Flags: --since <168h|YYYY-MM-DD>, --json.")
+	fmt.Fprintln(w, "  pin          Pin the trust gate into Claude Code managed settings so a")
+	fmt.Fprintln(w, "               non-privileged user cannot delete it (SPEC-0247 §7.3).")
+	fmt.Fprintln(w, "               Subcommands: generate | status | install. --strict for CISO lockdown.")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Commands (SPEC-0277 / agent-instance identity):")
 	fmt.Fprintln(w, "  agentid issue   Owner-sign an AgentID mandate (--owner --owner-key --for-agent")

--- a/cmd/skillctl/pin_cmds.go
+++ b/cmd/skillctl/pin_cmds.go
@@ -1,0 +1,392 @@
+package main
+
+// pin_cmds.go — SPEC-0247 §7.3 P1.3: managed-settings pinning.
+//
+//	skillctl pin generate  → emit the Claude Code managed-settings.json that
+//	                         wires the trust gate (SPEC-0247 §7.1) un-deletably.
+//	skillctl pin status    → read the platform managed-settings file and report
+//	                         whether the gate is pinned (advisory / partial /
+//	                         pinned / pinned-strict / tampered).
+//	skillctl pin install   → stage the file + print the privileged runbook
+//	                         (or, when run as root with --confirm, write it).
+//
+// Without this, SPEC-0247 §3.2's "a local user can just delete the hook" caveat
+// stands and the whole gate is advisory. This verb is the prerequisite (P0.0)
+// for SPEC-0317 (skillctl Enterprise). It makes no network calls and performs no
+// privileged write unless explicitly run as root with --confirm.
+//
+// Exit codes (operational, deliberately outside the SPEC-0188 trust range):
+//
+//	0  ok / pinned
+//	1  usage or I/O error
+//	2  not pinned (status: absent / partial / tampered)
+//	3  needs privilege — a manual sudo step is required (install, non-root)
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/pin"
+)
+
+// geteuid is a seam so tests can drive the privileged install branch.
+var geteuid = os.Geteuid
+
+const (
+	pinExitOK          = 0
+	pinExitError       = 1
+	pinExitNotPinned   = 2
+	pinExitNeedPrivMsg = 3
+)
+
+func runPin(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, pinUsage)
+		return pinExitError
+	}
+	sub := args[0]
+	rest := args[1:]
+	switch sub {
+	case "generate", "gen":
+		return runPinGenerate(rest, stdout, stderr)
+	case "status", "verify":
+		return runPinStatus(rest, stdout, stderr)
+	case "install":
+		return runPinInstall(rest, stdout, stderr)
+	case "-h", "--help", "help":
+		fmt.Fprintln(stdout, pinUsage)
+		return pinExitOK
+	default:
+		fmt.Fprintf(stderr, "skillctl pin: unknown subcommand %q\n\n%s\n", sub, pinUsage)
+		return pinExitError
+	}
+}
+
+const pinUsage = `Usage: skillctl pin <generate|status|install> [flags]
+
+  generate   Print the Claude Code managed-settings.json that pins the trust gate.
+             Flags: --binary <path> (default: this skillctl), --strict, --harden, --out <file>
+  status     Report whether the gate is pinned in managed settings.
+             Flags: --path <file> (override), --json
+  install    Stage the file and print the sudo runbook (root+--confirm writes it).
+             Flags: --binary <path>, --strict, --harden, --path <target>, --confirm
+
+--strict adds "allowManagedHooksOnly: true" — the full CISO lockdown that also
+DISABLES every other user/project hook. Without it the gate is already
+un-deletable by non-privileged (non-root) users and its deny is absolute; the
+operator's own hooks keep working. Root, or anyone with write access to the
+managed-settings directory, can still remove it (SPEC-0247 §3.2/§7.3).
+--harden implies --strict and also blocks --dangerously-skip-permissions.`
+
+// defaultBinary is the absolute path of the running skillctl (SPEC-0247 §7.2:
+// an absolute path makes a missing binary fail the spawn, not silently vanish).
+func defaultBinary() string {
+	if exe, err := os.Executable(); err == nil {
+		if resolved, err2 := filepath.EvalSymlinks(exe); err2 == nil {
+			return resolved
+		}
+		return exe
+	}
+	return "skillctl"
+}
+
+func runPinGenerate(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("pin generate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	binary := fs.String("binary", "", "absolute path to skillctl (default: this binary)")
+	strict := fs.Bool("strict", false, "add allowManagedHooksOnly:true (disables ALL user hooks)")
+	harden := fs.Bool("harden", false, "imply --strict and block --dangerously-skip-permissions")
+	out := fs.String("out", "", "write to file instead of stdout")
+	if err := fs.Parse(args); err != nil {
+		return pinExitError
+	}
+	bin := *binary
+	if bin == "" {
+		bin = defaultBinary()
+	}
+	b, err := pin.Generate(pin.GenerateOptions{BinaryPath: bin, Strict: *strict, Harden: *harden})
+	if err != nil {
+		fmt.Fprintf(stderr, "skillctl pin generate: %v\n", err)
+		return pinExitError
+	}
+	if *strict || *harden {
+		fmt.Fprintln(stderr, strictWarning)
+	}
+	if *out != "" {
+		if err := os.WriteFile(*out, b, 0o644); err != nil {
+			fmt.Fprintf(stderr, "skillctl pin generate: write %s: %v\n", *out, err)
+			return pinExitError
+		}
+		fmt.Fprintf(stderr, "wrote %s\n", *out)
+		return pinExitOK
+	}
+	_, _ = stdout.Write(b)
+	return pinExitOK
+}
+
+const strictWarning = `WARNING (--strict): allowManagedHooksOnly:true makes Claude Code run ONLY hooks
+defined in managed settings. Every other user/project hook (usage telemetry,
+formatters, etc.) will STOP running. Include any hooks you still need in the
+managed file. The gate is already un-deletable without --strict.`
+
+func runPinStatus(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("pin status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	pathOverride := fs.String("path", "", "managed-settings path override (default: platform path)")
+	asJSON := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return pinExitError
+	}
+	path := *pathOverride
+	if path == "" {
+		p, err := pin.DefaultManagedSettingsPath()
+		if err != nil {
+			fmt.Fprintf(stderr, "skillctl pin status: %v\n", err)
+			return pinExitError
+		}
+		path = p
+	}
+
+	data, readErr := os.ReadFile(path)
+	var res pin.StatusResult
+	absent := false
+	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			absent = true
+			res = pin.StatusResult{Level: pin.LevelAbsent, Findings: []string{
+				"no managed-settings file at " + path + " — the gate is ADVISORY (a user can delete the user-level hook). Run `skillctl pin install`.",
+			}}
+		} else {
+			fmt.Fprintf(stderr, "skillctl pin status: read %s: %v\n", path, readErr)
+			return pinExitError
+		}
+	} else {
+		res = pin.Verify(data)
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		out := struct {
+			Path string `json:"path"`
+			pin.StatusResult
+		}{Path: path, StatusResult: res}
+		if err := enc.Encode(out); err != nil {
+			fmt.Fprintf(stderr, "skillctl pin status: %v\n", err)
+			return pinExitError
+		}
+	} else {
+		fmt.Fprintf(stdout, "managed settings: %s\n", path)
+		fmt.Fprintf(stdout, "gate pinning:     %s\n", res.Level)
+		fmt.Fprintf(stdout, "  SessionStart sweep hook: %s\n", yesNo(res.HasSweepHook))
+		fmt.Fprintf(stdout, "  PreToolUse verify-hook:  %s\n", yesNo(res.HasVerifyHook))
+		if res.Pinned() {
+			fmt.Fprintf(stdout, "  allowManagedHooksOnly:   %s\n", yesNo(res.AllowManagedHooksOnly))
+			fmt.Fprintf(stdout, "  blocks --dangerously-skip-permissions: %s\n", yesNo(res.DisableBypass))
+		}
+		for _, f := range res.Findings {
+			fmt.Fprintf(stdout, "  - %s\n", f)
+		}
+	}
+	if res.Pinned() {
+		return pinExitOK
+	}
+	_ = absent
+	return pinExitNotPinned
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+func runPinInstall(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("pin install", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	binary := fs.String("binary", "", "absolute path to skillctl (default: this binary)")
+	strict := fs.Bool("strict", false, "add allowManagedHooksOnly:true (disables ALL user hooks)")
+	harden := fs.Bool("harden", false, "imply --strict and block --dangerously-skip-permissions")
+	pathOverride := fs.String("path", "", "target managed-settings path override")
+	confirm := fs.Bool("confirm", false, "when run as root, actually write the file")
+	if err := fs.Parse(args); err != nil {
+		return pinExitError
+	}
+	bin := *binary
+	if bin == "" {
+		bin = defaultBinary()
+	}
+	opts := pin.GenerateOptions{BinaryPath: bin, Strict: *strict, Harden: *harden}
+	target := *pathOverride
+	if target == "" {
+		p, perr := pin.DefaultManagedSettingsPath()
+		if perr != nil {
+			fmt.Fprintf(stderr, "skillctl pin install: %v\n", perr)
+			return pinExitError
+		}
+		target = p
+	}
+
+	// Never blind-overwrite: managed-settings.json is a SHARED policy file that
+	// may already carry other managed hooks / permission rules. Read it and MERGE
+	// our gate in, preserving everything else. If it exists but we cannot read it
+	// (permission), we can only produce a gate-only file the human must merge by
+	// hand — never a blind copy.
+	existing, readErr := os.ReadFile(target)
+	var content []byte
+	targetExists := false
+	safeToCopy := true
+	switch {
+	case readErr == nil:
+		targetExists = true
+		merged, mErr := pin.Merge(existing, opts)
+		if mErr != nil {
+			fmt.Fprintf(stderr, "skillctl pin install: %v\n", mErr)
+			return pinExitError
+		}
+		content = merged
+	case os.IsNotExist(readErr):
+		content, _ = pin.Generate(opts)
+	default:
+		// Exists but unreadable → cannot merge; emit gate-only + warn loudly.
+		targetExists = true
+		safeToCopy = false
+		content, _ = pin.Generate(opts)
+	}
+
+	if *strict || *harden {
+		fmt.Fprintln(stderr, strictWarning)
+	}
+
+	root := geteuid() == 0 // -1 (Windows/unsupported) → not root → runbook path
+	if root && *confirm {
+		if !safeToCopy {
+			fmt.Fprintf(stderr, "skillctl pin install: %s exists but is unreadable — refusing to overwrite; merge manually.\n", target)
+			return pinExitError
+		}
+		return pinRootWrite(target, content, targetExists, existing, stdout, stderr)
+	}
+
+	// Non-root (or root without --confirm): stage + emit the runbook. The staged
+	// file is the FULL merged result when the target was readable, so a copy is
+	// safe; otherwise it is gate-only and MUST be merged by hand.
+	staged, serr := stagePinFile(content)
+	if serr != nil {
+		fmt.Fprintf(stderr, "skillctl pin install: stage: %v\n", serr)
+		return pinExitError
+	}
+	printPinRunbook(stdout, staged, target, targetExists, safeToCopy)
+	return pinExitNeedPrivMsg
+}
+
+// pinRootWrite performs the privileged install: refuse a symlinked target, back
+// up any existing file, write the merged content, then RE-READ the file from
+// disk and verify what actually landed (not the in-memory buffer).
+func pinRootWrite(target string, content []byte, targetExists bool, existing []byte, stdout, stderr io.Writer) int {
+	if fi, err := os.Lstat(target); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		fmt.Fprintf(stderr, "skillctl pin install: %s is a symlink — refusing to write through it.\n", target)
+		return pinExitError
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		fmt.Fprintf(stderr, "skillctl pin install: mkdir %s: %v\n", filepath.Dir(target), err)
+		return pinExitError
+	}
+	if targetExists {
+		backup := target + ".bak-" + time.Now().UTC().Format("20060102-150405")
+		if fi, err := os.Lstat(backup); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+			fmt.Fprintf(stderr, "skillctl pin install: backup path %s is a symlink — refusing.\n", backup)
+			return pinExitError
+		}
+		if err := os.WriteFile(backup, existing, 0o644); err != nil {
+			fmt.Fprintf(stderr, "skillctl pin install: backup %s: %v\n", backup, err)
+			return pinExitError
+		}
+		fmt.Fprintf(stdout, "backed up existing managed settings → %s\n", backup)
+	}
+	if err := os.WriteFile(target, content, 0o644); err != nil {
+		fmt.Fprintf(stderr, "skillctl pin install: write %s: %v\n", target, err)
+		return pinExitError
+	}
+	// Honest re-verify: read back what actually landed on disk and verify THAT.
+	back, rerr := os.ReadFile(target)
+	if rerr != nil {
+		fmt.Fprintf(stderr, "skillctl pin install: wrote %s but cannot read it back: %v\n", target, rerr)
+		return pinExitError
+	}
+	res := pin.Verify(back)
+	fmt.Fprintf(stdout, "installed managed settings at %s (verified on disk: %s)\n", target, res.Level)
+	if !res.Pinned() {
+		fmt.Fprintln(stderr, "skillctl pin install: post-write verification did NOT read back as pinned — check the target.")
+		return pinExitNotPinned
+	}
+	return pinExitOK
+}
+
+// stagePinFile writes content to ~/.claude/skillctl/managed-settings.staged.json
+// (0600). It refuses to write through a symlink at that path.
+func stagePinFile(content []byte) (string, error) {
+	home, err := userHome()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".claude", "skillctl")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	staged := filepath.Join(dir, "managed-settings.staged.json")
+	if fi, err := os.Lstat(staged); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("%s is a symlink — refusing to write through it", staged)
+	}
+	if err := os.WriteFile(staged, content, 0o600); err != nil {
+		return "", err
+	}
+	// Tighten in case the file pre-existed with looser perms (WriteFile doesn't chmod).
+	_ = os.Chmod(staged, 0o600)
+	return staged, nil
+}
+
+func printPinRunbook(w io.Writer, staged, target string, targetExists, safeToCopy bool) {
+	dir := filepath.Dir(target)
+	fmt.Fprintln(w, "Staged the managed-settings content at:")
+	fmt.Fprintf(w, "  %s\n\n", staged)
+	fmt.Fprintln(w, "This is a privileged (🔴 red-governance) step — a human installs it with admin rights.")
+	if targetExists && !safeToCopy {
+		fmt.Fprintf(w, "\nNOTE: %s already exists but could not be read here, so the staged file\n", target)
+		fmt.Fprintln(w, "contains ONLY the gate. Do NOT blindly copy it — MERGE the two SessionStart/")
+		fmt.Fprintln(w, "PreToolUse gate hooks into the existing file to avoid destroying other policy.")
+		fmt.Fprintln(w, "")
+		fmt.Fprintln(w, "Then verify:  skillctl pin status")
+		return
+	}
+	if targetExists {
+		fmt.Fprintln(w, "(The staged file already MERGES your existing managed settings — other policy is preserved.)")
+	}
+	fmt.Fprintln(w, "Review the staged file, then run:")
+	fmt.Fprintln(w, "")
+	if runtime.GOOS == "windows" {
+		fmt.Fprintf(w, "  (Admin PowerShell)\n")
+		fmt.Fprintf(w, "  New-Item -ItemType Directory -Force -Path \"%s\"\n", dir)
+		fmt.Fprintf(w, "  Copy-Item -Force \"%s\" \"%s\"\n", staged, target)
+	} else {
+		fmt.Fprintf(w, "  sudo mkdir -p %s\n", shellQuote(dir))
+		fmt.Fprintf(w, "  sudo cp %s %s\n", shellQuote(staged), shellQuote(target))
+		fmt.Fprintf(w, "  sudo chmod 0644 %s\n", shellQuote(target))
+	}
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Then verify:  skillctl pin status")
+}
+
+func shellQuote(p string) string {
+	if strings.ContainsAny(p, " \t'\"") {
+		return "'" + strings.ReplaceAll(p, "'", `'\''`) + "'"
+	}
+	return p
+}

--- a/cmd/skillctl/pin_cmds_test.go
+++ b/cmd/skillctl/pin_cmds_test.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// withGeteuid swaps the geteuid seam so tests can drive the root/non-root paths
+// deterministically regardless of the CI user.
+func withGeteuid(t *testing.T, v int) {
+	t.Helper()
+	orig := geteuid
+	geteuid = func() int { return v }
+	t.Cleanup(func() { geteuid = orig })
+}
+
+func TestRunPin_NoArgsOrUnknown(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := runPin(nil, &out, &errb); code != pinExitError {
+		t.Errorf("no args: want %d got %d", pinExitError, code)
+	}
+	out.Reset()
+	errb.Reset()
+	if code := runPin([]string{"frobnicate"}, &out, &errb); code != pinExitError {
+		t.Errorf("unknown sub: want %d got %d", pinExitError, code)
+	}
+}
+
+func TestRunPinGenerate_Default(t *testing.T) {
+	var out, errb bytes.Buffer
+	code := runPinGenerate([]string{"--binary", "/usr/local/bin/skillctl"}, &out, &errb)
+	if code != pinExitOK {
+		t.Fatalf("code=%d stderr=%s", code, errb.String())
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+		t.Fatalf("output not JSON: %v\n%s", err, out.String())
+	}
+	if _, ok := raw["allowManagedHooksOnly"]; ok {
+		t.Error("default must not set allowManagedHooksOnly")
+	}
+	if strings.Contains(errb.String(), "WARNING") {
+		t.Error("default (non-strict) should not print the strict warning")
+	}
+}
+
+func TestRunPinGenerate_StrictWarns(t *testing.T) {
+	var out, errb bytes.Buffer
+	runPinGenerate([]string{"--strict"}, &out, &errb)
+	if !strings.Contains(out.String(), `"allowManagedHooksOnly": true`) {
+		t.Errorf("strict missing lock key:\n%s", out.String())
+	}
+	if !strings.Contains(errb.String(), "WARNING") {
+		t.Error("strict must print the user-hooks-disabled warning to stderr")
+	}
+}
+
+func TestRunPinGenerate_OutFile(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "managed.json")
+	var out, errb bytes.Buffer
+	if code := runPinGenerate([]string{"--out", f}, &out, &errb); code != pinExitOK {
+		t.Fatalf("code=%d stderr=%s", code, errb.String())
+	}
+	b, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "verify-hook") {
+		t.Errorf("out file missing gate hook:\n%s", b)
+	}
+}
+
+func writeTemp(t *testing.T, content string) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "managed-settings.json")
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func TestRunPinStatus_Levels(t *testing.T) {
+	// pinned → exit 0
+	pinned := `{"hooks":{"SessionStart":[{"matcher":"*","hooks":[{"type":"command","command":"skillctl verify --all --quarantine"}]}],"PreToolUse":[{"matcher":"Skill","hooks":[{"type":"command","command":"skillctl verify-hook"}]}]}}`
+	var out, errb bytes.Buffer
+	if code := runPinStatus([]string{"--path", writeTemp(t, pinned)}, &out, &errb); code != pinExitOK {
+		t.Errorf("pinned: want %d got %d (%s)", pinExitOK, code, out.String())
+	}
+	if !strings.Contains(out.String(), "pinned") {
+		t.Errorf("pinned status missing:\n%s", out.String())
+	}
+
+	// partial → exit 2
+	out.Reset()
+	partial := `{"hooks":{"PreToolUse":[{"matcher":"Skill","hooks":[{"type":"command","command":"skillctl verify-hook"}]}]}}`
+	if code := runPinStatus([]string{"--path", writeTemp(t, partial)}, &out, &errb); code != pinExitNotPinned {
+		t.Errorf("partial: want %d got %d", pinExitNotPinned, code)
+	}
+
+	// tampered → exit 2
+	out.Reset()
+	if code := runPinStatus([]string{"--path", writeTemp(t, "{ not json")}, &out, &errb); code != pinExitNotPinned {
+		t.Errorf("tampered: want %d got %d", pinExitNotPinned, code)
+	}
+
+	// absent → exit 2
+	out.Reset()
+	missing := filepath.Join(t.TempDir(), "does-not-exist.json")
+	if code := runPinStatus([]string{"--path", missing}, &out, &errb); code != pinExitNotPinned {
+		t.Errorf("absent: want %d got %d", pinExitNotPinned, code)
+	}
+	if !strings.Contains(out.String(), "ADVISORY") {
+		t.Errorf("absent status should warn the gate is advisory:\n%s", out.String())
+	}
+}
+
+func TestRunPinStatus_JSON(t *testing.T) {
+	pinned := `{"allowManagedHooksOnly":true,"hooks":{"SessionStart":[{"matcher":"*","hooks":[{"type":"command","command":"skillctl verify --all --quarantine"}]}],"PreToolUse":[{"matcher":"Skill","hooks":[{"type":"command","command":"skillctl verify-hook"}]}]}}`
+	var out, errb bytes.Buffer
+	code := runPinStatus([]string{"--path", writeTemp(t, pinned), "--json"}, &out, &errb)
+	if code != pinExitOK {
+		t.Fatalf("code=%d", code)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(out.Bytes(), &parsed); err != nil {
+		t.Fatalf("status --json not JSON: %v\n%s", err, out.String())
+	}
+	if parsed["level"] != "pinned-strict" {
+		t.Errorf("want level pinned-strict, got %v", parsed["level"])
+	}
+}
+
+func TestRunPinInstall_NonRootEmitsRunbook(t *testing.T) {
+	withGeteuid(t, 1000) // force non-root, deterministic
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
+	target := filepath.Join(t.TempDir(), "managed-settings.json")
+
+	var out, errb bytes.Buffer
+	code := runPinInstall([]string{"--path", target, "--binary", "/usr/local/bin/skillctl"}, &out, &errb)
+
+	if code != pinExitNeedPrivMsg {
+		t.Errorf("non-root install: want %d got %d", pinExitNeedPrivMsg, code)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Error("non-root install must NOT write the privileged target")
+	}
+	staged := filepath.Join(home, ".claude", "skillctl", "managed-settings.staged.json")
+	if _, err := os.Stat(staged); err != nil {
+		t.Errorf("staged file should exist: %v", err)
+	}
+	if !strings.Contains(out.String(), "pin status") {
+		t.Errorf("runbook should tell the operator to verify with pin status:\n%s", out.String())
+	}
+}
+
+func TestRunPinInstall_RootMergesPreservesForeignAndReVerifies(t *testing.T) {
+	withGeteuid(t, 0) // force root path
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	dir := t.TempDir()
+	target := filepath.Join(dir, "managed-settings.json")
+	// A pre-existing managed file with a foreign permission block + foreign hook.
+	prior := `{"permissions":{"deny":["Bash(rm -rf /)"]},"hooks":{"PostToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"/usr/local/bin/audit.sh"}]}]}}`
+	if err := os.WriteFile(target, []byte(prior), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errb bytes.Buffer
+	code := runPinInstall([]string{"--path", target, "--binary", "/usr/local/bin/skillctl", "--confirm"}, &out, &errb)
+	if code != pinExitOK {
+		t.Fatalf("root install: code=%d stderr=%s", code, errb.String())
+	}
+	got, _ := os.ReadFile(target)
+	s := string(got)
+	if !strings.Contains(s, "/usr/local/bin/audit.sh") {
+		t.Error("root install DESTROYED the foreign PostToolUse hook (must merge, not clobber)")
+	}
+	if !strings.Contains(s, "rm -rf /") {
+		t.Error("root install dropped the foreign permissions block")
+	}
+	if !strings.Contains(s, "verify-hook") {
+		t.Error("root install did not add the gate")
+	}
+	// A timestamped backup of the prior file must exist.
+	entries, _ := os.ReadDir(dir)
+	foundBak := false
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "managed-settings.json.bak-") {
+			foundBak = true
+		}
+	}
+	if !foundBak {
+		t.Error("root install must back up the pre-existing file")
+	}
+	if !strings.Contains(out.String(), "verified on disk") {
+		t.Errorf("root install must report the read-back verification:\n%s", out.String())
+	}
+}
+
+func TestRunPinInstall_RootRefusesSymlinkTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	withGeteuid(t, 0)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real.json")
+	if err := os.WriteFile(real, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "managed-settings.json")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	code := runPinInstall([]string{"--path", link, "--confirm"}, &out, &errb)
+	if code != pinExitError {
+		t.Errorf("root install through a symlink target must be refused (want %d, got %d)", pinExitError, code)
+	}
+	if !strings.Contains(errb.String(), "symlink") {
+		t.Errorf("expected a symlink refusal message:\n%s", errb.String())
+	}
+}

--- a/pkg/skillctl/pin/pin.go
+++ b/pkg/skillctl/pin/pin.go
@@ -1,0 +1,456 @@
+// Package pin implements SPEC-0247 §7.3 managed-settings pinning.
+//
+// It generates the Claude Code *managed settings* file that wires the skillctl
+// trust gate (SPEC-0247 §7.1: a SessionStart sweep + a PreToolUse(Skill)
+// verify-hook) into the one settings tier a non-privileged user cannot edit,
+// and it verifies whether that pinning is currently active. Stdlib-only; the
+// privileged install itself is a human/runbook step (the file lives under a
+// root-owned system directory).
+//
+// Verified mechanism (Claude Code docs, fetched 2026-07-08):
+//   - Managed settings occupy the HIGHEST precedence tier; nothing — not even a
+//     CLI flag or `--dangerously-skip-permissions` — overrides them.
+//   - A hook defined in managed settings cannot be suppressed or deleted by
+//     user/project settings, so the gate becomes un-deletable by non-root users
+//     (root, or anyone who can write the managed-settings dir, still can —
+//     SPEC-0247 §3.2).
+//   - A PreToolUse hook returning "deny" blocks even under
+//     `--dangerously-skip-permissions`, and a user "allow" hook can never
+//     override a "deny" — so a managed deny is absolute.
+//   - `allowManagedHooksOnly: true` (STRICT) additionally blocks ALL user and
+//     project hooks. That is the CISO lockdown, but it also disables any OTHER
+//     user hooks the operator relies on (e.g. usage telemetry) — callers MUST
+//     warn about this. Without it, the gate is still un-deletable by non-root
+//     users and its deny is still absolute; the operator's own hooks keep working.
+//
+// This package makes no privileged writes and reaches no network.
+package pin
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// ManagedSettingsPath returns the platform managed-settings.json path for goos
+// ("darwin"/"linux"/"windows"); pass runtime.GOOS in production. The paths are
+// the documented, admin/root-owned locations. An unknown goos is an error
+// rather than a silent guess (fail-closed).
+func ManagedSettingsPath(goos string) (string, error) {
+	switch goos {
+	case "darwin":
+		return "/Library/Application Support/ClaudeCode/managed-settings.json", nil
+	case "linux":
+		return "/etc/claude-code/managed-settings.json", nil
+	case "windows":
+		return `C:\Program Files\ClaudeCode\managed-settings.json`, nil
+	default:
+		return "", fmt.Errorf("pin: no known managed-settings path for GOOS %q", goos)
+	}
+}
+
+// DefaultManagedSettingsPath resolves the path for the running OS.
+func DefaultManagedSettingsPath() (string, error) { return ManagedSettingsPath(runtime.GOOS) }
+
+// GenerateOptions controls the emitted managed settings.
+type GenerateOptions struct {
+	// BinaryPath is the skillctl binary the hooks invoke. SPEC-0247 §7.2
+	// recommends an absolute path so a missing binary fails the spawn (and is
+	// noticed) rather than resolving to nothing. Empty → the bare name "skillctl".
+	BinaryPath string
+	// Strict adds `allowManagedHooksOnly: true` (blocks ALL non-managed hooks).
+	Strict bool
+	// Harden implies Strict and also sets `disableBypassPermissionsMode:"disable"`.
+	Harden bool
+}
+
+// wire structs — field order here is the emitted JSON key order (encoding/json
+// preserves struct field order). Security flags first, then hooks.
+type hookCommand struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
+}
+type hookMatcher struct {
+	Matcher string        `json:"matcher"`
+	Hooks   []hookCommand `json:"hooks"`
+}
+type hooksBlock struct {
+	SessionStart []hookMatcher `json:"SessionStart,omitempty"`
+	PreToolUse   []hookMatcher `json:"PreToolUse,omitempty"`
+}
+type managedSettings struct {
+	AllowManagedHooksOnly        bool       `json:"allowManagedHooksOnly,omitempty"`
+	DisableBypassPermissionsMode string     `json:"disableBypassPermissionsMode,omitempty"`
+	Hooks                        hooksBlock `json:"hooks"`
+}
+
+// Canonical gate command shapes (SPEC-0247 §7.1). Verify() matches on the
+// command's *argv shape* — the binary basename must be skillctl and the
+// subcommand tokens must match — NOT a loose substring, so decoys like
+// `echo verify-hook` or exit-suppressed `skillctl verify-hook || true` (which
+// would turn every DENY into an ALLOW) are rejected.
+const (
+	verifyHookSub = "verify-hook"
+	sweepSub      = "verify" // + must carry --all and --quarantine
+)
+
+func binaryOrDefault(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "skillctl"
+	}
+	return p
+}
+
+// quoteIfNeeded shell-quotes a binary path that contains whitespace so the
+// generated command string stays a single argv[0].
+func quoteIfNeeded(p string) string {
+	if strings.ContainsAny(p, " \t") {
+		return `"` + p + `"`
+	}
+	return p
+}
+
+// gateHooks builds the SessionStart sweep + PreToolUse(Skill) matchers for a
+// given binary, exactly per SPEC-0247 §7.1.
+func gateHooks(binary string) hooksBlock {
+	b := quoteIfNeeded(binaryOrDefault(binary))
+	return hooksBlock{
+		SessionStart: []hookMatcher{{
+			Matcher: "*",
+			Hooks:   []hookCommand{{Type: "command", Command: b + " verify --all --quarantine", Timeout: 90}},
+		}},
+		PreToolUse: []hookMatcher{{
+			Matcher: "Skill",
+			Hooks:   []hookCommand{{Type: "command", Command: b + " verify-hook", Timeout: 20}},
+		}},
+	}
+}
+
+// Generate returns the pretty-printed managed-settings.json bytes for the given
+// options (trailing newline included).
+func Generate(opts GenerateOptions) ([]byte, error) {
+	ms := managedSettings{Hooks: gateHooks(opts.BinaryPath)}
+	if opts.Strict || opts.Harden {
+		ms.AllowManagedHooksOnly = true
+	}
+	if opts.Harden {
+		ms.DisableBypassPermissionsMode = "disable"
+	}
+	b, err := json.MarshalIndent(ms, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+// Level classifies the managed-settings file's gate-pinning state.
+type Level int
+
+const (
+	// LevelAbsent — no managed-settings file exists (gate is advisory: a
+	// user-level hook, if any, is deletable). Set by the caller when the file
+	// is missing; Verify never returns it.
+	LevelAbsent Level = iota
+	// LevelTampered — the file exists but is not valid JSON.
+	LevelTampered
+	// LevelPartial — valid JSON, but one or both gate hooks are missing.
+	LevelPartial
+	// LevelPinned — both gate hooks are present in managed settings; the gate is
+	// un-deletable and its deny is absolute. User hooks still run.
+	LevelPinned
+	// LevelPinnedStrict — LevelPinned + allowManagedHooksOnly:true; no
+	// non-managed hooks run at all (full CISO lockdown).
+	LevelPinnedStrict
+)
+
+// MarshalJSON emits the human string ("pinned-strict", …) instead of the int,
+// so `pin status --json` and any downstream consumer read a stable label.
+func (l Level) MarshalJSON() ([]byte, error) { return json.Marshal(l.String()) }
+
+func (l Level) String() string {
+	switch l {
+	case LevelAbsent:
+		return "absent"
+	case LevelTampered:
+		return "tampered"
+	case LevelPartial:
+		return "partial"
+	case LevelPinned:
+		return "pinned"
+	case LevelPinnedStrict:
+		return "pinned-strict"
+	default:
+		return "unknown"
+	}
+}
+
+// StatusResult reports what Verify found. It is a pure read; nothing here gates
+// a decision.
+type StatusResult struct {
+	Level                 Level    `json:"level"`
+	HasSweepHook          bool     `json:"has_sweep_hook"`  // SessionStart → verify --all --quarantine
+	HasVerifyHook         bool     `json:"has_verify_hook"` // PreToolUse(Skill) → verify-hook
+	AllowManagedHooksOnly bool     `json:"allow_managed_hooks_only"`
+	DisableBypass         bool     `json:"disable_bypass_permissions_mode"`
+	Findings              []string `json:"findings,omitempty"`
+}
+
+// Pinned reports whether the gate is un-deletable (Pinned or PinnedStrict).
+func (s StatusResult) Pinned() bool {
+	return s.Level == LevelPinned || s.Level == LevelPinnedStrict
+}
+
+// Verify parses managed-settings bytes and reports the pinning level. It matches
+// gate hooks by *argv shape under a covering matcher*, not by substring, so a
+// hook wired under the wrong matcher (e.g. "Bash") or a decoy/exit-suppressed
+// command does NOT falsely classify as pinned. json.Unmarshal rejects trailing
+// bytes after the first JSON value, so `{good}{evil}` is LevelTampered. A parse
+// failure is LevelTampered (fail-closed: an unreadable managed file is NOT
+// treated as pinned).
+func Verify(settings []byte) StatusResult {
+	var res StatusResult
+	var ms managedSettings
+	if err := json.Unmarshal(settings, &ms); err != nil {
+		res.Level = LevelTampered
+		res.Findings = append(res.Findings, "managed-settings.json is not valid JSON: "+err.Error())
+		return res
+	}
+	res.AllowManagedHooksOnly = ms.AllowManagedHooksOnly
+	res.DisableBypass = ms.DisableBypassPermissionsMode == "disable"
+	res.HasSweepHook = hasGateHook(ms.Hooks.SessionStart, sessionStartCovers, isSweepCommand)
+	res.HasVerifyHook = hasGateHook(ms.Hooks.PreToolUse, preToolUseCovers, isVerifyHookCommand)
+
+	switch {
+	case res.HasSweepHook && res.HasVerifyHook && res.AllowManagedHooksOnly:
+		res.Level = LevelPinnedStrict
+	case res.HasSweepHook && res.HasVerifyHook:
+		res.Level = LevelPinned
+	default:
+		res.Level = LevelPartial
+	}
+	if !res.HasVerifyHook {
+		res.Findings = append(res.Findings, "no PreToolUse(Skill) → skillctl verify-hook (the run-time gate): missing, bound to a non-Skill matcher, or an exit-suppressed/decoy command")
+	}
+	if !res.HasSweepHook {
+		res.Findings = append(res.Findings, "no SessionStart(*) → skillctl verify --all --quarantine (the discovery sweep)")
+	}
+	if res.Pinned() && !res.AllowManagedHooksOnly {
+		res.Findings = append(res.Findings, "gate is un-deletable by non-root users, but not strict: a user may still run their own hooks (a managed deny still wins). Use --strict for the full CISO lockdown.")
+	}
+	if res.Pinned() && res.AllowManagedHooksOnly {
+		res.Findings = append(res.Findings, "un-deletable by non-root users only — root, or anyone with write access to the managed-settings directory, can still remove or rewrite it (SPEC-0247 §7.3, §3.2).")
+	}
+	return res
+}
+
+// hasGateHook reports whether any matcher that COVERS the target tool carries a
+// command with the required gate shape.
+func hasGateHook(matchers []hookMatcher, covers func(string) bool, shapeOK func(cmd string) bool) bool {
+	for _, m := range matchers {
+		if !covers(m.Matcher) {
+			continue
+		}
+		for _, h := range m.Hooks {
+			if shapeOK(h.Command) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// preToolUseCovers reports whether a PreToolUse matcher fires on the Skill tool.
+// Claude Code matchers are REGEX (e.g. "Edit|Write", "Skill.*"), so we test the
+// matcher — anchored to a full match — against the literal "Skill", plus the
+// "*"/"" match-all shorthands. A matcher that fails to compile falls back to an
+// exact/"|"-token check, so a plain "Skill" is never missed.
+func preToolUseCovers(matcher string) bool {
+	m := strings.TrimSpace(matcher)
+	if m == "" || m == "*" {
+		return true
+	}
+	if re, err := regexp.Compile("^(?:" + m + ")$"); err == nil {
+		return re.MatchString("Skill")
+	}
+	for _, tok := range strings.Split(m, "|") {
+		if strings.TrimSpace(tok) == "Skill" {
+			return true
+		}
+	}
+	return false
+}
+
+// sessionStartCovers: the sweep must run on every session start ("*" or "").
+func sessionStartCovers(matcher string) bool {
+	m := strings.TrimSpace(matcher)
+	return m == "" || m == "*"
+}
+
+// isVerifyHookCommand requires exactly `<...>/skillctl verify-hook` with no
+// trailing arguments and no shell control (which could suppress the exit code).
+func isVerifyHookCommand(cmd string) bool {
+	bin, args, ok := splitCommand(cmd)
+	if !ok || !isSkillctlBinary(bin) {
+		return false
+	}
+	return len(args) == 1 && args[0] == verifyHookSub
+}
+
+// isSweepCommand requires `<...>/skillctl verify --all --quarantine` (extra
+// flags such as --json are tolerated; shell control is not). NOTE: a
+// self-sabotaging operator can still pass a neutering flag (e.g. --budget 1ns,
+// --home /nonexistent) that leaves the sweep present-but-ineffective. That is a
+// root-configures-own-foot-gun, out of scope like the same-uid attacker
+// (SPEC-0247 §3.2); the per-invocation DENY gate (isVerifyHookCommand) is
+// arg-locked and not subject to this.
+func isSweepCommand(cmd string) bool {
+	bin, args, ok := splitCommand(cmd)
+	if !ok || !isSkillctlBinary(bin) {
+		return false
+	}
+	if len(args) < 3 || args[0] != sweepSub {
+		return false
+	}
+	return containsToken(args, "--all") && containsToken(args, "--quarantine")
+}
+
+func containsToken(ss []string, tok string) bool {
+	for _, s := range ss {
+		if s == tok {
+			return true
+		}
+	}
+	return false
+}
+
+// isSkillctlBinary checks the command's argv[0] basename is skillctl, so a decoy
+// like `echo verify-hook` or `/bin/true verify-hook` is rejected.
+func isSkillctlBinary(bin string) bool {
+	base := bin
+	if i := strings.LastIndexAny(base, `/\`); i >= 0 {
+		base = base[i+1:]
+	}
+	return base == "skillctl" || base == "skillctl.exe"
+}
+
+// splitCommand splits a hook command into argv[0] (binary, optionally single-
+// or double-quoted with spaces) and the remaining whitespace-separated args. It
+// returns ok=false if the command carries shell control that could alter the
+// gate's exit code (|| && ; | > < ` $ newline #), or if a quoted binary is
+// concatenated to more text with no separating whitespace (e.g.
+// `"skillctl"verify-hook`, which the shell would run as the single word
+// `skillctlverify-hook` → command-not-found → gate fails open) — such a command
+// is never a trustworthy gate.
+func splitCommand(cmd string) (bin string, args []string, ok bool) {
+	c := strings.TrimSpace(cmd)
+	if c == "" || containsShellControl(c) {
+		return "", nil, false
+	}
+	if q := c[0]; q == '"' || q == '\'' {
+		end := strings.IndexByte(c[1:], q)
+		if end < 0 {
+			return "", nil, false
+		}
+		bin = c[1 : 1+end]
+		rem := c[1+end+1:]
+		// The closing quote MUST end the token: end-of-string or whitespace.
+		if rem != "" && rem[0] != ' ' && rem[0] != '\t' {
+			return "", nil, false
+		}
+		return bin, strings.Fields(rem), true
+	}
+	fields := strings.Fields(c)
+	if len(fields) == 0 {
+		return "", nil, false
+	}
+	return fields[0], fields[1:], true
+}
+
+// containsShellControl reports whether a command carries shell metacharacters
+// that could suppress or override the gate's exit code (the `verify-hook || true`
+// class). The canonical gate commands contain none of these.
+func containsShellControl(cmd string) bool {
+	return strings.ContainsAny(cmd, "|&;<>`$\n\r#")
+}
+
+// Merge injects skillctl's gate hooks into an EXISTING managed-settings.json,
+// preserving every other key (other managed hooks, permission rules, env). It is
+// idempotent — a file already carrying the covering gate hook is not
+// duplicated — and never drops other entries. Empty/whitespace input returns a
+// fresh Generate(opts). Invalid existing JSON is an error (refuse to overwrite).
+func Merge(existing []byte, opts GenerateOptions) ([]byte, error) {
+	if len(strings.TrimSpace(string(existing))) == 0 {
+		return Generate(opts)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(existing, &doc); err != nil {
+		return nil, fmt.Errorf("existing managed-settings is not valid JSON (refusing to overwrite): %w", err)
+	}
+	gh := gateHooks(opts.BinaryPath)
+
+	hooks, _ := doc["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+	hooks["SessionStart"] = mergeMatcher(hooks["SessionStart"], gh.SessionStart[0], sessionStartCovers, isSweepCommand)
+	hooks["PreToolUse"] = mergeMatcher(hooks["PreToolUse"], gh.PreToolUse[0], preToolUseCovers, isVerifyHookCommand)
+	doc["hooks"] = hooks
+
+	if opts.Strict || opts.Harden {
+		doc["allowManagedHooksOnly"] = true
+	}
+	if opts.Harden {
+		doc["disableBypassPermissionsMode"] = "disable"
+	}
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+// mergeMatcher appends our gate matcher to an existing event array unless a
+// shape-valid gate command already exists UNDER A COVERING MATCHER (idempotent).
+// A shape-valid command under a NON-covering matcher (e.g. verify-hook under
+// "Bash") does NOT satisfy the gate, so we still append our covering matcher —
+// otherwise the merged file would fail its own Verify. Foreign entries are
+// preserved verbatim.
+func mergeMatcher(existing any, want hookMatcher, covers func(string) bool, shapeOK func(string) bool) []any {
+	arr, _ := existing.([]any)
+	for _, e := range arr {
+		em, _ := e.(map[string]any)
+		if em == nil {
+			continue
+		}
+		matcher, _ := em["matcher"].(string)
+		if !covers(matcher) {
+			continue
+		}
+		hs, _ := em["hooks"].([]any)
+		for _, h := range hs {
+			hm, _ := h.(map[string]any)
+			if hm == nil {
+				continue
+			}
+			if cmd, _ := hm["command"].(string); shapeOK(cmd) {
+				return arr // already covered by a covering matcher
+			}
+		}
+	}
+	// Append our matcher as a fresh map so it round-trips like the others.
+	add := map[string]any{"matcher": want.Matcher, "hooks": []any{}}
+	hs := []any{}
+	for _, h := range want.Hooks {
+		hc := map[string]any{"type": h.Type, "command": h.Command}
+		if h.Timeout != 0 {
+			hc["timeout"] = h.Timeout
+		}
+		hs = append(hs, hc)
+	}
+	add["hooks"] = hs
+	return append(arr, add)
+}

--- a/pkg/skillctl/pin/pin_test.go
+++ b/pkg/skillctl/pin/pin_test.go
@@ -1,0 +1,333 @@
+package pin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestManagedSettingsPath(t *testing.T) {
+	cases := map[string]string{
+		"darwin":  "/Library/Application Support/ClaudeCode/managed-settings.json",
+		"linux":   "/etc/claude-code/managed-settings.json",
+		"windows": `C:\Program Files\ClaudeCode\managed-settings.json`,
+	}
+	for goos, want := range cases {
+		got, err := ManagedSettingsPath(goos)
+		if err != nil {
+			t.Fatalf("%s: unexpected error %v", goos, err)
+		}
+		if got != want {
+			t.Errorf("%s: got %q want %q", goos, got, want)
+		}
+	}
+	if _, err := ManagedSettingsPath("plan9"); err == nil {
+		t.Error("expected error for unknown GOOS (fail-closed), got nil")
+	}
+}
+
+func TestGenerate_DefaultIsUnDeletableButNotStrict(t *testing.T) {
+	b, err := Generate(GenerateOptions{BinaryPath: "/usr/local/bin/skillctl"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Round-trips as JSON.
+	var raw map[string]any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("generated output is not valid JSON: %v\n%s", err, b)
+	}
+	if _, ok := raw["allowManagedHooksOnly"]; ok {
+		t.Error("default (non-strict) must NOT set allowManagedHooksOnly (it would disable user hooks)")
+	}
+	s := string(b)
+	if !strings.Contains(s, "/usr/local/bin/skillctl verify --all --quarantine") {
+		t.Errorf("missing SessionStart sweep command with absolute binary:\n%s", s)
+	}
+	if !strings.Contains(s, "/usr/local/bin/skillctl verify-hook") {
+		t.Errorf("missing PreToolUse verify-hook command:\n%s", s)
+	}
+	// Verify classifies its own default output as pinned (un-deletable).
+	res := Verify(b)
+	if res.Level != LevelPinned {
+		t.Errorf("default generate should verify as pinned, got %s", res.Level)
+	}
+	if !res.Pinned() {
+		t.Error("default generate should be Pinned()")
+	}
+}
+
+func TestGenerate_StrictAndHarden(t *testing.T) {
+	strict, _ := Generate(GenerateOptions{Strict: true})
+	if !strings.Contains(string(strict), `"allowManagedHooksOnly": true`) {
+		t.Errorf("strict must set allowManagedHooksOnly:true\n%s", strict)
+	}
+	if strings.Contains(string(strict), "disableBypassPermissionsMode") {
+		t.Error("strict (without harden) must NOT set disableBypassPermissionsMode")
+	}
+	if Verify(strict).Level != LevelPinnedStrict {
+		t.Errorf("strict should verify as pinned-strict, got %s", Verify(strict).Level)
+	}
+
+	harden, _ := Generate(GenerateOptions{Harden: true})
+	if !strings.Contains(string(harden), `"allowManagedHooksOnly": true`) {
+		t.Error("harden implies strict → allowManagedHooksOnly:true")
+	}
+	if !strings.Contains(string(harden), `"disableBypassPermissionsMode": "disable"`) {
+		t.Errorf("harden must set disableBypassPermissionsMode:disable\n%s", harden)
+	}
+	hs := Verify(harden)
+	if !hs.DisableBypass {
+		t.Error("Verify should report DisableBypass for hardened settings")
+	}
+}
+
+func TestGenerate_DefaultBinaryName(t *testing.T) {
+	b, _ := Generate(GenerateOptions{})
+	if !strings.Contains(string(b), "skillctl verify-hook") {
+		t.Errorf("empty BinaryPath should fall back to bare 'skillctl'\n%s", b)
+	}
+}
+
+func TestGenerate_QuotesBinaryWithSpaces(t *testing.T) {
+	b, _ := Generate(GenerateOptions{BinaryPath: "/Applications/My Tools/skillctl"})
+	// Decode the JSON and check the actual command value (raw bytes contain
+	// JSON-escaped quotes \" — assert on the decoded string, not the wire bytes).
+	var got struct {
+		Hooks struct {
+			PreToolUse []struct {
+				Hooks []struct {
+					Command string `json:"command"`
+				} `json:"hooks"`
+			} `json:"PreToolUse"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	cmd := got.Hooks.PreToolUse[0].Hooks[0].Command
+	if cmd != `"/Applications/My Tools/skillctl" verify-hook` {
+		t.Errorf("binary path with spaces must be shell-quoted; got %q", cmd)
+	}
+	// And it must still parse back as pinned (the escaped quotes are valid JSON).
+	if Verify(b).Level != LevelPinned {
+		t.Errorf("quoted-binary output should verify as pinned, got %s", Verify(b).Level)
+	}
+}
+
+func TestVerify_Tampered(t *testing.T) {
+	res := Verify([]byte(`{ this is not json `))
+	if res.Level != LevelTampered {
+		t.Errorf("malformed JSON must be tampered (fail-closed), got %s", res.Level)
+	}
+	if res.Pinned() {
+		t.Error("tampered must NOT count as pinned")
+	}
+}
+
+func TestVerify_Partial(t *testing.T) {
+	// Only the PreToolUse gate, no SessionStart sweep.
+	only := `{"hooks":{"PreToolUse":[{"matcher":"Skill","hooks":[{"type":"command","command":"skillctl verify-hook"}]}]}}`
+	res := Verify([]byte(only))
+	if res.Level != LevelPartial {
+		t.Errorf("one hook present should be partial, got %s", res.Level)
+	}
+	if !res.HasVerifyHook || res.HasSweepHook {
+		t.Errorf("expected verify-hook present, sweep absent; got %+v", res)
+	}
+	if res.Pinned() {
+		t.Error("partial must not be Pinned()")
+	}
+	if len(res.Findings) == 0 {
+		t.Error("partial should report a finding about the missing sweep")
+	}
+}
+
+func TestVerify_EmptyManagedFileIsPartial(t *testing.T) {
+	res := Verify([]byte(`{}`))
+	if res.Level != LevelPartial {
+		t.Errorf("empty-but-valid managed file → partial (gate not pinned), got %s", res.Level)
+	}
+}
+
+func TestVerify_MatchesForeignBinaryPath(t *testing.T) {
+	// A managed file installed with a different absolute binary path must still
+	// classify as pinned (shape match on the canonical subcommands).
+	foreign := `{"hooks":{
+	  "SessionStart":[{"matcher":"*","hooks":[{"type":"command","command":"/opt/sec/skillctl verify --all --quarantine","timeout":90}]}],
+	  "PreToolUse":[{"matcher":"Skill","hooks":[{"type":"command","command":"/opt/sec/skillctl verify-hook","timeout":20}]}]
+	}}`
+	if Verify([]byte(foreign)).Level != LevelPinned {
+		t.Errorf("foreign-path gate should still classify as pinned, got %s", Verify([]byte(foreign)).Level)
+	}
+}
+
+// preToolJSON builds a managed-settings doc with one PreToolUse matcher+command.
+func preToolJSON(t *testing.T, matcher, cmd string) []byte {
+	t.Helper()
+	m := map[string]any{"hooks": map[string]any{"PreToolUse": []any{
+		map[string]any{"matcher": matcher, "hooks": []any{
+			map[string]any{"type": "command", "command": cmd}}}}}}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestVerify_WrongMatcherIsNotPinned(t *testing.T) {
+	// verify-hook wired under "Bash" never fires on a Skill invocation.
+	if Verify(preToolJSON(t, "Bash", "skillctl verify-hook")).HasVerifyHook {
+		t.Error("verify-hook under matcher Bash must NOT count as the Skill gate")
+	}
+	// "Skill|Task" (a covering list) DOES count.
+	if !Verify(preToolJSON(t, "Skill|Task", "skillctl verify-hook")).HasVerifyHook {
+		t.Error("verify-hook under Skill|Task should count")
+	}
+	// "" and "*" cover all tools → count.
+	if !Verify(preToolJSON(t, "", "skillctl verify-hook")).HasVerifyHook {
+		t.Error(`empty matcher (matches all) should count`)
+	}
+}
+
+func TestVerify_DecoyAndExitSuppressedCommandsRejected(t *testing.T) {
+	decoys := []string{
+		"skillctl verify-hook || true",             // turns every DENY into ALLOW
+		"skillctl verify-hook; exit 0",             // same
+		"skillctl verify-hook && exit 0",           // same
+		"skillctl verify-hook > /dev/null; exit 0", // redirect + suppress
+		"echo verify-hook",                         // not skillctl
+		"/bin/true verify-hook",                    // not skillctl
+		"# skillctl verify-hook",                   // shell comment
+		"skillctl echo verify-hook",                // wrong subcommand
+		"skillctl verify-hook extra",               // trailing arg
+		"skillctl verify-hook `curl evil.sh`",      // command substitution
+	}
+	for _, d := range decoys {
+		if Verify(preToolJSON(t, "Skill", d)).HasVerifyHook {
+			t.Errorf("decoy/exit-suppressed command accepted as gate: %q", d)
+		}
+	}
+}
+
+func TestVerify_SweepToleratesExtraFlagsButNotSuppression(t *testing.T) {
+	ok := `{"hooks":{"SessionStart":[{"matcher":"*","hooks":[{"type":"command","command":"skillctl verify --all --quarantine --budget 90 --json"}]}]}}`
+	if !Verify([]byte(ok)).HasSweepHook {
+		t.Error("sweep with extra legit flags should still count")
+	}
+	bad := `{"hooks":{"SessionStart":[{"matcher":"*","hooks":[{"type":"command","command":"skillctl verify --all --quarantine || true"}]}]}}`
+	if Verify([]byte(bad)).HasSweepHook {
+		t.Error("exit-suppressed sweep must NOT count")
+	}
+}
+
+func TestVerify_TrailingGarbageIsTampered(t *testing.T) {
+	// json.Unmarshal rejects trailing bytes after the first value.
+	if Verify([]byte(`{"hooks":{}}{"evil":1}`)).Level != LevelTampered {
+		t.Error("trailing JSON after the first value must be tampered (fail-closed)")
+	}
+}
+
+func TestVerify_LockOnlyNoHooksIsPartial(t *testing.T) {
+	if Verify([]byte(`{"allowManagedHooksOnly":true}`)).Level != LevelPartial {
+		t.Error("allowManagedHooksOnly with no gate hooks must be partial, not pinned-strict")
+	}
+}
+
+func TestMerge_PreservesForeignPolicy(t *testing.T) {
+	existing := `{
+	  "permissions":{"deny":["Bash(rm -rf /)"]},
+	  "hooks":{"PostToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"/usr/local/bin/audit.sh"}]}]}
+	}`
+	merged, err := Merge([]byte(existing), GenerateOptions{BinaryPath: "/usr/local/bin/skillctl"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(merged)
+	if !strings.Contains(s, "rm -rf /") {
+		t.Error("Merge dropped the foreign permissions block")
+	}
+	if !strings.Contains(s, "/usr/local/bin/audit.sh") {
+		t.Error("Merge dropped the foreign PostToolUse hook")
+	}
+	if Verify(merged).Level != LevelPinned {
+		t.Errorf("Merge should yield a pinned file, got %s", Verify(merged).Level)
+	}
+}
+
+func TestMerge_Idempotent(t *testing.T) {
+	once, _ := Merge([]byte(`{}`), GenerateOptions{})
+	twice, _ := Merge(once, GenerateOptions{})
+	if strings.Count(string(twice), "verify-hook") != strings.Count(string(once), "verify-hook") {
+		t.Errorf("Merge duplicated the gate hook on re-run:\n%s", twice)
+	}
+}
+
+func TestMerge_RefusesInvalidExisting(t *testing.T) {
+	if _, err := Merge([]byte("{ not json"), GenerateOptions{}); err == nil {
+		t.Error("Merge must refuse invalid existing JSON (not silently overwrite)")
+	}
+}
+
+func TestMerge_EmptyGeneratesFresh(t *testing.T) {
+	b, err := Merge([]byte("   "), GenerateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if Verify(b).Level != LevelPinned {
+		t.Error("Merge of empty input should generate a fresh pinned file")
+	}
+}
+
+// D1: a quoted binary concatenated to more text with no separating whitespace
+// (`"skillctl"verify-hook`) would run as the single word `skillctlverify-hook`
+// at the shell → command-not-found → gate fails OPEN. It must NOT verify pinned.
+func TestVerify_QuoteConcatNotPinned(t *testing.T) {
+	concat := []string{
+		`"skillctl"verify-hook`,
+		`"skillctl"verify --all --quarantine`,
+		`'skillctl'verify-hook`,
+	}
+	for _, c := range concat {
+		if Verify(preToolJSON(t, "Skill", c)).HasVerifyHook {
+			t.Errorf("quote-concat command must NOT count as gate: %q", c)
+		}
+	}
+	// The legit quoted-with-space form still counts.
+	if !Verify(preToolJSON(t, "Skill", `"/opt/my tools/skillctl" verify-hook`)).HasVerifyHook {
+		t.Error("legit quoted binary (space after close-quote) should count")
+	}
+	if !Verify(preToolJSON(t, "Skill", `'skillctl' verify-hook`)).HasVerifyHook {
+		t.Error("legit single-quoted binary should count")
+	}
+}
+
+// D4: Claude Code matchers are regex — a regex that matches "Skill" covers it.
+func TestVerify_RegexMatcherCovers(t *testing.T) {
+	for _, m := range []string{".*", "Skill.*", "Sk.*", "Task|Skill"} {
+		if !Verify(preToolJSON(t, m, "skillctl verify-hook")).HasVerifyHook {
+			t.Errorf("regex matcher %q should cover the Skill tool", m)
+		}
+	}
+	for _, m := range []string{"Bash", "Edit|Write", "Task"} {
+		if Verify(preToolJSON(t, m, "skillctl verify-hook")).HasVerifyHook {
+			t.Errorf("matcher %q must NOT cover the Skill tool", m)
+		}
+	}
+}
+
+// D2: an existing verify-hook under a NON-covering matcher must not stop Merge
+// from adding the covering Skill matcher — else the merged file fails Verify.
+func TestMerge_AddsCoveringMatcherDespiteNonCoveringDecoy(t *testing.T) {
+	existing := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"skillctl verify-hook"}]}]}}`
+	merged, err := Merge([]byte(existing), GenerateOptions{BinaryPath: "skillctl"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !Verify(merged).HasVerifyHook {
+		t.Errorf("Merge must add a Skill-covering gate even when a Bash-bound one exists:\n%s", merged)
+	}
+	// The Bash entry is preserved (not clobbered).
+	if !strings.Contains(string(merged), `"Bash"`) {
+		t.Error("Merge dropped the pre-existing Bash matcher")
+	}
+}


### PR DESCRIPTION
## What

Implements **SPEC-0247 §7.3 P1.3** — pins the skillctl trust gate into Claude Code **managed settings** so a **non-root** user cannot delete or bypass it. This is the prerequisite (**P0.0**) for SPEC-0317 (skillctl Enterprise): without it, §3.2's "a local user can just delete the hook" caveat stands and the whole gate is advisory.

New verb `skillctl pin`:
- **generate** — emit the managed-settings.json wiring the §7.1 gate (SessionStart sweep + PreToolUse(Skill) verify-hook) with an absolute binary path. Default = un-deletable-but-not-strict; `--strict` adds `allowManagedHooksOnly` (warns loudly it disables ALL user hooks); `--harden` also blocks `--dangerously-skip-permissions`.
- **status** — read the platform managed file, report `absent/tampered/partial/pinned/pinned-strict` (exit 0 pinned, else 2). Reused later by SPEC-0317 `session-baseline`.
- **install** — **MERGE** the gate into any existing managed policy (never clobber), back up the prior file, and — only as **root with `--confirm`** — write it, then **re-read from disk** and verify what actually landed. Non-root prints the sudo runbook (exit 3); performs no privileged write.

New `pkg/skillctl/pin` is stdlib-only, no network.

## Mechanism — verified, not guessed

Confirmed against the official Claude Code docs (via the claude-code-guide agent): managed settings are the highest-precedence tier; a managed hook cannot be user-suppressed; a PreToolUse `deny` blocks **even under `--dangerously-skip-permissions`**. Paths: macOS `/Library/Application Support/ClaudeCode/`, Linux `/etc/claude-code/`, Windows `C:\Program Files\ClaudeCode\`.

## Challenge gate — run TWICE (both caught real bugs)

Per the trust-layer convention, the adversarial gate (hacker + security + correctness → judge) ran on this code, then a **focused hacker re-check** on the fixes. Both rounds found genuine defects; all fixed + locked with negative tests:

- **`Verify()` now shape-matches argv under a COVERING (regex) matcher**, not a substring. Rejected: a wrong-matcher hook (`verify-hook` under `Bash`), a decoy (`echo verify-hook`), an **exit-suppressed `verify-hook || true`** (which would turn every DENY into ALLOW), and a **quote-concat `"skillctl"verify-hook`** (shell runs a nonexistent binary → fails open).
- **install merges** instead of destroying other CISO policy (other managed hooks / permission rules); backs up first.
- **root re-verify reads the file back from disk**, not the in-memory buffer.
- **Honesty**: "un-deletable" is bounded to non-root everywhere; same-uid/root is out of scope (SPEC-0247 §3.2).

## Scoped out (documented)
- CISO-console policy source (SPEC-0192, cross-repo).
- A self-sabotaging root can pass a neutering sweep flag — root-configures-own-foot-gun, out of scope like the same-uid attacker (the per-invocation DENY gate is arg-locked).

## Tests
20 tests across `pkg/skillctl/pin` + `cmd/skillctl` pin verbs, green under `-race`; `go vet` + `gofmt` clean; smoke-tested end-to-end (generate / status / install-merge-preserves-foreign-policy / decoy-reject / quote-concat-reject).

🤖 Generated with [Claude Code](https://claude.com/claude-code)