### PR TITLE
chore: gitignore dist/ + migrate .goreleaser.yml off deprecated options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ go.work.sum
 
 # Build output
 build/
+# goreleaser output. MUST stay ignored: scripts/release.sh does `git add -A` on a
+# dirty tree, so a leftover local `goreleaser build/release --snapshot` would
+# otherwise be committed wholesale as the release commit.
+dist/
 /m3c-tools
 /m3c-tools-*
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,32 +85,36 @@ builds:
         goarch: arm64
 
 archives:
+  # goreleaser v2: `ids` replaces the deprecated `builds`, and `formats` (a list)
+  # replaces the deprecated scalar `format`. Names are unchanged on purpose —
+  # release.yml lists these filenames verbatim, and the published install.sh
+  # depends on them.
   - id: m3c-tools-archive
-    builds:
+    ids:
       - m3c-tools
     name_template: "m3c-tools-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
   - id: skillctl-archive
-    builds:
+    ids:
       - skillctl
     name_template: "skillctl-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
   # The demo ships as a self-contained bundle: skillctl-demo + the skillctl it
   # shells out to. Double-click on a locked-down Windows laptop, browser opens.
   - id: skillctl-demo-archive
-    builds:
+    ids:
       - skillctl-demo
       - skillctl
     name_template: "skillctl-demo-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
Two release-pipeline landmines found while cutting **v2.9.0**.

## 1. `dist/` was not gitignored — near-miss
`scripts/release.sh` does `git add -A && git commit` whenever the tree is dirty. A leftover local `goreleaser --snapshot` run leaves `dist/` behind, which would have been **committed wholesale as the release commit**. This nearly happened during the v2.9.0 cut (caught in a pre-flight check). Now ignored, with the *reason* recorded next to the entry so it isn't "tidied away" later.

## 2. `goreleaser check` was failing
`archives.builds` and `archives.format_overrides.format` are deprecated in goreleaser v2. `release.yml` only runs `goreleaser release` (which still tolerates them), so releases worked — but the config was one goreleaser major bump away from breaking the whole release pipeline. Migrated to `ids` + `formats`.

## Verification
- `goreleaser check` → `1 configuration file(s) validated`, **no deprecation errors** (was: `check failed`).
- Full `goreleaser release --snapshot --clean --skip=publish` succeeds (23s) and emits the **same 9 archive filenames** that `release.yml` lists verbatim:
  `{m3c-tools,skillctl,skillctl-demo}-{linux-amd64,linux-arm64}.tar.gz` + `-windows-amd64.zip`
  → **no artifact rename**; the published `install.sh` keeps working.
- `git status` no longer reports `dist/` even with 22 files in it.

No code changes; release machinery only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)