### PR TITLE
SPEC-0317 client strecke: outbox + enforce + sync + statemachine + guard-path (agent-built)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Install PortAudio
         run: brew install portaudio
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Install PortAudio
         run: brew install portaudio
@@ -63,7 +63,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Install PortAudio
         run: brew install portaudio
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       # The cgo packages (recorder/menubar) need PortAudio to typecheck, so run
       # on macOS like the other jobs rather than a pure-Go ubuntu runner.
@@ -95,7 +95,7 @@ jobs:
         run: brew install portaudio
 
       # govulncheck fails ONLY on vulns reachable from our code. The toolchain is
-      # pinned to a patched Go (go1.26.4, via go.mod `toolchain` + setup-go) so the
+      # pinned to a patched Go (go1.26.5, via go.mod `toolchain` + setup-go) so the
       # stdlib CVEs older toolchains carried are gone; this job keeps them from
       # regressing. Standalone (not in any build job's `needs`) so a fresh upstream
       # CVE blocks merge but never the release builds.
@@ -132,7 +132,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Install PortAudio (Homebrew, for native arm64 build)
         run: brew install portaudio pkg-config
@@ -181,7 +181,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Build linux/amd64
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
 
 jobs:
   # -----------------------------------------------------------------------

--- a/.github/workflows/skillctl-release.yml
+++ b/.github/workflows/skillctl-release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4" # patched toolchain (SPEC-0251 §5) — CVE-free binaries
+          go-version: "1.26.5" # patched toolchain (SPEC-0251 §5) — CVE-free binaries (GO-2026-5856)
 
       # 5-arch matrix, pure Go (skillctl needs no CGO), version-stamped with the
       # full skillctl/vX.Y.Z tag — exactly tools/skillctl-release.sh's set.

--- a/.github/workflows/windows-gate.yml
+++ b/.github/workflows/windows-gate.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: go vet (all packages)
@@ -120,7 +120,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: go vet (Windows)
@@ -171,7 +171,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       # (1) No -run allow-list may exist inside the windows-trust job.
@@ -224,7 +224,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Download Windows binaries

--- a/cmd/skillctl/enforce_cmds.go
+++ b/cmd/skillctl/enforce_cmds.go
@@ -1,0 +1,86 @@
+package main
+
+// enforce_cmds.go — `skillctl enforce` (SPEC-0317 P0).
+//
+// enforce is the enterprise-evidence twin of `verify-hook`: for a PreToolUse
+// Skill event it makes the EXACT SAME allow/deny decision (AC-1 byte-parity),
+// and additionally mirrors the resulting device-signed InvocationRecord into the
+// authoritative SPEC-0317 outbox (audit_events, write-once) so the evidence is
+// durable and later drainable to the KafShield ingest (P1 `skillctl sync`).
+//
+// Design — a pure silent router (the load-bearing byte-parity point):
+//   - enforce does NOT re-classify, re-decide, or emit anything of its own. It
+//     installs the outbox sink into the existing post-decision, fire-and-forget
+//     emit seam (invocationOutboxSink, fed from appendSignedInvocation) and then
+//     delegates the WHOLE decision to runVerifyHook. stdout, stderr, and the exit
+//     code are therefore produced entirely by runVerifyHook — byte-identical to
+//     `verify-hook` for an allow and for every deny class (AC-1).
+//   - The outbox write rides the SAME seam that writes invocation-trail.jsonl,
+//     never the hot decision path, and is fed the identical fully-signed record
+//     (dual-sink consistency: one event_id / one signature to both sinks).
+//   - The write happens BEFORE runEnforce returns: appendSignedInvocation runs in
+//     runVerifyHook's deferred logger, which completes before the return value
+//     propagates out through runEnforce.
+//
+// Decision-invariance (SPEC-0255, a LANDED contract — AC-2a): the sink is
+// fire-and-forget. A forced outbox failure (SQLITE_BUSY at the ~250ms pin, a full
+// disk, an open error, or an outright panic) is swallowed inside
+// appendSignedInvocation's recover and its result is discarded, so exit + stdout
+// + stderr stay byte-identical to the no-outbox path. On Append failure the row
+// is spooled (AppendOrSpool) so the evidence is not lost either — but even a total
+// double failure never alters the decision.
+
+import (
+	"io"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/outbox"
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+)
+
+// enforceOutboxSink is the outbox-write seam. Production points it at
+// defaultEnforceOutboxSink; the decision-invariance test injects a failing /
+// panicking sink to prove exit+output are unchanged (AC-2a).
+var enforceOutboxSink = defaultEnforceOutboxSink
+
+// runEnforce is the entrypoint for `skillctl enforce`. It returns the process
+// exit code (0 = allow, 2 = deny/block) — the very same value runVerifyHook
+// would return for the same event.
+//
+// It installs the outbox sink for the duration of the call and restores the
+// previous value on return. Restoring matters only for tests (which run enforce
+// and verify-hook in one process); in production each invocation is its own
+// process. Setting the package-level seam is safe because skillctl handles one
+// hook event per process — there is no concurrent gate in-process.
+func runEnforce(stdin io.Reader, stdout, stderr io.Writer) int {
+	prev := invocationOutboxSink
+	invocationOutboxSink = enforceOutboxSink
+	defer func() { invocationOutboxSink = prev }()
+	return runVerifyHook(stdin, stdout, stderr)
+}
+
+// defaultEnforceOutboxSink mirrors one fully-signed InvocationRecord into the
+// SPEC-0317 outbox. It is called from inside appendSignedInvocation (already
+// under a recover), but it defends itself as well so it is safe to call from any
+// future seam. It NEVER returns an error to the caller: on any failure it either
+// spools (AppendOrSpool) or drops silently, so the decision path is untouched.
+func defaultEnforceOutboxSink(home string, rec skillgate.InvocationRecord) {
+	defer func() { _ = recover() }()
+	if home == "" {
+		return // nowhere to anchor state (mirrors the trail sink's guard)
+	}
+	// Pin the exact signed bytes once (payload_json) + their hash, so the outbox
+	// row is byte-consistent with the trail projection.
+	payloadJSON, payloadHash, err := outbox.RecordPayload(rec)
+	if err != nil {
+		return // a record that refuses canonicalization is not evidence we can store
+	}
+	st, err := outbox.Open(home)
+	if err != nil {
+		return // fail-open on the WRITE only — never on the decision
+	}
+	defer st.Close()
+	// AppendOrSpool: on SQLITE_BUSY / db error the row falls back to spool.jsonl
+	// so a later `skillctl sync` Reconcile drains it. The returned error (only if
+	// BOTH sinks fail) is intentionally ignored — decision-invariance wins.
+	_ = st.AppendOrSpool(rec, payloadJSON, payloadHash)
+}

--- a/cmd/skillctl/enforce_cmds_test.go
+++ b/cmd/skillctl/enforce_cmds_test.go
@@ -1,0 +1,209 @@
+package main
+
+// Tests for `skillctl enforce` (SPEC-0317 P0).
+//
+// AC-1  — enforce is BYTE-IDENTICAL to verify-hook (exit + stdout + stderr) for
+//         an allow and for every deny class. enforce must be a pure silent router
+//         that only adds an outbox sink; it must never change a byte of output.
+// AC-2a — DECISION-INVARIANCE: a forced outbox-write failure (a panicking sink)
+//         leaves exit + stdout + stderr byte-identical to the healthy path, so the
+//         SPEC-0255 landed contract is preserved.
+//
+// The §7 chain stays behind the verifyManagedFn / verifyManagedOfflineFn seams,
+// stubbed here so the decision logic runs offline. Managed skills are faked with
+// a stashed .skb under a temp $HOME.
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/outbox"
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+)
+
+// runOne executes a single gate function against event on a FRESH temp $HOME with
+// the two verification seams stubbed to (retCode, retReason). Each call gets its
+// own home so state written by one run (trail, verdict cache, outbox) can never
+// leak into a comparison run — the only intended difference between enforce and
+// verify-hook is the outbox side effect, never the (exit, stdout, stderr) tuple.
+func runOne(t *testing.T, gate func(r *strings.Reader, o, e *bytes.Buffer) int, name, event string, retCode int, retReason string) (int, string, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if name != "" {
+		mkManagedSkill(t, home, name)
+	}
+	origF, origO := verifyManagedFn, verifyManagedOfflineFn
+	verifyManagedFn = func(string, gatePolicy) (int, string) { return retCode, retReason }
+	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return retCode, retReason, true }
+	t.Cleanup(func() { verifyManagedFn, verifyManagedOfflineFn = origF, origO })
+
+	var out, errb bytes.Buffer
+	code := gate(strings.NewReader(event), &out, &errb)
+	return code, out.String(), errb.String()
+}
+
+var hookViaVerify = func(r *strings.Reader, o, e *bytes.Buffer) int { return runVerifyHook(r, o, e) }
+var hookViaEnforce = func(r *strings.Reader, o, e *bytes.Buffer) int { return runEnforce(r, o, e) }
+
+// assertParity runs the same scenario through verify-hook and through enforce
+// (each on its own fresh home) and asserts the (exit, stdout, stderr) tuples are
+// byte-identical.
+func assertParity(t *testing.T, label, name, event string, retCode int, retReason string) {
+	t.Helper()
+	vc, vo, ve := runOne(t, hookViaVerify, name, event, retCode, retReason)
+	ec, eo, ee := runOne(t, hookViaEnforce, name, event, retCode, retReason)
+	if vc != ec {
+		t.Fatalf("[%s] exit: verify-hook=%d enforce=%d", label, vc, ec)
+	}
+	if vo != eo {
+		t.Fatalf("[%s] stdout diverged:\n verify-hook=%q\n enforce   =%q", label, vo, eo)
+	}
+	if ve != ee {
+		t.Fatalf("[%s] stderr diverged:\n verify-hook=%q\n enforce   =%q", label, ve, ee)
+	}
+}
+
+// TestEnforce_ByteParity_AllowAndDenyClasses is AC-1: enforce matches verify-hook
+// byte-for-byte across an allow and a representative set of deny classes.
+func TestEnforce_ByteParity_AllowAndDenyClasses(t *testing.T) {
+	skillEvent := `{"tool_name":"Skill","tool_input":{"skill":"subject"},"session_id":"s"}`
+
+	cases := []struct {
+		label  string
+		name   string // "" → unmanaged/no skill dir
+		event  string
+		code   int
+		reason string
+	}{
+		{"allow-managed", "subject", skillEvent, exitOK, ""},
+		{"deny-author-sig", "subject", skillEvent, 11, "author signature invalid"},
+		{"deny-digest-mismatch", "subject", skillEvent, 10, "bundle modified after signing (digest mismatch)"},
+		{"deny-governance", "subject", skillEvent, 13, "governance below required minimum"},
+		{"deny-revoked-author", "subject", skillEvent, 17, "author identity revoked"},
+		// Non-managed / input-validation paths (seams not consulted):
+		{"non-skill-tool", "", `{"tool_name":"Bash","tool_input":{"command":"ls"}}`, exitOK, ""},
+		{"no-skill-field", "", `{"tool_name":"Skill","tool_input":{"args":"x"}}`, exitOK, ""},
+		{"malformed-stdin", "", "not json at all", exitOK, ""},
+		{"unsafe-name", "", `{"tool_name":"Skill","tool_input":{"skill":"../../etc/passwd"}}`, exitOK, ""},
+	}
+	for _, c := range cases {
+		assertParity(t, c.label, c.name, c.event, c.code, c.reason)
+	}
+}
+
+// TestEnforce_UnmanagedPolicyDeny_Parity checks a deny that comes from policy
+// (unmanaged_skills=deny) rather than the §7 chain — a distinct deny class.
+func TestEnforce_UnmanagedPolicyDeny_Parity(t *testing.T) {
+	t.Setenv("SKILLCTL_GATE_UNMANAGED", "deny")
+	event := `{"tool_name":"Skill","tool_input":{"skill":"some-plugin:thing"}}`
+	assertParity(t, "unmanaged-policy-deny", "", event, exitOK, "")
+}
+
+// TestEnforce_WritesOutboxRow proves the added behaviour: on an allow decision,
+// enforce lands exactly one write-once evidence row in the outbox whose signed
+// payload re-verifies, and whose event_id matches the trail projection (dual-sink
+// consistency).
+func TestEnforce_WritesOutboxRow(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	mkManagedSkill(t, home, "subject")
+	orig := verifyManagedOfflineFn
+	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return exitOK, "ok", true }
+	t.Cleanup(func() { verifyManagedOfflineFn = orig })
+
+	var out, errb bytes.Buffer
+	if code := runEnforce(strings.NewReader(`{"tool_name":"Skill","tool_input":{"skill":"subject"},"session_id":"s"}`), &out, &errb); code != exitOK {
+		t.Fatalf("expected allow, got exit %d (stderr=%q)", code, errb.String())
+	}
+
+	st, err := outbox.Open(home)
+	if err != nil {
+		t.Fatalf("open outbox: %v", err)
+	}
+	defer st.Close()
+	n, err := st.PendingCount()
+	if err != nil {
+		t.Fatalf("pending count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("outbox pending rows = %d, want exactly 1", n)
+	}
+
+	batch, err := st.PendingBatch(10)
+	if err != nil {
+		t.Fatalf("pending batch: %v", err)
+	}
+	row := batch[0]
+	if row.Decision != "allow" || row.Tool != "Skill" || row.SkillName != "subject" {
+		t.Fatalf("row index columns wrong: %+v", row)
+	}
+	// Dual-sink consistency: the outbox row's event_id must be one the signed
+	// trail also carries (same fanned-out record). Re-derive the payload hash from
+	// the stored payload_json and confirm it matches the column.
+	var rec skillgate.InvocationRecord
+	if err := json.Unmarshal([]byte(row.PayloadJSON), &rec); err != nil {
+		t.Fatalf("payload_json not a record: %v", err)
+	}
+	if rec.EventID != row.EventID {
+		t.Fatalf("event_id divergence: column=%q payload=%q", row.EventID, rec.EventID)
+	}
+	_, wantHash, err := outbox.RecordPayload(rec)
+	if err != nil {
+		t.Fatalf("re-derive payload: %v", err)
+	}
+	if wantHash != row.PayloadHash {
+		t.Fatalf("payload_hash divergence: column=%q re-derived=%q", row.PayloadHash, wantHash)
+	}
+}
+
+// TestEnforce_OutboxFailure_DecisionInvariant is AC-2a: with a panicking outbox
+// sink, enforce's (exit, stdout, stderr) stays byte-identical to verify-hook —
+// the SPEC-0255 decision-invariance contract holds even when the write blows up.
+func TestEnforce_OutboxFailure_DecisionInvariant(t *testing.T) {
+	// Force the sink to panic on every call.
+	origSink := enforceOutboxSink
+	enforceOutboxSink = func(string, skillgate.InvocationRecord) { panic("outbox is on fire") }
+	t.Cleanup(func() { enforceOutboxSink = origSink })
+
+	skillEvent := `{"tool_name":"Skill","tool_input":{"skill":"subject"},"session_id":"s"}`
+	cases := []struct {
+		label  string
+		name   string
+		event  string
+		code   int
+		reason string
+	}{
+		{"allow", "subject", skillEvent, exitOK, ""},
+		{"deny", "subject", skillEvent, 11, "author signature invalid"},
+	}
+	for _, c := range cases {
+		// verify-hook baseline (no sink) vs enforce with the panicking sink.
+		vc, vo, ve := runOne(t, hookViaVerify, c.name, c.event, c.code, c.reason)
+		ec, eo, ee := runOne(t, hookViaEnforce, c.name, c.event, c.code, c.reason)
+		if vc != ec || vo != eo || ve != ee {
+			t.Fatalf("[%s] outbox panic altered output:\n exit %d/%d\n stdout %q/%q\n stderr %q/%q",
+				c.label, vc, ec, vo, eo, ve, ee)
+		}
+	}
+}
+
+// TestEnforce_OutboxFailure_StillDecidesAllow confirms a panicking sink does not
+// even flip the exit code on the healthy allow path (the specific worst case: an
+// outbox failure must not become a fail-open OR a spurious deny).
+func TestEnforce_OutboxFailure_StillDecidesAllow(t *testing.T) {
+	origSink := enforceOutboxSink
+	enforceOutboxSink = func(string, skillgate.InvocationRecord) { panic("boom") }
+	t.Cleanup(func() { enforceOutboxSink = origSink })
+
+	code, out, _ := runOne(t, hookViaEnforce, "subject",
+		`{"tool_name":"Skill","tool_input":{"skill":"subject"},"session_id":"s"}`, exitOK, "")
+	if code != exitOK {
+		t.Fatalf("outbox panic changed the decision: exit=%d, want %d (allow)", code, exitOK)
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("allow must emit nothing on stdout, got %q", out)
+	}
+}

