### PR TITLE
fix(plaud): resilient token extraction — Plaud renamed the localStorage key

### DIFF
--- a/pkg/plaud/auth.go
+++ b/pkg/plaud/auth.go
@@ -342,6 +342,33 @@ func findChrome() string {
 	return ""
 }
 
+// plaudTokenExtractJS reads the Plaud bearer token from a plaud.ai tab's
+// localStorage. Plaud renamed the key (the extractor hard-coded "tokenstr";
+// the debug path already probes "pld_tokenstr"), so this tries known keys in
+// priority order, then any key whose NAME mentions "token", then any JWT-shaped
+// value — returning {"token","via"} JSON. `via` is a fixed, secret-safe label
+// (never a raw key name, which can itself embed a JWT) so the caller can log
+// which path matched. Single-line so it embeds cleanly in the JXA path too.
+const plaudTokenExtractJS = `(function(){try{var known=["tokenstr","pld_tokenstr"];for(var i=0;i<known.length;i++){var v=localStorage.getItem(known[i]);if(v&&v.length>10)return JSON.stringify({token:v,via:known[i]});}var ls=localStorage;for(var j=0;j<ls.length;j++){var k=ls.key(j);var val=ls.getItem(k);if(val&&val.length>20&&/token/i.test(k))return JSON.stringify({token:val,via:"name-has-token"});}for(var m=0;m<ls.length;m++){var kk=ls.key(m);var vv=ls.getItem(kk);if(vv&&/^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\./.test(vv))return JSON.stringify({token:vv,via:"jwt-shape"});}return JSON.stringify({token:"",via:""});}catch(e){return JSON.stringify({token:"",via:""});}})()`
+
+// parsePlaudTokenResult parses the {"token","via"} JSON that plaudTokenExtractJS
+// returns (cdpEvaluate returns the JS string value directly, so this is a single
+// unmarshal). Returns an empty token if none was found or the value is
+// implausibly short.
+func parsePlaudTokenResult(raw string) (token, via string) {
+	var res struct {
+		Token string `json:"token"`
+		Via   string `json:"via"`
+	}
+	if json.Unmarshal([]byte(strings.TrimSpace(raw)), &res) != nil {
+		return "", ""
+	}
+	if len(res.Token) > 10 && res.Token != "null" {
+		return res.Token, res.Via
+	}
+	return "", ""
+}
+
 // extractTokenOsascript uses macOS osascript/JXA to read localStorage from Chrome.
 func extractTokenOsascript() (string, error) {
 	script := `
@@ -355,10 +382,8 @@ function run() {
 			for (var j = 0; j < tabs.length; j++) {
 				var u = tabs[j].url();
 				if (u && u.indexOf("plaud.ai") !== -1) {
-					var token = chrome.execute(tabs[j], {javascript: 'localStorage.getItem("tokenstr")'});
-					if (token && token !== "null" && token.length > 10) {
-						return token;
-					}
+					var res = chrome.execute(tabs[j], {javascript: '` + plaudTokenExtractJS + `'});
+					try { var o = JSON.parse(res); if (o && o.token && o.token.length > 10) return res; } catch(e) {}
 				}
 			}
 		}
@@ -376,10 +401,14 @@ function run() {
 	if strings.HasPrefix(result, "__ERR__:") {
 		return "", fmt.Errorf("%s", strings.TrimPrefix(result, "__ERR__:"))
 	}
-	if result == "" || result == "null" {
+	token, via := parsePlaudTokenResult(result)
+	if token == "" {
 		return "", fmt.Errorf("no token found in Chrome localStorage")
 	}
-	return result, nil
+	if via != "tokenstr" {
+		fmt.Fprintf(os.Stderr, "  [plaud] token found via %q (Plaud renamed the 'tokenstr' key — resilient fallback used)\n", via)
+	}
+	return token, nil
 }
 
 // ExtractTokenCDP connects to Chrome's DevTools Protocol on localhost:9222
@@ -449,12 +478,15 @@ func extractTokenCDP() (string, error) {
 					fmt.Fprintf(os.Stderr, "  [plaud-debug]   plaud.ai tab (%s) %s\n", plaudURLOrigin(t.URL), strings.Trim(summary, "\""))
 				}
 			}
-			token, err := cdpEvaluate(t.WebSocketURL, `localStorage.getItem("tokenstr")`)
+			raw, err := cdpEvaluate(t.WebSocketURL, plaudTokenExtractJS)
 			if err != nil {
 				continue
 			}
-			token = strings.Trim(token, "\"")
-			if token != "" && token != "null" && len(token) > 10 {
+			token, via := parsePlaudTokenResult(raw)
+			if token != "" {
+				if via != "tokenstr" {
+					fmt.Fprintf(os.Stderr, "  [plaud] token found via %q (Plaud renamed the 'tokenstr' key — resilient fallback used)\n", via)
+				}
 				return token, nil
 			}
 		}

--- a/pkg/plaud/auth_extract_test.go
+++ b/pkg/plaud/auth_extract_test.go
@@ -1,0 +1,63 @@
+package plaud
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePlaudTokenResult(t *testing.T) {
+	longTok := "eyJhbGciOiJIUzI1NiJ9.payloadpayloadpayload.sigsigsig"
+	cases := []struct {
+		name      string
+		raw       string
+		wantTok   string
+		wantVia   string
+		wantEmpty bool
+	}{
+		{"known tokenstr", `{"token":"` + longTok + `","via":"tokenstr"}`, longTok, "tokenstr", false},
+		{"renamed pld_tokenstr", `{"token":"` + longTok + `","via":"pld_tokenstr"}`, longTok, "pld_tokenstr", false},
+		{"name-has-token fallback", `{"token":"` + longTok + `","via":"name-has-token"}`, longTok, "name-has-token", false},
+		{"jwt-shape fallback", `{"token":"` + longTok + `","via":"jwt-shape"}`, longTok, "jwt-shape", false},
+		{"empty result", `{"token":"","via":""}`, "", "", true},
+		{"too-short token rejected", `{"token":"abc","via":"tokenstr"}`, "", "", true},
+		{"literal null rejected", `{"token":"null","via":"x"}`, "", "", true},
+		{"malformed json", `not json at all`, "", "", true},
+		{"surrounding whitespace", "  " + `{"token":"` + longTok + `","via":"tokenstr"}` + "\n", longTok, "tokenstr", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tok, via := parsePlaudTokenResult(c.raw)
+			if c.wantEmpty {
+				if tok != "" {
+					t.Errorf("expected empty token, got %q (via %q)", tok, via)
+				}
+				return
+			}
+			if tok != c.wantTok {
+				t.Errorf("token: got %q want %q", tok, c.wantTok)
+			}
+			if via != c.wantVia {
+				t.Errorf("via: got %q want %q", via, c.wantVia)
+			}
+		})
+	}
+}
+
+// TestPlaudTokenExtractJS_Shape guards the extractor JS against regressions that
+// would silently disable the resilient fallbacks: it must probe both known keys
+// and carry the JWT-shape + name-based fallbacks, and stay a single line so it
+// embeds in the JXA path.
+func TestPlaudTokenExtractJS_Shape(t *testing.T) {
+	js := plaudTokenExtractJS
+	for _, must := range []string{`"tokenstr"`, `"pld_tokenstr"`, "name-has-token", "jwt-shape", "localStorage", "JSON.stringify"} {
+		if !strings.Contains(js, must) {
+			t.Errorf("plaudTokenExtractJS missing %q — a fallback path was lost", must)
+		}
+	}
+	if strings.ContainsAny(js, "\n\r") {
+		t.Error("plaudTokenExtractJS must be single-line so it embeds in the JXA osascript path")
+	}
+	if strings.Contains(js, "`") {
+		t.Error("plaudTokenExtractJS must not contain a backtick (breaks the Go raw-string embedding)")
+	}
+}


