### PR TITLE
fix(release): skillctl release notes were never published (+ v0.3.0 notes, v0.2.11 changelog gap)

### DIFF
--- a/.github/workflows/skillctl-release.yml
+++ b/.github/workflows/skillctl-release.yml
@@ -116,9 +116,13 @@ jobs:
           sed -i "s#download/skillctl/[^\"}]*#download/${GITHUB_REF_NAME}#" dist/install.sh
           grep 'RELEASE_BASE:-' dist/install.sh | head -1
           [ -f INFRA/skillctl-release.pub ] && cp INFRA/skillctl-release.pub dist/ || true
+          # Until now `release/` was gitignored wholesale, so this lookup never hit
+          # in CI and every cut shipped the placeholder body. RELEASE_NOTES.md is
+          # tracked as of this commit.
           NOTES="release/${GITHUB_REF_NAME}/RELEASE_NOTES.md"
-          if [ -f "$NOTES" ]; then cp "$NOTES" dist/RELEASE_NOTES.md; \
-          else printf '# skillctl %s\n\nKeyless (cosign/OIDC) provenance release.\n' "${GITHUB_REF_NAME}" > dist/RELEASE_NOTES.md; fi
+          if [ -f "$NOTES" ]; then echo "using $NOTES"; cp "$NOTES" dist/RELEASE_NOTES.md; \
+          else echo "WARN: no $NOTES — falling back to the placeholder body"; \
+          printf '# skillctl %s\n\nKeyless (cosign/OIDC) provenance release.\n' "${GITHUB_REF_NAME#skillctl/}" > dist/RELEASE_NOTES.md; fi
 
       # DRAFT — the operator reviews, (transition) attaches the ed25519
       # SHA256SUMS.sig, and promotes. A broken cosign flow yields a draft, never

--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,16 @@ __pycache__/
 # Local-built thinking-engine binary (output of cmd/thinking-engine)
 /thinking-engine
 
-# skillctl release build artifacts (published to GitHub Releases, not git)
-/release/
+# skillctl release build artifacts (published to GitHub Releases, not git).
+#
+# EXCEPT RELEASE_NOTES.md: skillctl-release.yml reads
+# `release/<tag>/RELEASE_NOTES.md` FROM THE TAGGED TREE. Ignoring the whole dir
+# meant CI never saw those files, so every cut silently fell back to the generic
+# placeholder body (v0.2.9 … v0.2.11 all shipped it, despite hand-written notes
+# sitting untracked on the author's disk).
+/release/**
+!/release/**/
+!/release/**/RELEASE_NOTES.md
 
 # Packed skill bundles (build artifacts from `skillctl pack`; never source)
 *.skb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,55 @@ version is ldflags-stamped (`skillctl version`). Release tags: `skillctl/vX.Y.Z`
   a verbatim move ships half-extracted shared state, so it needs a dedicated
   refactor pass, not a release-eve edit.
 