--- a/cmd/skillctl/exitcode_guard_test.go
+++ b/cmd/skillctl/exitcode_guard_test.go
@@ -25,6 +25,7 @@ func TestCmdExitConsts_RegistryParity(t *testing.T) {
 		{"import_intent_capped", exitImportIntentCapped, exitcode.ImportIntentCapped.Number},
 		{"import_source_blocked", exitImportSourceBlocked, exitcode.ImportSourceBlocked.Number},
 		{"sign_invalid", exitSigInval, exitcode.SignInvalid.Number},
+		{"sidechannel_denied", exitSidechannelDenied, exitcode.GuardPathSidechannelDenied.Number},
 	}
 	for _, c := range cases {
 		if c.got != c.reg {

--- a/cmd/skillctl/guardpath_cmds.go
+++ b/cmd/skillctl/guardpath_cmds.go
@@ -1,0 +1,507 @@
+package main
+
+// guardpath_cmds.go — `skillctl guard-path` (SPEC-0317 R-6, P2).
+//
+// A SIDE-CHANNEL PreToolUse guard for the file-touching tools (Bash / Read /
+// Edit / Write). It reads the hook event on stdin, classifies the target
+// path(s) against the installed skill directories, and by default AUDITS-ALLOWS
+// (records a skill-dir hit, allows the tool). An opt-in enterprise mode DENIES a
+// skill-dir access (exit 2, refusal_code `sidechannel_denied`).
+//
+// HONEST SCOPE (R-6.4 — this guard is DETECTION / BAR-RAISING, NOT a seal):
+// it is defeatable by construction (symlinks, $HOME indirection, cd + relative
+// paths, base64 pipelines, copies made OUTSIDE the skills dir, content already
+// in the model's context, a direct /slash skill load). It is sold ONLY as
+// audited-allow detection; `guard-path --explain` prints the coverage gaps
+// verbatim rather than hiding them. Because it is not a seal, it fails OPEN: an
+// unreadable event, a panic, or an unresolvable path is a silent allow, and this
+// hook NEVER overrides another hook's deny (same silent-allow contract as
+// verify-hook: an allow emits nothing and exits 0).
+//
+// THE ONE CANONICALISATION FIXED POINT (R-6.2 — the load-bearing correctness
+// point): classification resolves BOTH the access target and the skills root
+// through install.CanonicalPath (expand ~, abs+clean, EvalSymlinks) and compares
+// the cleaned absolute real paths with filepath.Rel + a no-"../"-escape check. A
+// lexical HasPrefix on the skills dir is FORBIDDEN — that dir already contains
+// symlinks (browse → gstack/browse, find-skills → ../../.agents/skills), so a
+// HasPrefix check both false-negatives (a symlinked-in body) and false-positives.
+//
+// SELF-EXEMPTION (R-6.3): skillctl's own subprocess reads (compliance inventory,
+// the SessionStart sweep) and the harness's legitimate SKILL.md load must never
+// be denied. Where the event shape lets us tell (a Bash line that invokes
+// skillctl), we exempt; otherwise we DEFAULT TO ALLOW — the audited-allow default
+// already never denies, so an ambiguous case cannot become a false block.
+//
+// VOLUME-BOUNDING (R-6.1): Bash/Read/Edit/Write fire far more than Skill, so an
+// event is emitted ONLY on a deny or a skill-dir hit — never on an ordinary file
+// op. The telemetry rides a SEPARATE, off-by-default stream (guard-path.jsonl)
+// with its own consent basis (R-9); it is NEVER folded into the enforcement
+// evidence (invocation-trail.jsonl / the outbox), so SPEC-0276 readAndVerifyTrail
+// keeps reading the trail byte-for-byte.
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/bodyscan"
+	"github.com/kamir/m3c-tools/pkg/skillctl/install"
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+)
+
+// exitSidechannelDenied is the numbered refusal code carried in the signed guard
+// event on an opt-in deny. The PROCESS still exits exitHookBlock (2) to block the
+// PreToolUse call — 27 is carried in the human reason + the signed refusal_code,
+// exactly as exitBundleRevoked (17) / exitRevocationStale (22) do for verify-hook.
+const exitSidechannelDenied = 27 // = exitcode.GuardPathSidechannelDenied.Number
+
+// guardPathRefusalToken is the stable refusal_code token for a side-channel deny.
+const guardPathRefusalToken = "sidechannel_denied"
+
+// guardPathSink is the write seam for the SEPARATE side-channel telemetry stream.
+// Tests inject a capturing/failing sink.
+var guardPathSink = defaultGuardPathSink
+
+// runGuardPath is the entrypoint for `skillctl guard-path`. It returns the
+// process exit code: 0 = allow (audited-allow default OR any non-hit / self-exempt
+// / unreadable case), 2 = opt-in deny of a skill-dir access.
+func runGuardPath(args []string, stdin io.Reader, stdout, stderr io.Writer) (code int) {
+	fs := flag.NewFlagSet("guard-path", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	explain := fs.Bool("explain", false, "print the honest scope + coverage gaps and exit")
+	denyFlag := fs.Bool("deny", false, "opt-in: DENY (exit 2) a skill-dir access instead of audited-allow")
+	homeOverride := fs.String("home", "", "home dir override (default: $HOME)")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *explain {
+		printGuardPathExplain(stdout)
+		return exitOK
+	}
+
+	// Fail OPEN on panic: a detection side channel must NEVER false-block a tool
+	// (R-6.4 — it is not a seal and must not override another hook's decision).
+	defer func() {
+		if r := recover(); r != nil {
+			code = exitOK
+		}
+	}()
+
+	raw, err := io.ReadAll(io.LimitReader(stdin, 1<<20))
+	if err != nil || len(bytes.TrimSpace(raw)) == 0 {
+		return exitOK // nothing to guard → silent allow
+	}
+	var ev hookEvent
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		return exitOK // malformed → silent allow (never block on our own parse fail)
+	}
+
+	// Guard only the file-touching tools. Skill is verify-hook's job; anything
+	// else is a silent allow so this hook never overrides another.
+	switch ev.ToolName {
+	case "Bash", "Read", "Edit", "Write", "":
+	default:
+		return exitOK
+	}
+
+	home := *homeOverride
+	if home == "" {
+		home, _ = userHome()
+	}
+	canonRoot, ok := canonicalSkillsRoot(home)
+	if !ok {
+		return exitOK // no resolvable skills root → nothing to classify
+	}
+
+	// Self-exemption FIRST (R-6.3): never deny skillctl's own inventory read.
+	if guardSelfExempt(ev) {
+		return exitOK
+	}
+
+	hits := skillDirHits(canonRoot, ev)
+	if len(hits) == 0 {
+		// R-6.1 volume-bounding: emit NOTHING on a non-hit.
+		return exitOK
+	}
+
+	obfuscated := commandObfuscated(ev)
+	deny := guardDenyMode(*denyFlag)
+
+	if deny {
+		reason := fmt.Sprintf(
+			"skillctl guard-path: BLOCKED %s access to skill directory %q (side-channel deny, SPEC-0317 R-6.1; refusal_code=%s, code %d). This is opt-in detection, not a seal — clear SKILLCTL_GUARD_PATH / drop --deny if this access is legitimate.",
+			toolLabel(ev.ToolName), hits[0], guardPathRefusalToken, exitSidechannelDenied)
+		emitGuardEvent(home, canonRoot, ev, hits, "deny", guardPathRefusalToken, exitSidechannelDenied, obfuscated)
+		return emitDeny(stdout, stderr, reason)
+	}
+
+	// Default disposition: AUDITED-ALLOW — record the hit, allow the tool (exit 0,
+	// emit nothing on stdout/stderr).
+	emitGuardEvent(home, canonRoot, ev, hits, "audited-allow", "", exitOK, obfuscated)
+	return exitOK
+}
+
+// toolLabel renders a tool name for a message, defaulting to "file" for the
+// empty (matcher-only) case.
+func toolLabel(t string) string {
+	if t == "" {
+		return "file"
+	}
+	return t
+}
+
+// --- classification (the R-6.2 fixed point) -------------------------------
+
+// canonicalSkillsRoot resolves ~/.claude/skills through install.CanonicalPath.
+func canonicalSkillsRoot(home string) (string, bool) {
+	if home == "" {
+		return "", false
+	}
+	c, err := install.CanonicalPath(filepath.Join(home, ".claude", "skills"))
+	if err != nil {
+		return "", false
+	}
+	return c, true
+}
+
+// skillDirHits returns the canonical paths of every target that resolves to (or
+// under) the skills root. Both the target and the root are canonicalised first
+// (R-6.2), so a symlinked-in body is caught and a lexical `..`/symlink trick
+// cannot false-negative.
+func skillDirHits(canonRoot string, ev hookEvent) []string {
+	var hits []string
+	seen := map[string]struct{}{}
+	for _, p := range targetPaths(ev) {
+		ct, err := install.CanonicalPath(p)
+		if err != nil {
+			continue
+		}
+		if !underSkills(canonRoot, ct) {
+			continue
+		}
+		if _, dup := seen[ct]; dup {
+			continue
+		}
+		seen[ct] = struct{}{}
+		hits = append(hits, ct)
+	}
+	return hits
+}
+
+// underSkills reports whether canonTarget is the skills root itself or inside it,
+// using filepath.Rel + a no-"../"-escape check on the two already-canonical
+// absolute paths (NOT a lexical HasPrefix — R-6.2).
+func underSkills(canonRoot, canonTarget string) bool {
+	if canonRoot == "" || canonTarget == "" {
+		return false
+	}
+	if canonTarget == canonRoot {
+		return true
+	}
+	rel, err := filepath.Rel(canonRoot, canonTarget)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
+
+// skillNameForPath derives the skill name (the first path segment under the
+// skills root) from a canonical target already known to be under canonRoot.
+func skillNameForPath(canonRoot, canonTarget string) string {
+	rel, err := filepath.Rel(canonRoot, canonTarget)
+	if err != nil || rel == "" || rel == "." {
+		return ""
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[0]
+}
+
+// --- target extraction (R-6.4: read command/file_path) --------------------
+
+// targetPaths pulls the candidate file paths from a hook event: file_path for
+// Read/Edit/Write, and shell-word-extracted path-like args for Bash. The empty
+// tool name (a matcher-only event) is treated permissively.
+func targetPaths(ev hookEvent) []string {
+	var out []string
+	seen := map[string]struct{}{}
+	add := func(p string) {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			return
+		}
+		if _, dup := seen[p]; dup {
+			return
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	switch ev.ToolName {
+	case "Read", "Edit", "Write":
+		add(ev.ToolInput.FilePath)
+	case "Bash":
+		for _, tok := range shellPathTokens(ev.ToolInput.Command) {
+			add(tok)
+		}
+	default: // "" or anything else that slipped past the tool filter
+		add(ev.ToolInput.FilePath)
+		for _, tok := range shellPathTokens(ev.ToolInput.Command) {
+			add(tok)
+		}
+	}
+	return out
+}
+
+// shellPathTokens shell-word-splits a Bash command and returns the path-like
+// tokens (best-effort; the coverage gaps are enumerated in --explain).
+func shellPathTokens(cmd string) []string {
+	if strings.TrimSpace(cmd) == "" {
+		return nil
+	}
+	var out []string
+	for _, f := range shellSplit(cmd) {
+		f = strings.Trim(f, `"'`)
+		if f == "" || strings.HasPrefix(f, "-") {
+			continue // a flag, not a path
+		}
+		if looksPathLike(f) {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// shellSplit is a deliberately minimal tokeniser: it neutralises common shell
+// separators (so a piped/compound command still surfaces its path args) and
+// splits on whitespace. It is NOT a real shell parser — that limitation is part
+// of the honestly-enumerated coverage gap.
+func shellSplit(cmd string) []string {
+	repl := strings.NewReplacer(
+		"|", " ", ";", " ", "&", " ", ">", " ", "<", " ",
+		"(", " ", ")", " ", "`", " ", "\n", " ", "\t", " ",
+	)
+	return strings.Fields(repl.Replace(cmd))
+}
+
+// looksPathLike reports whether a token is shaped like a filesystem path.
+func looksPathLike(s string) bool {
+	if s == "" || s == "." || s == ".." {
+		return false
+	}
+	return strings.Contains(s, "/") || strings.HasPrefix(s, "~") || strings.HasPrefix(s, ".")
+}
+
+// --- self-exemption (R-6.3) -----------------------------------------------
+
+// guardSelfExempt reports whether the event is skillctl's own tool access (the
+// compliance inventory read, the SessionStart sweep), which must NEVER be denied.
+// When the event shape does not let us tell, it returns false — the audited-allow
+// default already never denies, so an ambiguous case cannot become a false block.
+//
+// R-6.3: the exemption is granted ONLY to a verified SOLE-skillctl command. A
+// compound / piped / substituted command forfeits it — otherwise the leading
+// `skillctl` word would whitelist a SECOND command chained after it
+// (`skillctl x; cat <victim>`), silently allowing the victim read AND blinding the
+// audit. commandHasSeparator strips that escape so the chained access still
+// surfaces its skill-dir hit (and, under --deny, is blocked).
+func guardSelfExempt(ev hookEvent) bool {
+	if ev.ToolName != "Bash" {
+		return false
+	}
+	if commandHasSeparator(ev.ToolInput.Command) {
+		return false // not a SOLE skillctl command — no exemption
+	}
+	return commandInvokesSkillctl(ev.ToolInput.Command)
+}
+
+// commandHasSeparator reports whether cmd chains or substitutes a second command
+// via any shell separator (;, &&, ||, |, &, newline, backtick, or $()). Any of
+// these means the command is NOT a verified SOLE-skillctl invocation, so it cannot
+// inherit skillctl's self-exemption (R-6.3). `&&`/`||` are covered by the single-
+// char scan for `&`/`|`.
+func commandHasSeparator(cmd string) bool {
+	if strings.ContainsAny(cmd, ";|&\n`") {
+		return true
+	}
+	return strings.Contains(cmd, "$(")
+}
+
+// commandInvokesSkillctl reports whether the first real command word is skillctl
+// (or the m3c-tools front-end), skipping leading VAR=val assignments and the
+// common env/sudo/command wrappers.
+func commandInvokesSkillctl(cmd string) bool {
+	for _, tok := range shellSplit(cmd) {
+		tok = strings.Trim(tok, `"'`)
+		if tok == "" {
+			continue
+		}
+		if strings.Contains(tok, "=") && !strings.Contains(tok, "/") {
+			continue // VAR=val assignment
+		}
+		switch tok {
+		case "env", "sudo", "command", "exec", "nohup", "time":
+			continue // wrapper — look at the next word
+		}
+		base := filepath.Base(tok)
+		return base == "skillctl" || base == "m3c-tools"
+	}
+	return false
+}
+
+// --- obfuscation flag (R-6.4: reuse bodyscan, not ad-hoc regexes) ----------
+
+// commandObfuscated flags a Bash command whose body trips bodyscan's
+// obfuscation rules (base64 / pipeline decoding). Advisory only — it annotates
+// the guard event; it never changes the allow/deny disposition.
+func commandObfuscated(ev hookEvent) bool {
+	if ev.ToolName != "Bash" || strings.TrimSpace(ev.ToolInput.Command) == "" {
+		return false
+	}
+	rep := bodyscan.Scan(bodyscan.Input{Body: ev.ToolInput.Command})
+	for _, f := range rep.Findings {
+		if f.Category == bodyscan.CategoryObfuscation {
+			return true
+		}
+	}
+	return false
+}
+
+// --- disposition ----------------------------------------------------------
+
+// guardDenyMode reports the opt-in deny disposition: the --deny flag OR the
+// SKILLCTL_GUARD_PATH env switch (deny|block). Default is audited-allow. The
+// enterprise offline profile reuses the same switch when it wires this guard.
+func guardDenyMode(flagDeny bool) bool {
+	if flagDeny {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("SKILLCTL_GUARD_PATH"))) {
+	case "deny", "block":
+		return true
+	}
+	return false
+}
+
+// --- emit (SEPARATE, off-by-default stream — R-9) --------------------------
+
+// guardPathLine is one JSONL record in the side-channel stream: the SIGNED
+// InvocationRecord (reusing the SPEC-0202 device-signed vocabulary + inv: event
+// id — NOT a new event format) embedded, plus the guard-specific advisory fields.
+// Embedding keeps the line a strict superset of the signed record, so the
+// signature still verifies against the canonical record bytes.
+type guardPathLine struct {
+	skillgate.InvocationRecord
+	Decision   string   `json:"guard_decision"` // audited-allow | deny
+	Targets    []string `json:"guard_targets"`  // all skill-dir hits (canonical)
+	Obfuscated bool     `json:"guard_obfuscated,omitempty"`
+}
+
+// guardPathLogPath is the SEPARATE stream file. It is NEVER invocation-trail.jsonl
+// (the enforcement-evidence projection) nor the outbox — R-9 keeps guard-path
+// file-access telemetry on its own consent basis.
+func guardPathLogPath(home string) string {
+	return filepath.Join(verdictDir(home), "guard-path.jsonl")
+}
+
+func defaultGuardPathSink(home string, line []byte) error {
+	dir := verdictDir(home)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(guardPathLogPath(home), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(append(line, '\n'))
+	return err
+}
+
+// emitGuardEvent device-signs one guard record and appends it to the side-channel
+// stream. Fire-and-forget + panic-safe: it can NEVER alter the disposition (the
+// caller has already decided). A missing device key just skips the write.
+func emitGuardEvent(home, canonRoot string, ev hookEvent, hits []string, decision, refusal string, exit int, obfuscated bool) {
+	defer func() { _ = recover() }()
+	if home == "" || len(hits) == 0 {
+		return
+	}
+	key, err := invocationDeviceKey(home)
+	if err != nil || key == nil {
+		return
+	}
+	rec := skillgate.InvocationRecord{
+		Schema:      skillgate.InvocationSchema,
+		EventID:     newInvocationEventID(),
+		EventType:   "path.guard.access",
+		SkillName:   skillNameForPath(canonRoot, hits[0]),
+		Action:      "file_access",
+		Tool:        ev.ToolName,
+		SessionID:   ev.SessionID,
+		OccurredAt:  time.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		DeviceKeyID: key.KeyID(),
+		ExitCode:    exit,
+		RefusalCode: refusal,
+	}
+	if err := skillgate.SignInvocationRecord(&rec, key.Sign, base64.StdEncoding.EncodeToString); err != nil {
+		return
+	}
+	line, err := json.Marshal(guardPathLine{
+		InvocationRecord: rec,
+		Decision:         decision,
+		Targets:          hits,
+		Obfuscated:       obfuscated,
+	})
+	if err != nil {
+		return
+	}
+	_ = guardPathSink(home, line)
+}
+
+// --- --explain (R-6.4: enumerate the honest scope + coverage gaps) ---------
+
+func printGuardPathExplain(w io.Writer) {
+	fmt.Fprintln(w, "skillctl guard-path — side-channel PreToolUse guard (SPEC-0317 R-6)")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "WHAT IT DOES")
+	fmt.Fprintln(w, "  Reads a Bash/Read/Edit/Write PreToolUse hook event on stdin and classifies")
+	fmt.Fprintln(w, "  the target path(s) against ~/.claude/skills using a SINGLE realpath fixed")
+	fmt.Fprintln(w, "  point (EvalSymlinks on both the target and the skills root — never a lexical")
+	fmt.Fprintln(w, "  HasPrefix, because the skills dir itself contains symlinks).")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "DISPOSITION")
+	fmt.Fprintln(w, "  default: AUDITED-ALLOW — record a skill-dir hit, allow the tool (exit 0).")
+	fmt.Fprintln(w, "  opt-in : DENY (--deny or SKILLCTL_GUARD_PATH=deny) — exit 2, refusal_code")
+	fmt.Fprintf(w, "           %q (code %d). skillctl's own reads are never denied.\n", guardPathRefusalToken, exitSidechannelDenied)
+	fmt.Fprintln(w, "  Emits ONLY on a deny or a skill-dir hit, to a SEPARATE off-by-default stream")
+	fmt.Fprintln(w, "  (guard-path.jsonl) — never folded into the enforcement evidence.")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "THIS IS DETECTION / BAR-RAISING, NOT A SEAL. Known coverage gaps:")
+	fmt.Fprintln(w, "  - copies of a skill body made OUTSIDE ~/.claude/skills are not classified;")
+	fmt.Fprintln(w, "  - a skill whose SKILL.md is already in the model's context needs no file op;")
+	fmt.Fprintln(w, "  - a direct /slash skill load does not pass through Bash/Read/Edit/Write;")
+	fmt.Fprintln(w, "  - a skill symlinked to a body OUTSIDE the skills root resolves outside it;")
+	fmt.Fprintln(w, "  - a SOLE leading-skillctl-word Bash command is self-exempt from --deny")
+	fmt.Fprintln(w, "    (trusted as skillctl's own read); the exemption is forfeited the moment")
+	fmt.Fprintln(w, "    the command chains a second one (;, &&, ||, |, &, backtick, $()), but a")
+	fmt.Fprintln(w, "    single skillctl invocation pointed at another skill's path is still trusted;")
+	fmt.Fprintln(w, "  - the Bash tokeniser is minimal (no full shell grammar): eval, here-docs,")
+	fmt.Fprintln(w, "    variable-built paths, and base64 pipelines can hide a path (bodyscan flags")
+	fmt.Fprintln(w, "    obvious base64/pipeline obfuscation, but this is advisory, not exhaustive);")
+	fmt.Fprintln(w, "  - it fails OPEN (unreadable event / panic / unresolvable path => allow) so it")
+	fmt.Fprintln(w, "    never overrides another hook's decision.")
+}

--- a/cmd/skillctl/guardpath_cmds.go
+++ b/cmd/skillctl/guardpath_cmds.go
@@ -299,11 +299,28 @@ func shellSplit(cmd string) []string {
 }
 
 // looksPathLike reports whether a token is shaped like a filesystem path.
+// Recognises BOTH separators and drive-qualified Windows paths: on windows a
+// native path (`C:\Users\...\.claude\skills\x\SKILL.md`) carries no '/', no '~'
+// and no leading '.', so a POSIX-only check silently classified it as "not a
+// path" and the guard never fired (Trust Surface / windows-latest).
+// A false positive here is harmless: the token is only fed to
+// install.CanonicalPath, and underSkills() still gates whether it is a real hit.
 func looksPathLike(s string) bool {
 	if s == "" || s == "." || s == ".." {
 		return false
 	}
-	return strings.Contains(s, "/") || strings.HasPrefix(s, "~") || strings.HasPrefix(s, ".")
+	if strings.HasPrefix(s, "~") || strings.HasPrefix(s, ".") {
+		return true
+	}
+	if strings.ContainsAny(s, `/\`) {
+		return true
+	}
+	// Drive-qualified Windows path with no separator (e.g. `C:file`).
+	return len(s) >= 2 && s[1] == ':' && isDriveLetter(s[0])
+}
+
+func isDriveLetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
 
 // --- self-exemption (R-6.3) -----------------------------------------------

--- a/cmd/skillctl/guardpath_cmds_test.go
+++ b/cmd/skillctl/guardpath_cmds_test.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+)
+
+// guardTestHome creates a fake home with a real skill dir under ~/.claude/skills.
+func guardTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	sk := filepath.Join(home, ".claude", "skills", "victim")
+	if err := os.MkdirAll(sk, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sk, "SKILL.md"), []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+// captureGuardSink swaps guardPathSink for a capturing one and restores it.
+func captureGuardSink(t *testing.T) *[][]byte {
+	t.Helper()
+	var lines [][]byte
+	orig := guardPathSink
+	guardPathSink = func(home string, line []byte) error {
+		cp := append([]byte(nil), line...)
+		lines = append(lines, cp)
+		return nil
+	}
+	t.Cleanup(func() { guardPathSink = orig })
+	return &lines
+}
+
+func readEvent(tool, filePath string) string {
+	ev := map[string]any{
+		"tool_name":  tool,
+		"session_id": "sess:guard",
+		"tool_input": map[string]any{"file_path": filePath},
+	}
+	b, _ := json.Marshal(ev)
+	return string(b)
+}
+
+func bashEvent(cmd string) string {
+	ev := map[string]any{
+		"tool_name":  "Bash",
+		"session_id": "sess:guard",
+		"tool_input": map[string]any{"command": cmd},
+	}
+	b, _ := json.Marshal(ev)
+	return string(b)
+}
+
+func runGP(t *testing.T, args []string, stdinJSON string) (int, string, string) {
+	t.Helper()
+	var out, errB bytes.Buffer
+	code := runGuardPath(args, strings.NewReader(stdinJSON), &out, &errB)
+	return code, out.String(), errB.String()
+}
+
+// TestGuardPath_SymlinkedSkillPathResolves — R-6.2/AC-6: a Read reaching a skill
+// through a symlink resolves to the real skill dir (a hit), NOT missed by a
+// lexical check.
+func TestGuardPath_SymlinkedSkillPathResolves(t *testing.T) {
+	home := guardTestHome(t)
+	skillsDir := filepath.Join(home, ".claude", "skills")
+	realDir := filepath.Join(skillsDir, "victim")
+	alias := filepath.Join(skillsDir, "alias")
+	if err := os.Symlink(realDir, alias); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	lines := captureGuardSink(t)
+
+	// Deny mode so a hit is observable as exit 2.
+	code, _, _ := runGP(t, []string{"--home", home, "--deny"},
+		readEvent("Read", filepath.Join(alias, "SKILL.md")))
+	if code != exitHookBlock {
+		t.Fatalf("symlinked skill Read: exit=%d, want %d (deny — the symlink must resolve to a hit)", code, exitHookBlock)
+	}
+	if len(*lines) != 1 {
+		t.Fatalf("expected 1 guard event, got %d", len(*lines))
+	}
+	// The recorded target must be the RESOLVED real path, and the skill name derived.
+	var rec guardPathLine
+	if err := json.Unmarshal((*lines)[0], &rec); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Decision != "deny" || rec.SkillName != "victim" {
+		t.Errorf("guard event = %+v, want decision=deny skill=victim", rec)
+	}
+	if rec.DeviceSignatureB64 == "" {
+		t.Error("guard event not device-signed")
+	}
+}
+
+// TestGuardPath_SelfReadNotDenied — R-6.3/AC-6: skillctl's own inventory read is
+// never denied, even in deny mode.
+func TestGuardPath_SelfReadNotDenied(t *testing.T) {
+	home := guardTestHome(t)
+	victim := filepath.Join(home, ".claude", "skills", "victim", "SKILL.md")
+	lines := captureGuardSink(t)
+
+	code, _, _ := runGP(t, []string{"--home", home, "--deny"},
+		bashEvent("skillctl compliance --inventory "+victim))
+	if code != exitOK {
+		t.Fatalf("self read: exit=%d, want %d (skillctl's own read must never be denied)", code, exitOK)
+	}
+	if len(*lines) != 0 {
+		t.Errorf("self-exempt access must not emit a guard event; got %d", len(*lines))
+	}
+}
+
+// TestGuardPath_CompoundSkillctlStillHits — R-6.3: self-exemption whitelists ONLY
+// a SOLE skillctl command. A compound command (`skillctl …; cat <victim>`)
+// forfeits the exemption, so the victim read still emits a skill-dir hit and,
+// under --deny, is blocked (the escape must not defeat --deny nor blind the audit).
+func TestGuardPath_CompoundSkillctlStillHits(t *testing.T) {
+	home := guardTestHome(t)
+	victim := filepath.Join(home, ".claude", "skills", "victim", "SKILL.md")
+	lines := captureGuardSink(t)
+
+	code, _, _ := runGP(t, []string{"--home", home, "--deny"},
+		bashEvent("skillctl version; cat "+victim))
+	if code != exitHookBlock {
+		t.Fatalf("compound skillctl+victim: exit=%d, want %d (a chained command forfeits self-exemption)", code, exitHookBlock)
+	}
+	if len(*lines) != 1 {
+		t.Fatalf("compound command must emit the skill-dir hit; got %d events", len(*lines))
+	}
+	var rec guardPathLine
+	if err := json.Unmarshal((*lines)[0], &rec); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Decision != "deny" || rec.SkillName != "victim" {
+		t.Errorf("guard event = %+v, want decision=deny skill=victim", rec)
+	}
+}
+
+// TestGuardPath_DenyOnlyInOptInMode — R-6.1/AC-6: a skill-dir Read is
+// audited-allowed by default and denied ONLY in opt-in deny mode.
+func TestGuardPath_DenyOnlyInOptInMode(t *testing.T) {
+	home := guardTestHome(t)
+	victim := filepath.Join(home, ".claude", "skills", "victim", "SKILL.md")
+
+	// Default: audited-allow (exit 0) but a guard event IS recorded.
+	lines := captureGuardSink(t)
+	code, out, errOut := runGP(t, []string{"--home", home}, readEvent("Read", victim))
+	if code != exitOK {
+		t.Fatalf("default mode: exit=%d, want %d (audited-allow)", code, exitOK)
+	}
+	if out != "" || errOut != "" {
+		t.Errorf("audited-allow must be silent; stdout=%q stderr=%q", out, errOut)
+	}
+	if len(*lines) != 1 || func() string {
+		var r guardPathLine
+		_ = json.Unmarshal((*lines)[0], &r)
+		return r.Decision
+	}() != "audited-allow" {
+		t.Errorf("default mode must record one audited-allow event; got %d", len(*lines))
+	}
+
+	// Opt-in deny: exit 2 + three-way deny shape.
+	code, out, errOut = runGP(t, []string{"--home", home, "--deny"}, readEvent("Read", victim))
+	if code != exitHookBlock {
+		t.Fatalf("deny mode: exit=%d, want %d", code, exitHookBlock)
+	}
+	if !strings.Contains(errOut, guardPathRefusalToken) {
+		t.Errorf("deny stderr missing refusal token %q: %q", guardPathRefusalToken, errOut)
+	}
+	var dec hookDecisionOut
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &dec); err != nil {
+		t.Fatalf("deny stdout is not a decision JSON: %v (%q)", err, out)
+	}
+	if dec.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("deny decision = %q, want deny", dec.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+// TestGuardPath_EnvOptInDeny — the SKILLCTL_GUARD_PATH env switch also engages
+// deny mode (the enterprise-profile wiring reuses this switch).
+func TestGuardPath_EnvOptInDeny(t *testing.T) {
+	home := guardTestHome(t)
+	victim := filepath.Join(home, ".claude", "skills", "victim", "SKILL.md")
+	t.Setenv("SKILLCTL_GUARD_PATH", "deny")
+	captureGuardSink(t)
+
+	code, _, _ := runGP(t, []string{"--home", home}, readEvent("Read", victim))
+	if code != exitHookBlock {
+		t.Fatalf("env deny: exit=%d, want %d", code, exitHookBlock)
+	}
+}
+
+// TestGuardPath_NonHitSilent — R-6.1 volume-bounding: a non-skill file op is a
+// silent allow that emits NOTHING (even in deny mode).
+func TestGuardPath_NonHitSilent(t *testing.T) {
+	home := guardTestHome(t)
+	lines := captureGuardSink(t)
+
+	code, out, errOut := runGP(t, []string{"--home", home, "--deny"},
+		readEvent("Read", filepath.Join(home, "notes.txt")))
+	if code != exitOK {
+		t.Fatalf("non-hit: exit=%d, want %d", code, exitOK)
+	}
+	if out != "" || errOut != "" {
+		t.Errorf("non-hit must be silent; stdout=%q stderr=%q", out, errOut)
+	}
+	if len(*lines) != 0 {
+		t.Errorf("non-hit must not emit a guard event; got %d", len(*lines))
+	}
+}
+
+// TestGuardPath_SkillToolNotGuarded — the Skill tool is verify-hook's job; guard
+// silently allows it so it never overrides the Skill decision.
+func TestGuardPath_SkillToolNotGuarded(t *testing.T) {
+	home := guardTestHome(t)
+	captureGuardSink(t)
+	ev := `{"tool_name":"Skill","tool_input":{"skill":"victim"}}`
+	code, out, errOut := runGP(t, []string{"--home", home, "--deny"}, ev)
+	if code != exitOK || out != "" || errOut != "" {
+		t.Errorf("Skill tool must be a silent allow; exit=%d out=%q err=%q", code, out, errOut)
+	}
+}
+
+// TestGuardPath_UnreadableFailsOpen — a malformed/empty event is a silent allow
+// (fail-open; the guard is not a seal and must not block on its own parse fail).
+func TestGuardPath_UnreadableFailsOpen(t *testing.T) {
+	home := guardTestHome(t)
+	for _, in := range []string{"", "   ", "{not json"} {
+		code, out, errOut := runGP(t, []string{"--home", home, "--deny"}, in)
+		if code != exitOK || out != "" || errOut != "" {
+			t.Errorf("input %q: exit=%d out=%q err=%q, want silent allow", in, code, out, errOut)
+		}
+	}
+}
+
+// TestGuardPath_BashPathExtraction — a Bash command touching a skill file is
+// classified from the extracted path arg.
+func TestGuardPath_BashPathExtraction(t *testing.T) {
+	home := guardTestHome(t)
+	victim := filepath.Join(home, ".claude", "skills", "victim", "SKILL.md")
+	captureGuardSink(t)
+	code, _, _ := runGP(t, []string{"--home", home, "--deny"},
+		bashEvent("cat "+victim+" | base64"))
+	if code != exitHookBlock {
+		t.Fatalf("bash skill read: exit=%d, want %d", code, exitHookBlock)
+	}
+}
+
+// TestGuardPath_Explain prints the honest scope + coverage gaps and exits 0.
+func TestGuardPath_Explain(t *testing.T) {
+	code, out, _ := runGP(t, []string{"--explain"}, "")
+	if code != exitOK {
+		t.Fatalf("--explain exit=%d, want 0", code)
+	}
+	for _, want := range []string{"NOT A SEAL", "coverage gaps", "AUDITED-ALLOW", "/slash"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--explain output missing %q", want)
+		}
+	}
+}
+
+// TestGuardPath_EventReusesSignedVocabulary — the emitted event embeds a valid
+// signed InvocationRecord with an inv: event id (no new vocabulary).
+func TestGuardPath_EventReusesSignedVocabulary(t *testing.T) {
+	home := guardTestHome(t)
+	victim := filepath.Join(home, ".claude", "skills", "victim", "SKILL.md")
+	lines := captureGuardSink(t)
+	if code, _, _ := runGP(t, []string{"--home", home}, readEvent("Edit", victim)); code != exitOK {
+		t.Fatalf("audited-allow exit=%d", code)
+	}
+	if len(*lines) != 1 {
+		t.Fatalf("want 1 event, got %d", len(*lines))
+	}
+	var rec skillgate.InvocationRecord
+	if err := json.Unmarshal((*lines)[0], &rec); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(rec.EventID, "inv:") {
+		t.Errorf("event id %q does not reuse the inv: vocabulary", rec.EventID)
+	}
+	if rec.Schema != skillgate.InvocationSchema {
+		t.Errorf("schema = %q, want %q", rec.Schema, skillgate.InvocationSchema)
+	}
+	if rec.Tool != "Edit" {
+		t.Errorf("tool = %q, want Edit", rec.Tool)
+	}
+}

--- a/cmd/skillctl/guardpath_cmds_test.go
+++ b/cmd/skillctl/guardpath_cmds_test.go
@@ -293,3 +293,31 @@ func TestGuardPath_EventReusesSignedVocabulary(t *testing.T) {
 		t.Errorf("tool = %q, want Edit", rec.Tool)
 	}
 }
+
+// TestLooksPathLike_CrossPlatform locks the Windows regression that made the
+// Trust Surface (windows-latest) job red: a native `C:\...\SKILL.md` token
+// carries no '/', no '~' and no leading '.', so a POSIX-only check classified
+// it as "not a path" and the guard never fired.
+func TestLooksPathLike_CrossPlatform(t *testing.T) {
+	pathLike := []string{
+		"/home/u/.claude/skills/x/SKILL.md",   // posix absolute
+		"~/.claude/skills/x/SKILL.md",         // tilde
+		"./relative/file",                     // leading dot
+		".claude/skills/x",                    // leading dot
+		`C:\Users\runner\.claude\skills\x.md`, // windows native
+		`C:/Users/runner/skills/x.md`,         // windows w/ forward slashes
+		`skills\x\SKILL.md`,                   // windows relative
+		"C:file",                              // drive-qualified, no separator
+	}
+	for _, p := range pathLike {
+		if !looksPathLike(p) {
+			t.Errorf("looksPathLike(%q) = false, want true", p)
+		}
+	}
+	notPathLike := []string{"", ".", "..", "cat", "base64", "skillctl", "version", "C", "5:30"}
+	for _, p := range notPathLike {
+		if looksPathLike(p) {
+			t.Errorf("looksPathLike(%q) = true, want false", p)
+		}
+	}
+}

--- a/cmd/skillctl/invocation_trail.go
+++ b/cmd/skillctl/invocation_trail.go
@@ -63,6 +63,23 @@ func invocationTrailPath(home string) string {
 // the gate decision is unchanged when the trail write fails.
 var invocationTrailSink = defaultInvocationTrailSink
 
+// invocationOutboxSink is an OPTIONAL second sink for the signed invocation
+// record (SPEC-0317 P0). It is fed the SAME fully-signed record as the trail —
+// transient fields (event_id/occurred_at/device_key_id) filled ONCE and the
+// signature computed ONCE, so the projection (invocation-trail.jsonl) and the
+// authoritative outbox row can NEVER diverge on id/signature (dual-sink
+// consistency).
+//
+// Production `verify-hook` leaves this nil, so it is byte-identical to the
+// pre-SPEC-0317 gate and writes only the trail. `skillctl enforce` installs a
+// sink that mirrors the record into the outbox (enforce_cmds.go).
+//
+// Fire-and-forget, decision-invariant (SPEC-0255): it runs inside
+// appendSignedInvocation's recover and its result is discarded, so a full disk /
+// SQLITE_BUSY / panic in the outbox sink can NEVER alter the gate decision, exit
+// code, or stdout/stderr bytes (AC-2a).
+var invocationOutboxSink func(home string, rec skillgate.InvocationRecord)
+
 // invocationDeviceKey is the device-key seam. Production points it at
 // device.EnsureKey (lazy-create on first use); tests can stub it to force a
 // key-acquisition failure and assert fail-safety.
@@ -139,6 +156,17 @@ func appendSignedInvocation(home string, rec skillgate.InvocationRecord) {
 		return
 	}
 	_ = invocationTrailSink(home, line)
+
+	// SPEC-0317 P0: fan the SAME fully-signed record out to the optional outbox
+	// sink (installed only by `skillctl enforce`). Called AFTER the trail write
+	// with the identical `rec` so the outbox row and the trail projection share
+	// event_id / occurred_at / signature. Nil in `verify-hook` (byte-identical to
+	// v1). Its result is intentionally ignored — this whole function is
+	// fire-and-forget under the top-level recover, so an outbox failure is
+	// decision-invariant (AC-2a).
+	if sink := invocationOutboxSink; sink != nil {
+		sink(home, rec)
+	}
 }
 
 // trailVerification is the result of reading + verifying the signed trail. It is

--- a/cmd/skillctl/login_cmds.go
+++ b/cmd/skillctl/login_cmds.go
@@ -40,6 +40,9 @@ var networkCommands = map[string]bool{
 	"room":      true,
 	"runbook":   true,
 	"install":   true,
+	// SPEC-0317 R-5.2: the sync agent authenticates to the ingest with the
+	// device token, so it autoloads the persisted token like other network cmds.
+	"sync": true,
 }
 
 // autoloadDeviceToken implements the read-back half of FR-0043. If

--- a/cmd/skillctl/main.go
+++ b/cmd/skillctl/main.go
@@ -100,6 +100,22 @@ func main() {
 	case "verify-hook":
 		runWithExit(func() int { return runVerifyHook(os.Stdin, os.Stdout, os.Stderr) })
 	// === END SPEC-0247 P0.1 ===
+	// === SPEC-0317 P0: enterprise-evidence enforce gate ===
+	// Byte-identical decision to verify-hook for a Skill event, PLUS mirrors the
+	// device-signed InvocationRecord into the write-once outbox (audit_events) for
+	// durable, drainable evidence. Fail-closed decision; fire-and-forget outbox
+	// write (a write failure never alters the decision — SPEC-0255 invariance).
+	case "enforce":
+		runWithExit(func() int { return runEnforce(os.Stdin, os.Stdout, os.Stderr) })
+	// === END SPEC-0317 P0 ===
+	// === SPEC-0317 R-6 (P2): side-channel path guard ===
+	// A SEPARATE PreToolUse hook for Bash/Read/Edit/Write (NOT a semantic change
+	// to the Skill decision — byte-parity of enforce/verify-hook is preserved). It
+	// audited-allows by default and opt-in denies a skill-dir access. Detection /
+	// bar-raising, not a seal — see `skillctl guard-path --explain`.
+	case "guard-path":
+		os.Exit(runGuardPath(os.Args[2:], os.Stdin, os.Stdout, os.Stderr))
+	// === END SPEC-0317 R-6 ===
 	// === SPEC-0277 P0+P1: agent-instance identity (issue/verify/show/revoke) ===
 	// `agentid verify` mirrors `verify --bundle`: SPEC-0188 §11 numbered exit
 	// codes (11/20/21/17/12/...) surface verbatim through runWithExit.
@@ -114,6 +130,12 @@ func main() {
 	case "pin":
 		os.Exit(runPin(os.Args[2:], os.Stdout, os.Stderr))
 	// === END SPEC-0247 P1.3 ===
+	// === SPEC-0317 R-7 (P2): named offline state machine — informational
+	// SessionStart context (prints online/degraded/offline/locked + the
+	// advisory-until-pinned banner). Pure read; gates nothing. ===
+	case "session-baseline":
+		os.Exit(runSessionBaseline(os.Args[2:], os.Stdout, os.Stderr))
+	// === END SPEC-0317 P2 ===
 	// === SPEC-0189 S0a: scanner family dispatchers (imported from
 	// feature/thinking-engine-phase1; pre-SPEC-0189 behaviour preserved). ===
 	case "scan":
@@ -140,6 +162,14 @@ func main() {
 	case "sync-usage":
 		cmdSyncUsage(os.Args[2:])
 	// === END SPEC-0189 S0a ===
+	// === SPEC-0317 R-5 (P1): enforcement-evidence sync agent ===
+	// Distinct from `sync-usage` (the PII skill-telemetry drain): `sync`
+	// drains the device-signed audit_events outbox to the KafShield ingest,
+	// marks rows synced ONLY on a valid signed durable-seq, and is a SEPARATE
+	// process never invoked on the hook path.
+	case "sync":
+		os.Exit(runSync(os.Args[2:], os.Stdout, os.Stderr))
+	// === END SPEC-0317 R-5 ===
 	// === SPEC-0195 S2 / Streams M1+M2: awareness + intent ===
 	// `awareness` (M1) dispatches to runAwareness with sub-routes
 	// {sync, verify, reset}. `intent` (M2) dispatches to runIntent
@@ -219,6 +249,8 @@ func printUsage(w *os.File) {
 	fmt.Fprintln(w, "Commands (SPEC-0247 / Claude Code trust gate):")
 	fmt.Fprintln(w, "  verify-hook  PreToolUse(Skill) gate: reads a hook event on stdin, verifies the")
 	fmt.Fprintln(w, "               §7 chain, and emits allow/deny. Fail-closed. Wire as a hook, not by hand.")
+	fmt.Fprintln(w, "  enforce      Same decision as verify-hook, plus records the signed evidence into the")
+	fmt.Fprintln(w, "               write-once outbox for durable, drainable audit (SPEC-0317). Fail-closed.")
 	fmt.Fprintln(w, "  gate-stats   Summarise the gate-audit.jsonl (decisions, top blocks, cache-hit rate).")
 	fmt.Fprintln(w, "               Flags: --since <168h|YYYY-MM-DD>, --json.")
 	fmt.Fprintln(w, "  pin          Pin the trust gate into Claude Code managed settings so a")

--- a/cmd/skillctl/session_baseline_cmds.go
+++ b/cmd/skillctl/session_baseline_cmds.go
@@ -1,0 +1,278 @@
+package main
+
+// session_baseline_cmds.go — SPEC-0317 R-7 (P2) `skillctl session-baseline`.
+//
+// SessionStart INFORMATIONAL context: it prints the current named offline state
+// (online / degraded / offline / locked — pkg/skillctl/statemachine) computed
+// from (connectivity × cache ages × anchor presence × trust-basis presence), and
+// — the AC-8 fallback — a RED "advisory-only until SPEC-0247 P1.3 pinned" banner
+// whenever the managed-settings gate is NOT pinned.
+//
+// It is a PURE READ. It gates NOTHING, blocks NOTHING, and (by default) reaches
+// NO network — a SessionStart hook must be fast and must never wedge a session.
+// The state it prints only NAMES the posture; the authoritative decision ladder
+// still lives in verify-hook (R-7.4). Because it is off the hot path it is not
+// fail-closed: an IO/usage error is exit 1, never a gate deny.
+//
+// The three never-brick invariants are inherited from the statemachine package:
+// trust-basis breadth (self/ER1 roots + .m3c-provenance sidecar, not only the
+// SPEC-0188 roots), locked is enterprise-opt-in only, and the emergency channel
+// is exempt — this verb only DISPLAYS them.
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/pin"
+	"github.com/kamir/m3c-tools/pkg/skillctl/statemachine"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// advisoryUntilPinnedMsg is the exact AC-8 banner text (kept as a const so the
+// test and the operator see the same string).
+const advisoryUntilPinnedMsg = "advisory-only until SPEC-0247 P1.3 pinned"
+
+// --- test seams -------------------------------------------------------------
+
+// sessionBaselineNow is the injectable clock. The statemachine is a pure
+// function of an injected clock; this is where production injects time.Now.
+var sessionBaselineNow = time.Now
+
+// sessionBaselineGather assembles the statemachine.Inputs snapshot from the local
+// filesystem. It is a package var so tests can drive any state without a real
+// home. forceOnline reflects the operator's --online assertion (SessionStart must
+// not do a blocking network probe by default).
+var sessionBaselineGather = defaultSessionBaselineGather
+
+// sessionBaselinePinStatus reads the managed-settings file and reports the pin
+// level. Seam so tests exercise the pinned / not-pinned banner branches without
+// touching the platform path.
+var sessionBaselinePinStatus = defaultSessionBaselinePinStatus
+
+// ---------------------------------------------------------------------------
+
+func runSessionBaseline(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("session-baseline", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	homeOverride := fs.String("home", "", "home dir override (default: $HOME)")
+	msPath := fs.String("managed-settings", "", "managed-settings.json path override (default: platform path)")
+	trustRootsPath := fs.String("trust-roots", "", "trust-roots.yaml path override (default: ~/.claude/skill-trust-roots.yaml)")
+	online := fs.Bool("online", false, "assert the registry is reachable (SessionStart does NOT probe the network by default)")
+	asJSON := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	home := *homeOverride
+	if home == "" {
+		h, err := userHome()
+		if err != nil {
+			fmt.Fprintf(stderr, "skillctl session-baseline: resolve home: %v\n", err)
+			return 1
+		}
+		home = h
+	}
+
+	// Resolve the offline policy from the trust roots (best-effort — a missing or
+	// malformed trust-roots file must not wedge SessionStart; we surface a note
+	// and fall back to the shipped default, which never locks).
+	pol, polNote := resolveSessionOfflinePolicy(home, *trustRootsPath)
+
+	// Snapshot inputs against the injected clock and compute the state.
+	now := sessionBaselineNow().UTC()
+	in := sessionBaselineGather(home, *online, now)
+	dec := statemachine.Decide(in, pol)
+
+	// Pin status → the AC-8 advisory banner.
+	pinStatus := sessionBaselinePinStatus(*msPath)
+
+	if *asJSON {
+		out := struct {
+			statemachine.StateDecision
+			PinLevel        string   `json:"pin_level"`
+			Pinned          bool     `json:"pinned"`
+			AdvisoryBanner  string   `json:"advisory_banner,omitempty"`
+			Notes           []string `json:"notes,omitempty"`
+			RequireLocalAud bool     `json:"require_local_audit"`
+		}{
+			StateDecision:   dec,
+			PinLevel:        pinStatus.Level.String(),
+			Pinned:          pinStatus.Pinned(),
+			RequireLocalAud: pol.RequireLocalAudit,
+		}
+		if !pinStatus.Pinned() {
+			out.AdvisoryBanner = advisoryUntilPinnedMsg
+		}
+		if polNote != "" {
+			out.Notes = append(out.Notes, polNote)
+		}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(out); err != nil {
+			fmt.Fprintf(stderr, "skillctl session-baseline: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
+	// Human output.
+	fmt.Fprintf(stdout, "skillctl session baseline\n")
+	fmt.Fprintf(stdout, "  offline state:        %s\n", dec.State)
+	fmt.Fprintf(stdout, "  registry reachable:   %s\n", yesNo(dec.RegistryReachable))
+	fmt.Fprintf(stdout, "  trust basis present:  %s (SPEC-0188 roots OR self/ER1 roots OR .m3c-provenance)\n", yesNo(dec.TrustBasisPresent))
+	fmt.Fprintf(stdout, "  translog anchor:      %s\n", yesNo(dec.AnchorPresent))
+	fmt.Fprintf(stdout, "  enterprise profile:   %s\n", yesNo(dec.Enterprise))
+	fmt.Fprintf(stdout, "  online fallback:      %s  [INFORMATIONAL — posture only; the runtime gate still falls back until R-7.2 wiring lands]\n", allowedBlocked(dec.AllowOnlineFallback))
+	fmt.Fprintf(stdout, "  high-risk fail-closed:%s\n", yesNoPad(dec.HighRiskFailsClosed))
+	fmt.Fprintf(stdout, "  deny all managed:     %s  [INFORMATIONAL — not enforced until R-7.2 wiring + exit 28 land]\n", yesNo(dec.DenyAllManaged))
+	if polNote != "" {
+		fmt.Fprintf(stdout, "  note: %s\n", polNote)
+	}
+
+	// AC-8: the RED advisory-until-pinned banner when the gate is not pinned.
+	fmt.Fprintf(stdout, "  gate pinning:         %s\n", pinStatus.Level)
+	if !pinStatus.Pinned() {
+		fmt.Fprintf(stdout, "%s  [!] %s — without managed-settings pinning (SPEC-0247 P1.3) this whole enforcement layer is ADVISORY: an operator can delete the hooks. Run `skillctl pin install`.%s\n",
+			ansiRed, advisoryUntilPinnedMsg, ansiReset)
+	}
+	return 0
+}
+
+// resolveSessionOfflinePolicy loads the trust roots and selects the machine-wide
+// offline policy. Selection: the FIRST root that opts into `enterprise` wins (the
+// enterprise profile is machine-wide and the most consequential); otherwise the
+// first declared offline_policy; otherwise the zero policy (the shipped default,
+// which never locks). A missing/malformed trust-roots file returns the zero
+// policy plus a human note — SessionStart must never wedge on config trouble.
+func resolveSessionOfflinePolicy(home, pathOverride string) (statemachine.OfflinePolicy, string) {
+	path := pathOverride
+	if path == "" {
+		path = filepath.Join(home, verify.DefaultTrustRootsPath)
+	}
+	tr, err := verify.Load(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return statemachine.OfflinePolicy{}, "no trust-roots file — using the shipped default (unmanaged=allow, never locks)"
+		}
+		return statemachine.OfflinePolicy{}, fmt.Sprintf("trust-roots unreadable (%v) — using the shipped default", err)
+	}
+
+	var firstDeclared *statemachine.OfflinePolicy
+	for i := range tr.Roots {
+		p, perr := tr.Roots[i].ResolveOfflinePolicy()
+		if perr != nil {
+			// Load already validated, so this should not happen; be defensive.
+			continue
+		}
+		if tr.Roots[i].OfflinePolicy == nil {
+			continue
+		}
+		if p.Enterprise {
+			return p, ""
+		}
+		if firstDeclared == nil {
+			pc := p
+			firstDeclared = &pc
+		}
+	}
+	if firstDeclared != nil {
+		return *firstDeclared, ""
+	}
+	return statemachine.OfflinePolicy{}, ""
+}
+
+// defaultSessionBaselineGather assembles the inputs from the local filesystem.
+// Cache ages are derived from the mtime of the loose cache files (the P2 tables
+// are not yet populated; R-2.3 keeps the loose files as the fallback read). All
+// of it is best-effort: a missing file yields a zero age (treated fresh — and
+// under the shipped no-ceiling default, age is not consulted anyway).
+func defaultSessionBaselineGather(home string, forceOnline bool, now time.Time) statemachine.Inputs {
+	return statemachine.Inputs{
+		RegistryReachable: forceOnline,
+		PolicyAge:         fileAge(now, verdictCachePath(home)), // policy proxy (loose fallback)
+		TrustAge:          fileAge(now, verdictCachePath(home)), // trust proxy
+		RevocationAge:     fileAge(now, revocationCachePath(home)),
+		AnchorPresent:     fileExists(transparencyLogPath(home)),
+		TrustBasisPresent: trustBasisPresent(home),
+		Now:               now,
+	}
+}
+
+// trustBasisPresent folds the BROAD R-7.1 trust-basis definition: a trust basis
+// exists if ANY of the SPEC-0188 skill-trust-roots.yaml, the SPEC-0225 self/ER1
+// trust-roots, OR a .m3c-provenance sidecar under ~/.claude/skills is present.
+// This breadth is the never-brick guard — a self/ER1 sidecar-only host counts.
+func trustBasisPresent(home string) bool {
+	if fileExists(filepath.Join(home, verify.DefaultTrustRootsPath)) {
+		return true // SPEC-0188 skill-trust-roots.yaml
+	}
+	if fileExists(filepath.Join(home, ".claude", "trust-roots.yaml")) {
+		return true // SPEC-0225 self/ER1 trust-roots (registry.DefaultSelfTrustRootsPath)
+	}
+	// SPEC-0225 install-trust-mode writes a .m3c-provenance.json sidecar next to
+	// each installed skill body — a legitimate trust basis on self/ER1 hosts that
+	// have no skill-trust-roots.yaml at all (SPEC-0247 §10c).
+	matches, _ := filepath.Glob(filepath.Join(home, ".claude", "skills", "*", ".m3c-provenance.json"))
+	return len(matches) > 0
+}
+
+// revocationCachePath is the loose signed revoked-digest cache (the revocation
+// cache's loose fallback per R-2.3).
+func revocationCachePath(home string) string {
+	return filepath.Join(verdictDir(home), "revoked-digests.json")
+}
+
+// transparencyLogPath is the SPEC-0278 L1 translog anchor file.
+func transparencyLogPath(home string) string {
+	return filepath.Join(verdictDir(home), "transparency-log.jsonl")
+}
+
+// fileAge returns now - mtime for path, or 0 when the file is missing/unstattable
+// (treated fresh — under the shipped no-ceiling default the age is not consulted).
+func fileAge(now time.Time, path string) time.Duration {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return now.Sub(fi.ModTime())
+}
+
+// defaultSessionBaselinePinStatus reads the managed-settings file and reports the
+// pin level (mirrors `pin status`). A missing file is LevelAbsent (advisory); an
+// unreadable/other error is treated as absent for the informational banner — the
+// safe reading for "is the gate pinned?" is NO.
+func defaultSessionBaselinePinStatus(pathOverride string) pin.StatusResult {
+	path := pathOverride
+	if path == "" {
+		p, err := pin.DefaultManagedSettingsPath()
+		if err != nil {
+			return pin.StatusResult{Level: pin.LevelAbsent, Findings: []string{"no managed-settings path for this platform"}}
+		}
+		path = p
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return pin.StatusResult{Level: pin.LevelAbsent, Findings: []string{"managed-settings not readable at " + path}}
+	}
+	return pin.Verify(data)
+}
+
+func allowedBlocked(b bool) string {
+	if b {
+		return "allowed (online state)"
+	}
+	return "blocked (strictly local)"
+}
+
+func yesNoPad(b bool) string {
+	if b {
+		return " yes"
+	}
+	return " no"
+}

--- a/cmd/skillctl/session_baseline_cmds_test.go
+++ b/cmd/skillctl/session_baseline_cmds_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/pin"
+	"github.com/kamir/m3c-tools/pkg/skillctl/statemachine"
+)
+
+// testPubkeyB64 is a syntactically valid base64 of 32 zero bytes — enough for
+// the trust-roots loader's length + base64 validation (these tests never verify
+// a signature).
+func testPubkeyB64() string {
+	return base64.StdEncoding.EncodeToString(make([]byte, 32))
+}
+
+// withSessionBaselineSeams installs test seams and restores them on cleanup.
+func withSessionBaselineSeams(t *testing.T, in statemachine.Inputs, pinRes pin.StatusResult) {
+	t.Helper()
+	origGather := sessionBaselineGather
+	origPin := sessionBaselinePinStatus
+	origNow := sessionBaselineNow
+	sessionBaselineGather = func(home string, forceOnline bool, now time.Time) statemachine.Inputs {
+		cp := in
+		cp.RegistryReachable = in.RegistryReachable || forceOnline
+		cp.Now = now
+		return cp
+	}
+	sessionBaselinePinStatus = func(path string) pin.StatusResult { return pinRes }
+	sessionBaselineNow = func() time.Time { return time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC) }
+	t.Cleanup(func() {
+		sessionBaselineGather = origGather
+		sessionBaselinePinStatus = origPin
+		sessionBaselineNow = origNow
+	})
+}
+
+// TestSessionBaseline_AdvisoryBannerWhenNotPinned is the AC-8 fallback: the RED
+// advisory-until-pinned banner must appear when the gate is NOT pinned.
+func TestSessionBaseline_AdvisoryBannerWhenNotPinned(t *testing.T) {
+	home := t.TempDir()
+	in := statemachine.Inputs{RegistryReachable: true, TrustBasisPresent: true}
+	withSessionBaselineSeams(t, in, pin.StatusResult{Level: pin.LevelAbsent})
+
+	var out, errb bytes.Buffer
+	code := runSessionBaseline([]string{"--home", home}, &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (informational). stderr=%s", code, errb.String())
+	}
+	if !strings.Contains(out.String(), advisoryUntilPinnedMsg) {
+		t.Fatalf("expected advisory banner %q in output:\n%s", advisoryUntilPinnedMsg, out.String())
+	}
+	if !strings.Contains(out.String(), "online") {
+		t.Fatalf("expected the online state in output:\n%s", out.String())
+	}
+}
+
+// TestSessionBaseline_NoBannerWhenPinned: a pinned gate must NOT print the
+// advisory banner.
+func TestSessionBaseline_NoBannerWhenPinned(t *testing.T) {
+	home := t.TempDir()
+	in := statemachine.Inputs{RegistryReachable: false, TrustBasisPresent: true}
+	withSessionBaselineSeams(t, in, pin.StatusResult{Level: pin.LevelPinned, HasSweepHook: true, HasVerifyHook: true})
+
+	var out, errb bytes.Buffer
+	if code := runSessionBaseline([]string{"--home", home}, &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if strings.Contains(out.String(), advisoryUntilPinnedMsg) {
+		t.Fatalf("advisory banner must NOT appear when pinned:\n%s", out.String())
+	}
+	// Disconnected but fresh (no ceilings) → degraded.
+	if !strings.Contains(out.String(), "degraded") {
+		t.Fatalf("expected degraded state:\n%s", out.String())
+	}
+}
+
+// TestSessionBaseline_JSON emits the decision + pin fields.
+func TestSessionBaseline_JSON(t *testing.T) {
+	home := t.TempDir()
+	in := statemachine.Inputs{RegistryReachable: true, TrustBasisPresent: true}
+	withSessionBaselineSeams(t, in, pin.StatusResult{Level: pin.LevelAbsent})
+
+	var out, errb bytes.Buffer
+	if code := runSessionBaseline([]string{"--home", home, "--json"}, &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, want 0. stderr=%s", code, errb.String())
+	}
+	var doc struct {
+		State          string `json:"state"`
+		Pinned         bool   `json:"pinned"`
+		AdvisoryBanner string `json:"advisory_banner"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if doc.State != "online" {
+		t.Errorf("state = %q, want online", doc.State)
+	}
+	if doc.Pinned {
+		t.Errorf("pinned = true, want false (LevelAbsent)")
+	}
+	if doc.AdvisoryBanner != advisoryUntilPinnedMsg {
+		t.Errorf("advisory_banner = %q, want %q", doc.AdvisoryBanner, advisoryUntilPinnedMsg)
+	}
+}
+
+// TestResolveSessionOfflinePolicy_EnterpriseWins: an enterprise root's policy is
+// selected machine-wide, and a non-enterprise/absent config yields the shipped
+// default (never locks).
+func TestResolveSessionOfflinePolicy(t *testing.T) {
+	home := t.TempDir()
+	trPath := filepath.Join(home, ".claude", "skill-trust-roots.yaml")
+	if err := os.MkdirAll(filepath.Dir(trPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// A valid trust-roots with an enterprise offline_policy on the second root.
+	yaml := `trust_roots:
+  - registry_url: https://a.example.com/api/skills
+    registry_keys:
+      - id: k1
+        pubkey: ` + testPubkeyB64() + `
+    identity_keys_authorized: from-registry
+    governance_minimum: green
+  - registry_url: https://b.example.com/api/skills
+    registry_keys:
+      - id: k2
+        pubkey: ` + testPubkeyB64() + `
+    identity_keys_authorized: from-registry
+    governance_minimum: green
+    offline_policy:
+      enterprise: true
+      max_policy_cache_age: 24h
+      max_revocation_cache_age: 12h
+      require_local_audit: true
+`
+	if err := os.WriteFile(trPath, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pol, note := resolveSessionOfflinePolicy(home, trPath)
+	if !pol.Enterprise {
+		t.Fatalf("expected enterprise policy selected, note=%q", note)
+	}
+	if pol.MaxPolicyCacheAge != 24*time.Hour {
+		t.Errorf("MaxPolicyCacheAge = %v, want 24h", pol.MaxPolicyCacheAge)
+	}
+	if pol.MaxRevocationCacheAge != 12*time.Hour {
+		t.Errorf("MaxRevocationCacheAge = %v, want 12h", pol.MaxRevocationCacheAge)
+	}
+	if !pol.RequireLocalAudit {
+		t.Errorf("RequireLocalAudit not carried through")
+	}
+
+	// Missing file → zero policy (never locks) + a note.
+	pol2, note2 := resolveSessionOfflinePolicy(home, filepath.Join(home, "nope.yaml"))
+	if pol2.Enterprise {
+		t.Errorf("missing trust-roots must yield a non-enterprise default")
+	}
+	if note2 == "" {
+		t.Errorf("expected a note explaining the fallback default")
+	}
+}
+
+// TestResolveSessionOfflinePolicy_RejectsRequireLocalAuditWithoutEnterprise:
+// Load must refuse require_local_audit without enterprise (R-7.3/R-8), so the
+// baseline surfaces the fallback note rather than silently honouring it.
+func TestResolveSessionOfflinePolicy_RejectsRequireLocalAuditWithoutEnterprise(t *testing.T) {
+	home := t.TempDir()
+	trPath := filepath.Join(home, "roots.yaml")
+	yaml := `trust_roots:
+  - registry_url: https://a.example.com/api/skills
+    registry_keys:
+      - id: k1
+        pubkey: ` + testPubkeyB64() + `
+    identity_keys_authorized: from-registry
+    governance_minimum: green
+    offline_policy:
+      require_local_audit: true
+`
+	if err := os.WriteFile(trPath, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pol, note := resolveSessionOfflinePolicy(home, trPath)
+	if pol.RequireLocalAudit || pol.Enterprise {
+		t.Fatalf("require_local_audit without enterprise must be rejected at Load, got pol=%+v", pol)
+	}
+	if !strings.Contains(note, "unreadable") {
+		t.Errorf("expected a fallback note about the unreadable/invalid config, got %q", note)
+	}
+}

--- a/cmd/skillctl/sync_cmds.go
+++ b/cmd/skillctl/sync_cmds.go
@@ -1,0 +1,471 @@
+package main
+
+// sync_cmds.go — SPEC-0317 §R-5 (P1): the sync agent.
+//
+//	skillctl sync --once     drain audit_events → the KafShield ingest, then exit.
+//	skillctl sync --daemon   loop the same drain on an interval with a
+//	                         signal-handled graceful shutdown.
+//
+// This is a SEPARATE process. It is NEVER invoked on the PreToolUse hook path —
+// the hot path only writes the outbox (P0) and, at most, best-effort "nudges" a
+// sync. Draining, HTTPS egress, backoff and dedup all live here, off the hot
+// path, so decision latency (AC-3) and decision-invariance (SPEC-0255) are
+// untouched.
+//
+// Contract (R-5.3 / AC-4): a row is marked synced ONLY on a VALID signed
+// durable-seq ack. A bare-2xx from a non-durable stub does NOT mark synced. A
+// replay of an already-acked event_id is a client-side no-op (dedup by the
+// signature-bound event_id — an already-synced row never re-enters the drain
+// set, and the outbox INSERT/MarkSynced are idempotent). Transient 5xx →
+// delivery_attempts row with retryqueue-shaped backoff. A 4xx auth reject →
+// exit 29 (ingest_rejected).
+//
+// Egress posture (R-9.1): the drain is DEFAULT-OFF. With no endpoint configured
+// the command reports "local-only evidence" and exits 0 without egress. The
+// enforcement-evidence records ship verbatim (they are device-signed; mutating
+// them for data-minimisation would break verifiability) — cwd/host_id/session_id
+// minimisation is a property of the SEPARATE PII telemetry stream (sync-usage),
+// not this signed-evidence stream (R-9.2).
+//
+// HTTPS-only (R-5.2). --insecure (skip TLS verify) is honoured ONLY for a
+// loopback endpoint; a prod (non-loopback) endpoint never inherits
+// InsecureSkipVerify.
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/device"
+	"github.com/kamir/m3c-tools/pkg/skillctl/exitcode"
+	"github.com/kamir/m3c-tools/pkg/skillctl/outbox"
+	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+	"github.com/kamir/m3c-tools/pkg/tracking"
+)
+
+const (
+	syncExitOK             = 0
+	syncExitError          = 1
+	syncExitUsage          = 2
+	syncExitIngestRejected = 29 // exitcode.SyncIngestRejected — auth/validation reject (4xx)
+)
+
+// syncDefaultBatch is the default drain batch size (R-5.1).
+const syncDefaultBatch = 100
+
+// syncDefaultInterval is the default --daemon loop interval.
+const syncDefaultInterval = 60 * time.Second
+
+// --- test seams ---------------------------------------------------------------
+
+// syncNow is the clock seam (synced_at / attempt timestamps). Tests pin it.
+var syncNow = func() time.Time { return time.Now().UTC() }
+
+// syncResolveDevicePub resolves the ed25519 public key for a row's device_key_id
+// so the drain can re-verify the row's signature locally before egress. Default:
+// the local device key (a row this host wrote). Tests inject the signer's key.
+// A row whose key cannot be resolved still ships if its payload↔hash binding is
+// intact (the load-bearing tamper check); the signature check is best-effort.
+var syncResolveDevicePub = func(home, keyID string) (ed25519.PublicKey, bool) {
+	k, err := device.Load(home)
+	if err != nil || k == nil {
+		return nil, false
+	}
+	if k.KeyID() != keyID {
+		return nil, false
+	}
+	return k.PublicKey(), true
+}
+
+// --- entry point --------------------------------------------------------------
+
+func runSync(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("sync", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		once     = fs.Bool("once", false, "Drain pending evidence once, then exit.")
+		daemon   = fs.Bool("daemon", false, "Loop the drain on --interval with a signal-handled shutdown.")
+		batch    = fs.Int("batch", syncDefaultBatch, "Max rows per drain batch.")
+		endpoint = fs.String("endpoint", "", "Ingest endpoint base URL (https). Default OFF (local-only evidence).")
+		pubkey   = fs.String("ingest-pubkey", "", "PEM (SPKI) ed25519 public key that signs durable-seq acks. Required to mark rows synced.")
+		logID    = fs.String("log-id", "skillctl-local", "Log id the durable-seq signature is bound to.")
+		interval = fs.Duration("interval", syncDefaultInterval, "Daemon loop interval.")
+		insecure = fs.Bool("insecure", false, "Skip TLS verification (loopback endpoints only).")
+	)
+	if err := fs.Parse(args); err != nil {
+		return syncExitUsage
+	}
+	if *once == *daemon {
+		fmt.Fprintln(stderr, "skillctl sync: choose exactly one of --once or --daemon")
+		return syncExitUsage
+	}
+	if *batch <= 0 {
+		*batch = syncDefaultBatch
+	}
+
+	home, err := userHome()
+	if err != nil {
+		fmt.Fprintf(stderr, "skillctl sync: resolve home: %v\n", err)
+		return syncExitError
+	}
+
+	// R-9.1 egress gate: default-OFF. Endpoint may also come from the
+	// environment so a daemon unit need not repeat it on the command line.
+	ep := strings.TrimSpace(*endpoint)
+	if ep == "" {
+		ep = strings.TrimSpace(os.Getenv("M3C_INGEST_ENDPOINT"))
+	}
+	if ep == "" {
+		fmt.Fprintln(stdout, "skillctl sync: egress disabled (local-only evidence); set --endpoint or M3C_INGEST_ENDPOINT to enable")
+		return syncExitOK
+	}
+
+	client, err := buildIngestClient(ep, *pubkey, *logID, *insecure, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillctl sync: %v\n", err)
+		return syncExitError
+	}
+
+	store, err := outbox.Open(home)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillctl sync: open outbox: %v\n", err)
+		return syncExitError
+	}
+	defer store.Close()
+
+	if *daemon {
+		return runSyncDaemon(store, client, home, *batch, *interval, stdout, stderr)
+	}
+	code, res := drainAll(context.Background(), store, client, home, *batch, stderr)
+	reportDrain(stdout, res)
+	return code
+}
+
+// buildIngestClient assembles the IngestClient and its HTTP transport. HTTPS is
+// enforced by IngestClient.PostBatch; here we gate InsecureSkipVerify to
+// loopback so a prod endpoint can never inherit it (R-5.2).
+func buildIngestClient(endpoint, pubkeyPath, logID string, insecure bool, stderr io.Writer) (*outbox.IngestClient, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("parse endpoint: %w", err)
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("endpoint must be https, got %q", u.Scheme)
+	}
+
+	transport := &http.Transport{}
+	if insecure {
+		if !isLoopbackHost(u.Hostname()) {
+			return nil, fmt.Errorf("--insecure is only permitted for a loopback endpoint (got host %q)", u.Hostname())
+		}
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // loopback-only, gated above
+	}
+
+	var pub ed25519.PublicKey
+	if strings.TrimSpace(pubkeyPath) != "" {
+		pub, err = signing.LoadPublicKey(pubkeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("load ingest pubkey: %w", err)
+		}
+	} else {
+		fmt.Fprintln(stderr, "[skillctl sync] no --ingest-pubkey: durable-seq acks cannot be verified; rows will NOT be marked synced")
+	}
+
+	return &outbox.IngestClient{
+		Endpoint:    endpoint,
+		Token:       strings.TrimSpace(os.Getenv("ER1_DEVICE_TOKEN")),
+		LogID:       logID,
+		PubKey:      pub,
+		Client:      &http.Client{Timeout: 15 * time.Second, Transport: transport},
+		ClientEpoch: syncNow().Unix(),
+	}, nil
+}
+
+// isLoopbackHost reports whether host is a loopback address or "localhost".
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// --- daemon -------------------------------------------------------------------
+
+func runSyncDaemon(store *outbox.Store, client *outbox.IngestClient, home string, batch int, interval time.Duration, stdout, stderr io.Writer) int {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	fmt.Fprintf(stdout, "skillctl sync: daemon started (interval %s, batch %d)\n", interval, batch)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// Drain immediately on start, then on each tick.
+	for {
+		code, res := drainAll(ctx, store, client, home, batch, stderr)
+		reportDrain(stdout, res)
+		if code == syncExitIngestRejected {
+			fmt.Fprintln(stderr, "skillctl sync: ingest rejected the batch (auth/validation); stopping daemon")
+			_ = store.Checkpoint()
+			return syncExitIngestRejected
+		}
+		select {
+		case <-ctx.Done():
+			fmt.Fprintln(stdout, "skillctl sync: shutdown signal received; checkpointing and exiting")
+			_ = store.Checkpoint()
+			return syncExitOK
+		case <-ticker.C:
+		}
+	}
+}
+
+// --- drain --------------------------------------------------------------------
+
+// drainResult accumulates one drain invocation's counters for reporting.
+type drainResult struct {
+	Reconciled int
+	Posted     int
+	Synced     int
+	Deferred   int // rows that got a backoff row (bare-2xx / transient / invalid ack)
+	Flagged    int // rows dropped for a payload↔hash divergence (tamper signal)
+}
+
+func reportDrain(stdout io.Writer, r drainResult) {
+	fmt.Fprintf(stdout, "skillctl sync: reconciled=%d posted=%d synced=%d deferred=%d flagged=%d\n",
+		r.Reconciled, r.Posted, r.Synced, r.Deferred, r.Flagged)
+}
+
+// drainAll runs the full drain: reconcile the spool, then post batches until no
+// forward progress is made (an empty pending set, or a batch where nothing could
+// be marked synced — the bare-2xx stub case, which must not loop forever). It
+// returns an exit code and the accumulated counters.
+func drainAll(ctx context.Context, store *outbox.Store, client *outbox.IngestClient, home string, batch int, stderr io.Writer) (int, drainResult) {
+	var res drainResult
+
+	// Rows backed off during THIS drain: never re-posted within the same cycle.
+	// The PendingBatchDue due-gate excludes deferred rows ACROSS cycles (their
+	// next_retry_at is in the future); this in-memory set is the belt-and-suspenders
+	// guard for the same cycle — chiefly the capped-attempt case whose next_retry_at
+	// no longer advances (INSERT OR IGNORE at the attempt ceiling), which would
+	// otherwise re-enter the drain set behind a marked row.
+	deferred := map[string]struct{}{}
+
+	// R-5.1 / R-2.5: reconcile the spool BEFORE the first batch so spilled rows are
+	// drained into audit_events in occurred_at order ahead of fresh evidence.
+	// (Per-batch translog anchoring — AC-5a — is NOT-YET-BUILT: nothing stamps
+	// translog_seq, so there is no local-monotonicity claim here.)
+	if n, err := store.Reconcile(); err != nil {
+		fmt.Fprintf(stderr, "skillctl sync: reconcile spool: %v\n", err)
+	} else {
+		res.Reconciled = n
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return syncExitOK, res
+		}
+		// Backoff-aware drain set (R-5.3): a row whose delivery_attempts.next_retry_at
+		// is still in the future is NOT due and is excluded — so a deferred row is not
+		// re-POSTed before its backoff elapses.
+		pending, err := store.PendingBatchDue(batch, syncNow().UTC().Format(time.RFC3339))
+		if err != nil {
+			fmt.Fprintf(stderr, "skillctl sync: pending batch: %v\n", err)
+			return syncExitError, res
+		}
+		pending = filterDeferred(pending, deferred)
+		if len(pending) == 0 {
+			return syncExitOK, res
+		}
+
+		// Re-verify each row locally and collect the shippable records. A
+		// payload↔hash divergence is a tamper signal (R-2.6): drop the row from
+		// egress (it stays in the store, flagged) rather than shipping an
+		// unverifiable local row.
+		records := make([][]byte, 0, len(pending))
+		rows := make([]outbox.Event, 0, len(pending))
+		for _, ev := range pending {
+			if !reVerifyRow(home, ev) {
+				res.Flagged++
+				continue
+			}
+			records = append(records, []byte(ev.PayloadJSON))
+			rows = append(rows, ev)
+		}
+		if len(records) == 0 {
+			// Every row in this batch is unverifiable; no forward progress is
+			// possible without operator action. Stop to avoid a hot loop.
+			return syncExitOK, res
+		}
+
+		resp, status, err := client.PostBatch(ctx, records)
+		res.Posted += len(records)
+		switch {
+		case err != nil || status == 0 || status/100 == 5:
+			// Transient: record a backoff attempt for every posted row and stop
+			// this drain cycle (the daemon retries on the next tick; --once
+			// exits, leaving the rows for a later run).
+			if err != nil {
+				fmt.Fprintf(stderr, "skillctl sync: post batch: %v\n", err)
+			} else {
+				fmt.Fprintf(stderr, "skillctl sync: ingest transient status %d; backing off\n", status)
+			}
+			for _, ev := range rows {
+				recordBackoff(store, ev.EventID, status, transientMsg(err, status))
+				deferred[ev.EventID] = struct{}{}
+				res.Deferred++
+			}
+			return syncExitOK, res
+		case status/100 == 4:
+			// Auth / validation reject — not transient. Surface the numbered
+			// code so an operator (non-hot-path) sees it.
+			fmt.Fprintf(stderr, "skillctl sync: ingest rejected batch with status %d (%s)\n",
+				status, exitcode.SyncIngestRejected.Label)
+			return syncExitIngestRejected, res
+		}
+
+		// 2xx: mark synced ONLY those rows with a VALID signed durable-seq ack.
+		acks := map[string]outbox.DurableAck{}
+		for _, a := range resp.Acks {
+			acks[a.EventID] = a
+		}
+		markedThisBatch := 0
+		for _, ev := range rows {
+			ack, ok := acks[ev.EventID]
+			if ok && client.VerifyAck(ack) {
+				if err := store.MarkSynced(ev.EventID, syncNow().UTC().Format(time.RFC3339)); err != nil {
+					fmt.Fprintf(stderr, "skillctl sync: mark synced %s: %v\n", ev.EventID, err)
+					continue
+				}
+				res.Synced++
+				markedThisBatch++
+			} else {
+				// Bare-2xx (no/invalid durable-seq): DO NOT mark synced. Record a
+				// backoff attempt so the row is retried later (R-5.3 / AC-4).
+				recordBackoff(store, ev.EventID, status, "bare-2xx: no valid durable-seq ack")
+				deferred[ev.EventID] = struct{}{}
+				res.Deferred++
+			}
+		}
+		if markedThisBatch == 0 {
+			// No forward progress (e.g. a bare-2xx stub). Stop so PendingBatch
+			// does not return the same rows forever.
+			return syncExitOK, res
+		}
+	}
+}
+
+// filterDeferred drops rows already backed off in the current drain cycle so a
+// mixed-ack batch (some rows marked synced, some deferred) does not re-POST the
+// deferred rows behind a marked row within the same cycle. It reuses evs's backing
+// array (evs is freshly queried each iteration, so this is safe).
+func filterDeferred(evs []outbox.Event, deferred map[string]struct{}) []outbox.Event {
+	if len(deferred) == 0 {
+		return evs
+	}
+	out := evs[:0]
+	for _, e := range evs {
+		if _, skip := deferred[e.EventID]; skip {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// transientMsg renders a compact error string for a delivery_attempts row.
+func transientMsg(err error, status int) string {
+	if err != nil {
+		return err.Error()
+	}
+	return fmt.Sprintf("http %d", status)
+}
+
+// recordBackoff appends one delivery_attempts row with retryqueue-shaped backoff
+// (30s→1h, cap 10 attempts, scale 2.0 — reused from pkg/tracking). The attempt
+// number is monotonic per event_id; next_retry_at = now + backoff(attempt-1),
+// mirroring RetryQueueDB.UpdateAttempt. The attempt is CAPPED at the intended
+// ceiling (DefaultMaxAttempts=10) so a chronically-failing row cannot grow an
+// unbounded number of delivery_attempts rows — at the ceiling the (event_id,
+// attempt) INSERT OR IGNORE is a no-op. Best-effort: a bookkeeping failure never
+// blocks the drain (the evidence row itself is untouched — write-once).
+func recordBackoff(store *outbox.Store, eventID string, httpStatus int, errMsg string) {
+	prior, _ := store.Attempts(eventID)
+	attempt := len(prior) + 1
+	if attempt > tracking.DefaultMaxAttempts {
+		attempt = tracking.DefaultMaxAttempts // ceiling: do not accrue rows past the cap
+	}
+	now := syncNow().UTC()
+	delay := syncBackoff(attempt - 1)
+	next := now.Add(delay).Format(time.RFC3339)
+	_ = store.RecordAttempt(eventID, attempt, now.Format(time.RFC3339), httpStatus, errMsg, next)
+}
+
+// syncBackoff computes min(base * scale^attempt, maxDelay) using the shared
+// pkg/tracking defaults, so the sync agent and the ER1 retry queue back off
+// identically. attempt is 0-indexed (attempt 0 → base delay).
+func syncBackoff(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	if attempt > tracking.DefaultMaxAttempts {
+		attempt = tracking.DefaultMaxAttempts
+	}
+	delay := float64(tracking.DefaultBaseDelay)
+	for i := 0; i < attempt; i++ {
+		delay *= tracking.DefaultBackoffScale
+		if delay >= float64(tracking.DefaultMaxDelay) {
+			return tracking.DefaultMaxDelay
+		}
+	}
+	if delay > float64(tracking.DefaultMaxDelay) {
+		return tracking.DefaultMaxDelay
+	}
+	return time.Duration(delay)
+}
+
+// reVerifyRow reconstructs the canonical bytes from the row's payload_json and
+// asserts (a) the recomputed sha256 equals the stored payload_hash column — the
+// column↔payload divergence tamper check (R-2.6), which needs no key — and
+// (b) when the device pubkey is resolvable, the detached signature verifies. A
+// row that fails EITHER available check is not shipped.
+func reVerifyRow(home string, ev outbox.Event) bool {
+	if strings.TrimSpace(ev.PayloadJSON) == "" {
+		return false // payload retention-nulled: nothing to ship
+	}
+	var rec skillgate.InvocationRecord
+	if err := json.Unmarshal([]byte(ev.PayloadJSON), &rec); err != nil {
+		return false
+	}
+	canon, err := skillgate.CanonicalizeInvocationRecord(&rec)
+	if err != nil {
+		return false
+	}
+	sum := sha256.Sum256(canon)
+	if hex.EncodeToString(sum[:]) != ev.PayloadHash {
+		return false // column↔payload divergence — tamper signal
+	}
+	if pub, ok := syncResolveDevicePub(home, rec.DeviceKeyID); ok {
+		if !skillgate.VerifyInvocationRecord(&rec, pub, base64.StdEncoding.DecodeString) {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/skillctl/sync_cmds_test.go
+++ b/cmd/skillctl/sync_cmds_test.go
@@ -1,0 +1,396 @@
+package main
+
+// sync_cmds_test.go — SPEC-0317 AC-4 against a CONTRACT DOUBLE (httptest).
+//
+// No real Kafka, no real backend: the double is an httptest.NewTLSServer that
+// mimics the ingest ACK contract. The four AC-4 assertions:
+//   - valid signed durable-seq  → row marked synced.
+//   - bare-2xx (no durable-seq)  → row NOT synced (+ a delivery_attempts row).
+//   - replay of an acked event   → client no-op (drain set is empty; no re-post).
+//   - 5xx transient              → row NOT synced (+ a delivery_attempts backoff row).
+// Plus: 4xx → exit 29 (ingest_rejected); HTTPS-only; loopback-gated --insecure.
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/outbox"
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+)
+
+// --- fixtures -----------------------------------------------------------------
+
+func syncTestDeviceKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i + 3)
+	}
+	return ed25519.NewKeyFromSeed(seed)
+}
+
+func syncTestIngestKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(0x80 + i)
+	}
+	return ed25519.NewKeyFromSeed(seed)
+}
+
+// writeIngestPubPEM writes an ed25519 pubkey as SPKI PEM (the form
+// signing.LoadPublicKey accepts) and returns the path.
+func writeIngestPubPEM(t *testing.T, dir string, pub ed25519.PublicKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal pub: %v", err)
+	}
+	p := filepath.Join(dir, "ingest.pub.pem")
+	blk := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	if err := os.WriteFile(p, blk, 0o600); err != nil {
+		t.Fatalf("write pem: %v", err)
+	}
+	return p
+}
+
+// appendSignedRow builds, signs and appends one InvocationRecord to the store.
+func appendSignedRow(t *testing.T, store *outbox.Store, priv ed25519.PrivateKey, keyID, eventID, occurred string) {
+	t.Helper()
+	rec := skillgate.InvocationRecord{
+		Schema:      skillgate.InvocationSchema,
+		EventID:     eventID,
+		EventType:   "skill.invocation",
+		SkillName:   "demo",
+		SkillDigest: "sha256:cafe",
+		Tool:        "Skill",
+		OccurredAt:  occurred,
+		DeviceKeyID: keyID,
+	}
+	if err := skillgate.SignInvocationRecord(&rec, func(m []byte) []byte { return ed25519.Sign(priv, m) }, base64.StdEncoding.EncodeToString); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	pj, ph, err := outbox.RecordPayload(rec)
+	if err != nil {
+		t.Fatalf("RecordPayload: %v", err)
+	}
+	if err := store.Append(rec, pj, ph); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+}
+
+// ackMode selects the contract double's behaviour.
+type ackMode int
+
+const (
+	ackDurable ackMode = iota // valid signed durable-seq for every record
+	ackBare                   // 2xx, empty acks (no durable-seq)
+	ack5xx                    // 500
+	ack4xx                    // 401
+)
+
+// contractDouble is an httptest.NewTLSServer that mimics the ingest ACK
+// contract. It counts posts and echoes signed durable-seqs in ackDurable mode.
+func contractDouble(t *testing.T, ingest ed25519.PrivateKey, logID string, mode ackMode, posts *int32) *httptest.Server {
+	t.Helper()
+	var seq int64
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(posts, 1)
+		var batch outbox.IngestBatch
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &batch)
+		switch mode {
+		case ack5xx:
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		case ack4xx:
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		case ackBare:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(outbox.IngestResponse{})
+			return
+		case ackDurable:
+			var acks []outbox.DurableAck
+			for _, raw := range batch.Records {
+				var rec skillgate.InvocationRecord
+				if err := json.Unmarshal(raw, &rec); err != nil {
+					continue
+				}
+				seq++
+				sig := ed25519.Sign(ingest, outbox.CanonicalDurableSeq(logID, rec.EventID, seq))
+				acks = append(acks, outbox.DurableAck{
+					EventID: rec.EventID, DurableSeq: seq, SeqSigB64: base64.StdEncoding.EncodeToString(sig),
+				})
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(outbox.IngestResponse{Acks: acks})
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// syncHarness wires HOME + the device-pub seam and returns an opened store.
+func syncHarness(t *testing.T, priv ed25519.PrivateKey, keyID string) (home string, store *outbox.Store) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ER1_DEVICE_TOKEN", "test-token")
+	pub := priv.Public().(ed25519.PublicKey)
+	orig := syncResolveDevicePub
+	syncResolveDevicePub = func(h, id string) (ed25519.PublicKey, bool) {
+		if id == keyID {
+			return pub, true
+		}
+		return nil, false
+	}
+	t.Cleanup(func() { syncResolveDevicePub = orig })
+
+	s, err := outbox.Open(home)
+	if err != nil {
+		t.Fatalf("open outbox: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return home, s
+}
+
+func reopenStore(t *testing.T, home string) *outbox.Store {
+	t.Helper()
+	s, err := outbox.Open(home)
+	if err != nil {
+		t.Fatalf("reopen outbox: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// --- AC-4 -----------------------------------------------------------------
+
+func TestSync_AC4_DurableSeqMarksSynced(t *testing.T) {
+	dev := syncTestDeviceKey(t)
+	ingest := syncTestIngestKey(t)
+	const keyID, logID = "device:test", "skillctl-local"
+	home, store := syncHarness(t, dev, keyID)
+	appendSignedRow(t, store, dev, keyID, "inv:0000000000001:aa", "2026-07-08T10:00:00Z")
+	appendSignedRow(t, store, dev, keyID, "inv:0000000000002:bb", "2026-07-08T10:00:01Z")
+	_ = store.Close()
+
+	pemPath := writeIngestPubPEM(t, home, ingest.Public().(ed25519.PublicKey))
+	var posts int32
+	srv := contractDouble(t, ingest, logID, ackDurable, &posts)
+
+	var out, errb bytes.Buffer
+	code := runSync([]string{"--once", "--endpoint", srv.URL, "--ingest-pubkey", pemPath, "--log-id", logID, "--insecure"}, &out, &errb)
+	if code != syncExitOK {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, errb.String())
+	}
+
+	s := reopenStore(t, home)
+	if n, _ := s.PendingCount(); n != 0 {
+		t.Fatalf("pending after sync = %d, want 0", n)
+	}
+	for _, id := range []string{"inv:0000000000001:aa", "inv:0000000000002:bb"} {
+		ev, ok, _ := s.Get(id)
+		if !ok || ev.SyncStatus != 1 || ev.SyncedAt == "" {
+			t.Fatalf("row %s not marked synced: %+v", id, ev)
+		}
+	}
+}
+
+func TestSync_AC4_BareTwoXXDoesNotMarkSynced(t *testing.T) {
+	dev := syncTestDeviceKey(t)
+	ingest := syncTestIngestKey(t)
+	const keyID, logID = "device:test", "skillctl-local"
+	home, store := syncHarness(t, dev, keyID)
+	appendSignedRow(t, store, dev, keyID, "inv:0000000000010:aa", "2026-07-08T10:00:00Z")
+	_ = store.Close()
+
+	pemPath := writeIngestPubPEM(t, home, ingest.Public().(ed25519.PublicKey))
+	var posts int32
+	srv := contractDouble(t, ingest, logID, ackBare, &posts)
+
+	var out, errb bytes.Buffer
+	code := runSync([]string{"--once", "--endpoint", srv.URL, "--ingest-pubkey", pemPath, "--log-id", logID, "--insecure"}, &out, &errb)
+	if code != syncExitOK {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, errb.String())
+	}
+
+	s := reopenStore(t, home)
+	ev, ok, _ := s.Get("inv:0000000000010:aa")
+	if !ok || ev.SyncStatus != 0 {
+		t.Fatalf("bare-2xx must NOT mark synced: %+v", ev)
+	}
+	att, _ := s.Attempts("inv:0000000000010:aa")
+	if len(att) != 1 {
+		t.Fatalf("want 1 delivery attempt after bare-2xx, got %d", len(att))
+	}
+	if atomic.LoadInt32(&posts) != 1 {
+		t.Fatalf("want exactly 1 post, got %d", posts)
+	}
+}
+
+func TestSync_AC4_ReplayIsNoOp(t *testing.T) {
+	dev := syncTestDeviceKey(t)
+	ingest := syncTestIngestKey(t)
+	const keyID, logID = "device:test", "skillctl-local"
+	home, store := syncHarness(t, dev, keyID)
+	appendSignedRow(t, store, dev, keyID, "inv:0000000000020:aa", "2026-07-08T10:00:00Z")
+	// Replay: appending the SAME event_id again is an INSERT OR IGNORE no-op.
+	appendSignedRow(t, store, dev, keyID, "inv:0000000000020:aa", "2026-07-08T10:00:00Z")
+	if n, _ := store.PendingCount(); n != 1 {
+		t.Fatalf("duplicate event_id must not create a 2nd row; pending=%d", n)
+	}
+	_ = store.Close()
+
+	pemPath := writeIngestPubPEM(t, home, ingest.Public().(ed25519.PublicKey))
+	var posts int32
+	srv := contractDouble(t, ingest, logID, ackDurable, &posts)
+
+	args := []string{"--once", "--endpoint", srv.URL, "--ingest-pubkey", pemPath, "--log-id", logID, "--insecure"}
+	var out, errb bytes.Buffer
+	if code := runSync(args, &out, &errb); code != syncExitOK {
+		t.Fatalf("first sync exit=%d; stderr=%s", code, errb.String())
+	}
+	// Second run: the row is already synced, so the drain set is empty and no
+	// new POST is made — a client-side no-op.
+	out.Reset()
+	errb.Reset()
+	if code := runSync(args, &out, &errb); code != syncExitOK {
+		t.Fatalf("replay sync exit=%d; stderr=%s", code, errb.String())
+	}
+	if got := atomic.LoadInt32(&posts); got != 1 {
+		t.Fatalf("replay must not re-post an acked event; posts=%d, want 1", got)
+	}
+}
+
+func TestSync_AC4_FiveXXBacksOff(t *testing.T) {
+	dev := syncTestDeviceKey(t)
+	ingest := syncTestIngestKey(t)
+	const keyID, logID = "device:test", "skillctl-local"
+	home, store := syncHarness(t, dev, keyID)
+	appendSignedRow(t, store, dev, keyID, "inv:0000000000030:aa", "2026-07-08T10:00:00Z")
+	_ = store.Close()
+
+	pemPath := writeIngestPubPEM(t, home, ingest.Public().(ed25519.PublicKey))
+	var posts int32
+	srv := contractDouble(t, ingest, logID, ack5xx, &posts)
+
+	var out, errb bytes.Buffer
+	code := runSync([]string{"--once", "--endpoint", srv.URL, "--ingest-pubkey", pemPath, "--log-id", logID, "--insecure"}, &out, &errb)
+	if code != syncExitOK {
+		t.Fatalf("exit = %d, want 0 (transient is not fatal); stderr=%s", code, errb.String())
+	}
+
+	s := reopenStore(t, home)
+	ev, ok, _ := s.Get("inv:0000000000030:aa")
+	if !ok || ev.SyncStatus != 0 {
+		t.Fatalf("5xx must NOT mark synced: %+v", ev)
+	}
+	att, _ := s.Attempts("inv:0000000000030:aa")
+	if len(att) != 1 {
+		t.Fatalf("want 1 backoff attempt after 5xx, got %d", len(att))
+	}
+	if att[0].NextRetryAt == "" || att[0].HTTPStatus != 500 {
+		t.Fatalf("backoff row malformed: %+v", att[0])
+	}
+}
+
+func TestSync_FourXXExitsIngestRejected(t *testing.T) {
+	dev := syncTestDeviceKey(t)
+	ingest := syncTestIngestKey(t)
+	const keyID, logID = "device:test", "skillctl-local"
+	home, store := syncHarness(t, dev, keyID)
+	appendSignedRow(t, store, dev, keyID, "inv:0000000000040:aa", "2026-07-08T10:00:00Z")
+	_ = store.Close()
+
+	pemPath := writeIngestPubPEM(t, home, ingest.Public().(ed25519.PublicKey))
+	var posts int32
+	srv := contractDouble(t, ingest, logID, ack4xx, &posts)
+
+	var out, errb bytes.Buffer
+	code := runSync([]string{"--once", "--endpoint", srv.URL, "--ingest-pubkey", pemPath, "--log-id", logID, "--insecure"}, &out, &errb)
+	if code != syncExitIngestRejected {
+		t.Fatalf("exit = %d, want %d (ingest_rejected); stderr=%s", code, syncExitIngestRejected, errb.String())
+	}
+}
+
+// --- egress posture + transport hardening ---------------------------------
+
+func TestSync_EgressDefaultOff(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("M3C_INGEST_ENDPOINT", "")
+	var out, errb bytes.Buffer
+	code := runSync([]string{"--once"}, &out, &errb)
+	if code != syncExitOK {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("egress disabled")) {
+		t.Fatalf("expected default-off notice, got %q", out.String())
+	}
+}
+
+func TestSync_InsecureRejectedForNonLoopback(t *testing.T) {
+	_, err := buildIngestClient("https://ingest.example.com", "", "L", true, io.Discard)
+	if err == nil {
+		t.Fatal("--insecure against a non-loopback endpoint must be rejected")
+	}
+}
+
+func TestSync_RejectsNonHTTPSEndpoint(t *testing.T) {
+	_, err := buildIngestClient("http://ingest.example.com", "", "L", false, io.Discard)
+	if err == nil {
+		t.Fatal("non-https endpoint must be rejected (HTTPS-only)")
+	}
+}
+
+func TestSync_TamperedRowNotShipped(t *testing.T) {
+	dev := syncTestDeviceKey(t)
+	ingest := syncTestIngestKey(t)
+	const keyID, logID = "device:test", "skillctl-local"
+	home, store := syncHarness(t, dev, keyID)
+
+	// Build a valid record, then corrupt the payload_hash column so it diverges
+	// from the payload_json bytes (a tamper signal). Such a row must not ship.
+	rec := skillgate.InvocationRecord{
+		Schema: skillgate.InvocationSchema, EventID: "inv:0000000000050:aa", EventType: "skill.invocation",
+		SkillName: "demo", Tool: "Skill", OccurredAt: "2026-07-08T10:00:00Z", DeviceKeyID: keyID,
+	}
+	if err := skillgate.SignInvocationRecord(&rec, func(m []byte) []byte { return ed25519.Sign(dev, m) }, base64.StdEncoding.EncodeToString); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	pj, _, _ := outbox.RecordPayload(rec)
+	if err := store.Append(rec, pj, "deadbeefdivergenthash"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	_ = store.Close()
+
+	pemPath := writeIngestPubPEM(t, home, ingest.Public().(ed25519.PublicKey))
+	var posts int32
+	srv := contractDouble(t, ingest, logID, ackDurable, &posts)
+
+	var out, errb bytes.Buffer
+	code := runSync([]string{"--once", "--endpoint", srv.URL, "--ingest-pubkey", pemPath, "--log-id", logID, "--insecure"}, &out, &errb)
+	if code != syncExitOK {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if atomic.LoadInt32(&posts) != 0 {
+		t.Fatalf("a divergent row must not be posted; posts=%d", posts)
+	}
+	s := reopenStore(t, home)
+	if ev, _, _ := s.Get("inv:0000000000050:aa"); ev.SyncStatus != 0 {
+		t.Fatalf("divergent row must stay unsynced: %+v", ev)
+	}
+}

--- a/cmd/skillctl/verify_hook_cmds.go
+++ b/cmd/skillctl/verify_hook_cmds.go
@@ -135,6 +135,13 @@ type hookToolInput struct {
 	SkillName string `json:"skill_name"` // defensive fallback (docs-named)
 	Name      string `json:"name"`       // defensive fallback
 	Args      string `json:"args"`
+	// SPEC-0317 R-6.4 — the Bash/Read/Edit/Write side-channel guard (`skillctl
+	// guard-path`) reads these. Command is the Bash tool's shell line; FilePath is
+	// the Read/Edit/Write target. They are unused by the Skill gate (verify-hook),
+	// so adding them is inert for the Skill decision — a plain widening of the
+	// shared envelope, not a semantic change.
+	Command  string `json:"command"`   // Bash tool
+	FilePath string `json:"file_path"` // Read | Edit | Write tool
 }
 
 // skillID returns the invoked skill name, trying the confirmed field first.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kamir/m3c-tools
 
 go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	fyne.io/systray v1.12.0

--- a/pkg/skillctl/exitcode/registry.go
+++ b/pkg/skillctl/exitcode/registry.go
@@ -50,16 +50,16 @@ type Code struct {
 // ---------------------------------------------------------------------------
 
 var (
-	VerifyDigestMismatch      = Code{10, "trust-chain digest", "verify", "digest_mismatch"}
-	VerifyAuthorSigInvalid    = Code{11, "trust-chain signature", "verify", "author_sig_invalid"}
-	VerifyRegistryNotTrusted  = Code{12, "trust-chain registry-root", "verify", "registry_not_trusted"}
-	VerifyGovernanceBelowMin  = Code{13, "policy governance", "verify", "governance_below_min"}
-	VerifyDepsUnsatisfied     = Code{14, "policy dependency", "verify", "deps_unsatisfied"}
-	VerifyBlobMissing         = Code{15, "trust-chain blob", "verify", "blob_missing"}
-	VerifyTenantBlocked       = Code{16, "policy tenant", "verify", "tenant_blocked"}
-	VerifyDataSourceDenied    = Code{17, "data-source / source-policy", "verify", "data_source_denied"}
-	VerifyIntentInconsistent  = Code{18, "intent contradiction", "verify", "intent_inconsistent"}
-	VerifyIdentityMismatch    = Code{19, "identity / source-block", "verify", "identity_mismatch"}
+	VerifyDigestMismatch     = Code{10, "trust-chain digest", "verify", "digest_mismatch"}
+	VerifyAuthorSigInvalid   = Code{11, "trust-chain signature", "verify", "author_sig_invalid"}
+	VerifyRegistryNotTrusted = Code{12, "trust-chain registry-root", "verify", "registry_not_trusted"}
+	VerifyGovernanceBelowMin = Code{13, "policy governance", "verify", "governance_below_min"}
+	VerifyDepsUnsatisfied    = Code{14, "policy dependency", "verify", "deps_unsatisfied"}
+	VerifyBlobMissing        = Code{15, "trust-chain blob", "verify", "blob_missing"}
+	VerifyTenantBlocked      = Code{16, "policy tenant", "verify", "tenant_blocked"}
+	VerifyDataSourceDenied   = Code{17, "data-source / source-policy", "verify", "data_source_denied"}
+	VerifyIntentInconsistent = Code{18, "intent contradiction", "verify", "intent_inconsistent"}
+	VerifyIdentityMismatch   = Code{19, "identity / source-block", "verify", "identity_mismatch"}
 )
 
 // ---------------------------------------------------------------------------
@@ -68,11 +68,11 @@ var (
 // ---------------------------------------------------------------------------
 
 var (
-	ImportPinRequired      = Code{4, "input validation", "import-public", "pin_required"}
-	ImportScannerRefuse    = Code{5, "scanner / policy", "import-public", "scanner_refuse"}
-	ImportNoSourcePolicy   = Code{17, "data-source / source-policy", "import-public", "no_source_policy"}
-	ImportIntentCapped     = Code{18, "intent contradiction", "import-public", "intent_capped"}
-	ImportSourceBlocked    = Code{19, "identity / source-block", "import-public", "source_blocked"}
+	ImportPinRequired    = Code{4, "input validation", "import-public", "pin_required"}
+	ImportScannerRefuse  = Code{5, "scanner / policy", "import-public", "scanner_refuse"}
+	ImportNoSourcePolicy = Code{17, "data-source / source-policy", "import-public", "no_source_policy"}
+	ImportIntentCapped   = Code{18, "intent contradiction", "import-public", "intent_capped"}
+	ImportSourceBlocked  = Code{19, "identity / source-block", "import-public", "source_blocked"}
 )
 
 // ---------------------------------------------------------------------------
@@ -96,6 +96,29 @@ var (
 	RevokeIdentityRevoked = Code{17, "data-source / source-policy", "revoke", "identity_revoked"}
 )
 
+// ---------------------------------------------------------------------------
+// Tier 5 — sync agent / KafShield ingest surface (SPEC-0317 R-5, P1).
+// 29 is a fresh, uniquely-themed egress code; it does not share a Number with
+// any existing surface, so the Number↔Theme invariant holds trivially.
+// ---------------------------------------------------------------------------
+
+var (
+	SyncIngestRejected = Code{29, "egress / ingest", "sync", "ingest_rejected"}
+)
+
+// ---------------------------------------------------------------------------
+// Tier 6 — side-channel path guard (SPEC-0317 R-6, P2; cmd/skillctl/guardpath_cmds.go).
+// 27 is a fresh, uniquely-themed code carried in the signed refusal_code of a
+// `skillctl guard-path` opt-in deny (the PROCESS still exits 2 to block the
+// PreToolUse call, mirroring verify-hook's exitBundleRevoked/exitRevocationStale
+// convention). It does not share a Number with any other surface, so the
+// Number↔Theme invariant holds trivially.
+// ---------------------------------------------------------------------------
+
+var (
+	GuardPathSidechannelDenied = Code{27, "side-channel / path-guard", "guard-path", "sidechannel_denied"}
+)
+
 // AllCodes returns every Code currently registered. Used by the
 // CI invariant test (TestCodes_NumberTheme) and by the generator
 // that emits the SKILLCTL-MANUAL.md exit-code table.
@@ -113,5 +136,9 @@ func AllCodes() []Code {
 		SignInvalid,
 		// Tier 4 — revoke
 		RevokeIdentityRevoked,
+		// Tier 5 — sync / ingest
+		SyncIngestRejected,
+		// Tier 6 — guard-path side channel
+		GuardPathSidechannelDenied,
 	}
 }

--- a/pkg/skillctl/install/canonical_path_test.go
+++ b/pkg/skillctl/install/canonical_path_test.go
@@ -1,0 +1,73 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCanonicalPath_ResolvesSymlink locks the R-6.2 fixed point: a path that
+// reaches its target through a symlink resolves to the symlink's real target, so
+// the guard classifier cannot be fooled by a symlinked-in body.
+func TestCanonicalPath_ResolvesSymlink(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realFile := filepath.Join(realDir, "SKILL.md")
+	if err := os.WriteFile(realFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "alias")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	got, err := CanonicalPath(filepath.Join(link, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("CanonicalPath: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(realFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("CanonicalPath via symlink = %q, want %q", got, want)
+	}
+}
+
+// TestCanonicalPath_NonExistentTail resolves the longest existing ancestor and
+// re-appends the not-yet-existing tail (a Write creating a new file), while still
+// resolving a symlinked ancestor.
+func TestCanonicalPath_NonExistentTail(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "alias")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	got, err := CanonicalPath(filepath.Join(link, "newfile.txt"))
+	if err != nil {
+		t.Fatalf("CanonicalPath: %v", err)
+	}
+	realResolved, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(realResolved, "newfile.txt")
+	if got != want {
+		t.Errorf("CanonicalPath non-existent tail = %q, want %q", got, want)
+	}
+}
+
+// TestCanonicalPath_Empty rejects an empty path.
+func TestCanonicalPath_Empty(t *testing.T) {
+	if _, err := CanonicalPath("  "); err == nil {
+		t.Error("CanonicalPath(\"  \") = nil error, want rejection")
+	}
+}

--- a/pkg/skillctl/install/install.go
+++ b/pkg/skillctl/install/install.go
@@ -540,6 +540,64 @@ func CanonicalSkillName(name string) (string, error) {
 	return name, nil
 }
 
+// CanonicalPath is the ONE realpath fixed point for path classification (SPEC-0317
+// R-6.2). The `skillctl guard-path` side-channel guard MUST resolve BOTH the
+// access target and the skills root through THIS function before comparing them,
+// so a lexical HasPrefix check (which the skills dir's own symlinks — browse →
+// gstack/browse, find-skills → ../../.agents/skills — would both false-negative
+// and false-positive) is never the classifier. It is the path analogue of
+// CanonicalSkillName: one resolution both classify and any future enforce share,
+// so they cannot diverge.
+//
+// It expands a leading ~, makes the path absolute + lexically clean, then resolves
+// symlinks (filepath.EvalSymlinks) to a single fixed point. A target that does not
+// yet exist (e.g. a Write creating a new file) has no realpath, so the LONGEST
+// EXISTING ANCESTOR is resolved and the not-yet-existing tail is re-appended —
+// this still defeats a symlinked-in ancestor while classifying a create-in-place.
+func CanonicalPath(p string) (string, error) {
+	if strings.TrimSpace(p) == "" {
+		return "", errors.New("empty path")
+	}
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil && home != "" {
+			if p == "~" {
+				p = home
+			} else {
+				p = filepath.Join(home, p[2:])
+			}
+		}
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	return evalSymlinksLongestPrefix(abs), nil
+}
+
+// evalSymlinksLongestPrefix resolves symlinks on abs, or — when abs does not
+// exist — on its deepest existing ancestor, re-joining the non-existent tail.
+// Never fails: an unresolvable path degrades to the lexically-cleaned abs (still
+// a deterministic fixed point for the classify comparison).
+func evalSymlinksLongestPrefix(abs string) string {
+	if r, err := filepath.EvalSymlinks(abs); err == nil {
+		return r
+	}
+	dir := abs
+	var tail []string
+	for {
+		parent := filepath.Dir(dir)
+		if parent == dir { // hit the filesystem root; nothing resolvable
+			return abs
+		}
+		tail = append([]string{filepath.Base(dir)}, tail...)
+		dir = parent
+		if r, err := filepath.EvalSymlinks(dir); err == nil {
+			return filepath.Join(append([]string{r}, tail...)...)
+		}
+	}
+}
+
 // sanitizeFilename strips path-traversal-shaped characters from a string
 // before using it as a single path segment. Conservative: anything that
 // isn't alnum / dash / underscore / dot is dropped.

--- a/pkg/skillctl/outbox/caches.go
+++ b/pkg/skillctl/outbox/caches.go
@@ -1,0 +1,132 @@
+// caches.go — typed accessors for the table-backed trust/policy/revocation
+// caches (R-2.3). The tables are created in P0; they are POPULATED in P2 (the
+// loose files — verdicts.json / gate-policy.yaml / revoked-*.json — remain the
+// migration source and the fallback read per R-2.3). The accessors here carry
+// the epoch-monotonic guarantee (R-7): a Put with an epoch LOWER than the stored
+// one is rejected in Go, so a rollback to a stale, previously-valid signed HEAD
+// cannot silently downgrade the cache.
+package outbox
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// CacheEntry is one row of a signed-HEAD cache. Key is the primary key column
+// (name for trust/policy, digest for revocation). ContentDigest + SignedHeadB64
+// carry the R-7 signed-HEAD/content-digest semantics; PayloadJSON is the full
+// cached document.
+type CacheEntry struct {
+	Key           string
+	Epoch         int64
+	IssuedAt      string
+	ContentDigest string
+	SignedHeadB64 string
+	PayloadJSON   string
+	UpdatedAt     string
+}
+
+// ErrEpochRegression is returned by a Put whose epoch is strictly lower than the
+// stored epoch for the same key — the monotonicity floor (R-7).
+var ErrEpochRegression = errors.New("outbox: cache epoch regression (stored epoch is newer)")
+
+type cacheTable struct {
+	table  string // trust_cache | policy_cache | revocation_cache
+	keyCol string // name | digest
+}
+
+var (
+	trustCache      = cacheTable{table: "trust_cache", keyCol: "name"}
+	policyCache     = cacheTable{table: "policy_cache", keyCol: "name"}
+	revocationCache = cacheTable{table: "revocation_cache", keyCol: "digest"}
+)
+
+// put upserts a cache row under the epoch-monotonic guard. It reads the stored
+// epoch first and rejects a strictly-lower epoch; then it UPSERTs. The read +
+// write are wrapped in a single transaction so a concurrent higher-epoch write
+// cannot be clobbered by a stale one that passed the check on an old read.
+func (t cacheTable) put(s *Store, e CacheEntry) error {
+	if strings.TrimSpace(e.Key) == "" {
+		return fmt.Errorf("outbox: %s: empty key", t.table)
+	}
+	if e.UpdatedAt == "" {
+		e.UpdatedAt = rfc3339(nowUTC())
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("outbox: %s: begin: %w", t.table, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var storedEpoch int64
+	row := tx.QueryRow(fmt.Sprintf(`SELECT epoch FROM %s WHERE %s=?`, t.table, t.keyCol), e.Key)
+	switch err := row.Scan(&storedEpoch); {
+	case errors.Is(err, sql.ErrNoRows):
+		// fresh insert
+	case err != nil:
+		return fmt.Errorf("outbox: %s: read epoch: %w", t.table, err)
+	default:
+		if e.Epoch < storedEpoch {
+			return ErrEpochRegression
+		}
+	}
+
+	_, err = tx.Exec(fmt.Sprintf(`
+INSERT INTO %s (%s, epoch, issued_at, content_digest, signed_head_b64, payload_json, updated_at)
+VALUES (?,?,?,?,?,?,?)
+ON CONFLICT(%s) DO UPDATE SET
+  epoch=excluded.epoch, issued_at=excluded.issued_at, content_digest=excluded.content_digest,
+  signed_head_b64=excluded.signed_head_b64, payload_json=excluded.payload_json,
+  updated_at=excluded.updated_at`, t.table, t.keyCol, t.keyCol),
+		e.Key, e.Epoch, e.IssuedAt, e.ContentDigest, nullIfEmpty(e.SignedHeadB64), e.PayloadJSON, e.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("outbox: %s: upsert: %w", t.table, err)
+	}
+	return tx.Commit()
+}
+
+func (t cacheTable) get(s *Store, key string) (CacheEntry, bool, error) {
+	var (
+		e        CacheEntry
+		signed   sql.NullString
+		issuedAt sql.NullString
+	)
+	e.Key = key
+	err := s.db.QueryRow(fmt.Sprintf(`
+SELECT epoch, issued_at, content_digest, signed_head_b64, payload_json, updated_at
+FROM %s WHERE %s=?`, t.table, t.keyCol), key).
+		Scan(&e.Epoch, &issuedAt, &e.ContentDigest, &signed, &e.PayloadJSON, &e.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return CacheEntry{}, false, nil
+	}
+	if err != nil {
+		return CacheEntry{}, false, fmt.Errorf("outbox: %s: get: %w", t.table, err)
+	}
+	e.IssuedAt = issuedAt.String
+	e.SignedHeadB64 = signed.String
+	return e, true, nil
+}
+
+// PutTrustCache upserts a trust-cache row (epoch-monotonic).
+func (s *Store) PutTrustCache(e CacheEntry) error { return trustCache.put(s, e) }
+
+// GetTrustCache reads a trust-cache row by name.
+func (s *Store) GetTrustCache(name string) (CacheEntry, bool, error) { return trustCache.get(s, name) }
+
+// PutPolicyCache upserts a policy-cache row (epoch-monotonic).
+func (s *Store) PutPolicyCache(e CacheEntry) error { return policyCache.put(s, e) }
+
+// GetPolicyCache reads a policy-cache row by name.
+func (s *Store) GetPolicyCache(name string) (CacheEntry, bool, error) {
+	return policyCache.get(s, name)
+}
+
+// PutRevocationCache upserts a revocation-cache row (epoch-monotonic).
+func (s *Store) PutRevocationCache(e CacheEntry) error { return revocationCache.put(s, e) }
+
+// GetRevocationCache reads a revocation-cache row by digest.
+func (s *Store) GetRevocationCache(digest string) (CacheEntry, bool, error) {
+	return revocationCache.get(s, digest)
+}

--- a/pkg/skillctl/outbox/driver_hook_cgo.go
+++ b/pkg/skillctl/outbox/driver_hook_cgo.go
@@ -1,0 +1,48 @@
+// driver_hook_cgo.go — cgo (mattn/go-sqlite3) hot-path handle.
+//
+//go:build cgo
+
+package outbox
+
+import (
+	"database/sql"
+	"sync"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
+
+// hotPathDriverName is a DISTINCT driver registration wrapping mattn with a
+// ConnectHook. We cannot pin busy_timeout via a DSN param alone: mattn parses
+// `_busy_timeout` while modernc parses `_pragma=busy_timeout(250)` — a DSN-only
+// pin silently fails on one driver. Registering our own driver with a
+// ConnectHook makes the pin fire on EVERY physical connection (R-2.4).
+const hotPathDriverName = "sqlite3_m3c_outbox"
+
+var registerHookOnce sync.Once
+
+func registerHotPathDriver() {
+	registerHookOnce.Do(func() {
+		sql.Register(hotPathDriverName, &sqlite3.SQLiteDriver{
+			ConnectHook: func(c *sqlite3.SQLiteConn) error {
+				// 250ms, NOT the 5000ms house default: a stalled hook would
+				// silently fail the harness open (read as ALLOW). The gate must
+				// return within ~250ms and spool instead (R-2.4, AC-3).
+				_, err := c.Exec("PRAGMA busy_timeout=250", nil)
+				return err
+			},
+		})
+	})
+}
+
+// openHotPathDB opens the outbox handle with the per-connection busy_timeout pin
+// and SetMaxOpenConns(1) so the ONE pinned connection is never bypassed by an
+// un-pinned second pool connection.
+func openHotPathDB(dbPath string) (*sql.DB, error) {
+	registerHotPathDriver()
+	db, err := sql.Open(hotPathDriverName, dbPath)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	return db, nil
+}

--- a/pkg/skillctl/outbox/driver_hook_nocgo.go
+++ b/pkg/skillctl/outbox/driver_hook_nocgo.go
@@ -1,0 +1,27 @@
+// driver_hook_nocgo.go — pure-Go (modernc.org/sqlite) hot-path handle.
+//
+//go:build !cgo
+
+package outbox
+
+import (
+	"database/sql"
+
+	"github.com/kamir/m3c-tools/internal/dbdriver"
+)
+
+// openHotPathDB opens the outbox handle on the modernc driver. modernc pins
+// per-connection pragmas via the `_pragma=` DSN form (distinct from mattn's
+// `_busy_timeout` — see driver_hook_cgo.go), applied on EVERY physical
+// connection by the driver. 250ms, NOT the 5000ms house default (R-2.4): the
+// gate must return quickly and spool rather than freeze the harness open.
+// SetMaxOpenConns(1) keeps the single pinned connection from being bypassed.
+func openHotPathDB(dbPath string) (*sql.DB, error) {
+	dsn := dbPath + "?_pragma=busy_timeout(250)&_pragma=journal_mode(WAL)"
+	db, err := sql.Open(dbdriver.DriverName(), dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	return db, nil
+}

--- a/pkg/skillctl/outbox/ingest.go
+++ b/pkg/skillctl/outbox/ingest.go
@@ -1,0 +1,206 @@
+// ingest.go — the SPEC-0317 (P1) KafShield ingest CLIENT contract.
+//
+// The sync agent (cmd/skillctl/sync_cmds.go) drains audit_events over HTTPS to
+// this endpoint. The contract's load-bearing rule (R-5.3 / AC-4) is the ACK
+// shape: the server acknowledges each accepted event_id with a SIGNED
+// durable-seq — a monotonic sequence number counter-signed over the canonical
+// (log_id, event_id, durable_seq) message with the ingest key. The client marks
+// a row synced ONLY on a valid signed durable-seq; a bare-2xx (an in-memory stub
+// that returns 200 with no signed seq) does NOT mark rows synced. This half is
+// fully testable at P1 against a contract double (httptest); the assertion that
+// the real backend's durable-seq reflects Kafka persistence is the P3 gate.
+//
+// HTTPS-only (R-5.2): PostBatch refuses any non-https endpoint. The decision to
+// tolerate a self-signed cert (InsecureSkipVerify) lives in the CALLER's
+// http.Client and is gated to loopback there — prod endpoints never inherit it.
+//
+// Transport auth (R-5.2) is the SPEC-0127 device token as a bearer, NOT the
+// shared X-API-KEY. The client sends NO authorization-bearing tenant field:
+// tenant is derived SERVER-side from the token→tenant binding (R-9.2 / AC-12).
+package outbox
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// IngestPath is the enforcement-events ingest route (R-5.3). Appended to the
+// configured endpoint base.
+const IngestPath = "/api/skills/enforcement/events"
+
+// durableSeqDomain is the domain-separation tag for the signed durable-seq ack
+// message. It is DISTINCT from the invocation_event_v1 canonical (event.go): the
+// ack is the ingest's counter-signature, a different signed-message family. This
+// is NOT a new audit-event vocabulary — event_id / the record canonical are
+// unchanged.
+const durableSeqDomain = "durable-seq-v1"
+
+// CanonicalDurableSeq is the exact byte message the ingest signs (and the client
+// re-verifies) for one durable-seq ack. Domain-separated first line, LF-framed,
+// fixed field order, trailing LF — the same discipline as the record canonical.
+// The contract double MUST sign these exact bytes.
+//
+//	durable-seq-v1
+//	log_id=<...>
+//	event_id=<...>
+//	durable_seq=<int>
+func CanonicalDurableSeq(logID, eventID string, seq int64) []byte {
+	var b strings.Builder
+	b.WriteString(durableSeqDomain)
+	b.WriteByte('\n')
+	b.WriteString("log_id=" + logID + "\n")
+	b.WriteString("event_id=" + eventID + "\n")
+	b.WriteString("durable_seq=" + strconv.FormatInt(seq, 10) + "\n")
+	return []byte(b.String())
+}
+
+// IngestBatch is the POST body. Records are the EXACT signed InvocationRecord
+// bytes (payload_json), embedded verbatim as raw JSON so the server re-verifies
+// the same bytes the device signed — no re-marshalling, no field reordering.
+type IngestBatch struct {
+	Records     []json.RawMessage `json:"records"`
+	ClientEpoch int64             `json:"client_epoch"`
+}
+
+// DurableAck is one per-event acknowledgement. A VALID ack (VerifyAck true) is
+// the ONLY thing that lets the client mark a row synced.
+type DurableAck struct {
+	EventID    string `json:"event_id"`
+	DurableSeq int64  `json:"durable_seq"`
+	SeqSigB64  string `json:"seq_sig_b64"`
+}
+
+// IngestResponse is the ack envelope. A response with an empty Acks slice (or
+// acks that fail VerifyAck) is a bare-2xx: accepted at the HTTP layer but NOT
+// durably acknowledged, so nothing is marked synced.
+type IngestResponse struct {
+	Acks []DurableAck `json:"acks"`
+}
+
+// IngestClient posts batches to the ingest endpoint and verifies durable-seq
+// acks. It is constructed by the sync agent; it is NEVER on the hook path.
+type IngestClient struct {
+	// Endpoint is the base URL (scheme MUST be https). IngestPath is appended.
+	Endpoint string
+	// Token is the SPEC-0127 device bearer token (R-5.2). Sent as
+	// Authorization: Bearer <token>. Empty is allowed only for a contract
+	// double that does not enforce auth.
+	Token string
+	// LogID binds the durable-seq signature (the ack is over this log_id).
+	LogID string
+	// PubKey is the ingest public key the durable-seq signature verifies
+	// against (pinned in trust roots / endpoint config). Zero-length disables
+	// ack verification → nothing is ever marked synced (fail-closed).
+	PubKey ed25519.PublicKey
+	// Client is the HTTP client. The CALLER owns TLS policy (InsecureSkipVerify
+	// only for loopback). Nil → a 15s-timeout default (verifies certs).
+	Client *http.Client
+	// ClientEpoch is stamped into each batch body (R-5.3 wire field).
+	ClientEpoch int64
+}
+
+// eventsURL returns Endpoint + IngestPath after validating the scheme is https.
+func (c *IngestClient) eventsURL() (string, error) {
+	raw := strings.TrimRight(strings.TrimSpace(c.Endpoint), "/")
+	if raw == "" {
+		return "", fmt.Errorf("outbox: ingest endpoint is empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("outbox: parse ingest endpoint: %w", err)
+	}
+	if u.Scheme != "https" {
+		return "", fmt.Errorf("outbox: ingest endpoint must be https, got %q", u.Scheme)
+	}
+	return raw + IngestPath, nil
+}
+
+// PostBatch marshals the records into an IngestBatch and POSTs it. records are
+// the raw payload_json bytes of each row (already the signed record). It returns
+// the parsed response (nil on a non-2xx or transport error), the HTTP status
+// (0 on a transport error), and an error.
+//
+// The caller interprets status: 2xx → inspect acks (valid durable-seq → synced,
+// otherwise not); 4xx → auth/validation reject (exit ingest_rejected); 5xx or
+// status==0 → transient, backoff.
+func (c *IngestClient) PostBatch(ctx context.Context, records [][]byte) (*IngestResponse, int, error) {
+	target, err := c.eventsURL()
+	if err != nil {
+		return nil, 0, err
+	}
+	raws := make([]json.RawMessage, 0, len(records))
+	for _, r := range records {
+		raws = append(raws, json.RawMessage(r))
+	}
+	body, err := json.Marshal(IngestBatch{Records: raws, ClientEpoch: c.ClientEpoch})
+	if err != nil {
+		return nil, 0, fmt.Errorf("outbox: marshal ingest batch: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, fmt.Errorf("outbox: build ingest request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "m3c-skillctl-sync/1.0")
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+
+	client := c.Client
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("outbox: post ingest batch: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode/100 != 2 {
+		return nil, resp.StatusCode, nil
+	}
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("outbox: read ingest response: %w", err)
+	}
+	var out IngestResponse
+	if len(bytes.TrimSpace(respBody)) > 0 {
+		if err := json.Unmarshal(respBody, &out); err != nil {
+			// A 2xx with an unparseable body is a bare-2xx: no usable acks.
+			return &IngestResponse{}, resp.StatusCode, nil
+		}
+	}
+	return &out, resp.StatusCode, nil
+}
+
+// VerifyAck reports whether ack carries a valid signed durable-seq for this
+// client's pinned ingest pubkey and log id. A false result means the caller MUST
+// NOT mark the row synced (R-5.3 / AC-4). Fail-closed on a missing pubkey.
+func (c *IngestClient) VerifyAck(ack DurableAck) bool {
+	if len(c.PubKey) != ed25519.PublicKeySize {
+		return false
+	}
+	if strings.TrimSpace(ack.EventID) == "" || strings.TrimSpace(ack.SeqSigB64) == "" {
+		return false
+	}
+	sig, err := base64.StdEncoding.DecodeString(ack.SeqSigB64)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return false
+	}
+	msg := CanonicalDurableSeq(c.LogID, ack.EventID, ack.DurableSeq)
+	return ed25519.Verify(c.PubKey, msg, sig)
+}

--- a/pkg/skillctl/outbox/ingest_test.go
+++ b/pkg/skillctl/outbox/ingest_test.go
@@ -1,0 +1,94 @@
+package outbox
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ingestKey is a fixed ingest signing key so durable-seq acks are deterministic.
+var ingestKey = func() ed25519.PrivateKey {
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(0x40 + i)
+	}
+	return ed25519.NewKeyFromSeed(seed)
+}()
+
+func signDurable(logID, eventID string, seq int64) string {
+	sig := ed25519.Sign(ingestKey, CanonicalDurableSeq(logID, eventID, seq))
+	return base64.StdEncoding.EncodeToString(sig)
+}
+
+func TestIngest_PostBatch_RejectsNonHTTPS(t *testing.T) {
+	c := &IngestClient{Endpoint: "http://example.com", LogID: "L"}
+	if _, _, err := c.PostBatch(context.Background(), [][]byte{[]byte(`{}`)}); err == nil {
+		t.Fatal("expected https-only rejection, got nil error")
+	}
+}
+
+func TestIngest_PostBatch_ParsesSignedAcks(t *testing.T) {
+	var gotBody IngestBatch
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != IngestPath {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		resp := IngestResponse{Acks: []DurableAck{
+			{EventID: "inv:1", DurableSeq: 7, SeqSigB64: signDurable("L", "inv:1", 7)},
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := &IngestClient{
+		Endpoint: srv.URL, LogID: "L", PubKey: ingestKey.Public().(ed25519.PublicKey),
+		Client: srv.Client(), ClientEpoch: 99,
+	}
+	resp, status, err := c.PostBatch(context.Background(), [][]byte{[]byte(`{"event_id":"inv:1"}`)})
+	if err != nil {
+		t.Fatalf("PostBatch: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if gotBody.ClientEpoch != 99 || len(gotBody.Records) != 1 {
+		t.Fatalf("body not forwarded verbatim: %+v", gotBody)
+	}
+	if len(resp.Acks) != 1 || !c.VerifyAck(resp.Acks[0]) {
+		t.Fatalf("ack did not verify: %+v", resp.Acks)
+	}
+}
+
+func TestIngest_VerifyAck(t *testing.T) {
+	c := &IngestClient{LogID: "L", PubKey: ingestKey.Public().(ed25519.PublicKey)}
+
+	// Valid.
+	if !c.VerifyAck(DurableAck{EventID: "e1", DurableSeq: 3, SeqSigB64: signDurable("L", "e1", 3)}) {
+		t.Fatal("valid ack should verify")
+	}
+	// Wrong seq (signature is over a different message).
+	if c.VerifyAck(DurableAck{EventID: "e1", DurableSeq: 4, SeqSigB64: signDurable("L", "e1", 3)}) {
+		t.Fatal("tampered seq must not verify")
+	}
+	// Wrong log id.
+	if c.VerifyAck(DurableAck{EventID: "e1", DurableSeq: 3, SeqSigB64: signDurable("OTHER", "e1", 3)}) {
+		t.Fatal("wrong log id must not verify")
+	}
+	// Empty signature (bare-2xx shape).
+	if c.VerifyAck(DurableAck{EventID: "e1", DurableSeq: 3}) {
+		t.Fatal("empty sig must not verify")
+	}
+	// No pubkey → fail-closed.
+	noKey := &IngestClient{LogID: "L"}
+	if noKey.VerifyAck(DurableAck{EventID: "e1", DurableSeq: 3, SeqSigB64: signDurable("L", "e1", 3)}) {
+		t.Fatal("missing pubkey must fail closed")
+	}
+}

--- a/pkg/skillctl/outbox/outbox.go
+++ b/pkg/skillctl/outbox/outbox.go
@@ -1,0 +1,463 @@
+// Package outbox is the SPEC-0317 (P0) transactional audit outbox: the single
+// AUTHORITATIVE, write-once store of signed skill-invocation evidence.
+//
+// It is a trust-critical LEAF package — stdlib + internal/dbdriver only; it does
+// NOT import pkg/skillctl/registry (or any heavy skillctl surface) so it can be
+// depended on from the hot path without pulling the world.
+//
+// Each row wraps the existing device-signed skillgate.InvocationRecord
+// (canonical invocation_event_v1, detached ed25519, event_id =
+// inv:<unix-ms>:<10-byte-hex>). payload_hash = sha256(canonical bytes) is stored
+// as a COLUMN (R-4.1) — not folded into the signed canonical, so no format bump.
+// event_id is the ONLY dedup key end-to-end.
+//
+// HOT-PATH SAFETY (R-2.4, the hard constraint): the handle pins
+// busy_timeout≈250ms per connection (driver_hook_*.go) and SetMaxOpenConns(1).
+// On SQLITE_BUSY / open failure Append returns the error so the CALLER spools
+// (spool.go) — the decision returns regardless (R-2.4 / R-8.1 default). Append
+// itself stays pure and testable.
+package outbox
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+)
+
+// Store is the outbox handle. It mirrors the shape of pkg/tracking's
+// RetryQueueDB: a *sql.DB plus the resolved home so spool.jsonl lands beside the
+// db under ~/.claude/skillctl.
+type Store struct {
+	db   *sql.DB
+	home string
+	dir  string
+}
+
+// Event is one materialized audit_events row (the non-authoritative index view).
+// Consumers that ENFORCE or DISPLAY a decision must reconstruct the canonical
+// bytes from PayloadJSON and re-verify SignatureB64 (R-2.6) — the flat columns
+// are indices only.
+type Event struct {
+	EventID      string
+	OccurredAt   string
+	EventType    string
+	Tool         string
+	SkillDigest  string
+	SkillName    string
+	Decision     string
+	RefusalCode  string
+	ExitCode     int
+	PayloadJSON  string
+	PayloadHash  string
+	DeviceKeyID  string
+	SignatureB64 string
+	TranslogSeq  sql.NullInt64
+	SyncStatus   int
+	SyncedAt     string
+	CreatedAt    string
+}
+
+// dirName is the state directory, matching the ~/.claude/skillctl 0700
+// convention used by verdict_cache.go / invocation_trail.go.
+func dirName(home string) string { return filepath.Join(home, ".claude", "skillctl") }
+
+// DBPath is the outbox database path for a given home.
+func DBPath(home string) string { return filepath.Join(dirName(home), "outbox.db") }
+
+// nowUTC is a seam so tests can pin time; production is time.Now().
+var nowUTC = func() time.Time { return time.Now().UTC() }
+
+func rfc3339(t time.Time) string { return t.UTC().Format(time.RFC3339) }
+
+// Open opens (creating if needed) the outbox at ~/.claude/skillctl/outbox.db.
+// The directory is created 0700 and the db file chmod'd 0600. migrate() sets
+// WAL once and creates the write-once schema. An empty home is an error (there
+// is nowhere to anchor state).
+func Open(home string) (*Store, error) {
+	if strings.TrimSpace(home) == "" {
+		return nil, errors.New("outbox: empty home")
+	}
+	dir := dirName(home)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("outbox: create state dir: %w", err)
+	}
+	dbPath := DBPath(home)
+	db, err := openHotPathDB(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("outbox: open sqlite: %w", err)
+	}
+	// Tighten the db file to 0600 (best-effort; WAL/-shm sidecars inherit the
+	// 0700 dir). A chmod failure is not fatal to correctness.
+	_ = os.Chmod(dbPath, 0o600)
+
+	s := &Store{db: db, home: home, dir: dir}
+	if err := s.migrate(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("outbox: migrate: %w", err)
+	}
+	return s, nil
+}
+
+// Close closes the underlying handle.
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+// Home returns the resolved home the store was opened against.
+func (s *Store) Home() string { return s.home }
+
+// Checkpoint runs a WAL checkpoint (TRUNCATE) so the -wal sidecar is folded back
+// into the main db file. The sync daemon calls this on graceful shutdown so a
+// long-lived process does not leave an unbounded WAL. Best-effort: a checkpoint
+// failure is not fatal (the WAL is still valid and replays on next open).
+func (s *Store) Checkpoint() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if _, err := s.db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+		return fmt.Errorf("outbox: wal checkpoint: %w", err)
+	}
+	return nil
+}
+
+// migrate sets WAL once (persisted in the file header) then applies the
+// idempotent DDL (tables + write-once triggers + indexes).
+func (s *Store) migrate() error {
+	if _, err := s.db.Exec(pragmaWAL); err != nil {
+		return fmt.Errorf("set WAL: %w", err)
+	}
+	if _, err := s.db.Exec(ddl); err != nil {
+		return fmt.Errorf("apply ddl: %w", err)
+	}
+	return nil
+}
+
+// RecordPayload derives the two stored derivations of a record: the full JSON
+// (payload_json, the authoritative bytes we can re-verify) and payload_hash =
+// hex(sha256(canonical bytes)) (R-4.1 — a COLUMN, NOT part of the signed
+// canonical; the "sha256:" prefix is added by translog anchoring, so this is
+// stored bare-hex). Returns an error if the record refuses canonicalization
+// (e.g. a newline-smuggled field).
+func RecordPayload(rec skillgate.InvocationRecord) (payloadJSON, payloadHash string, err error) {
+	canon, err := skillgate.CanonicalizeInvocationRecord(&rec)
+	if err != nil {
+		return "", "", err
+	}
+	sum := sha256.Sum256(canon)
+	pj, err := json.Marshal(rec)
+	if err != nil {
+		return "", "", err
+	}
+	return string(pj), hex.EncodeToString(sum[:]), nil
+}
+
+// deriveDecision maps a record to the non-authoritative decision index: a
+// present refusal_code means the invocation was denied, otherwise allowed. This
+// is an INDEX only (R-2.6) — enforcement re-derives from the signed payload.
+func deriveDecision(rec skillgate.InvocationRecord) string {
+	if strings.TrimSpace(rec.RefusalCode) != "" {
+		return "deny"
+	}
+	return "allow"
+}
+
+// Append inserts one decided evidence row. It is the hot-path write: a single
+// INSERT OR IGNORE keyed on event_id (a replay/reconcile duplicate is a no-op —
+// this is where the trail's Replays signal moves to, AC-11). It is PURE: on
+// SQLITE_BUSY / any db error it returns the error so the caller spools
+// (Spool / AppendOrSpool). It performs no I/O beyond the single INSERT.
+//
+// payloadJSON and payloadHash are supplied by the caller (see RecordPayload) so
+// the exact signed bytes are pinned once and fanned out identically to every
+// sink (never re-marshalled per-sink, which would risk divergence).
+func (s *Store) Append(rec skillgate.InvocationRecord, payloadJSON, payloadHash string) error {
+	if strings.TrimSpace(rec.EventID) == "" {
+		return errors.New("outbox: append: empty event_id")
+	}
+	now := rfc3339(nowUTC())
+	_, err := s.db.Exec(`
+INSERT OR IGNORE INTO audit_events
+  (event_id, occurred_at, event_type, tool, skill_digest, skill_name, decision,
+   refusal_code, exit_code, payload_json, payload_hash, device_key_id,
+   signature_b64, sync_status, created_at)
+VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0,?)`,
+		rec.EventID, rec.OccurredAt, rec.EventType, rec.Tool, rec.SkillDigest,
+		rec.SkillName, deriveDecision(rec), rec.RefusalCode, rec.ExitCode,
+		payloadJSON, payloadHash, rec.DeviceKeyID, rec.DeviceSignatureB64, now)
+	if err != nil {
+		return fmt.Errorf("outbox: append: %w", err)
+	}
+	return nil
+}
+
+// AppendOrSpool tries Append; on ANY failure (SQLITE_BUSY, open error) it falls
+// back to the spool.jsonl fallback so the decision can return regardless
+// (R-2.4 / R-8.1 default). It returns nil if EITHER sink accepted the row; it
+// returns a joined error only if BOTH failed (a genuinely un-recordable state).
+func (s *Store) AppendOrSpool(rec skillgate.InvocationRecord, payloadJSON, payloadHash string) error {
+	if err := s.Append(rec, payloadJSON, payloadHash); err != nil {
+		if serr := s.Spool(rec, payloadJSON, payloadHash); serr != nil {
+			return errors.Join(err, serr)
+		}
+		return nil
+	}
+	return nil
+}
+
+// PendingBatch returns up to limit unsynced rows (sync_status=0) in occurred_at
+// order (oldest first) — the drain order the P1 sync uses. limit<=0 defaults to
+// 100. Read-only.
+func (s *Store) PendingBatch(limit int) ([]Event, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.Query(`
+SELECT event_id, occurred_at, event_type, tool, skill_digest, skill_name,
+       decision, refusal_code, exit_code, payload_json, payload_hash,
+       device_key_id, signature_b64, translog_seq, sync_status, synced_at, created_at
+FROM audit_events
+WHERE sync_status=0
+ORDER BY occurred_at ASC, event_id ASC
+LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("outbox: pending batch: %w", err)
+	}
+	defer rows.Close()
+	return scanEvents(rows)
+}
+
+// PendingBatchDue returns up to limit unsynced rows (sync_status=0) that are DUE
+// for a (re)post: a row is EXCLUDED while it still has a delivery_attempts row
+// whose next_retry_at is in the future, mirroring retryqueue.go's
+// `next_retry_at <= now` due gate. A row with no attempts (never posted) is always
+// due. Ordered oldest-first by occurred_at — the drain order the P1 sync uses.
+//
+// This is the backoff-aware variant of PendingBatch: without it the sync daemon
+// re-POSTs every unsynced row each interval regardless of its deferral, and a
+// mixed-ack batch re-POSTs a just-deferred row within one drain. now is an RFC3339
+// UTC string (string comparison is valid: all timestamps are fixed-width UTC 'Z').
+// limit<=0 defaults to 100. Read-only.
+func (s *Store) PendingBatchDue(limit int, now string) ([]Event, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.Query(`
+SELECT event_id, occurred_at, event_type, tool, skill_digest, skill_name,
+       decision, refusal_code, exit_code, payload_json, payload_hash,
+       device_key_id, signature_b64, translog_seq, sync_status, synced_at, created_at
+FROM audit_events e
+WHERE sync_status=0
+  AND NOT EXISTS (
+        SELECT 1 FROM delivery_attempts d
+        WHERE d.event_id = e.event_id
+          AND d.next_retry_at IS NOT NULL
+          AND d.next_retry_at > ?
+      )
+ORDER BY occurred_at ASC, event_id ASC
+LIMIT ?`, now, limit)
+	if err != nil {
+		return nil, fmt.Errorf("outbox: pending batch due: %w", err)
+	}
+	defer rows.Close()
+	return scanEvents(rows)
+}
+
+func scanEvents(rows *sql.Rows) ([]Event, error) {
+	var out []Event
+	for rows.Next() {
+		var (
+			e           Event
+			skillDigest sql.NullString
+			skillName   sql.NullString
+			refusalCode sql.NullString
+			payloadJSON sql.NullString
+			syncedAt    sql.NullString
+		)
+		if err := rows.Scan(&e.EventID, &e.OccurredAt, &e.EventType, &e.Tool,
+			&skillDigest, &skillName, &e.Decision, &refusalCode, &e.ExitCode,
+			&payloadJSON, &e.PayloadHash, &e.DeviceKeyID, &e.SignatureB64,
+			&e.TranslogSeq, &e.SyncStatus, &syncedAt, &e.CreatedAt); err != nil {
+			return nil, fmt.Errorf("outbox: scan: %w", err)
+		}
+		e.SkillDigest = skillDigest.String
+		e.SkillName = skillName.String
+		e.RefusalCode = refusalCode.String
+		e.PayloadJSON = payloadJSON.String
+		e.SyncedAt = syncedAt.String
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// Get returns a single row by event_id (ok=false if absent). Read-only helper
+// used by tests and the P1 drain's re-verify step.
+func (s *Store) Get(eventID string) (Event, bool, error) {
+	rows, err := s.db.Query(`
+SELECT event_id, occurred_at, event_type, tool, skill_digest, skill_name,
+       decision, refusal_code, exit_code, payload_json, payload_hash,
+       device_key_id, signature_b64, translog_seq, sync_status, synced_at, created_at
+FROM audit_events WHERE event_id=?`, eventID)
+	if err != nil {
+		return Event{}, false, fmt.Errorf("outbox: get: %w", err)
+	}
+	defer rows.Close()
+	evs, err := scanEvents(rows)
+	if err != nil {
+		return Event{}, false, err
+	}
+	if len(evs) == 0 {
+		return Event{}, false, nil
+	}
+	return evs[0], true, nil
+}
+
+// PendingCount returns the number of unsynced rows. Read-only.
+func (s *Store) PendingCount() (int, error) {
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM audit_events WHERE sync_status=0`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("outbox: pending count: %w", err)
+	}
+	return n, nil
+}
+
+// MarkSynced flips sync_status=1 and stamps synced_at for an event that received
+// a VALID signed durable-seq ack (the P1 caller enforces that; here it is the
+// write). It touches ONLY the two sync-bookkeeping columns, so the write-once
+// trigger permits it. Idempotent: re-marking an already-synced event is a no-op.
+func (s *Store) MarkSynced(eventID, syncedAt string) error {
+	if strings.TrimSpace(syncedAt) == "" {
+		syncedAt = rfc3339(nowUTC())
+	}
+	_, err := s.db.Exec(`UPDATE audit_events SET sync_status=1, synced_at=? WHERE event_id=?`,
+		syncedAt, eventID)
+	if err != nil {
+		return fmt.Errorf("outbox: mark synced: %w", err)
+	}
+	return nil
+}
+
+// BackfillTranslogSeq records the Merkle leaf index for a row, once. It updates
+// translog_seq ONLY where it is currently NULL (the write-once trigger also
+// forbids a NULL→value→other-value rewrite), so a re-anchor cannot silently
+// move an already-anchored row (R-4.2).
+//
+// NOT-YET-WIRED (AC-5a): no production path calls this yet — the sync/enforce
+// drain does not anchor — so translog_seq is NULL in production. It exists (and is
+// unit-tested) as the one-shot backfill the future per-batch anchor will use; do
+// not read the schema comments as a claim that anchoring runs today.
+func (s *Store) BackfillTranslogSeq(eventID string, seq int64) error {
+	_, err := s.db.Exec(`UPDATE audit_events SET translog_seq=? WHERE event_id=? AND translog_seq IS NULL`,
+		seq, eventID)
+	if err != nil {
+		return fmt.Errorf("outbox: backfill translog_seq: %w", err)
+	}
+	return nil
+}
+
+// RecordAttempt inserts one delivery attempt row (the retryqueue.go backoff
+// lane: 30s→1h, cap 10, scale 2.0 — computed by the P1 caller). Keyed on
+// (event_id, attempt) so a replayed attempt number is an INSERT OR IGNORE no-op.
+// httpStatus<=0 stores NULL. This is bookkeeping on the SEPARATE
+// delivery_attempts table; it never mutates the write-once evidence row.
+func (s *Store) RecordAttempt(eventID string, attempt int, at string, httpStatus int, errMsg, nextRetryAt string) error {
+	if strings.TrimSpace(at) == "" {
+		at = rfc3339(nowUTC())
+	}
+	var status sql.NullInt64
+	if httpStatus > 0 {
+		status = sql.NullInt64{Int64: int64(httpStatus), Valid: true}
+	}
+	_, err := s.db.Exec(`
+INSERT OR IGNORE INTO delivery_attempts (event_id, attempt, at, http_status, error, next_retry_at)
+VALUES (?,?,?,?,?,?)`, eventID, attempt, at, status, nullIfEmpty(errMsg), nullIfEmpty(nextRetryAt))
+	if err != nil {
+		return fmt.Errorf("outbox: record attempt: %w", err)
+	}
+	return nil
+}
+
+// Attempts returns the recorded delivery attempts for an event, oldest first.
+// Read-only helper for tests / the P1 backoff scheduler.
+func (s *Store) Attempts(eventID string) ([]Attempt, error) {
+	rows, err := s.db.Query(`
+SELECT event_id, attempt, at, http_status, error, next_retry_at
+FROM delivery_attempts WHERE event_id=? ORDER BY attempt ASC`, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("outbox: attempts: %w", err)
+	}
+	defer rows.Close()
+	var out []Attempt
+	for rows.Next() {
+		var (
+			a           Attempt
+			httpStatus  sql.NullInt64
+			errMsg      sql.NullString
+			nextRetryAt sql.NullString
+		)
+		if err := rows.Scan(&a.EventID, &a.Attempt, &a.At, &httpStatus, &errMsg, &nextRetryAt); err != nil {
+			return nil, fmt.Errorf("outbox: scan attempt: %w", err)
+		}
+		if httpStatus.Valid {
+			a.HTTPStatus = int(httpStatus.Int64)
+		}
+		a.Error = errMsg.String
+		a.NextRetryAt = nextRetryAt.String
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// Attempt is one delivery_attempts row.
+type Attempt struct {
+	EventID     string
+	Attempt     int
+	At          string
+	HTTPStatus  int
+	Error       string
+	NextRetryAt string
+}
+
+// SetSyncState upserts a sync_state key (high_water_seq, last_success_ts,
+// endpoint_epoch, ingest_pubkey …). The P1 sync owns the semantics; P0 provides
+// the durable key/value.
+func (s *Store) SetSyncState(k, v string) error {
+	_, err := s.db.Exec(`
+INSERT INTO sync_state (k, v) VALUES (?, ?)
+ON CONFLICT(k) DO UPDATE SET v=excluded.v`, k, v)
+	if err != nil {
+		return fmt.Errorf("outbox: set sync state: %w", err)
+	}
+	return nil
+}
+
+// GetSyncState reads a sync_state key (ok=false if absent).
+func (s *Store) GetSyncState(k string) (string, bool, error) {
+	var v string
+	err := s.db.QueryRow(`SELECT v FROM sync_state WHERE k=?`, k).Scan(&v)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("outbox: get sync state: %w", err)
+	}
+	return v, true, nil
+}
+
+func nullIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/pkg/skillctl/outbox/outbox_test.go
+++ b/pkg/skillctl/outbox/outbox_test.go
@@ -1,0 +1,337 @@
+package outbox
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+)
+
+// testKey is a fixed ed25519 key so records are deterministically signable.
+var testKey = func() ed25519.PrivateKey {
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+	return ed25519.NewKeyFromSeed(seed)
+}()
+
+// makeRecord builds a signed InvocationRecord with a distinct event_id and
+// occurred_at, plus its RecordPayload derivations.
+func makeRecord(t *testing.T, idx int, occurred string) (skillgate.InvocationRecord, string, string) {
+	t.Helper()
+	rec := skillgate.InvocationRecord{
+		Schema:      skillgate.InvocationSchema,
+		EventID:     fmt.Sprintf("inv:%013d:%04x", time.Now().UnixMilli(), idx),
+		EventType:   "skill.invocation",
+		SkillName:   "demo-skill",
+		SkillDigest: "sha256:deadbeef",
+		Tool:        "Skill",
+		OccurredAt:  occurred,
+		DeviceKeyID: "test-key",
+		ExitCode:    0,
+	}
+	signFn := func(msg []byte) []byte { return ed25519.Sign(testKey, msg) }
+	if err := skillgate.SignInvocationRecord(&rec, signFn, base64.StdEncoding.EncodeToString); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	pj, ph, err := RecordPayload(rec)
+	if err != nil {
+		t.Fatalf("RecordPayload: %v", err)
+	}
+	return rec, pj, ph
+}
+
+func openTemp(t *testing.T) *Store {
+	t.Helper()
+	home := t.TempDir()
+	s, err := Open(home)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestAppendAndPendingBatch(t *testing.T) {
+	s := openTemp(t)
+	rec, pj, ph := makeRecord(t, 1, "2026-07-08T10:00:00Z")
+	if err := s.Append(rec, pj, ph); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	batch, err := s.PendingBatch(10)
+	if err != nil {
+		t.Fatalf("PendingBatch: %v", err)
+	}
+	if len(batch) != 1 {
+		t.Fatalf("want 1 pending, got %d", len(batch))
+	}
+	got := batch[0]
+	if got.EventID != rec.EventID || got.PayloadHash != ph || got.SignatureB64 != rec.DeviceSignatureB64 {
+		t.Fatalf("row mismatch: %+v", got)
+	}
+	if got.Decision != "allow" {
+		t.Fatalf("decision: want allow got %q", got.Decision)
+	}
+	if got.SyncStatus != 0 {
+		t.Fatalf("sync_status: want 0 got %d", got.SyncStatus)
+	}
+}
+
+func TestAppendDedupOnEventID(t *testing.T) {
+	s := openTemp(t)
+	rec, pj, ph := makeRecord(t, 7, "2026-07-08T10:00:00Z")
+	for i := 0; i < 3; i++ {
+		if err := s.Append(rec, pj, ph); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+	n, err := s.PendingCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("replayed event_id must dedup: want 1 got %d", n)
+	}
+}
+
+// TestPendingBatchDueExcludesFutureBackoff — the backoff-aware drain set: a row
+// whose delivery_attempts.next_retry_at is in the future is EXCLUDED until the
+// backoff elapses, while a row with no attempts (or an elapsed next_retry_at) is
+// due. This is what stops the sync daemon re-posting a just-deferred row.
+func TestPendingBatchDueExcludesFutureBackoff(t *testing.T) {
+	s := openTemp(t)
+	recA, pjA, phA := makeRecord(t, 1, "2026-07-08T10:00:00Z")
+	recB, pjB, phB := makeRecord(t, 2, "2026-07-08T10:00:01Z")
+	if err := s.Append(recA, pjA, phA); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Append(recB, pjB, phB); err != nil {
+		t.Fatal(err)
+	}
+
+	const now = "2026-07-08T12:00:00Z"
+	// A: deferred into the future — must be excluded.
+	if err := s.RecordAttempt(recA.EventID, 1, "2026-07-08T11:59:00Z", 500, "5xx", "2026-07-08T12:30:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	// B: an elapsed backoff — must be due again.
+	if err := s.RecordAttempt(recB.EventID, 1, "2026-07-08T11:00:00Z", 500, "5xx", "2026-07-08T11:30:00Z"); err != nil {
+		t.Fatal(err)
+	}
+
+	due, err := s.PendingBatchDue(10, now)
+	if err != nil {
+		t.Fatalf("PendingBatchDue: %v", err)
+	}
+	if len(due) != 1 || due[0].EventID != recB.EventID {
+		var ids []string
+		for _, e := range due {
+			ids = append(ids, e.EventID)
+		}
+		t.Fatalf("due set = %v, want only %s (A is backed off into the future)", ids, recB.EventID)
+	}
+
+	// After A's backoff elapses, both are due.
+	if all, _ := s.PendingBatchDue(10, "2026-07-08T13:00:00Z"); len(all) != 2 {
+		t.Fatalf("after backoff elapses both rows must be due; got %d", len(all))
+	}
+}
+
+func TestConcurrentAppend(t *testing.T) {
+	s := openTemp(t)
+	const n = 64
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			rec, pj, ph := makeRecord(t, i, "2026-07-08T10:00:00Z")
+			errs[i] = s.Append(rec, pj, ph)
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+	count, err := s.PendingCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != n {
+		t.Fatalf("want %d rows, got %d", n, count)
+	}
+}
+
+func TestMarkSynced(t *testing.T) {
+	s := openTemp(t)
+	rec, pj, ph := makeRecord(t, 2, "2026-07-08T10:00:00Z")
+	if err := s.Append(rec, pj, ph); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkSynced(rec.EventID, "2026-07-08T11:00:00Z"); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+	if n, _ := s.PendingCount(); n != 0 {
+		t.Fatalf("synced row must leave pending: got %d", n)
+	}
+	ev, ok, err := s.Get(rec.EventID)
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if ev.SyncStatus != 1 || ev.SyncedAt != "2026-07-08T11:00:00Z" {
+		t.Fatalf("mark-synced not persisted: %+v", ev)
+	}
+	// Idempotent re-mark.
+	if err := s.MarkSynced(rec.EventID, "2026-07-08T12:00:00Z"); err != nil {
+		t.Fatalf("re-MarkSynced: %v", err)
+	}
+}
+
+func TestWriteOnceEvidenceColumnsRejected(t *testing.T) {
+	s := openTemp(t)
+	rec, pj, ph := makeRecord(t, 3, "2026-07-08T10:00:00Z")
+	if err := s.Append(rec, pj, ph); err != nil {
+		t.Fatal(err)
+	}
+
+	// Direct mutation of an evidence column must ABORT via the trigger.
+	if _, err := s.db.Exec(`UPDATE audit_events SET decision='deny' WHERE event_id=?`, rec.EventID); err == nil {
+		t.Fatal("expected trigger to reject decision rewrite")
+	}
+	if _, err := s.db.Exec(`UPDATE audit_events SET signature_b64='forged' WHERE event_id=?`, rec.EventID); err == nil {
+		t.Fatal("expected trigger to reject signature rewrite")
+	}
+	if _, err := s.db.Exec(`UPDATE audit_events SET payload_json='{"tampered":true}' WHERE event_id=?`, rec.EventID); err == nil {
+		t.Fatal("expected trigger to reject payload_json rewrite")
+	}
+	// DELETE is forbidden entirely.
+	if _, err := s.db.Exec(`DELETE FROM audit_events WHERE event_id=?`, rec.EventID); err == nil {
+		t.Fatal("expected trigger to reject DELETE")
+	}
+
+	// Retention NULL-ing of payload_json is PERMITTED.
+	if _, err := s.db.Exec(`UPDATE audit_events SET payload_json=NULL WHERE event_id=?`, rec.EventID); err != nil {
+		t.Fatalf("retention null of payload_json must be permitted: %v", err)
+	}
+}
+
+func TestBackfillTranslogSeqOnceThenLocked(t *testing.T) {
+	s := openTemp(t)
+	rec, pj, ph := makeRecord(t, 4, "2026-07-08T10:00:00Z")
+	if err := s.Append(rec, pj, ph); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.BackfillTranslogSeq(rec.EventID, 5); err != nil {
+		t.Fatalf("first backfill: %v", err)
+	}
+	ev, _, _ := s.Get(rec.EventID)
+	if !ev.TranslogSeq.Valid || ev.TranslogSeq.Int64 != 5 {
+		t.Fatalf("translog_seq not set: %+v", ev.TranslogSeq)
+	}
+	// A second backfill via the guarded API is a no-op (WHERE seq IS NULL).
+	if err := s.BackfillTranslogSeq(rec.EventID, 6); err != nil {
+		t.Fatalf("guarded re-backfill should be a no-op: %v", err)
+	}
+	ev, _, _ = s.Get(rec.EventID)
+	if ev.TranslogSeq.Int64 != 5 {
+		t.Fatalf("guarded re-backfill changed seq to %d", ev.TranslogSeq.Int64)
+	}
+	// A direct rewrite of an already-set seq must ABORT via the trigger.
+	if _, err := s.db.Exec(`UPDATE audit_events SET translog_seq=6 WHERE event_id=?`, rec.EventID); err == nil {
+		t.Fatal("expected trigger to reject translog_seq rewrite once set")
+	}
+}
+
+func TestRecordAttempt(t *testing.T) {
+	s := openTemp(t)
+	rec, pj, ph := makeRecord(t, 5, "2026-07-08T10:00:00Z")
+	if err := s.Append(rec, pj, ph); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RecordAttempt(rec.EventID, 1, "2026-07-08T10:01:00Z", 503, "server busy", "2026-07-08T10:01:30Z"); err != nil {
+		t.Fatalf("RecordAttempt: %v", err)
+	}
+	if err := s.RecordAttempt(rec.EventID, 2, "2026-07-08T10:02:00Z", 0, "dial timeout", "2026-07-08T10:03:00Z"); err != nil {
+		t.Fatalf("RecordAttempt 2: %v", err)
+	}
+	// Replayed attempt number dedups.
+	if err := s.RecordAttempt(rec.EventID, 1, "x", 500, "dup", "y"); err != nil {
+		t.Fatalf("RecordAttempt dup: %v", err)
+	}
+	atts, err := s.Attempts(rec.EventID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(atts) != 2 {
+		t.Fatalf("want 2 attempts, got %d", len(atts))
+	}
+	if atts[0].HTTPStatus != 503 || atts[1].HTTPStatus != 0 {
+		t.Fatalf("attempt status mismatch: %+v", atts)
+	}
+	if atts[0].NextRetryAt != "2026-07-08T10:01:30Z" {
+		t.Fatalf("next_retry_at mismatch: %q", atts[0].NextRetryAt)
+	}
+}
+
+func TestSyncState(t *testing.T) {
+	s := openTemp(t)
+	if _, ok, _ := s.GetSyncState("high_water_seq"); ok {
+		t.Fatal("expected absent key")
+	}
+	if err := s.SetSyncState("high_water_seq", "42"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetSyncState("high_water_seq", "43"); err != nil {
+		t.Fatal(err)
+	}
+	v, ok, err := s.GetSyncState("high_water_seq")
+	if err != nil || !ok || v != "43" {
+		t.Fatalf("sync_state upsert: v=%q ok=%v err=%v", v, ok, err)
+	}
+}
+
+func TestCachesEpochMonotonic(t *testing.T) {
+	s := openTemp(t)
+	base := CacheEntry{Key: "self-roots", Epoch: 5, ContentDigest: "sha256:aa", PayloadJSON: `{"v":5}`}
+	if err := s.PutTrustCache(base); err != nil {
+		t.Fatalf("put epoch 5: %v", err)
+	}
+	// Higher epoch accepted.
+	if err := s.PutTrustCache(CacheEntry{Key: "self-roots", Epoch: 6, ContentDigest: "sha256:bb", PayloadJSON: `{"v":6}`}); err != nil {
+		t.Fatalf("put epoch 6: %v", err)
+	}
+	// Lower epoch rejected.
+	err := s.PutTrustCache(CacheEntry{Key: "self-roots", Epoch: 4, ContentDigest: "sha256:cc", PayloadJSON: `{"v":4}`})
+	if err != ErrEpochRegression {
+		t.Fatalf("want ErrEpochRegression, got %v", err)
+	}
+	got, ok, err := s.GetTrustCache("self-roots")
+	if err != nil || !ok {
+		t.Fatalf("GetTrustCache: ok=%v err=%v", ok, err)
+	}
+	if got.Epoch != 6 || got.PayloadJSON != `{"v":6}` {
+		t.Fatalf("stale write leaked through: %+v", got)
+	}
+	// Equal epoch is permitted (a re-fetch of the same head).
+	if err := s.PutPolicyCache(CacheEntry{Key: "p", Epoch: 1, ContentDigest: "d", PayloadJSON: "{}"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PutPolicyCache(CacheEntry{Key: "p", Epoch: 1, ContentDigest: "d", PayloadJSON: "{}"}); err != nil {
+		t.Fatalf("equal epoch should be permitted: %v", err)
+	}
+	// Revocation cache keyed on digest.
+	if err := s.PutRevocationCache(CacheEntry{Key: "sha256:evil", Epoch: 1, ContentDigest: "d", PayloadJSON: "{}"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.GetRevocationCache("sha256:evil"); !ok {
+		t.Fatal("revocation entry not found")
+	}
+}

--- a/pkg/skillctl/outbox/pragma_test.go
+++ b/pkg/skillctl/outbox/pragma_test.go
@@ -1,0 +1,64 @@
+// pragma_test.go proves the R-2.4 hot-path constraint on the PURE-GO (modernc)
+// driver path: with a competing writer holding the file's write lock, the hot
+// Append must return within the pinned busy_timeout (~250ms) — NEVER the 5000ms
+// house default (a 5s stall would freeze the hook and the harness could read the
+// non-return as ALLOW, AC-3). The caller then spools.
+//
+// This test is nocgo-only because the modernc `_pragma=` DSN pin is the path
+// that would silently fail if we relied on mattn's `_busy_timeout` spelling.
+//
+//go:build !cgo
+
+package outbox
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBusyTimeoutBoundedModernc(t *testing.T) {
+	home := t.TempDir()
+	s, err := Open(home)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+
+	// A SECOND independent handle to the same file (the cross-process
+	// contention R-2.4 addresses — each process has its own pinned connection).
+	blocker, err := openHotPathDB(DBPath(home))
+	if err != nil {
+		t.Fatalf("open blocker: %v", err)
+	}
+	defer blocker.Close()
+
+	tx, err := blocker.Begin()
+	if err != nil {
+		t.Fatalf("begin blocker tx: %v", err)
+	}
+	// Acquire and HOLD the WAL write lock.
+	if _, err := tx.Exec(`INSERT INTO sync_state(k,v) VALUES('lock','1')`); err != nil {
+		t.Fatalf("blocker write: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rec, pj, ph := makeRecord(t, 99, "2026-07-08T10:00:00Z")
+	start := time.Now()
+	err = s.Append(rec, pj, ph)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected SQLITE_BUSY while the write lock is held")
+	}
+	// The discriminator: 250ms pin returns fast; the 5000ms default would blow
+	// past 2s. A generous 2s ceiling keeps the test stable on slow CI.
+	if elapsed > 2*time.Second {
+		t.Fatalf("busy_timeout not pinned to ~250ms: Append took %v (house default would be ~5s)", elapsed)
+	}
+
+	// And the caller's fallback (spool) still records the row → decision returns
+	// regardless (R-2.4 / R-8.1 default).
+	if serr := s.Spool(rec, pj, ph); serr != nil {
+		t.Fatalf("spool fallback failed: %v", serr)
+	}
+}

--- a/pkg/skillctl/outbox/schema.go
+++ b/pkg/skillctl/outbox/schema.go
@@ -1,0 +1,112 @@
+// schema.go — DDL for the SPEC-0317 (R-2.3) transactional audit outbox.
+//
+// The store is the single AUTHORITATIVE system of record for signed skill
+// invocation evidence (R-2.5). Decided rows are write-once (R-2.6): the schema
+// enforces immutability with TRIGGERS — not convention — so a same-uid rewrite
+// of an evidence column ABORTs at the SQL layer. The only permitted mutations
+// are the sync bookkeeping (sync_status / synced_at), the one-shot translog_seq
+// backfill (NULL→value, per-sync-batch anchoring, R-4.2), and the retention
+// NULL-ing of payload_json (R-5.5). Everything else RAISE(ABORT)s.
+//
+// The flat columns (decision, refusal_code, identity, payload_hash …) are
+// NON-authoritative indices (R-2.6): any display/enforcement reconstructs the
+// canonical bytes from payload_json and re-verifies signature_b64. A
+// column↔payload divergence is itself a tamper signal the ingest flags.
+package outbox
+
+// pragmaWAL is executed once at migrate() time; WAL is persisted in the file
+// header so it survives reopen. It is kept SEPARATE from the per-connection
+// busy_timeout pin (driver_hook_*.go) which must be re-applied every connection.
+const pragmaWAL = `PRAGMA journal_mode=WAL;`
+
+// ddl is the full CREATE ... IF NOT EXISTS schema. Idempotent; safe to run on
+// every Open. Style mirrors pkg/tracking/retryqueue.go.
+const ddl = `
+CREATE TABLE IF NOT EXISTS audit_events (
+    event_id       TEXT PRIMARY KEY,          -- inv:<unix-ms>:<10-byte-hex>; the ONLY dedup key (R-4.1)
+    occurred_at    TEXT NOT NULL,             -- RFC3339 UTC
+    event_type     TEXT NOT NULL,             -- e.g. skill.invocation
+    tool           TEXT NOT NULL,             -- Skill | Bash | Read | Edit | Write
+    skill_digest   TEXT,                      -- sha256:<hex> or ''
+    skill_name     TEXT,
+    decision       TEXT NOT NULL,             -- allow | deny  (NON-authoritative index, R-2.6)
+    refusal_code   TEXT,                      -- stable token or ''
+    exit_code      INTEGER NOT NULL,
+    payload_json   TEXT,                      -- full signed InvocationRecord JSON (nullable ONLY by retention)
+    payload_hash   TEXT NOT NULL,             -- sha256 hex of canonical bytes (R-4.1 column, not in signed msg)
+    device_key_id  TEXT NOT NULL,
+    signature_b64  TEXT NOT NULL,             -- detached ed25519 over canonical bytes (authoritative)
+    translog_seq   INTEGER,                   -- Merkle leaf index; backfilled per sync batch (R-4.2)
+    sync_status    INTEGER NOT NULL DEFAULT 0,-- 0 unsynced, 1 synced
+    synced_at      TEXT,
+    created_at     TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_audit_events_sync ON audit_events(sync_status, occurred_at);
+CREATE INDEX IF NOT EXISTS idx_audit_events_seq  ON audit_events(translog_seq);
+
+-- Write-once evidence (R-2.6): the only permitted mutations are sync_status /
+-- synced_at, the translog_seq backfill (NULL->value once), and the retention
+-- NULL-ing of payload_json (R-5.5). Any other change to an evidence column
+-- ABORTs the UPDATE.
+CREATE TRIGGER IF NOT EXISTS audit_events_immutable
+BEFORE UPDATE ON audit_events
+BEGIN
+  SELECT CASE WHEN
+       OLD.event_id      <> NEW.event_id
+    OR OLD.occurred_at   <> NEW.occurred_at
+    OR OLD.event_type    <> NEW.event_type
+    OR OLD.tool          <> NEW.tool
+    OR OLD.decision      <> NEW.decision
+    OR OLD.exit_code     <> NEW.exit_code
+    OR OLD.refusal_code  IS NOT NEW.refusal_code
+    OR OLD.skill_digest  IS NOT NEW.skill_digest
+    OR OLD.skill_name    IS NOT NEW.skill_name
+    OR OLD.payload_hash  <> NEW.payload_hash
+    OR OLD.device_key_id <> NEW.device_key_id
+    OR OLD.signature_b64 <> NEW.signature_b64
+    OR OLD.created_at    <> NEW.created_at
+    OR (OLD.translog_seq IS NOT NULL AND OLD.translog_seq <> NEW.translog_seq) -- seq backfills once
+  THEN RAISE(ABORT, 'audit_events: evidence columns are write-once') END;
+  SELECT CASE WHEN NEW.payload_json IS NOT NULL AND NEW.payload_json <> OLD.payload_json
+  THEN RAISE(ABORT, 'audit_events: payload_json is write-once (retention may only NULL it)') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_events_no_delete
+BEFORE DELETE ON audit_events
+BEGIN
+  SELECT RAISE(ABORT, 'audit_events: rows are never deleted; retention nulls payload_json only');
+END;
+
+CREATE TABLE IF NOT EXISTS sync_state (
+    k TEXT PRIMARY KEY,   -- high_water_seq | last_success_ts | endpoint_epoch | ingest_pubkey
+    v TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS delivery_attempts (
+    event_id      TEXT NOT NULL,
+    attempt       INTEGER NOT NULL,
+    at            TEXT NOT NULL,
+    http_status   INTEGER,
+    error         TEXT,
+    next_retry_at TEXT,                                  -- retryqueue.go backoff 30s->1h cap 10
+    PRIMARY KEY (event_id, attempt),
+    FOREIGN KEY (event_id) REFERENCES audit_events(event_id)
+);
+CREATE INDEX IF NOT EXISTS idx_delivery_attempts_next ON delivery_attempts(next_retry_at);
+
+-- Table-backed successors to verdicts.json / gate-policy.yaml / revoked-*.json
+-- (R-2.3): same signed-HEAD + epoch-monotonic + content-digest semantics (R-7).
+-- Loose files remain the migration source + fallback read. epoch is monotonic;
+-- a write with a lower epoch than stored is rejected in Go (caches.go).
+CREATE TABLE IF NOT EXISTS trust_cache (
+    name TEXT PRIMARY KEY, epoch INTEGER NOT NULL, issued_at TEXT, content_digest TEXT NOT NULL,
+    signed_head_b64 TEXT, payload_json TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS policy_cache (
+    name TEXT PRIMARY KEY, epoch INTEGER NOT NULL, issued_at TEXT, content_digest TEXT NOT NULL,
+    signed_head_b64 TEXT, payload_json TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS revocation_cache (
+    digest TEXT PRIMARY KEY, epoch INTEGER NOT NULL, issued_at TEXT, content_digest TEXT NOT NULL,
+    signed_head_b64 TEXT, payload_json TEXT NOT NULL, updated_at TEXT NOT NULL
+);`

--- a/pkg/skillctl/outbox/spool.go
+++ b/pkg/skillctl/outbox/spool.go
@@ -1,0 +1,135 @@
+// spool.go — the bounded JSONL fallback for R-2.4 hot-path safety.
+//
+// When Append can't reach the db (SQLITE_BUSY at the ~250ms pin, or an open
+// failure), the caller spools the row here so the DECISION RETURNS REGARDLESS
+// (R-2.4 / R-8.1 default). The spool is a single O_APPEND Write per line (0600),
+// which is cross-process atomic for lines below PIPE_BUF — the same discipline
+// the invocation-trail.jsonl appender uses. The next sync/enforce Reconcile
+// drains it into audit_events in occurred_at order (R-2.5).
+//
+// NOT-YET-BUILT (AC-5a): per-batch translog anchoring — stamping translog_seq and
+// emitting a signed tree head so the local trail becomes tamper-EVIDENT — is not
+// wired. BackfillTranslogSeq exists and is unit-tested, but NOTHING in the
+// sync/enforce drain calls it, so translog_seq stays NULL in production and there
+// is no local-monotonicity guarantee to preserve here. The tamper-detection claim
+// is therefore scoped to the sync DURABLE-SEQ path (a row is marked synced only on
+// a VALID counter-signed durable-seq ack), NOT to local translog monotonicity.
+// Reconcile only ORDERS rows by occurred_at; it does not anchor.
+package outbox
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+)
+
+// spoolEntry is the on-disk envelope: the full signed record plus the two
+// derivations Append needs. Storing payload_json/payload_hash here (rather than
+// re-deriving on reconcile) pins the exact bytes once so the spooled row and a
+// directly-appended row are byte-identical (no per-sink divergence).
+type spoolEntry struct {
+	Record      skillgate.InvocationRecord `json:"record"`
+	PayloadJSON string                     `json:"payload_json"`
+	PayloadHash string                     `json:"payload_hash"`
+}
+
+// SpoolPath is the fallback file beside outbox.db.
+func (s *Store) SpoolPath() string { return filepath.Join(s.dir, "spool.jsonl") }
+
+// Spool appends one row to spool.jsonl as a single O_APPEND Write (0600). It is
+// the fallback the caller invokes when Append fails; it performs no db I/O so it
+// cannot itself stall on the lock that made Append fail.
+func (s *Store) Spool(rec skillgate.InvocationRecord, payloadJSON, payloadHash string) error {
+	line, err := json.Marshal(spoolEntry{Record: rec, PayloadJSON: payloadJSON, PayloadHash: payloadHash})
+	if err != nil {
+		return fmt.Errorf("outbox: spool marshal: %w", err)
+	}
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("outbox: spool mkdir: %w", err)
+	}
+	f, err := os.OpenFile(s.SpoolPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("outbox: spool open: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("outbox: spool write: %w", err)
+	}
+	return nil
+}
+
+// Reconcile drains spool.jsonl into audit_events in occurred_at order and, on
+// success, removes the spool file. It is idempotent end-to-end: each row is an
+// INSERT OR IGNORE keyed on event_id, so a crash between the inserts and the
+// unlink just replays the same no-ops on the next Reconcile. Returns the number
+// of rows drained (distinct inserts attempted, including dedup no-ops).
+//
+// Ordering (R-2.5): rows are sorted by occurred_at (then event_id) before insert
+// so a FUTURE translog anchor (AC-5a, NOT-YET-BUILT) could stamp translog_seq in a
+// stable order; today nothing anchors, so this ordering only fixes the insert
+// order of spilled rows. A malformed line is SKIPPED (counted) rather than
+// aborting the whole drain — one bad line must not strand the rest of the queue.
+func (s *Store) Reconcile() (drained int, err error) {
+	path := s.SpoolPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil // nothing spooled
+		}
+		return 0, fmt.Errorf("outbox: reconcile read: %w", err)
+	}
+
+	var (
+		entries []spoolEntry
+		skipped int
+	)
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
+	for sc.Scan() {
+		raw := bytes.TrimSpace(sc.Bytes())
+		if len(raw) == 0 {
+			continue
+		}
+		var e spoolEntry
+		if uerr := json.Unmarshal(raw, &e); uerr != nil || e.Record.EventID == "" {
+			skipped++
+			continue
+		}
+		entries = append(entries, e)
+	}
+	if serr := sc.Err(); serr != nil {
+		return 0, fmt.Errorf("outbox: reconcile scan: %w", serr)
+	}
+
+	// occurred_at order (R-2.5), stable on event_id.
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Record.OccurredAt != entries[j].Record.OccurredAt {
+			return entries[i].Record.OccurredAt < entries[j].Record.OccurredAt
+		}
+		return entries[i].Record.EventID < entries[j].Record.EventID
+	})
+
+	for _, e := range entries {
+		if aerr := s.Append(e.Record, e.PayloadJSON, e.PayloadHash); aerr != nil {
+			// The db is still contended — leave the spool in place so a later
+			// Reconcile retries (idempotent). Report what we managed to drain.
+			return drained, fmt.Errorf("outbox: reconcile append: %w", aerr)
+		}
+		drained++
+	}
+
+	// All rows landed (dedup no-ops included). Remove the spool; a fresh failure
+	// re-creates it. Skipped malformed lines are dropped with the file — they are
+	// unusable evidence by definition (no valid event_id to anchor).
+	if rerr := os.Remove(path); rerr != nil && !os.IsNotExist(rerr) {
+		return drained, fmt.Errorf("outbox: reconcile cleanup: %w", rerr)
+	}
+	_ = skipped
+	return drained, nil
+}

--- a/pkg/skillctl/outbox/spool_test.go
+++ b/pkg/skillctl/outbox/spool_test.go
@@ -1,0 +1,129 @@
+package outbox
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSpoolThenReconcileOrdersByOccurredAt(t *testing.T) {
+	s := openTemp(t)
+
+	// Spool three rows OUT of occurred_at order.
+	recC, pjC, phC := makeRecord(t, 30, "2026-07-08T10:03:00Z")
+	recA, pjA, phA := makeRecord(t, 10, "2026-07-08T10:01:00Z")
+	recB, pjB, phB := makeRecord(t, 20, "2026-07-08T10:02:00Z")
+	if err := s.Spool(recC, pjC, phC); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Spool(recA, pjA, phA); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Spool(recB, pjB, phB); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(s.SpoolPath()); err != nil {
+		t.Fatalf("spool file should exist: %v", err)
+	}
+
+	drained, err := s.Reconcile()
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if drained != 3 {
+		t.Fatalf("want 3 drained, got %d", drained)
+	}
+
+	// Spool file removed after a clean drain.
+	if _, err := os.Stat(s.SpoolPath()); !os.IsNotExist(err) {
+		t.Fatalf("spool file should be gone after reconcile: %v", err)
+	}
+
+	batch, err := s.PendingBatch(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch) != 3 {
+		t.Fatalf("want 3 rows, got %d", len(batch))
+	}
+	// PendingBatch orders by occurred_at ASC → A, B, C.
+	wantOrder := []string{recA.EventID, recB.EventID, recC.EventID}
+	for i, id := range wantOrder {
+		if batch[i].EventID != id {
+			t.Fatalf("row %d: want %s got %s", i, id, batch[i].EventID)
+		}
+	}
+}
+
+func TestReconcileIdempotentAndDedups(t *testing.T) {
+	s := openTemp(t)
+	rec, pj, ph := makeRecord(t, 40, "2026-07-08T10:00:00Z")
+
+	// Same row directly appended AND spooled → reconcile must dedup on event_id.
+	if err := s.Append(rec, pj, ph); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Spool(rec, pj, ph); err != nil {
+		t.Fatal(err)
+	}
+	drained, err := s.Reconcile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if drained != 1 {
+		t.Fatalf("want 1 drained, got %d", drained)
+	}
+	if n, _ := s.PendingCount(); n != 1 {
+		t.Fatalf("dedup failed: want 1 row got %d", n)
+	}
+
+	// Reconcile on an empty/absent spool is a clean no-op.
+	drained, err = s.Reconcile()
+	if err != nil {
+		t.Fatalf("reconcile empty: %v", err)
+	}
+	if drained != 0 {
+		t.Fatalf("want 0 drained on empty spool, got %d", drained)
+	}
+}
+
+func TestReconcileSkipsMalformedLine(t *testing.T) {
+	s := openTemp(t)
+	rec, pj, ph := makeRecord(t, 50, "2026-07-08T10:00:00Z")
+	if err := s.Spool(rec, pj, ph); err != nil {
+		t.Fatal(err)
+	}
+	// Append a garbage line directly to the spool file.
+	f, err := os.OpenFile(s.SpoolPath(), os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString("{not json\n")
+	_ = f.Close()
+
+	drained, err := s.Reconcile()
+	if err != nil {
+		t.Fatalf("Reconcile should skip garbage, not fail: %v", err)
+	}
+	if drained != 1 {
+		t.Fatalf("want 1 valid row drained, got %d", drained)
+	}
+	if n, _ := s.PendingCount(); n != 1 {
+		t.Fatalf("want 1 row, got %d", n)
+	}
+}
+
+func TestAppendOrSpoolUsesDBWhenHealthy(t *testing.T) {
+	s := openTemp(t)
+	rec, pj, ph := makeRecord(t, 60, "2026-07-08T10:00:00Z")
+	if err := s.AppendOrSpool(rec, pj, ph); err != nil {
+		t.Fatalf("AppendOrSpool: %v", err)
+	}
+	// Healthy db → no spool file created.
+	if _, err := os.Stat(s.SpoolPath()); !os.IsNotExist(err) {
+		t.Fatalf("healthy AppendOrSpool must not spool: %v", err)
+	}
+	if n, _ := s.PendingCount(); n != 1 {
+		t.Fatalf("want 1 row, got %d", n)
+	}
+}

--- a/pkg/skillctl/statemachine/statemachine.go
+++ b/pkg/skillctl/statemachine/statemachine.go
@@ -1,0 +1,371 @@
+// Package statemachine implements SPEC-0317 R-7: the named offline state
+// machine that makes skillctl's fail-open/fail-closed posture EXPLICIT.
+//
+// It is a pure, stdlib-only leaf: Compute maps
+//
+//	(connectivity × cache ages × anchor presence × trust-basis presence)
+//
+// to one of four named states — online / degraded / offline / locked — via an
+// INJECTABLE clock. It holds NO state, touches NO filesystem, and reaches NO
+// network; the caller gathers the Inputs (cache issued-at → ages against the
+// injected clock, reachability probe, trust-basis file sweep) and this package
+// decides.
+//
+// What this package IS (R-7.4): the state machine introduces NO second decision
+// ladder. It only supplies the `online` flag that gates the R-1.3 online
+// fallback (AllowOnlineFallback) plus two advisory predicates
+// (HighRiskFailsClosed, DenyAllManaged) that MIRROR — never replace — the
+// authoritative freshness.go R3 floor and the SPEC-0247 unmanaged=allow default.
+// The precedence remains the one R-1.3 ladder: emergency deny-list > allowlist >
+// revoked/revocation staleness > verdict cache > unmanaged policy > state
+// default.
+//
+// Three load-bearing invariants (the day-one brick traps this file must NOT
+// fall into):
+//
+//   - NEVER-BRICK (R-7.1/7.2): a healthy self/ER1 sidecar-only host with fresh
+//     caches computes online (or degraded when disconnected), NEVER locked.
+//     `trust basis present` INCLUDES the SPEC-0225 self/ER1 roots and the
+//     `.m3c-provenance` sidecar — not only the SPEC-0188 skill-trust-roots.yaml
+//     (legitimately absent on self hosts). The caller folds all of those into
+//     Inputs.TrustBasisPresent.
+//
+//   - LOCKED IS OPT-IN (R-7.2, AC-7): `locked = deny all managed skills` is
+//     enterprise policy ONLY. A fresh / unmanaged / air-gapped machine WITHOUT
+//     an enterprise profile (OfflinePolicy.Enterprise == false) NEVER enters
+//     locked — the shipped unmanaged=allow default is untouched.
+//
+//   - EMERGENCY IS EXEMPT (R-7.3, AC-7): the emergency deny-list is exempt from
+//     cache expiry and from the state machine. EmergencyActive is a pure
+//     passthrough that deliberately does NOT take the state as an input, so no
+//     state (not even locked/offline with everything expired) can suppress the
+//     compromise channel.
+package statemachine
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// State is the named offline posture (SPEC-0317 R-7.1). Compute is TOTAL: it
+// always returns exactly one of these four, so the zero value is never produced
+// by omission. The ordering is a severity ladder (online → locked) but carries
+// no arithmetic meaning; branch on the named constants, never on the int.
+type State int
+
+const (
+	// StateOnline — the registry is reachable, so the online verify fallback is
+	// available. The fully healthy posture. This is the ONLY state in which the
+	// R-1.4 online fallback may run.
+	StateOnline State = iota
+
+	// StateDegraded — the registry is unreachable BUT the policy / trust /
+	// revocation caches are all fresh within the configured max_*_age ceilings.
+	// The hot path is strictly local; local decisions are trustworthy because
+	// the caches are current.
+	StateDegraded
+
+	// StateOffline — caches are present but AGING past their ceilings. The hot
+	// path is strictly local and high-risk actions fail closed per SPEC-0279
+	// (enforced by freshness.go — this state only NAMES the posture).
+	StateOffline
+
+	// StateLocked — there is NO trust basis at all AND an enterprise profile has
+	// opted in. Deny all managed skills (exit 28 `offline_locked`). NEVER reached
+	// without OfflinePolicy.Enterprise, so it can never brick a self / unmanaged /
+	// air-gapped host (R-7.2).
+	StateLocked
+)
+
+// MarshalJSON emits the human label ("online", …) rather than the int, so a
+// StateDecision and any downstream console read a stable token (mirrors
+// pin.Level.MarshalJSON).
+func (s State) MarshalJSON() ([]byte, error) { return json.Marshal(s.String()) }
+
+// String returns the stable lower-case label used in `session-baseline` output,
+// audit records, and any downstream console. Keep these tokens stable — they are
+// an additive contract.
+func (s State) String() string {
+	switch s {
+	case StateOnline:
+		return "online"
+	case StateDegraded:
+		return "degraded"
+	case StateOffline:
+		return "offline"
+	case StateLocked:
+		return "locked"
+	default:
+		return "unknown"
+	}
+}
+
+// OfflinePolicy is the RESOLVED (parsed + defaulted) offline policy that gates
+// the state machine. It is the stdlib-only counterpart of the YAML
+// `offline_policy` block on verify.TrustRoot (R-7.3); verify parses its
+// duration strings once at Load and hands this over. Constructed by
+// verify.TrustRoot.ResolvedOfflinePolicy(); never assembled by hand outside
+// tests.
+//
+// The zero value is the SHIPPED DEFAULT: not enterprise, no cache ceilings
+// (0 == "no ceiling" → caches never expire the posture), unmanaged=allow. A host
+// with no offline_policy block therefore computes online/degraded and NEVER
+// locked — exactly the day-one plugin-compat behaviour.
+type OfflinePolicy struct {
+	// AllowCachedTrustedSkills allows a cached, trust-verified skill to run while
+	// disconnected (degraded/offline). Advisory to the decision ladder; the state
+	// machine does not itself gate on it.
+	AllowCachedTrustedSkills bool
+
+	// DenyUnknownSkills denies a skill with no cached trust basis while
+	// disconnected. It flips the unmanaged=allow default for UNKNOWN skills only;
+	// it does NOT by itself produce the `locked` state (that needs Enterprise +
+	// no-trust-basis). Advisory to the decision ladder.
+	DenyUnknownSkills bool
+
+	// MaxPolicyCacheAge bounds the policy cache AND the trust cache freshness.
+	// Zero == no ceiling (never stale). A snapshot older than this pushes the
+	// disconnected posture from degraded to offline.
+	MaxPolicyCacheAge time.Duration
+
+	// MaxRevocationCacheAge bounds the revocation cache freshness. Zero == no
+	// ceiling. NOTE: this bounds the ORDINARY revocation cache only — the
+	// emergency deny-list is EXEMPT (see EmergencyActive).
+	MaxRevocationCacheAge time.Duration
+
+	// RequireLocalAudit is the SPEC-0317 R-8 inversion of the SPEC-0255
+	// decision-invariance contract. It is ENTERPRISE-ONLY (verify.Load rejects it
+	// without Enterprise) and is consumed by the enforce path, not by Compute.
+	// Carried here so the resolved policy is one surface.
+	RequireLocalAudit bool
+
+	// Enterprise gates the two consequential knobs: it is the opt-in that enables
+	// the `locked` state and permits RequireLocalAudit. Without it the host can
+	// NEVER lock — the never-brick guard lives HERE and in Compute.
+	Enterprise bool
+}
+
+// Inputs is the pure snapshot Compute maps to a State. The caller gathers it
+// against a single INJECTED clock (Now): the cache *Age fields are that clock
+// minus each cache's issued_at, and Now is retained so Decide can stamp an
+// auditable record with the exact clock the posture was computed at (SPEC-0279
+// R6 "every state decision is audited").
+type Inputs struct {
+	// RegistryReachable is the result of the caller's reachability probe. It is
+	// THE discriminator between online and the disconnected ladder: reachable →
+	// online (the fallback is available); unreachable → degraded/offline/locked.
+	RegistryReachable bool
+
+	// PolicyAge is now - policy_cache.issued_at. Negative (future-dated) values
+	// are treated fail-safe as stale (see ageFresh).
+	PolicyAge time.Duration
+
+	// RevocationAge is now - revocation_cache.issued_at (ordinary list; the
+	// emergency channel is exempt).
+	RevocationAge time.Duration
+
+	// TrustAge is now - trust_cache.issued_at. Bounded by MaxPolicyCacheAge.
+	TrustAge time.Duration
+
+	// AnchorPresent reports whether a translog anchor (STH) is present. It counts
+	// toward "some trust basis exists" for the locked guard, but note (per the
+	// SPEC threat model) a purely-local anchor is only tamper-EVIDENT once
+	// witnessed off-box; it is not itself a freshness signal here.
+	AnchorPresent bool
+
+	// TrustBasisPresent is the folded-in "is ANY trust basis present" flag. The
+	// caller sets it true if ANY of: SPEC-0188 skill-trust-roots.yaml, the
+	// SPEC-0225 self/ER1 trust-roots, OR a .m3c-provenance sidecar is present.
+	// This breadth is what stops a self/ER1 sidecar-only host from bricking.
+	TrustBasisPresent bool
+
+	// Now is the injected clock at which the snapshot was taken. Used for the
+	// audit record (Decide); the age comparisons use the *Age fields, which the
+	// caller derived from this same clock.
+	Now time.Time
+}
+
+// Compute is the pure state function (SPEC-0317 R-7.1). It is TOTAL and has no
+// side effects.
+//
+// Precedence (this is a VIEW of the R-1.3 ladder's state-default rung, not a new
+// ladder — R-7.4):
+//
+//  1. locked  — ENTERPRISE opt-in AND no trust basis at all. Checked first
+//     because "no policy basis" is the most severe posture. The Enterprise gate
+//     is the never-brick guard: a non-enterprise host can never reach this rung.
+//  2. online  — the registry is reachable, so the online fallback is available.
+//     Reachability is the discriminator; a reachable host can always refresh, so
+//     it is online regardless of current cache age.
+//  3. degraded — disconnected but every cache is fresh within its ceiling.
+//  4. offline — disconnected and at least one cache is aging past its ceiling
+//     (high-risk fails closed per SPEC-0279, enforced downstream).
+func Compute(in Inputs, pol OfflinePolicy) State {
+	// (1) locked — enterprise opt-in ONLY, and only with NO trust basis at all.
+	// `trust basis present` is broad (SPEC-0188 roots OR self/ER1 roots OR the
+	// .m3c-provenance sidecar OR a translog anchor), folded by the caller into
+	// TrustBasisPresent / AnchorPresent. A self / unmanaged / air-gapped host —
+	// or ANY non-enterprise host — therefore never locks.
+	if pol.Enterprise && !hasTrustBasis(in) {
+		return StateLocked
+	}
+
+	// (2) online — the registry is reachable: the R-1.4 online fallback is
+	// available. A reachable host can always re-sync, so cache age does not
+	// demote it below online.
+	if in.RegistryReachable {
+		return StateOnline
+	}
+
+	// (3) degraded — disconnected but caches fresh within the configured ceilings.
+	if cachesFresh(in, pol) {
+		return StateDegraded
+	}
+
+	// (4) offline — disconnected and caches aging past a ceiling.
+	return StateOffline
+}
+
+// hasTrustBasis reports whether ANY trust basis is present. Deliberately broad
+// (R-7.1): a translog anchor OR any of the folded-in root/sidecar sources counts.
+func hasTrustBasis(in Inputs) bool {
+	return in.TrustBasisPresent || in.AnchorPresent
+}
+
+// cachesFresh reports whether the policy, trust, and (ordinary) revocation
+// caches are all within their configured ceilings. A zero ceiling means "no
+// ceiling" → that cache never counts as stale. The trust cache is bounded by the
+// policy ceiling (R-7.3 documents only max_policy_cache_age / max_revocation_
+// cache_age; trust roots ride the policy ceiling).
+func cachesFresh(in Inputs, pol OfflinePolicy) bool {
+	if !ageFresh(in.PolicyAge, pol.MaxPolicyCacheAge) {
+		return false
+	}
+	if !ageFresh(in.TrustAge, pol.MaxPolicyCacheAge) {
+		return false
+	}
+	if !ageFresh(in.RevocationAge, pol.MaxRevocationCacheAge) {
+		return false
+	}
+	return true
+}
+
+// maxFutureSkew is how far a cache's issued_at may sit in the FUTURE relative to
+// the injected clock (a negative age) before it is treated as dishonest. A small
+// skew (NTP jitter, sub-second rounding) is tolerated; beyond it the cache is
+// treated as stale (fail-safe), mirroring freshness.go's maxFutureClockSkew — a
+// future-dated cache must not "look fresh forever".
+const maxFutureSkew = 5 * time.Minute
+
+// ageFresh reports whether an age is within a ceiling. Zero (or negative)
+// ceiling means "no ceiling" → always fresh. A future-dated cache (age below
+// -maxFutureSkew) is treated as STALE (fail-safe toward the more restrictive
+// offline posture), never as freshest-possible.
+func ageFresh(age, ceiling time.Duration) bool {
+	if ceiling <= 0 {
+		return true // no ceiling configured
+	}
+	if age < -maxFutureSkew {
+		return false // dishonest future-dated cache → treat as stale
+	}
+	if age < 0 {
+		age = 0 // tolerate small clock skew
+	}
+	return age <= ceiling
+}
+
+// AllowOnlineFallback reports whether the R-1.3 online fallback may run in the
+// given state (SPEC-0317 R-1.4 P2, opt-in). ONLY `online` permits it; in
+// degraded / offline / locked the hot path is strictly local. This is the single
+// flag the state machine feeds the ladder — it does NOT reorder the ladder.
+func AllowOnlineFallback(s State) bool { return s == StateOnline }
+
+// DenyAllManaged reports whether the state denies ALL managed skills. ONLY
+// `locked` does (enterprise opt-in, exit 28 `offline_locked`). It NEVER affects
+// unmanaged skills — the shipped unmanaged=allow default is untouched (R-7.2).
+// Because Compute only returns locked under Enterprise, this can never brick a
+// non-enterprise host.
+func DenyAllManaged(s State) bool { return s == StateLocked }
+
+// HighRiskFailsClosed reports whether high-risk actions fail closed in the given
+// state. True for offline and locked; false for online and degraded (degraded
+// caches are fresh, so cached trust decisions stand). This MIRRORS the
+// authoritative SPEC-0279 freshness.go R3 floor for display/gating; it is NOT the
+// enforcer — freshness.go remains the one place high-risk fail-closed is applied
+// (R-7.4). A defensive default: any unrecognised (never-produced) state also
+// fails closed.
+func HighRiskFailsClosed(s State) bool {
+	return s != StateOnline && s != StateDegraded
+}
+
+// EmergencyActive reports whether the emergency deny-list is in force. It is a
+// PURE PASSTHROUGH of emergencyPresent — the state is intentionally the blank
+// parameter so this signature documents, at the type level, that NO state may
+// suppress the compromise channel (R-7.3, AC-7). The emergency deny-list is
+// EXEMPT from cache expiry: an old-but-valid emergency list still denies in
+// EVERY state, including locked and fully-expired offline. The decision ladder
+// evaluates emergency FIRST (R-7.4), before this package's state is even
+// consulted.
+func EmergencyActive(emergencyPresent bool, _ State) bool { return emergencyPresent }
+
+// StateDecision is the auditable record of one Compute evaluation (SPEC-0279 R6
+// pattern: every state decision is audited). The session-baseline verb and the
+// gate emit it; it is a projection, never a trust input.
+type StateDecision struct {
+	// State is the computed posture.
+	State State `json:"state"`
+	// RegistryReachable echoes the connectivity input.
+	RegistryReachable bool `json:"registry_reachable"`
+	// TrustBasisPresent echoes the folded trust-basis input.
+	TrustBasisPresent bool `json:"trust_basis_present"`
+	// AnchorPresent echoes the translog-anchor input.
+	AnchorPresent bool `json:"anchor_present"`
+	// Enterprise echoes whether the enterprise profile is engaged.
+	Enterprise bool `json:"enterprise"`
+	// PolicyAgeSeconds / RevocationAgeSeconds / TrustAgeSeconds are the measured
+	// cache ages (seconds; negative clamped to 0) at the injected clock.
+	PolicyAgeSeconds     int64 `json:"policy_age_seconds"`
+	RevocationAgeSeconds int64 `json:"revocation_age_seconds"`
+	TrustAgeSeconds      int64 `json:"trust_age_seconds"`
+	// AllowOnlineFallback / HighRiskFailsClosed / DenyAllManaged are the resolved
+	// posture predicates, materialised so a console need not re-derive them.
+	AllowOnlineFallback bool `json:"allow_online_fallback"`
+	HighRiskFailsClosed bool `json:"high_risk_fails_closed"`
+	DenyAllManaged      bool `json:"deny_all_managed"`
+	// ComputedAt is the injected clock (RFC3339 UTC) the posture was computed at.
+	ComputedAt string `json:"computed_at"`
+}
+
+// Decide computes the State and returns it alongside a fully-populated auditable
+// StateDecision. It is the same pure function as Compute (Decide.State ==
+// Compute(in, pol)); the record is a convenience for the audited callers.
+func Decide(in Inputs, pol OfflinePolicy) StateDecision {
+	s := Compute(in, pol)
+	computedAt := ""
+	if !in.Now.IsZero() {
+		computedAt = in.Now.UTC().Format(time.RFC3339)
+	}
+	return StateDecision{
+		State:                s,
+		RegistryReachable:    in.RegistryReachable,
+		TrustBasisPresent:    in.TrustBasisPresent,
+		AnchorPresent:        in.AnchorPresent,
+		Enterprise:           pol.Enterprise,
+		PolicyAgeSeconds:     clampSeconds(in.PolicyAge),
+		RevocationAgeSeconds: clampSeconds(in.RevocationAge),
+		TrustAgeSeconds:      clampSeconds(in.TrustAge),
+		AllowOnlineFallback:  AllowOnlineFallback(s),
+		HighRiskFailsClosed:  HighRiskFailsClosed(s),
+		DenyAllManaged:       DenyAllManaged(s),
+		ComputedAt:           computedAt,
+	}
+}
+
+// clampSeconds renders a duration as whole seconds, clamping a negative
+// (future-dated) age to 0 for the record.
+func clampSeconds(d time.Duration) int64 {
+	if d < 0 {
+		return 0
+	}
+	return int64(d / time.Second)
+}

--- a/pkg/skillctl/statemachine/statemachine_test.go
+++ b/pkg/skillctl/statemachine/statemachine_test.go
@@ -1,0 +1,293 @@
+package statemachine
+
+import (
+	"testing"
+	"time"
+)
+
+// A fixed injected clock; the state machine must never reach for time.Now().
+var testNow = time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+
+// enterprisePol is a representative enterprise profile with 24h ceilings.
+func enterprisePol() OfflinePolicy {
+	return OfflinePolicy{
+		Enterprise:            true,
+		MaxPolicyCacheAge:     24 * time.Hour,
+		MaxRevocationCacheAge: 24 * time.Hour,
+	}
+}
+
+// TestCompute_TableStates exercises the four states across the input matrix.
+func TestCompute_TableStates(t *testing.T) {
+	fresh := 1 * time.Hour
+	stale := 48 * time.Hour
+
+	cases := []struct {
+		name string
+		in   Inputs
+		pol  OfflinePolicy
+		want State
+	}{
+		{
+			name: "reachable + fresh + basis → online",
+			in:   Inputs{RegistryReachable: true, PolicyAge: fresh, RevocationAge: fresh, TrustAge: fresh, TrustBasisPresent: true, Now: testNow},
+			pol:  enterprisePol(),
+			want: StateOnline,
+		},
+		{
+			name: "reachable but stale caches → still online (can refresh)",
+			in:   Inputs{RegistryReachable: true, PolicyAge: stale, RevocationAge: stale, TrustAge: stale, TrustBasisPresent: true, Now: testNow},
+			pol:  enterprisePol(),
+			want: StateOnline,
+		},
+		{
+			name: "disconnected + fresh → degraded",
+			in:   Inputs{RegistryReachable: false, PolicyAge: fresh, RevocationAge: fresh, TrustAge: fresh, TrustBasisPresent: true, Now: testNow},
+			pol:  enterprisePol(),
+			want: StateDegraded,
+		},
+		{
+			name: "disconnected + stale policy → offline",
+			in:   Inputs{RegistryReachable: false, PolicyAge: stale, RevocationAge: fresh, TrustAge: fresh, TrustBasisPresent: true, Now: testNow},
+			pol:  enterprisePol(),
+			want: StateOffline,
+		},
+		{
+			name: "disconnected + stale revocation → offline",
+			in:   Inputs{RegistryReachable: false, PolicyAge: fresh, RevocationAge: stale, TrustAge: fresh, TrustBasisPresent: true, Now: testNow},
+			pol:  enterprisePol(),
+			want: StateOffline,
+		},
+		{
+			name: "disconnected + stale trust → offline",
+			in:   Inputs{RegistryReachable: false, PolicyAge: fresh, RevocationAge: fresh, TrustAge: stale, TrustBasisPresent: true, Now: testNow},
+			pol:  enterprisePol(),
+			want: StateOffline,
+		},
+		{
+			name: "enterprise + no trust basis at all → locked",
+			in:   Inputs{RegistryReachable: false, TrustBasisPresent: false, AnchorPresent: false, Now: testNow},
+			pol:  enterprisePol(),
+			want: StateLocked,
+		},
+		{
+			name: "enterprise + no basis but reachable → still locked (no basis to verify)",
+			in:   Inputs{RegistryReachable: true, TrustBasisPresent: false, AnchorPresent: false, Now: testNow},
+			pol:  enterprisePol(),
+			want: StateLocked,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Compute(c.in, c.pol); got != c.want {
+				t.Fatalf("Compute = %s, want %s", got, c.want)
+			}
+		})
+	}
+}
+
+// TestCompute_NeverBrick_SelfER1SidecarOnly is the load-bearing R-7.1/7.2 case:
+// a self/ER1 host that has NO SPEC-0188 skill-trust-roots.yaml but DOES have a
+// .m3c-provenance sidecar (folded into TrustBasisPresent) must compute
+// online/degraded and NEVER locked — even under an enterprise profile.
+func TestCompute_NeverBrick_SelfER1SidecarOnly(t *testing.T) {
+	sidecarOnly := Inputs{
+		RegistryReachable: false,
+		PolicyAge:         1 * time.Hour,
+		RevocationAge:     1 * time.Hour,
+		TrustAge:          1 * time.Hour,
+		TrustBasisPresent: true, // the .m3c-provenance sidecar is a trust basis
+		AnchorPresent:     false,
+		Now:               testNow,
+	}
+
+	// Even under an enterprise profile, sidecar-present ⇒ not locked.
+	if got := Compute(sidecarOnly, enterprisePol()); got == StateLocked {
+		t.Fatalf("sidecar-only host locked under enterprise profile — day-one brick trap (R-7.2)")
+	}
+	if got := Compute(sidecarOnly, enterprisePol()); got != StateDegraded {
+		t.Fatalf("disconnected sidecar-only host = %s, want degraded", got)
+	}
+
+	// Reachable ⇒ online.
+	reach := sidecarOnly
+	reach.RegistryReachable = true
+	if got := Compute(reach, enterprisePol()); got != StateOnline {
+		t.Fatalf("reachable sidecar-only host = %s, want online", got)
+	}
+}
+
+// TestCompute_NeverBrick_UnmanagedHostNeverLocks: a fresh / unmanaged /
+// air-gapped machine WITHOUT an enterprise profile, and with NO trust basis at
+// all, must NEVER enter locked (R-7.2: locked is enterprise opt-in only). The
+// shipped unmanaged=allow default must not be flipped.
+func TestCompute_NeverBrick_UnmanagedHostNeverLocks(t *testing.T) {
+	airgapped := Inputs{
+		RegistryReachable: false,
+		TrustBasisPresent: false,
+		AnchorPresent:     false,
+		Now:               testNow,
+	}
+	// Zero-value policy = the shipped default (not enterprise, no ceilings).
+	if got := Compute(airgapped, OfflinePolicy{}); got == StateLocked {
+		t.Fatalf("unmanaged air-gapped host locked WITHOUT an enterprise profile — the shipped default must never lock (R-7.2)")
+	}
+	// With no ceilings, disconnected-with-no-basis is degraded (caches trivially
+	// "fresh" because there is no ceiling), never locked.
+	if got := Compute(airgapped, OfflinePolicy{}); got != StateDegraded {
+		t.Fatalf("unmanaged disconnected host = %s, want degraded (no enterprise, no ceilings)", got)
+	}
+	// And DenyAllManaged must be false for whatever state it lands in.
+	if DenyAllManaged(Compute(airgapped, OfflinePolicy{})) {
+		t.Fatalf("unmanaged host must not deny all managed skills")
+	}
+}
+
+// TestCompute_AnchorAloneIsTrustBasis: a translog anchor alone counts as a trust
+// basis for the locked guard (even under enterprise), so an anchored host never
+// locks.
+func TestCompute_AnchorAloneIsTrustBasis(t *testing.T) {
+	anchored := Inputs{
+		RegistryReachable: false,
+		PolicyAge:         1 * time.Hour,
+		RevocationAge:     1 * time.Hour,
+		TrustAge:          1 * time.Hour,
+		TrustBasisPresent: false,
+		AnchorPresent:     true,
+		Now:               testNow,
+	}
+	if got := Compute(anchored, enterprisePol()); got == StateLocked {
+		t.Fatalf("anchored host locked — a translog anchor is a trust basis (R-7.1)")
+	}
+}
+
+// TestEmergencyActive_ExemptFromStateAndExpiry is the AC-7 emergency case: an
+// old-but-valid emergency deny-list still denies in EVERY state, including
+// locked and fully-expired offline. The emergency channel is exempt from cache
+// expiry and from the state machine — EmergencyActive does not even accept the
+// age/ceiling, and ignores the state.
+func TestEmergencyActive_ExemptFromStateAndExpiry(t *testing.T) {
+	for _, s := range []State{StateOnline, StateDegraded, StateOffline, StateLocked} {
+		if !EmergencyActive(true, s) {
+			t.Fatalf("emergency deny-list suppressed in state %s — the compromise channel must be exempt from every state (AC-7)", s)
+		}
+		if EmergencyActive(false, s) {
+			t.Fatalf("EmergencyActive(false, %s) = true; must be a pure passthrough", s)
+		}
+	}
+
+	// Concretely: a host whose caches are ALL expired (offline) still honours the
+	// emergency list — expiry of the ordinary revocation cache does not expire the
+	// emergency channel.
+	expired := Inputs{RegistryReachable: false, PolicyAge: 999 * time.Hour, RevocationAge: 999 * time.Hour, TrustAge: 999 * time.Hour, TrustBasisPresent: true, Now: testNow}
+	st := Compute(expired, enterprisePol())
+	if st != StateOffline {
+		t.Fatalf("all-expired disconnected host = %s, want offline", st)
+	}
+	if !EmergencyActive(true, st) {
+		t.Fatalf("emergency list not active in fully-expired offline state (AC-7)")
+	}
+}
+
+// TestPredicates pins the posture predicates that gate the R-1.4 fallback and
+// name the fail-closed / deny-all postures.
+func TestPredicates(t *testing.T) {
+	// Online is the ONLY state that permits the online fallback.
+	for _, s := range []State{StateOnline, StateDegraded, StateOffline, StateLocked} {
+		want := s == StateOnline
+		if got := AllowOnlineFallback(s); got != want {
+			t.Errorf("AllowOnlineFallback(%s) = %v, want %v", s, got, want)
+		}
+	}
+	// High-risk fails closed everywhere except online/degraded.
+	if HighRiskFailsClosed(StateOnline) || HighRiskFailsClosed(StateDegraded) {
+		t.Errorf("high-risk must not fail closed in online/degraded")
+	}
+	if !HighRiskFailsClosed(StateOffline) || !HighRiskFailsClosed(StateLocked) {
+		t.Errorf("high-risk must fail closed in offline/locked")
+	}
+	// Deny-all is locked only.
+	if DenyAllManaged(StateOnline) || DenyAllManaged(StateDegraded) || DenyAllManaged(StateOffline) {
+		t.Errorf("only locked may deny all managed skills")
+	}
+	if !DenyAllManaged(StateLocked) {
+		t.Errorf("locked must deny all managed skills")
+	}
+}
+
+// TestAgeFresh_FutureDatedIsStale: a cache dated in the FUTURE beyond the skew
+// tolerance is treated as STALE (fail-safe), so it cannot "look fresh forever"
+// and dodge the offline demotion.
+func TestAgeFresh_FutureDated(t *testing.T) {
+	ceiling := 24 * time.Hour
+	// Small future skew (2m) is tolerated → fresh.
+	if !ageFresh(-2*time.Minute, ceiling) {
+		t.Errorf("small future skew should be tolerated as fresh")
+	}
+	// Large future skew (1h) → stale.
+	if ageFresh(-1*time.Hour, ceiling) {
+		t.Errorf("large future-dated cache must be treated as stale (fail-safe)")
+	}
+	// No ceiling → always fresh regardless of age.
+	if !ageFresh(999*time.Hour, 0) {
+		t.Errorf("zero ceiling means no ceiling → always fresh")
+	}
+
+	// A disconnected host with a wildly future-dated policy cache under an
+	// enterprise ceiling must be offline, not degraded.
+	in := Inputs{RegistryReachable: false, PolicyAge: -10 * time.Hour, RevocationAge: time.Hour, TrustAge: time.Hour, TrustBasisPresent: true, Now: testNow}
+	if got := Compute(in, enterprisePol()); got != StateOffline {
+		t.Fatalf("future-dated policy cache = %s, want offline (fail-safe)", got)
+	}
+}
+
+// TestDecide_AuditRecord: Decide.State must equal Compute, and the record must
+// materialise the posture predicates + the injected clock.
+func TestDecide_AuditRecord(t *testing.T) {
+	in := Inputs{RegistryReachable: false, PolicyAge: 2 * time.Hour, RevocationAge: 90 * time.Minute, TrustAge: time.Hour, TrustBasisPresent: true, Now: testNow}
+	pol := enterprisePol()
+
+	dec := Decide(in, pol)
+	if dec.State != Compute(in, pol) {
+		t.Fatalf("Decide.State %s != Compute %s", dec.State, Compute(in, pol))
+	}
+	if dec.State != StateDegraded {
+		t.Fatalf("Decide.State = %s, want degraded", dec.State)
+	}
+	if dec.AllowOnlineFallback {
+		t.Errorf("degraded must not allow the online fallback")
+	}
+	if dec.PolicyAgeSeconds != int64((2 * time.Hour).Seconds()) {
+		t.Errorf("PolicyAgeSeconds = %d, want %d", dec.PolicyAgeSeconds, int64((2 * time.Hour).Seconds()))
+	}
+	if dec.ComputedAt != testNow.Format(time.RFC3339) {
+		t.Errorf("ComputedAt = %q, want %q", dec.ComputedAt, testNow.Format(time.RFC3339))
+	}
+	if dec.Enterprise != true {
+		t.Errorf("Enterprise not echoed")
+	}
+
+	// Negative (future) age clamps to 0 in the record.
+	in2 := in
+	in2.PolicyAge = -time.Hour
+	if got := Decide(in2, pol).PolicyAgeSeconds; got != 0 {
+		t.Errorf("future PolicyAge should clamp to 0 in record, got %d", got)
+	}
+}
+
+// TestState_String pins the stable labels.
+func TestState_String(t *testing.T) {
+	cases := map[State]string{
+		StateOnline:   "online",
+		StateDegraded: "degraded",
+		StateOffline:  "offline",
+		StateLocked:   "locked",
+		State(99):     "unknown",
+	}
+	for s, want := range cases {
+		if got := s.String(); got != want {
+			t.Errorf("State(%d).String() = %q, want %q", int(s), got, want)
+		}
+	}
+}

--- a/pkg/skillctl/verify/trustroots.go
+++ b/pkg/skillctl/verify/trustroots.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/govlevel"
 	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
+	"github.com/kamir/m3c-tools/pkg/skillctl/statemachine"
 	"gopkg.in/yaml.v3"
 )
 
@@ -249,6 +250,95 @@ type TrustRoot struct {
 	// max_staleness; that would defeat R3). validate() enforces both the closed
 	// key/value vocabulary AND the high⇒closed floor.
 	FailPolicyByRisk map[string]string `yaml:"fail_policy_by_risk,omitempty"`
+
+	// OfflinePolicy is the SPEC-0317 R-7.3 offline-state-machine policy block.
+	// It is the ONE surface (extends this TrustRoot, not a new file) that
+	// configures the named online/degraded/offline/locked state machine
+	// (pkg/skillctl/statemachine). Absent (nil) = the shipped default: not
+	// enterprise, no cache ceilings, unmanaged=allow — a host with no block
+	// NEVER enters `locked`. Validated at Load via ResolveOfflinePolicy so a bad
+	// duration or an enterprise-only knob set without `enterprise` is refused
+	// loudly (a typo cannot lie dormant). The strict loader (KnownFields(true))
+	// requires this to be a declared field.
+	OfflinePolicy *OfflinePolicyBlock `yaml:"offline_policy,omitempty"`
+}
+
+// OfflinePolicyBlock is the YAML surface of the SPEC-0317 R-7.3 `offline_policy`
+// block. It carries Go-duration STRINGS (parsed once at Load, like the SPEC-0279
+// freshness fields) and the enterprise gate. ResolveOfflinePolicy parses it into
+// the stdlib-only statemachine.OfflinePolicy the pure Compute consumes.
+//
+// The strict loader means every field here must be declared; an unknown key
+// under `offline_policy:` is rejected at Load.
+type OfflinePolicyBlock struct {
+	// AllowCachedTrustedSkills allows a cached, trust-verified skill to run while
+	// disconnected (degraded/offline). Advisory to the decision ladder.
+	AllowCachedTrustedSkills bool `yaml:"allow_cached_trusted_skills,omitempty"`
+
+	// DenyUnknownSkills denies a skill with no cached trust basis while
+	// disconnected. It flips unmanaged=allow for UNKNOWN skills only; it does NOT
+	// by itself produce `locked` (that needs `enterprise` + no trust basis).
+	DenyUnknownSkills bool `yaml:"deny_unknown_skills,omitempty"`
+
+	// MaxPolicyCacheAge bounds policy- AND trust-cache freshness. Go duration
+	// string ("24h"); empty = no ceiling. Rejected at Load if unparseable/negative.
+	MaxPolicyCacheAge string `yaml:"max_policy_cache_age,omitempty"`
+
+	// MaxRevocationCacheAge bounds the ORDINARY revocation cache. Go duration
+	// string; empty = no ceiling. The emergency deny-list is EXEMPT from this.
+	MaxRevocationCacheAge string `yaml:"max_revocation_cache_age,omitempty"`
+
+	// RequireLocalAudit is the SPEC-0317 R-8 inversion of the SPEC-0255
+	// decision-invariance contract. ENTERPRISE-ONLY: Load refuses it unless
+	// Enterprise is also true (the floor cannot be set on a non-enterprise host).
+	RequireLocalAudit bool `yaml:"require_local_audit,omitempty"`
+
+	// Enterprise is the opt-in that enables the `locked` state and permits
+	// RequireLocalAudit. Without it the host can NEVER lock (R-7.2 never-brick).
+	Enterprise bool `yaml:"enterprise,omitempty"`
+}
+
+// ResolveOfflinePolicy parses this trust root's SPEC-0317 R-7.3 offline_policy
+// block into the resolved, stdlib-only statemachine.OfflinePolicy the pure
+// Compute consumes. A nil block resolves to the zero policy (the shipped default:
+// not enterprise, no ceilings). Called by validate() (so a bad value is refused
+// at Load) AND by the consumers (so they read the same resolved policy) — the
+// same pattern as TrustRoot.Freshness().
+//
+// Validation (fail-safe, never fail-open):
+//   - durations parse as Go durations and are non-negative (empty → 0 = no ceiling);
+//   - require_local_audit is refused unless enterprise is set (R-7.3/R-8: the
+//     decision-invariance carve-out is enterprise opt-in only).
+//
+// There is deliberately NO high-risk fail-open knob here: the SPEC-0279
+// freshness.go R3 floor remains the authoritative high-risk fail-closed enforcer
+// (R-7.4), so the offline policy cannot configure a high-risk action fail-open.
+func (t *TrustRoot) ResolveOfflinePolicy() (statemachine.OfflinePolicy, error) {
+	if t == nil || t.OfflinePolicy == nil {
+		return statemachine.OfflinePolicy{}, nil
+	}
+	b := t.OfflinePolicy
+
+	maxPolicy, err := parseFreshnessDuration("max_policy_cache_age", b.MaxPolicyCacheAge, 0)
+	if err != nil {
+		return statemachine.OfflinePolicy{}, err
+	}
+	maxRevocation, err := parseFreshnessDuration("max_revocation_cache_age", b.MaxRevocationCacheAge, 0)
+	if err != nil {
+		return statemachine.OfflinePolicy{}, err
+	}
+	if b.RequireLocalAudit && !b.Enterprise {
+		return statemachine.OfflinePolicy{}, fmt.Errorf("offline_policy: require_local_audit is enterprise-only — set enterprise: true (SPEC-0317 R-7.3/R-8; the decision-invariance carve-out cannot be enabled on a non-enterprise host)")
+	}
+
+	return statemachine.OfflinePolicy{
+		AllowCachedTrustedSkills: b.AllowCachedTrustedSkills,
+		DenyUnknownSkills:        b.DenyUnknownSkills,
+		MaxPolicyCacheAge:        maxPolicy,
+		MaxRevocationCacheAge:    maxRevocation,
+		RequireLocalAudit:        b.RequireLocalAudit,
+		Enterprise:               b.Enterprise,
+	}, nil
 }
 
 // ActiveKeys returns the subset of RegistryKeys that are not retired. It
@@ -820,6 +910,14 @@ func (t *TrustRoots) validate() error {
 		// dormant and silently disable the staleness ceiling.
 		if _, ferr := root.Freshness(); ferr != nil {
 			return fmt.Errorf("trust_roots[%d] %s: %w", i, root.RegistryURL, ferr)
+		}
+
+		// SPEC-0317 R-7.3 — the offline_policy block. Resolve it at Load so a
+		// bad duration or an enterprise-only knob set without `enterprise` is
+		// refused loudly (a typo cannot lie dormant and silently mis-state the
+		// offline posture). Mirrors the Freshness() call above.
+		if _, oerr := root.ResolveOfflinePolicy(); oerr != nil {
+			return fmt.Errorf("trust_roots[%d] %s: %w", i, root.RegistryURL, oerr)
 		}
 
 		if root.GovernanceMinimum == "" {


### PR DESCRIPTION
## What

The **SPEC-0317 client strecke**, built end-to-end by a **12-agent workflow** (design → P0 → P1 → P2 → integrate → adversarial gate → fix). **~3.75k LOC + 57 tests, green under `-race` across 24 packages**, 0 data races. Gate verdict **ship-after-mustfix**; all 4 must-fixes applied. Independently re-verified: `go build ./...`, `go vet`, `-race` all green; **AC-1 byte-parity smoke-confirmed** (enforce ≡ verify-hook, exit+stdout+stderr identical); enforce writes the outbox end-to-end.

> Stacked on **#78** (P1.3 pin) — base is the pin branch so this diff is strecke-only. Retarget base → `master` after #78 merges.

## Honest status (load-bearing vs scoped)

**✅ LOAD-BEARING (working):**
- **P0 `pkg/skillctl/outbox`** — transactional SQLite audit store (`audit_events`/`sync_state`/`delivery_attempts` + cache tables), hot-path-safe (`SetMaxOpenConns(1)` + per-conn `busy_timeout=250` via cgo/nocgo driver hooks), `spool.jsonl` fallback, write-once rows (SQL triggers). Wraps the device-signed `InvocationRecord`.
- **P0 `skillctl enforce`** — byte-identical to verify-hook for a Skill event (AC-1) + mirrors the decision into the outbox via the invocation-trail seam (fire-and-forget, SPEC-0255 decision-invariance preserved — AC-2a).

**🟡 CONTRACT-COMPLETE (client half; needs P3 backend to be real):**
- **P1 `skillctl sync --once|--daemon`** — drains over HTTPS to the KafShield ingest **contract** (device-token auth, marks synced ONLY on a valid signed durable-seq, backoff-gated retries, replay no-op). Tested against an httptest double; **no Kafka in the client**. Egress default-OFF pending EC-NNNN.

**🟠 BUILT + TESTED but NOT yet wired into the runtime gate (scoped honestly):**
- **P2 `pkg/skillctl/statemachine`** — online/degraded/offline/locked + `offline_policy` (self/ER1 + sidecar count as trust basis; `locked` never bricks unmanaged — R-7.2). Surfaced by `skillctl session-baseline` as **INFORMATIONAL** only — the gate does **not** yet consume `require_local_audit` (exit 26) or `locked` (exit 28).
- **P2 `skillctl guard-path`** — side-channel guard, single realpath fixed point, audited-allow default, opt-in deny. translog per-batch anchoring is **stubbed** (`translog_seq` NULL in prod; AC-5a NOT-YET-BUILT).

## Adversarial gate (ran inside the workflow) — 4 must-fixes, all applied
1. guard-path compound-command self-exemption escape (`skillctl version; cat <victim>`) closed.
2. translog-anchoring overclaim softened to honest scoping (tamper-detection scoped to the durable-seq path).
3. session-baseline unenforced postures qualified INFORMATIONAL.
4. decorative backoff made due-gated + attempt-capped.

## Out of scope
The **KafShield backend** (durable Kafka sink, real durable-seq, ingest handler, dashboard) is a separate **P3 aims-core** track per the SPEC.

## Residual follow-ups (documented, non-blocking)
- exit 26/28 not yet in `exitcode.AllCodes()`; statemachine not consumed at the gate; `reVerifyRow` skips foreign `device_key_id` sig checks; `drainAll` oldest-first wedge risk; session-baseline cache-age proxy; `outbox.db` mode 0644 vs 0600 (dir is 0700).

**Review posture:** this is a large agent-built landing. Recommend human review before merge; the residuals above are the natural next fix-workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)