### PR DESCRIPTION
## Symptom
The Plaud token-sync routine broke overnight ("worked yesterday"):
`found 3 plaud.ai tab(s) ... but none had a 'tokenstr' in localStorage`.

## Root cause
`pkg/plaud/auth.go` (both the Chrome-CDP path and the macOS osascript/JXA path) **hard-coded `localStorage["tokenstr"]`**. Our code was unchanged since 2026-07-02 → **Plaud renamed the key server-side** (the BUG-0168 debug probe already sniffed a `pld_tokenstr` variant — a prior hint the key drifts).

## Fix
Both paths now share a single-line `plaudTokenExtractJS` that tries, in order:
1. known keys `tokenstr` → `pld_tokenstr`
2. any localStorage key whose **name** mentions "token"
3. any **JWT-shaped** value (`^eyJ…\.…\.`)

…returning `{"token","via"}` JSON parsed by `parsePlaudTokenResult`. A non-`tokenstr` match logs the **secret-safe `via` label** so we notice the drift. Resilient to future renames.

Locked by `pkg/plaud/auth_extract_test.go`. `go build`/`vet`/`test` green.

## Known follow-up (not in this hotfix)
The login opener sends users to `web.plaud.ai` while the extractor navigates `app.plaud.ai`; localStorage is per-origin. The multi-tab scan papers over it today. If the fallbacks ever stop working, the token likely moved out of localStorage (sessionStorage/cookie) — run `M3C_PLAUD_DEBUG=1` to inspect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)