### PR TITLE
SPEC-0317 R-7.2: enforce the offline `locked` state at the gate (was unreachable)

### DIFF
--- a/cmd/skillctl/enforce_cmds_test.go
+++ b/cmd/skillctl/enforce_cmds_test.go
@@ -39,6 +39,14 @@ func runOne(t *testing.T, gate func(r *strings.Reader, o, e *bytes.Buffer) int, 
 	verifyManagedFn = func(string, gatePolicy) (int, string) { return retCode, retReason }
 	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return retCode, retReason, true }
 	t.Cleanup(func() { verifyManagedFn, verifyManagedOfflineFn = origF, origO })
+	// Hermetic: the shipped default reads the real platform managed-settings file
+	// (root-owned /Library/…), which must never influence a unit test. Pin the
+	// enterprise source OFF so the R-7.2 `locked` rung is inert here unless a test
+	// explicitly overrides gateOfflineStateDeniesManaged (the higher seam runOne
+	// leaves untouched).
+	origEnt := gateManagedEnterprise
+	gateManagedEnterprise = func() bool { return false }
+	t.Cleanup(func() { gateManagedEnterprise = origEnt })
 
 	var out, errb bytes.Buffer
 	code := gate(strings.NewReader(event), &out, &errb)

--- a/cmd/skillctl/enforce_locked_test.go
+++ b/cmd/skillctl/enforce_locked_test.go
@@ -1,0 +1,170 @@
+package main
+
+// Tests for SPEC-0317 R-7.2 — the `locked` state wired into the runtime gate.
+//
+// locked = a MANAGED-ENTERPRISE host (opt-in via the root-owned managed settings)
+// with NO trust basis at all (no trust roots, self/ER1 roots, or provenance
+// sidecar) denies non-allowlisted managed skills (exit 28 `offline_locked`). It must:
+//   - be REACHABLE (the whole point — the old file-existence trust-basis check
+//     made it dead by construction);
+//   - be INERT on every non-enterprise host (byte-parity preserved, never-brick);
+//   - NEVER affect unmanaged skills.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withGateLocked stubs the higher-level R-7.2 seam (which runOne leaves
+// untouched) so a ladder test can force the locked outcome deterministically.
+func withGateLocked(t *testing.T, v bool) {
+	t.Helper()
+	orig := gateOfflineStateDeniesManaged
+	gateOfflineStateDeniesManaged = func(string, time.Time) bool { return v }
+	t.Cleanup(func() { gateOfflineStateDeniesManaged = orig })
+}
+
+func TestGate_LockedDeniesManaged(t *testing.T) {
+	withGateLocked(t, true)
+	code, _, se := runOne(t, hookViaEnforce, "subject",
+		`{"tool_name":"Skill","tool_input":{"skill":"subject"}}`, exitOK, "")
+	if code != exitHookBlock {
+		t.Fatalf("locked managed skill: want exit %d, got %d (stderr=%s)", exitHookBlock, code, se)
+	}
+	if !strings.Contains(se, "locked") || !strings.Contains(se, "exit 28") {
+		t.Errorf("expected an offline_locked deny naming exit 28:\n%s", se)
+	}
+}
+
+// Byte-parity holds when the rung is inert (the shipped, non-enterprise default).
+func TestGate_LockedInertPreservesParity(t *testing.T) {
+	withGateLocked(t, false)
+	assertParity(t, "locked-inert-allow", "subject",
+		`{"tool_name":"Skill","tool_input":{"skill":"subject"}}`, exitOK, "")
+	assertParity(t, "locked-inert-deny", "subject",
+		`{"tool_name":"Skill","tool_input":{"skill":"subject"}}`, 11, "author signature invalid")
+}
+
+// locked must NEVER touch unmanaged skills — they return via the unmanaged policy
+// BEFORE the rung.
+func TestGate_LockedNeverAffectsUnmanaged(t *testing.T) {
+	withGateLocked(t, true) // even fully locked
+	code, _, se := runOne(t, hookViaEnforce, "",
+		`{"tool_name":"Skill","tool_input":{"skill":"some-plugin:thing"}}`, exitOK, "")
+	if strings.Contains(se, "locked") {
+		t.Errorf("locked must never affect an unmanaged skill:\n%s", se)
+	}
+	if code != exitOK {
+		t.Errorf("unmanaged under shipped default (allow) should exit %d, got %d", exitOK, code)
+	}
+}
+
+// The refusal token is the queryable Art.12 label for the deny.
+func TestRefusalCode_OfflineLocked(t *testing.T) {
+	got := refusalCodeForHook(exitHookBlock,
+		"offline_locked (managed-enterprise, no trust basis; SPEC-0317 R-7.2)")
+	if got != "offline_locked" {
+		t.Errorf("want offline_locked, got %q", got)
+	}
+}
+
+// TestGate_LockedReachable_RealPath exercises the REAL defaultGateOfflineStateDeniesManaged
+// (resolve policy → gather inputs → Compute), driven only by the managed-enterprise
+// source seam. It proves locked is genuinely reachable AND that any trust basis
+// (here a provenance sidecar) lifts the host out of locked (never-brick breadth).
+func TestGate_LockedReachable_RealPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	mkManagedSkill(t, home, "subject") // managed, but NO trust roots / sidecar → no trust basis
+
+	// managed-enterprise ON via the ONLY enterprise source (managed settings).
+	origEnt := gateManagedEnterprise
+	gateManagedEnterprise = func() bool { return true }
+	t.Cleanup(func() { gateManagedEnterprise = origEnt })
+
+	// Stub the §7 chain to an ALLOW, so if the locked rung did NOT fire we would
+	// wrongly see exit 0 — the test then only passes because locked denied first.
+	of, oo := verifyManagedFn, verifyManagedOfflineFn
+	verifyManagedFn = func(string, gatePolicy) (int, string) { return exitOK, "" }
+	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return exitOK, "", true }
+	t.Cleanup(func() { verifyManagedFn, verifyManagedOfflineFn = of, oo })
+
+	event := `{"tool_name":"Skill","tool_input":{"skill":"subject"}}`
+
+	var out, errb bytes.Buffer
+	if code := runEnforce(strings.NewReader(event), &out, &errb); code != exitHookBlock ||
+		!strings.Contains(errb.String(), "exit 28") {
+		t.Fatalf("enterprise + no trust basis must LOCK (exit 28); got code=%d stderr=%s", code, errb.String())
+	}
+
+	// Add a trust basis (a provenance sidecar next to the skill) → NOT locked → the
+	// stubbed allow wins. This is the never-brick breadth: a sidecar counts.
+	sidecar := filepath.Join(home, ".claude", "skills", "subject", ".m3c-provenance.json")
+	if err := os.WriteFile(sidecar, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	errb.Reset()
+	if code := runEnforce(strings.NewReader(event), &out, &errb); code != exitOK {
+		t.Fatalf("with a trust basis (sidecar) the host must NOT lock; got code=%d stderr=%s", code, errb.String())
+	}
+}
+
+// F2 (adversarial finding, honest scope): the operator allowlist (§9.4, read from
+// the USER-owned gate-policy.yaml) sits ABOVE the locked rung, so a same-uid user
+// can allowlist a specific managed skill past the lock. This test PINS that
+// behaviour so the "non-allowlisted" wording stays honest.
+func TestGate_LockedBypassedByAllowlist(t *testing.T) {
+	withGateLocked(t, true) // host is fully locked
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	mkManagedSkill(t, home, "subject")
+	if err := os.MkdirAll(verdictDir(home), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(verdictDir(home), "gate-policy.yaml"),
+		[]byte("allowlist:\n  - subject\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	code := runEnforce(strings.NewReader(`{"tool_name":"Skill","tool_input":{"skill":"subject"}}`), &out, &errb)
+	if code != exitOK {
+		t.Fatalf("an allowlisted skill must bypass locked (exit %d), got %d (stderr=%s)", exitOK, code, errb.String())
+	}
+	if strings.Contains(errb.String(), "locked") {
+		t.Errorf("allowlisted skill must not hit the locked deny:\n%s", errb.String())
+	}
+}
+
+// Never-brick breadth: a PRESENT-but-malformed skill-trust-roots.yaml still counts
+// as a trust basis (file-existence breadth), so even a managed-enterprise host does
+// NOT lock. Locking on a broken config would be exactly the brick R-7.2 forbids.
+func TestGate_MalformedTrustRootsDoesNotLock(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	mkManagedSkill(t, home, "subject")
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "skill-trust-roots.yaml"),
+		[]byte("this: is: : not: valid: yaml\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	origEnt := gateManagedEnterprise
+	gateManagedEnterprise = func() bool { return true } // enterprise ON
+	t.Cleanup(func() { gateManagedEnterprise = origEnt })
+	of, oo := verifyManagedFn, verifyManagedOfflineFn
+	verifyManagedFn = func(string, gatePolicy) (int, string) { return exitOK, "" }
+	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return exitOK, "", true }
+	t.Cleanup(func() { verifyManagedFn, verifyManagedOfflineFn = of, oo })
+
+	var out, errb bytes.Buffer
+	code := runEnforce(strings.NewReader(`{"tool_name":"Skill","tool_input":{"skill":"subject"}}`), &out, &errb)
+	if code != exitOK || strings.Contains(errb.String(), "locked") {
+		t.Fatalf("a present (even malformed) trust-roots file is a trust basis → must NOT lock; got code=%d stderr=%s", code, errb.String())
+	}
+}

--- a/cmd/skillctl/pin_cmds.go
+++ b/cmd/skillctl/pin_cmds.go
@@ -72,11 +72,11 @@ func runPin(args []string, stdout, stderr io.Writer) int {
 const pinUsage = `Usage: skillctl pin <generate|status|install> [flags]
 
   generate   Print the Claude Code managed-settings.json that pins the trust gate.
-             Flags: --binary <path> (default: this skillctl), --strict, --harden, --out <file>
+             Flags: --binary <path> (default: this skillctl), --strict, --harden, --enterprise, --out <file>
   status     Report whether the gate is pinned in managed settings.
              Flags: --path <file> (override), --json
   install    Stage the file and print the sudo runbook (root+--confirm writes it).
-             Flags: --binary <path>, --strict, --harden, --path <target>, --confirm
+             Flags: --binary <path>, --strict, --harden, --enterprise, --path <target>, --confirm
 
 --strict adds "allowManagedHooksOnly: true" — the full CISO lockdown that also
 DISABLES every other user/project hook. Without it the gate is already
@@ -103,6 +103,7 @@ func runPinGenerate(args []string, stdout, stderr io.Writer) int {
 	binary := fs.String("binary", "", "absolute path to skillctl (default: this binary)")
 	strict := fs.Bool("strict", false, "add allowManagedHooksOnly:true (disables ALL user hooks)")
 	harden := fs.Bool("harden", false, "imply --strict and block --dangerously-skip-permissions")
+	enterprise := fs.Bool("enterprise", false, "add skillctlEnterprise:true — enables the R-7.2 offline `locked` state")
 	out := fs.String("out", "", "write to file instead of stdout")
 	if err := fs.Parse(args); err != nil {
 		return pinExitError
@@ -111,7 +112,7 @@ func runPinGenerate(args []string, stdout, stderr io.Writer) int {
 	if bin == "" {
 		bin = defaultBinary()
 	}
-	b, err := pin.Generate(pin.GenerateOptions{BinaryPath: bin, Strict: *strict, Harden: *harden})
+	b, err := pin.Generate(pin.GenerateOptions{BinaryPath: bin, Strict: *strict, Harden: *harden, Enterprise: *enterprise})
 	if err != nil {
 		fmt.Fprintf(stderr, "skillctl pin generate: %v\n", err)
 		return pinExitError
@@ -215,6 +216,7 @@ func runPinInstall(args []string, stdout, stderr io.Writer) int {
 	binary := fs.String("binary", "", "absolute path to skillctl (default: this binary)")
 	strict := fs.Bool("strict", false, "add allowManagedHooksOnly:true (disables ALL user hooks)")
 	harden := fs.Bool("harden", false, "imply --strict and block --dangerously-skip-permissions")
+	enterprise := fs.Bool("enterprise", false, "add skillctlEnterprise:true — enables the R-7.2 offline `locked` state")
 	pathOverride := fs.String("path", "", "target managed-settings path override")
 	confirm := fs.Bool("confirm", false, "when run as root, actually write the file")
 	if err := fs.Parse(args); err != nil {
@@ -224,7 +226,7 @@ func runPinInstall(args []string, stdout, stderr io.Writer) int {
 	if bin == "" {
 		bin = defaultBinary()
 	}
-	opts := pin.GenerateOptions{BinaryPath: bin, Strict: *strict, Harden: *harden}
+	opts := pin.GenerateOptions{BinaryPath: bin, Strict: *strict, Harden: *harden, Enterprise: *enterprise}
 	target := *pathOverride
 	if target == "" {
 		p, perr := pin.DefaultManagedSettingsPath()

--- a/cmd/skillctl/session_baseline_cmds.go
+++ b/cmd/skillctl/session_baseline_cmds.go
@@ -83,6 +83,10 @@ func runSessionBaseline(args []string, stdout, stderr io.Writer) int {
 	// malformed trust-roots file must not wedge SessionStart; we surface a note
 	// and fall back to the shipped default, which never locks).
 	pol, polNote := resolveSessionOfflinePolicy(home, *trustRootsPath)
+	// SPEC-0317 R-7.2 (Option B): the `enterprise` opt-in that permits `locked` is
+	// sourced from the ROOT-OWNED managed settings, never the trust-roots file —
+	// so the displayed posture matches what the runtime gate actually enforces.
+	pol.Enterprise = gateManagedEnterprise()
 
 	// Snapshot inputs against the injected clock and compute the state.
 	now := sessionBaselineNow().UTC()
@@ -128,9 +132,9 @@ func runSessionBaseline(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "  trust basis present:  %s (SPEC-0188 roots OR self/ER1 roots OR .m3c-provenance)\n", yesNo(dec.TrustBasisPresent))
 	fmt.Fprintf(stdout, "  translog anchor:      %s\n", yesNo(dec.AnchorPresent))
 	fmt.Fprintf(stdout, "  enterprise profile:   %s\n", yesNo(dec.Enterprise))
-	fmt.Fprintf(stdout, "  online fallback:      %s  [INFORMATIONAL — posture only; the runtime gate still falls back until R-7.2 wiring lands]\n", allowedBlocked(dec.AllowOnlineFallback))
+	fmt.Fprintf(stdout, "  online fallback:      %s  [INFORMATIONAL — posture only; state-gating the online fallback is R-1.4 P2, not yet wired: the runtime gate still falls back]\n", allowedBlocked(dec.AllowOnlineFallback))
 	fmt.Fprintf(stdout, "  high-risk fail-closed:%s\n", yesNoPad(dec.HighRiskFailsClosed))
-	fmt.Fprintf(stdout, "  deny all managed:     %s  [INFORMATIONAL — not enforced until R-7.2 wiring + exit 28 land]\n", yesNo(dec.DenyAllManaged))
+	fmt.Fprintf(stdout, "  deny all managed:     %s  [ENFORCED (R-7.2) by verify-hook/enforce when the gate is pinned: a locked host denies non-allowlisted managed skills, exit 28]\n", yesNo(dec.DenyAllManaged))
 	if polNote != "" {
 		fmt.Fprintf(stdout, "  note: %s\n", polNote)
 	}

--- a/cmd/skillctl/verify_hook_cmds.go
+++ b/cmd/skillctl/verify_hook_cmds.go
@@ -39,11 +39,63 @@ import (
 	"time"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/install"
+	"github.com/kamir/m3c-tools/pkg/skillctl/pin"
 	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+	"github.com/kamir/m3c-tools/pkg/skillctl/statemachine"
 	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
 	"github.com/kamir/m3c-tools/pkg/skillgate"
 	"gopkg.in/yaml.v3"
 )
+
+// exitOfflineLocked is the semantic exit code carried in the message + signed
+// refusal_code when the SPEC-0317 R-7.2 `locked` state denies a managed skill.
+// The PROCESS still exits exitHookBlock (2); this rides the message, mirroring
+// exitBundleRevoked (17) / exitRevocationStale (22) / exitSidechannelDenied (27).
+const exitOfflineLocked = 28 // = exitcode.OfflineLocked.Number
+
+// gateManagedEnterprise reports whether the ROOT-OWNED managed settings enable
+// the SPEC-0317 enterprise posture (`skillctlEnterprise: true`). This is the ONLY
+// source of the `locked` opt-in (Option B): sourcing it from the trust-roots file
+// would make declaring "enterprise" itself create a trust basis — the conflation
+// that left `locked` unreachable. A missing/unreadable/malformed managed file →
+// false (never-brick: `locked` is the most destructive posture and must not
+// engage on a file we cannot cleanly read). Seam: tests set it directly.
+var gateManagedEnterprise = func() bool {
+	path, err := pin.DefaultManagedSettingsPath()
+	if err != nil {
+		return false
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return pin.EnterpriseFromBytes(b)
+}
+
+// gateOfflineStateDeniesManaged reports whether the SPEC-0317 R-7.2 `locked`
+// state denies this (already-classified-managed) skill. Seam for tests.
+//
+// It performs NO network probe: `locked` depends only on the managed enterprise
+// opt-in AND trust-basis presence (Compute checks locked BEFORE RegistryReachable),
+// so the hot path stays strictly local. It fast-paths to false for every
+// non-enterprise host BEFORE any filesystem gather — so a default machine pays
+// nothing and AC-1 byte-parity holds trivially.
+var gateOfflineStateDeniesManaged = defaultGateOfflineStateDeniesManaged
+
+func defaultGateOfflineStateDeniesManaged(home string, now time.Time) bool {
+	if !gateManagedEnterprise() {
+		return false // never-brick: only a managed-enterprise host can ever lock
+	}
+	pol, _ := resolveSessionOfflinePolicy(home, "") // the freshness knobs
+	// SPEC-0317 R-7.2 (Option B): the enterprise opt-in for `locked` comes from the
+	// managed settings, overriding whatever the trust-roots offline_policy declared.
+	// NOTE: pol.RequireLocalAudit still originates from trust-roots and is inert
+	// today (Compute/gate never read it). When R-8 wires require_local_audit, its
+	// enterprise source must be reconciled with this one before it is consumed.
+	pol.Enterprise = true
+	in := sessionBaselineGather(home, false, now) // forceOnline=false; locked ignores reachability
+	return statemachine.DenyAllManaged(statemachine.Compute(in, pol))
+}
 
 // refusalCodeForHook maps the hook's (exitCode, reason) into a stable
 // refusal_code token for the signed invocation record. An allow (exit 0) has
@@ -55,6 +107,10 @@ func refusalCodeForHook(exitCode int, reason string) string {
 		return ""
 	}
 	switch {
+	// SPEC-0317 R-7.2 — the `locked`-state managed deny. A unique token; placed
+	// first as it cannot be a substring of any other reason.
+	case strings.Contains(reason, "offline_locked"):
+		return "offline_locked"
 	// SPEC-0277 P1 — agent-authorization denies. Checked BEFORE the generic
 	// "revoked"/"unmanaged" cases so an agent deny gets its specific token (e.g.
 	// an "agent_revoked" reason must not be flattened to "bundle_revoked").
@@ -351,6 +407,26 @@ func runVerifyHook(stdin io.Reader, stdout, stderr io.Writer) (code int) {
 			audReason = fmt.Sprintf("unmanaged (%s) + policy allow", why)
 			return allow()
 		}
+	}
+
+	// SPEC-0317 R-7.2 — `locked` STATE: a managed-enterprise host with NO trust
+	// basis at all (roots/self-roots/sidecar all gone) denies ALL MANAGED skills
+	// here — BEFORE the revoked/verdict cache, so a cached allow cannot outlive a
+	// fleet that has lost its policy basis. Unmanaged skills already returned above
+	// and are untouched (R-7.2). The enterprise opt-in is read from the ROOT-OWNED
+	// managed settings (Option B), so this is inert on every non-enterprise host —
+	// it never bricks a default / self-ER1 / air-gapped machine and preserves AC-1
+	// byte-parity. Emergency already ran first (unconditional); the AgentID grant
+	// still wraps the eventual allow() elsewhere.
+	// NOTE ON SCOPE: this rung sits BELOW the operator allowlist (§9.4) above,
+	// which is read from the USER-owned gate-policy.yaml — so a same-uid user can
+	// allowlist a specific managed skill past the lock without root. That matches
+	// the allowlist's existing role as the escape hatch that bypasses all §7
+	// verification; the message therefore says "non-allowlisted", not "all".
+	if gateOfflineStateDeniesManaged(home, now) {
+		audReason = "offline_locked (managed-enterprise, no trust basis; SPEC-0317 R-7.2)"
+		return emitDeny(stdout, stderr,
+			fmt.Sprintf("skillctl: BLOCKED '%s' — offline 'locked' state (exit %d): the host is managed-enterprise but has NO trust basis (no trust roots, self/ER1 roots, or provenance sidecar), so offline_policy denies all non-allowlisted managed skills. Restore a trust root or a signed offline checkpoint.", skill, exitOfflineLocked))
 	}
 
 	// SPEC-0266 F1: a bundle revoked AFTER install is denied by the offline gate

--- a/pkg/skillctl/exitcode/registry.go
+++ b/pkg/skillctl/exitcode/registry.go
@@ -119,6 +119,20 @@ var (
 	GuardPathSidechannelDenied = Code{27, "side-channel / path-guard", "guard-path", "sidechannel_denied"}
 )
 
+// ---------------------------------------------------------------------------
+// Tier 7 — offline state machine (SPEC-0317 R-7.2, P2; the runtime gate).
+// 28 is a fresh, uniquely-themed code carried in the signed refusal_code when the
+// `locked` state (enterprise opt-in via managed settings + NO trust basis at all)
+// denies a MANAGED skill. The PROCESS still exits 2 to block the PreToolUse call,
+// mirroring the guard-path/verify-hook convention. Reserved-but-not-yet-emitted:
+// 26 (local_audit_unavailable, R-8 require_local_audit) — registered when that
+// carve-out is wired, so it is NOT in AllCodes yet.
+// ---------------------------------------------------------------------------
+
+var (
+	OfflineLocked = Code{28, "offline / no-policy-basis", "state-machine", "offline_locked"}
+)
+
 // AllCodes returns every Code currently registered. Used by the
 // CI invariant test (TestCodes_NumberTheme) and by the generator
 // that emits the SKILLCTL-MANUAL.md exit-code table.
@@ -140,5 +154,7 @@ func AllCodes() []Code {
 		SyncIngestRejected,
 		// Tier 6 — guard-path side channel
 		GuardPathSidechannelDenied,
+		// Tier 7 — offline state machine (locked)
+		OfflineLocked,
 	}
 }

--- a/pkg/skillctl/pin/pin.go
+++ b/pkg/skillctl/pin/pin.go
@@ -64,6 +64,13 @@ type GenerateOptions struct {
 	Strict bool
 	// Harden implies Strict and also sets `disableBypassPermissionsMode:"disable"`.
 	Harden bool
+	// Enterprise emits `skillctlEnterprise: true` — the SPEC-0317 R-7.2 opt-in
+	// that the runtime gate reads to enable the `offline_locked` state. It lives
+	// HERE (the root-owned managed-settings tier), deliberately separate from the
+	// trust-roots verification material: declaring "enterprise" must not itself
+	// create a trust basis (that conflation made `locked` unreachable). Claude
+	// Code ignores the unknown key (its schema is additive); skillctl reads it.
+	Enterprise bool
 }
 
 // wire structs — field order here is the emitted JSON key order (encoding/json
@@ -84,6 +91,7 @@ type hooksBlock struct {
 type managedSettings struct {
 	AllowManagedHooksOnly        bool       `json:"allowManagedHooksOnly,omitempty"`
 	DisableBypassPermissionsMode string     `json:"disableBypassPermissionsMode,omitempty"`
+	SkillctlEnterprise           bool       `json:"skillctlEnterprise,omitempty"`
 	Hooks                        hooksBlock `json:"hooks"`
 }
 
@@ -134,6 +142,9 @@ func gateHooks(binary string) hooksBlock {
 // options (trailing newline included).
 func Generate(opts GenerateOptions) ([]byte, error) {
 	ms := managedSettings{Hooks: gateHooks(opts.BinaryPath)}
+	if opts.Enterprise {
+		ms.SkillctlEnterprise = true
+	}
 	if opts.Strict || opts.Harden {
 		ms.AllowManagedHooksOnly = true
 	}
@@ -202,6 +213,24 @@ type StatusResult struct {
 // Pinned reports whether the gate is un-deletable (Pinned or PinnedStrict).
 func (s StatusResult) Pinned() bool {
 	return s.Level == LevelPinned || s.Level == LevelPinnedStrict
+}
+
+// EnterpriseFromBytes reports whether managed settings enable the SPEC-0317
+// R-7.2 enterprise posture (`skillctlEnterprise: true`) — the opt-in the runtime
+// gate reads to permit the destructive `offline_locked` state.
+//
+// It is deliberately conservative and the OPPOSITE of the gate-hook checks: a
+// MISSING or MALFORMED managed file yields false, so an unreadable managed file
+// can never ENGAGE `locked` (R-7.2 never-brick priority — locking on a corrupt
+// file would brick a host). Only a cleanly-parsed true engages it. It lives in
+// the root-owned managed tier precisely so declaring "enterprise" does NOT create
+// a trust basis (the conflation that made `locked` unreachable).
+func EnterpriseFromBytes(settings []byte) bool {
+	var ms managedSettings
+	if json.Unmarshal(settings, &ms) != nil {
+		return false
+	}
+	return ms.SkillctlEnterprise
 }
 
 // Verify parses managed-settings bytes and reports the pinning level. It matches

--- a/pkg/skillctl/pin/pin_test.go
+++ b/pkg/skillctl/pin/pin_test.go
@@ -331,3 +331,49 @@ func TestMerge_AddsCoveringMatcherDespiteNonCoveringDecoy(t *testing.T) {
 		t.Error("Merge dropped the pre-existing Bash matcher")
 	}
 }
+
+// TestEnterpriseFromBytes locks the SPEC-0317 R-7.2 managed enterprise reader:
+// only a cleanly-parsed skillctlEnterprise:true engages it; missing/false/
+// malformed all yield false (never-brick — locking on a corrupt file would brick).
+func TestEnterpriseFromBytes(t *testing.T) {
+	if !EnterpriseFromBytes([]byte(`{"skillctlEnterprise":true}`)) {
+		t.Error("skillctlEnterprise:true must read as enterprise")
+	}
+	for _, neg := range []string{
+		`{"skillctlEnterprise":false}`,
+		`{}`,
+		`{"other":1}`,
+		`{ not json`,
+		``,
+	} {
+		if EnterpriseFromBytes([]byte(neg)) {
+			t.Errorf("must be non-enterprise (never-brick): %q", neg)
+		}
+	}
+	if EnterpriseFromBytes(nil) {
+		t.Error("nil must be non-enterprise")
+	}
+	// The flag coexists with the gate hooks + strict lock and does not disturb the
+	// pinning classification.
+	b, err := Generate(GenerateOptions{Enterprise: true, Strict: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !EnterpriseFromBytes(b) {
+		t.Error("Generate(Enterprise) must round-trip through EnterpriseFromBytes")
+	}
+	if Verify(b).Level != LevelPinnedStrict {
+		t.Errorf("enterprise flag must not change the pinning level, got %s", Verify(b).Level)
+	}
+}
+
+func TestGenerate_EnterpriseKey(t *testing.T) {
+	on, _ := Generate(GenerateOptions{Enterprise: true})
+	if !strings.Contains(string(on), `"skillctlEnterprise": true`) {
+		t.Errorf("--enterprise must emit the key:\n%s", on)
+	}
+	off, _ := Generate(GenerateOptions{})
+	if strings.Contains(string(off), "skillctlEnterprise") {
+		t.Errorf("default must NOT emit the enterprise key:\n%s", off)
+	}
+}

--- a/pkg/skillctl/statemachine/statemachine.go
+++ b/pkg/skillctl/statemachine/statemachine.go
@@ -280,11 +280,14 @@ func ageFresh(age, ceiling time.Duration) bool {
 // flag the state machine feeds the ladder — it does NOT reorder the ladder.
 func AllowOnlineFallback(s State) bool { return s == StateOnline }
 
-// DenyAllManaged reports whether the state denies ALL managed skills. ONLY
-// `locked` does (enterprise opt-in, exit 28 `offline_locked`). It NEVER affects
-// unmanaged skills — the shipped unmanaged=allow default is untouched (R-7.2).
-// Because Compute only returns locked under Enterprise, this can never brick a
-// non-enterprise host.
+// DenyAllManaged reports whether the state denies managed skills. ONLY `locked`
+// does (enterprise opt-in, exit 28 `offline_locked`). It NEVER affects unmanaged
+// skills — the shipped unmanaged=allow default is untouched (R-7.2). Because
+// Compute only returns locked under Enterprise, this can never brick a
+// non-enterprise host. NOTE (scope): at the gate this rung sits below the
+// operator allowlist (§9.4), so a same-uid user can allowlist a specific managed
+// skill past the lock — the deny is over NON-ALLOWLISTED managed skills, not
+// literally all of them.
 func DenyAllManaged(s State) bool { return s == StateLocked }
 
 // HighRiskFailsClosed reports whether high-risk actions fail closed in the given


### PR DESCRIPTION
Turns SPEC-0317's `locked` posture from **informational** into **enforcing**: a managed-enterprise host with no trust basis now denies non-allowlisted managed skills at the runtime gate (exit 28 `offline_locked`), before the revoked/verdict cache.

## The bug found while wiring it
`locked` was **unreachable by construction**. The `enterprise` opt-in lived in `skill-trust-roots.yaml`, and `trustBasisPresent()` returned true merely because that file existed → enterprise-on ⇒ trust-basis-present ⇒ `Compute` never returned `StateLocked`. A naive rung would have been dead theater — the exact "looks-verified ≠ is-verified" trap.

## Fix (Option B, chosen by the maintainer): source enterprise from the managed tier
The enterprise opt-in now comes from the **root-owned managed settings** (`skillctlEnterprise: true`), decoupled from the trust-roots verification material. Declaring "enterprise" no longer creates a trust basis, so `locked` is genuinely reachable — and the flag lives in the un-deletable tier we just built `skillctl pin` for: `skillctl pin generate|install --enterprise`.

## Never-brick (paramount R-7.2 rule) — held + tested
A non-enterprise / self-ER1-sidecar-only / air-gapped / default host can **never** lock (`Compute` returns locked only under Enterprise; a missing/malformed managed file → not enterprise). A present-but-malformed trust-roots file still counts as a basis and does not lock. The rung fast-paths to false for every non-enterprise host → zero hot-path cost, **AC-1 byte-parity preserved**.

## Adversarial gate — ran, findings applied
Verdict: *"substantially clean — locked genuinely reachable, never-brick holds, byte-parity holds, ordering correct."* Applied:
- **F1**: session-baseline no longer prints "not enforced" for a posture that now **is** enforced.
- **F2 (honest scope)**: the message + statemachine doc say "**non-allowlisted** managed skills" — a same-uid user CAN allowlist a managed skill past the lock via the user-owned `gate-policy.yaml` (the existing §9.4 escape hatch). Pinned by a test.
- **F3**: the two-enterprise-source split (managed for `locked`; trust-roots for the still-inert `require_local_audit`) is documented for R-8 reconciliation.
- **F4**: added allowlist-bypass + malformed-roots-no-lock tests.

## Scope
- **In**: `locked`/exit 28 enforced. **Out (follow-ups)**: `require_local_audit`/exit 26 (R-8, inverts SPEC-0255 — deserves its own PR); state-gating the online fallback (R-1.4 P2); translog per-batch anchoring.

Tests: reachable-real-path, inert-parity, unmanaged-untouched, allowlist-bypass, malformed-roots-no-lock, refusal token, pin reader — `-race` + vet + gofmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)