+## [skillctl/v0.3.0] — 2026-07-10 — enterprise evidence backbone + managed-settings pinning
+Full notes: `release/skillctl/v0.3.0/RELEASE_NOTES.md`.
+### Added
+- **`skillctl pin`** (SPEC-0247 §7.3 P1.3) — pins the trust gate into Claude Code
+  **managed settings**, making it un-deletable by non-root users. `generate` /
+  `status` / `install`; install **merges** into existing managed policy (never
+  clobbers), backs it up, and re-reads the file from disk to verify what landed.
+- **`skillctl enforce`** (SPEC-0317 P0) — byte-identical to `verify-hook` for a
+  Skill event, plus a transactional **SQLite outbox** (`pkg/skillctl/outbox`,
+  hot-path-safe, `spool.jsonl` fallback, write-once rows). The SPEC-0255
+  decision-invariance contract is preserved.
+- **`skillctl sync --once|--daemon`** (SPEC-0317 P1) — separate-process drain of
+  the outbox to the audit-plane ingest contract; marks synced only on a valid
+  signed durable-seq; backoff via `delivery_attempts`. HTTPS-only, no Kafka client.
+- **`skillctl guard-path`** (SPEC-0317 P2) — side-channel guard over
+  Bash/Read/Edit/Write with a single realpath fixed point; audited-allow default.
+- **`skillctl session-baseline`** + `pkg/skillctl/statemachine`
+  (`online/degraded/offline/locked`) — informational posture.
+- **Fleet kill-switch** (FR-0045 D1–D5) — signed revocation HEAD (epoch
+  monotonicity, set-root binding), emergency deny-list, opt-in fail-closed
+  freshness (exit `22`).
+- **`skillctl-demo`** binary + **Kata training mode** (`--mode kata`).
+### Security
+- **Go 1.26.5** toolchain (`GO-2026-5856`, `crypto/tls` ECH privacy leak);
+  `govulncheck` clean.
+- **Windows `guard-path` parity** — native `C:\…\SKILL.md` tokens were classified
+  "not a path", so the guard never fired on Windows. Fixed; locked by a
+  cross-platform test.
+### Scope (not claimed)
+- Pinning is un-deletable by **non-root only**; root / same-uid is out of scope.
+- `guard-path` is **not a seal** (copies outside the skills dir, in-context reads
+  and `/slash` are uncovered).
+- The state machine is **informational**: the gate does not yet consume
+  `require_local_audit` (exit 26) or `locked` (exit 28).
+- `sync` is contract-complete against a test double; egress is **default-OFF**.
+  Per-batch transparency-log anchoring is not wired (`translog_seq` is NULL).
+
+## [skillctl/v0.2.11] — 2026-06-18 — bundled runbooks + `runbook publish`
+Recorded retroactively: this tag shipped without a changelog entry.
+### Added
+- **Skill-bundled runbooks** (SPEC-0275 P0) — auto-registered on publish.
+- **`skillctl runbook publish`** — push an onboarding runbook to the THOH catalog.
+- **Opt-in auto-publish** of a runbook on release (SPEC-0272).
+- **Author selector** (Eric / Mirko) coupling identity + context + key.
+### Fixed
+- `publish --attest/--revoke` auto-resolve the digest from the packed `.skb`.
+- Release workflow stamps `install.sh`'s `RELEASE_BASE` to the tag.
+- Runbook smoke test made optional (skills may ship none); author labels genericised.
+
 ## [skillctl/v0.2.10] — 2026-06-13 — security review remediation (SPEC-0266)
 Closes the adversarial security review (`CISO-WORK/SECURITY-REVIEW-skillctl-m3c-tools-2026-06-13.md`).
 ### Security — P0

--- a/release/skillctl/v0.2.0/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.0/RELEASE_NOTES.md
@@ -1,0 +1,30 @@
+# skillctl v0.2.0
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.0/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.0 bash
+```
+
+## What's new
+- `skillctl publish --share-room <label>` — map a bundle into a SPEC-0096
+  co-learning room at admit time (repeatable; `$SKILL_SHARE_ROOMS`).
+- `skillctl room share|unshare <skill> --room <label>` — back-fill / remove the
+  room mapping on already-published bundles.
+- `skillctl version` — prints the stamped release tag.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.1/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.1/RELEASE_NOTES.md
@@ -1,0 +1,30 @@
+# skillctl v0.2.1
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.1/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.1 bash
+```
+
+## What's new
+- `skillctl publish --share-room <label>` — map a bundle into a SPEC-0096
+  co-learning room at admit time (repeatable; `$SKILL_SHARE_ROOMS`).
+- `skillctl room share|unshare <skill> --room <label>` — back-fill / remove the
+  room mapping on already-published bundles.
+- `skillctl version` — prints the stamped release tag.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.10/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.10/RELEASE_NOTES.md
@@ -1,0 +1,33 @@
+# skillctl v0.2.10 — security review remediation (SPEC-0266)
+
+Keyless (cosign/OIDC) provenance release. Dual-track install (cosign-preferred,
+pinned-ed25519 fallback). Closes the 2026-06-13 adversarial security review.
+
+## P0 (trust spine)
+- **F2 + F19** — the self/ER1 sidecar gate now **re-verifies a signed attestation
+  against the pinned (off-machine) key**: a repacked `.skb` is denied and
+  governance comes from the SIGNED attestation, not the attacker-writable sidecar.
+  Trust-roots mandatory when re-anchoring.
+- **F1** — post-install bundle revocation: the sweep is the revocation authority
+  (quarantines revoked installs + 12h offline cache); a forged revoke is ignored.
+- **F12** — gate↔verifier canonicalization fixed point.
+- **F25** — credential clients no longer leak `X-API-KEY`/`X-Context-ID` on a
+  cross-host redirect.
+
+## P1 (defense-in-depth)
+- M7 third TLS path (healthcheck loopback-only), ffmpeg concat-list injection
+  guard, F-ENV gate-policy validation, F5 stash hygiene, F4/F9 intrinsic digest binding.
+
+~28 new regression tests; full suite + vet + linux/windows + golangci green.
+
+> **Consumer migration:** reinstall the green skill set so each box carries the
+> `.skillctl-attest.json` stash and is re-anchored; ensure `~/.claude/trust-roots.yaml`
+> is pinned. Legacy installs WARN + content-bind meanwhile (no breakage).
+
+## Verify
+```
+cosign verify-blob SHA256SUMS --bundle SHA256SUMS.cosign.bundle \
+  --certificate-identity-regexp '^https://github.com/kamir/m3c-tools/\.github/workflows/skillctl-release\.yml@refs/tags/skillctl/v' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.11-rc1/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.11-rc1/RELEASE_NOTES.md
@@ -1,0 +1,30 @@
+# skillctl v0.2.11-rc1
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.11-rc1/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.11-rc1 bash
+```
+
+## What's new
+- `skillctl publish --share-room <label>` — map a bundle into a SPEC-0096
+  co-learning room at admit time (repeatable; `$SKILL_SHARE_ROOMS`).
+- `skillctl room share|unshare <skill> --room <label>` — back-fill / remove the
+  room mapping on already-published bundles.
+- `skillctl version` — prints the stamped release tag.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.11-rc2/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.11-rc2/RELEASE_NOTES.md
@@ -1,0 +1,30 @@
+# skillctl v0.2.11-rc2
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.11-rc2/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.11-rc2 bash
+```
+
+## What's new
+- `skillctl publish --share-room <label>` — map a bundle into a SPEC-0096
+  co-learning room at admit time (repeatable; `$SKILL_SHARE_ROOMS`).
+- `skillctl room share|unshare <skill> --room <label>` — back-fill / remove the
+  room mapping on already-published bundles.
+- `skillctl version` — prints the stamped release tag.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.11-rc3/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.11-rc3/RELEASE_NOTES.md
@@ -1,0 +1,30 @@
+# skillctl v0.2.11-rc3
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.11-rc3/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.11-rc3 bash
+```
+
+## What's new
+- `skillctl publish --share-room <label>` — map a bundle into a SPEC-0096
+  co-learning room at admit time (repeatable; `$SKILL_SHARE_ROOMS`).
+- `skillctl room share|unshare <skill> --room <label>` — back-fill / remove the
+  room mapping on already-published bundles.
+- `skillctl version` — prints the stamped release tag.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.11-rc4/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.11-rc4/RELEASE_NOTES.md
@@ -1,0 +1,30 @@
+# skillctl v0.2.11-rc4
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.11-rc4/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.11-rc4 bash
+```
+
+## What's new
+- `skillctl publish --share-room <label>` — map a bundle into a SPEC-0096
+  co-learning room at admit time (repeatable; `$SKILL_SHARE_ROOMS`).
+- `skillctl room share|unshare <skill> --room <label>` — back-fill / remove the
+  room mapping on already-published bundles.
+- `skillctl version` — prints the stamped release tag.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.11/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.11/RELEASE_NOTES.md
@@ -1,0 +1,30 @@
+# skillctl v0.2.11
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.11/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.11 bash
+```
+
+## What's new
+- `skillctl publish --share-room <label>` — map a bundle into a SPEC-0096
+  co-learning room at admit time (repeatable; `$SKILL_SHARE_ROOMS`).
+- `skillctl room share|unshare <skill> --room <label>` — back-fill / remove the
+  room mapping on already-published bundles.
+- `skillctl version` — prints the stamped release tag.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.2/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.2/RELEASE_NOTES.md
@@ -1,0 +1,30 @@
+# skillctl v0.2.2
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.2/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.2 bash
+```
+
+## What's new
+- `skillctl publish --share-room <label>` — map a bundle into a SPEC-0096
+  co-learning room at admit time (repeatable; `$SKILL_SHARE_ROOMS`).
+- `skillctl room share|unshare <skill> --room <label>` — back-fill / remove the
+  room mapping on already-published bundles.
+- `skillctl version` — prints the stamped release tag.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.3/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.3/RELEASE_NOTES.md
@@ -1,0 +1,38 @@
+# skillctl v0.2.3
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.3/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.3 bash
+```
+
+## What's new — SPEC-0247 Claude Code trust gate (load-time verification)
+- `skillctl verify-hook` — a Claude Code **PreToolUse(Skill)** gate: re-verifies a
+  skill at load time and **denies** (exit 2) on a bad signature / digest mismatch.
+- `skillctl verify --all [--quarantine] [--json] [--budget]` — a **SessionStart sweep**
+  that verifies every installed skill and (with `--quarantine`) moves trust-failures
+  out of `~/.claude/skills/` before the agent loads them. Follows symlinks.
+- **Network-free verification + content-binding**: re-binds the extracted on-disk
+  `SKILL.md` to the signed `.skb` so an edited body is caught as a digest mismatch.
+- **self/ER1 (pull) format**: pull-installed skills (`.m3c-provenance.json`) are
+  verified offline — content-binding + governance floor + trust-root fingerprint.
+- Offline **verdict cache** (HMAC-keyed by content digest) for a fast, offline gate.
+- Cross-platform: gate tests validated on the windows-latest CI runner.
+- Carries forward SPEC-0246 `publish --share-room` / `room share|unshare`;
+  `skillctl version` prints the stamped release tag.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.4/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.4/RELEASE_NOTES.md
@@ -1,0 +1,48 @@
+# skillctl v0.2.4 — security release
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+> ⚠️ **Supersedes v0.2.3.** This release fixes the 7 P0 findings from the
+> 2026-06-10 security audit (SPEC-0251). **Upgrade from v0.2.3** — its binaries
+> and installer contained the pre-fix code.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.4/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.4 bash
+```
+
+## Security fixes (SPEC-0251 P0 remediation)
+- **Governance-verdict forgery (HIGH):** the self/ER1 pull now verifies the
+  attestation **and** revocation event envelope signatures before trusting a
+  bundle's governance level — a forged "green" attestation can no longer pass
+  the green floor.
+- **Decompression-bomb caps** (100 MiB · 10k files · `O_EXCL` · symlink refusal)
+  on the self/ER1 extractor **and** the per-invocation gate content check.
+- **Load-time gate (SPEC-0247):** content-binding is now enforced on **every**
+  managed verify path, and a sidecar skill with no stashed `.skb` **fails
+  closed** — "edited body → exit 10" now holds everywhere.
+- **Path-traversal** install write blocked (bundle-name sanitisation).
+- **Local servers** (config editor / review / browse) bind **127.0.0.1** only,
+  with a loopback Host-header guard (were `0.0.0.0`, secret-bearing).
+- **This installer pins the release-key fingerprint** and fails closed on
+  mismatch (a poisoned origin can no longer swap key+sig+binary).
+- **Windows signing unblocked** — key perm-check is GOOS-guarded; `signing` is
+  now exercised on the windows-latest CI gate.
+
+Carries forward SPEC-0246 `publish --share-room` / `room share|unshare`;
+`skillctl version` prints the stamped tag.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.5/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.5/RELEASE_NOTES.md
@@ -1,0 +1,47 @@
+# skillctl v0.2.5 — P1 hardening
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+> Builds on the **v0.2.4 security release** (7 P0 fixes). This release lands the
+> SPEC-0251 **P1 hardening** batch. Recommended upgrade.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.5/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.5 bash
+```
+
+## P1 hardening (SPEC-0251)
+- **Load-time gate is panic-safe by design** — a panic anywhere in `verify-hook`
+  now yields a fail-closed DENY (exit 2), never a crash the harness might read as allow.
+- **Strict, fail-closed policy & trust-roots** — `gate-policy.yaml` and the self
+  trust-roots parse strictly (unknown/typo'd fields no longer silently allow-all);
+  `governance_minimum: red` is rejected and the floor is case-normalised so it can't
+  collapse.
+- **Install-token fails closed** on RNG failure (no world-known fallback key on the
+  destructive-overwrite guard).
+- **Verdict cache** uses a unique temp file per write (no concurrent-rename corruption).
+- **TLS:** `ER1_VERIFY_SSL=false` is honoured **only for loopback** — verification is
+  forced on for any remote host (closes a stage/unknown-target downgrade).
+- **Windows URL/file open** uses `rundll32 url.dll,FileProtocolHandler` (no `cmd /c
+  start` metacharacter surface), everywhere.
+- **Plaud token** via env / `--token-file` (bare-argv form deprecated + warned);
+  DocID validated; `findSetupScript` anchored to the binary path.
+- **CI** now runs the skillctl security tests under `-race`.
+
+Carries forward SPEC-0246 `publish --share-room` / `room share|unshare`;
+`skillctl version` prints the stamped tag.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.6/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.6/RELEASE_NOTES.md
@@ -1,0 +1,61 @@
+# skillctl v0.2.6 — P2 trust-chain convergence
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+> Builds on **v0.2.4** (7 P0 security fixes) and **v0.2.5** (P1 hardening). This
+> release lands the **SPEC-0252 trust-chain convergence** — a structural refactor
+> that removes the copy-paste drift behind the audit's "weak twin" findings.
+> **No new feature surface; no behaviour change for honest bundles.** Recommended upgrade.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.6/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.6 bash
+```
+
+## What changed (SPEC-0252)
+
+The most security-sensitive code — *decompress an attacker-influenced gzip+tar
+and turn its entries into files on disk* — used to be implemented **three times**
+(HTTP install, self/ER1 install, and the hot per-invocation gate comparator),
+each with its own path-sanitiser, wrapper-strip, bomb caps, and file-mode logic.
+Every hardening fix had to be applied two or three times, and they had drifted.
+v0.2.6 collapses them onto **one hardened core** (`pkg/skillbundle.Unpack` /
+`ExtractTo` / `SafeJoin`):
+
+- **One gzip+tar reader.** Single decompression pass; per-entry `io.LimitReader`
+  against a running byte ceiling (gzip-bomb) + a file-count cap (tar-bomb);
+  one path-escape proof; symlink/hardlink/device refusal; `O_EXCL` fail-closed
+  writes; one `scripts/*`→0755-else-0644 mode policy.
+- **One wrapper-strip rule** — the installer and the integrity check can no
+  longer disagree on which files belong to a signed bundle.
+- **One canonical extraction cap** definition (install/registry now alias it).
+- **Stricter sanitiser** — absolute / `..`-escaping / Windows-volume / backslash /
+  NUL names are now **rejected** (the old self/ER1 path silently *rewrote*
+  traversal); the gate comparator now fails closed on a `.skb` carrying a
+  symlink (previously skipped).
+- **One governance-level guard** (`pkg/skillctl/govlevel`) shared by both
+  trust-root loaders — permanently closes the **SEC-L1** case-collapse class
+  (a mixed-case `governance_minimum` can never silently disable the gate).
+
+**Adversarially verified:** an independent review tried to prove the converged
+path weaker than any of the three originals across 9 input classes and could
+not — it found only tightenings. Build + `go vet ./...` + the full skillctl
+security suite under `-race` are green.
+
+Carries forward SPEC-0246 `publish --share-room` / `room share|unshare`;
+`skillctl version` prints the stamped tag.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.7/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.7/RELEASE_NOTES.md
@@ -1,0 +1,53 @@
+# skillctl v0.2.7 — hygiene, hardening & observability
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+> Builds on **v0.2.6** (trust-chain convergence). This release lands the
+> **SPEC-0251 §5 hygiene floor + SPEC-0255 gate observability** — the binaries are
+> now built CVE-free, the CI enforces supply-chain gates, and the gate finally
+> keeps a record. **No breaking changes.** Recommended upgrade.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.7/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.7 bash
+```
+
+## What changed
+
+- **Patched toolchain — 14 → 0 reachable CVEs.** govulncheck found the prior
+  releases' binaries carried **14 reachable Go-stdlib CVEs** (crypto/x509,
+  html/template, …); the build moved to **go1.26.4**, which clears all of them.
+  These v0.2.7 binaries are built on the patched stdlib.
+- **Supply-chain gates in CI** — `govulncheck` (blocks on reachable CVEs) and
+  `gitleaks` (full-history secret scan) now gate every push; `dependabot.yml`
+  keeps deps + actions current.
+- **`skillctl gate-stats` — gate observability (SPEC-0255).** Every gate decision
+  (PreToolUse hook + SessionStart sweep) is now appended to an advisory
+  `~/.claude/skillctl/gate-audit.jsonl`; `gate-stats [--since 168h|YYYY-MM-DD]
+  [--json]` summarises decisions, top blocked skills, and the hook cache-hit rate.
+  The log is **fire-and-forget telemetry, never a trust input** — a logging
+  failure provably cannot change a gate decision (decision-invariance is tested).
+- **Exit-code single source of truth (SPEC-0251 §5).** Guard tests pin the 10–19
+  ladder to `pkg/skillctl/exitcode`; drift fails CI. (Codified the SPEC-0198
+  exit-17 overload: data-source-denied **and** author-identity-revoked share 17.)
+- **Zero `//nolint:unused`** — the four dead WIP symbols were removed; the
+  `unused` linter is a real enforcer again. CI (lint, unit, `-race` security
+  suite, govulncheck, gitleaks, builds) + the Windows Gate are all green.
+
+`skillctl version` prints the stamped tag; SPEC-0246 `publish --share-room` /
+`room share|unshare` and the SPEC-0247 load gate carry forward unchanged.
+
+## Provenance
+Binaries are checksummed (`SHA256SUMS`) and the manifest is ed25519-signed
+(`SHA256SUMS.sig`) by the skillctl **release key** (separate from skill-author
+keys). Verify against the pinned public key:
+
+- `skillctl-release.pub` (also at `INFRA/skillctl-release.pub` in the repo)
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```

--- a/release/skillctl/v0.2.8/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.8/RELEASE_NOTES.md
@@ -1,0 +1,41 @@
+# skillctl v0.2.8 — keyless provenance (cosign/OIDC)
+
+Trust-and-governance CLI for AI-agent skills. Single static Go binary — no Node.
+
+> First skillctl release **built and signed entirely in CI** with **keyless
+> Sigstore cosign + GitHub OIDC** (no long-lived signing key) — plus a SLSA build
+> provenance attestation. The pinned-ed25519 track is retained so existing
+> installs keep verifying. No code changes vs v0.2.7; this is the provenance
+> upgrade (SPEC-0253). Recommended upgrade.
+
+## Install (verifies signature + checksum)
+
+```sh
+curl -fsSL https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.8/install.sh \
+  | RELEASE_BASE=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.2.8 bash
+```
+
+`install.sh` is now **dual-track**: when `cosign` is present it verifies the
+keyless bundle against the release workflow's OIDC identity; otherwise it falls
+back to the pinned-ed25519 signature. A present-but-invalid cosign bundle
+fails closed (no downgrade). `SKILLCTL_REQUIRE_COSIGN=1` forces cosign-only.
+
+## Provenance — two tracks
+
+**Keyless (cosign + GitHub OIDC):**
+```sh
+cosign verify-blob SHA256SUMS --bundle SHA256SUMS.cosign.bundle \
+  --certificate-identity-regexp '^https://github.com/kamir/m3c-tools/\.github/workflows/skillctl-release\.yml@refs/tags/skillctl/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+# SLSA build provenance:
+gh attestation verify skillctl-linux-amd64 --repo kamir/m3c-tools
+```
+
+**Pinned ed25519 (transition fallback):**
+```sh
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub -rawin \
+  -in SHA256SUMS -sigfile SHA256SUMS.sig
+```
+- K-release fingerprint: `sha256:5f8f39cb0454dcd8ac04c6729af2fa4b71a13a5e125e56924701d9e38187a9c2`
+
+Built on go1.26.4 (CVE-free stdlib). Carries forward all v0.2.4–v0.2.7 hardening.

--- a/release/skillctl/v0.2.9/RELEASE_NOTES.md
+++ b/release/skillctl/v0.2.9/RELEASE_NOTES.md
@@ -1,0 +1,43 @@
+# skillctl v0.2.9 — lifecycle validation harness + constrained-low closure
+
+Keyless (cosign/OIDC) provenance release. Dual-track install (cosign-preferred,
+pinned-ed25519 fallback) — unchanged from v0.2.8.
+
+## Added
+- **Lifecycle tamper-detection harness** (SPEC-0265): a hermetic Go E2E
+  (`TestLifecycleTamper_E2E`) and an operator shell simulation
+  (`tools/lifecycle-tamper-sim/run.sh`, `--mode local|ssh`) that drive the **real**
+  binary through bundle → install → tamper → **block (exit 2)** → **quarantine** →
+  **gate-stats alert**. The shell harness runs the tamper over SSH on a remote
+  Linux box (the production-shaped target) and emits a compliance evidence pack.
+  Backed by `CISO-WORK/TEST-CONCEPT-skillctl-lifecycle-tamper-detection.md`.
+- **SBOM release asset** (CycloneDX) — emitted alongside the signed artifacts
+  (WARN-only; a syft hiccup never blocks a cut). Closes the optional SPEC-0253
+  follow-up.
+
+## Security (constrained lows, 2026-06-10 audit)
+- **M10** — login-callback Device Hub reflected XSS closed: `context_id`/`baseURL`
+  HTML-escaped + strict CSP (`default-src 'none'; style-src 'unsafe-inline'`) +
+  `nosniff`/`no-referrer`. Regression test.
+- **L7** — Plaud S3 allowlist hardened: `https`-only, S3 bucket-style hosts only
+  (dropped broad `*.amazonaws.com`/`*.cloudfront.net` wildcards; CloudFront
+  pinned), read ceilings 50 MB → 16 MB. Regression test.
+- **L5** (device token off the GET query string) deferred — cross-system ER1+client
+  contract change; tracked.
+
+## Verification
+```
+# cosign (keyless) — when cosign is present:
+cosign verify-blob SHA256SUMS \
+  --bundle SHA256SUMS.cosign.bundle \
+  --certificate-identity-regexp '^https://github.com/kamir/m3c-tools/\.github/workflows/skillctl-release\.yml@refs/tags/skillctl/v' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# ed25519 fallback (pinned fingerprint):
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub \
+  -rawin -in SHA256SUMS -sigfile SHA256SUMS.sig
+```
+
+The skillctl binary itself is functionally unchanged from v0.2.8 (this cut adds
+the SBOM provenance asset + tags the validated tree state); the M10/L7 fixes live
+in the `m3c-tools` product binary and ride the next `v*` product cut.

--- a/release/skillctl/v0.3.0/RELEASE_NOTES.md
+++ b/release/skillctl/v0.3.0/RELEASE_NOTES.md
@@ -1,0 +1,85 @@
+# skillctl v0.3.0 — enterprise evidence backbone + managed-settings pinning
+
+Keyless (cosign/OIDC) provenance release. Dual-track install (cosign-preferred,
+pinned-ed25519 fallback) — unchanged from v0.2.8.
+
+The largest cut since the trust gate landed: the runtime gate becomes
+**un-deletable by non-root users**, and enforcement decisions gain a durable,
+local-first evidence store with an eventual central sync path.
+
+## Added
+
+- **`skillctl pin`** (SPEC-0247 §7.3 P1.3) — pins the trust gate into Claude
+  Code **managed settings**, the one tier a non-privileged user cannot edit.
+  `generate` emits the canonical hook wiring; `status` reports
+  `absent/tampered/partial/pinned/pinned-strict`; `install` **merges** into any
+  existing managed policy (never clobbers), backs it up, and — only as root with
+  `--confirm` — writes it, then re-reads the file from disk and verifies what
+  actually landed. `--strict` adds `allowManagedHooksOnly` and warns loudly that
+  it disables every other user hook.
+- **`skillctl enforce`** (SPEC-0317 P0) — byte-identical to `verify-hook` for a
+  Skill event, and additionally mirrors the device-signed `InvocationRecord`
+  into a new transactional **SQLite outbox** (`pkg/skillctl/outbox`). Hot-path
+  safe (single pinned connection, `busy_timeout=250ms`, `spool.jsonl` fallback);
+  write-once rows enforced by SQL triggers. The SPEC-0255 decision-invariance
+  contract holds: an outbox-write failure can never change a gate decision.
+- **`skillctl sync --once|--daemon`** (SPEC-0317 P1) — a **separate process**,
+  never on the hook path, that drains the outbox over HTTPS to the audit-plane
+  ingest contract. Marks a row synced **only** on a valid signed durable-seq ack;
+  backoff-gated retries via `delivery_attempts`; replay of an acked `event_id` is
+  a no-op. No Kafka in the client.
+- **`skillctl guard-path`** (SPEC-0317 P2) — a side-channel guard for
+  Bash/Read/Edit/Write against skill directories, with a single
+  realpath-canonicalisation fixed point. **Audited-allow by default**, opt-in
+  deny.
+- **`skillctl session-baseline`** — prints the offline posture
+  (`online/degraded/offline/locked`) from the new `pkg/skillctl/statemachine`.
+- **Fleet kill-switch** (FR-0045 D1–D5) — signed revocation HEAD with epoch
+  monotonicity + set-root binding, an emergency deny-list consulted first and
+  unconditionally, and opt-in fail-closed revocation freshness (exit `22`).
+- **`skillctl-demo`** — a self-contained offline CISO skill-trust demo binary,
+  plus a hands-on **Kata training mode** (`--mode kata`): five katas, each
+  driving a real skillctl exit code.
+
+## Security & CI
+
+- **Go 1.26.5** toolchain (`GO-2026-5856`, `crypto/tls` ECH privacy leak). This
+  release is built with the patched stdlib; `govulncheck` is clean.
+- **Windows parity fix** — `guard-path` classified native `C:\…\SKILL.md` tokens
+  as "not a path", so the guard never fired on Windows. Fixed and locked by a
+  cross-platform test.
+- Command packages now run under `-race` in CI.
+
+## What this release does NOT claim (honest scope)
+
+Read this before quoting the feature list:
+
+- **Pinning is un-deletable by *non-root* users only.** Root, or anyone able to
+  write the managed-settings directory, can still remove it. A same-uid attacker
+  is explicitly out of scope (SPEC-0247 §3.2/§7.3).
+- **`guard-path` is not a seal.** It raises cost and creates an audit signal.
+  Copies made outside the skills dir, content already read into context, and the
+  `/slash` prompt-expansion path are **not** covered.
+- **The offline state machine is informational, not yet enforcing.**
+  `session-baseline` prints the posture, but the runtime gate does not yet consume
+  `require_local_audit` (exit 26) or `locked` (exit 28).
+- **`sync` is contract-complete against a test double.** The durable audit
+  backend is a separate track; egress ships **default-OFF** pending an egress
+  contract. Local evidence is fully functional without it.
+- **Per-batch transparency-log anchoring is not wired** (`translog_seq` is NULL
+  in production). Tamper-evidence is scoped to the signed durable-seq path once
+  synced — not to local log monotonicity.
+
+## Verification
+
+```
+# cosign (keyless) — when cosign is present:
+cosign verify-blob SHA256SUMS \
+  --bundle SHA256SUMS.cosign.bundle \
+  --certificate-identity-regexp '^https://github.com/kamir/m3c-tools/\.github/workflows/skillctl-release\.yml@refs/tags/skillctl/v' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# ed25519 fallback (pinned fingerprint):
+openssl pkeyutl -verify -pubin -inkey skillctl-release.pub \
+  -rawin -in SHA256SUMS -sigfile SHA256SUMS.sig
+```


### PR DESCRIPTION
Started as "write the v0.3.0 release notes", uncovered a **dead mechanism in the release pipeline**.

## The bug
`.gitignore` ignored **`/release/` wholesale**, but `skillctl-release.yml` reads `release/<tag>/RELEASE_NOTES.md` **from the tagged tree**. Not one file under `release/` was ever tracked (`git ls-files release/` → **0**), so the lookup never hit in CI and **every skillctl cut silently shipped the generic placeholder body** — while carefully hand-written notes sat untracked on the author's disk.

**Proof:** the published bodies of `skillctl/v0.2.9` and `skillctl/v0.2.11` are both
`# skillctl <tag>` + `Keyless (cosign/OIDC) provenance release.` — not their local `RELEASE_NOTES.md`.

## The fix
- `.gitignore`: `/release/**` + re-include directories + `!/release/**/RELEASE_NOTES.md`.
  Build artifacts under `release/` **stay ignored** (verified with `git check-ignore`: a dropped `skillctl-linux-amd64` is still ignored; the notes are trackable).
- Tracks the **17 existing `RELEASE_NOTES.md`** (v0.2.0 … v0.2.11-rc4) so the history is preserved and any re-tag reproduces its notes.
- Workflow: logs which path it used, **warns loudly** on fallback, and strips the `skillctl/` prefix so the placeholder no longer reads `# skillctl skillctl/v0.2.11`.

## Also in this PR
- **`release/skillctl/v0.3.0/RELEASE_NOTES.md`** — the notes for the upcoming cut. Carries an explicit *"what this does NOT claim"* section: pinning is un-deletable by **non-root only**; `guard-path` is **not a seal**; the offline state machine is **informational** (exit 26/28 unconsumed); `sync`'s egress is **default-OFF** and per-batch translog anchoring is **unwired**.
- **CHANGELOG**: adds `[skillctl/v0.3.0]`, and records **`[skillctl/v0.2.11]` retroactively** — it was tagged and released on 2026-06-18 with no changelog entry.

Docs + CI only; no product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)