### PR TITLE
SPEC-0317 R-8.2: require_local_audit — opt-in fail-closed on un-recordable allow

### DIFF
--- a/cmd/skillctl/enforce_cmds.go
+++ b/cmd/skillctl/enforce_cmds.go
@@ -31,16 +31,39 @@ package main
 // double failure never alters the decision.
 
 import (
+	"fmt"
 	"io"
+	"os"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/outbox"
+	"github.com/kamir/m3c-tools/pkg/skillctl/pin"
 	"github.com/kamir/m3c-tools/pkg/skillgate"
 )
 
-// enforceOutboxSink is the outbox-write seam. Production points it at
-// defaultEnforceOutboxSink; the decision-invariance test injects a failing /
-// panicking sink to prove exit+output are unchanged (AC-2a).
+// enforceOutboxSink is the outbox-write seam. It returns whether the record was
+// DURABLY recorded (outbox row OR spool line — AppendOrSpool==nil). The bool is
+// consumed ONLY by the R-8.2 require_local_audit path in runEnforce; the default
+// (flag unset) ignores it, so the fire-and-forget contract is untouched. The
+// decision-invariance test injects a failing / panicking sink to prove exit+output
+// are unchanged (AC-2a).
 var enforceOutboxSink = defaultEnforceOutboxSink
+
+// gateRequireLocalAudit reports whether the ROOT-OWNED managed settings enable the
+// SPEC-0317 R-8.2 require_local_audit posture (enterprise-gated). Same source as
+// the R-7.2 enterprise flag — one managed tier for both knobs. A missing/unreadable/
+// malformed managed file → false (the carve-out is opt-in; absence is the default
+// fire-and-forget behaviour). Seam: tests set it directly.
+var gateRequireLocalAudit = func() bool {
+	path, err := pin.DefaultManagedSettingsPath()
+	if err != nil {
+		return false
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return pin.RequireLocalAuditFromBytes(b)
+}
 
 // runEnforce is the entrypoint for `skillctl enforce`. It returns the process
 // exit code (0 = allow, 2 = deny/block) — the very same value runVerifyHook
@@ -52,35 +75,96 @@ var enforceOutboxSink = defaultEnforceOutboxSink
 // process. Setting the package-level seam is safe because skillctl handles one
 // hook event per process — there is no concurrent gate in-process.
 func runEnforce(stdin io.Reader, stdout, stderr io.Writer) int {
+	reqAudit := gateRequireLocalAudit()
+
+	// The sink is invoked once per GATED SKILL (from appendSignedInvocation, after
+	// the decision). sinkCalled therefore distinguishes a real skill decision from a
+	// non-Skill / no-skill passthrough allow — for which nothing is gated and
+	// require_local_audit must NOT apply. durable = the record landed (outbox row or
+	// spool line). Both are captured for the R-8.2 override below and otherwise ignored.
+	var sinkCalled, durable bool
 	prev := invocationOutboxSink
-	invocationOutboxSink = enforceOutboxSink
+	invocationOutboxSink = func(h string, rec skillgate.InvocationRecord) {
+		sinkCalled = true
+		if enforceOutboxSink(h, rec) {
+			durable = true
+		}
+	}
 	defer func() { invocationOutboxSink = prev }()
-	return runVerifyHook(stdin, stdout, stderr)
+
+	code := runVerifyHook(stdin, stdout, stderr)
+
+	// SPEC-0317 R-8.2 — require_local_audit inverts the SPEC-0255 fire-and-forget
+	// contract, OPT-IN via managed settings. It escalates a skill ALLOW whose
+	// evidence could not be durably recorded (outbox row AND spool line both failed)
+	// into a fail-closed deny (exit 26). A deny already stands (fail-closed); the
+	// DEFAULT (flag unset) returns `code` unchanged, so decision-invariance / AC-2a
+	// is preserved byte-for-byte. An allow emits nothing to stdout, so writing the
+	// deny now is clean.
+	//
+	// SCOPE (breadth): "a skill ALLOW" means EVERY audited Skill decision the gate
+	// allowed — managed, UNMANAGED (default-allow plugins / namespaced skills), AND
+	// allowlisted. audActive is set before those branches, so all reach the sink.
+	// So on a host whose outbox is unrecordable, turning on require_local_audit
+	// denies the whole plugin ecosystem + the operator's allowlisted escapes too.
+	// That is the intended enterprise posture ("no un-audited allow"), not a bug.
+	//
+	// The load-bearing store is the OUTBOX (+ its spool); the signed trail is a
+	// best-effort projection. Because the sink spools even when outbox.Open fails
+	// (defaultEnforceOutboxSink), durability tracks the SAME writable-dir condition
+	// the trail write depends on — so the two land together or fail together, and a
+	// fail-closed deny never coexists with a trail that recorded the allow.
+	//
+	// KNOWN NON-ESCALATED gaps (sink never reached → sinkCalled=false): home
+	// unavailable, device key unavailable, sign-refusal (e.g. a newline-smuggled
+	// field), or record marshal failure. A gated allow on such a degraded host is
+	// NOT escalated — rare, and out of the disk-full case R-8.2 targets.
+	if reqAudit && code == exitOK && sinkCalled && !durable {
+		return emitDeny(stdout, stderr,
+			fmt.Sprintf("skillctl: BLOCKED — require_local_audit is set but the enforcement event could not be durably recorded (outbox + spool both failed); refusing to allow un-audited (exit %d local_audit_unavailable, SPEC-0317 R-8.2).", exitLocalAuditUnavailable))
+	}
+	return code
 }
+
+// exitLocalAuditUnavailable is the semantic code carried in the R-8.2 fail-closed
+// deny message. The PROCESS still exits exitHookBlock (2); the number rides the
+// message, mirroring exitOfflineLocked / exitSidechannelDenied.
+const exitLocalAuditUnavailable = 26 // = exitcode.LocalAuditUnavailable.Number
 
 // defaultEnforceOutboxSink mirrors one fully-signed InvocationRecord into the
 // SPEC-0317 outbox. It is called from inside appendSignedInvocation (already
 // under a recover), but it defends itself as well so it is safe to call from any
 // future seam. It NEVER returns an error to the caller: on any failure it either
 // spools (AppendOrSpool) or drops silently, so the decision path is untouched.
-func defaultEnforceOutboxSink(home string, rec skillgate.InvocationRecord) {
-	defer func() { _ = recover() }()
+func defaultEnforceOutboxSink(home string, rec skillgate.InvocationRecord) (durable bool) {
+	defer func() {
+		if recover() != nil {
+			durable = false // a panic is not a durable write
+		}
+	}()
 	if home == "" {
-		return // nowhere to anchor state (mirrors the trail sink's guard)
+		return false // nowhere to anchor state (mirrors the trail sink's guard)
 	}
 	// Pin the exact signed bytes once (payload_json) + their hash, so the outbox
 	// row is byte-consistent with the trail projection.
 	payloadJSON, payloadHash, err := outbox.RecordPayload(rec)
 	if err != nil {
-		return // a record that refuses canonicalization is not evidence we can store
+		return false // a record that refuses canonicalization is not evidence we can store
 	}
 	st, err := outbox.Open(home)
 	if err != nil {
-		return // fail-open on the WRITE only — never on the decision
+		// Open ITSELF failed — e.g. a corrupt outbox.db on an otherwise-WRITABLE
+		// dir. Do NOT give up: spool the row directly (no db I/O). This keeps
+		// durability tracking the same writable-dir condition the signed trail
+		// write depends on, so R-8.2 never fires a spurious deny (spool would have
+		// worked) and never leaves the trail recording an allow the process denied.
+		// A truly unwritable dir fails BOTH this spool and the trail → consistent.
+		return outbox.SpoolTo(home, rec, payloadJSON, payloadHash) == nil
 	}
 	defer st.Close()
-	// AppendOrSpool: on SQLITE_BUSY / db error the row falls back to spool.jsonl
-	// so a later `skillctl sync` Reconcile drains it. The returned error (only if
-	// BOTH sinks fail) is intentionally ignored — decision-invariance wins.
-	_ = st.AppendOrSpool(rec, payloadJSON, payloadHash)
+	// AppendOrSpool: on SQLITE_BUSY / db error the row falls back to spool.jsonl so a
+	// later `skillctl sync` Reconcile drains it. It returns nil iff the outbox row OR
+	// the spool line landed → durable. The default (fire-and-forget) path ignores
+	// this bool; only R-8.2 require_local_audit consumes it.
+	return st.AppendOrSpool(rec, payloadJSON, payloadHash) == nil
 }

--- a/cmd/skillctl/enforce_cmds_test.go
+++ b/cmd/skillctl/enforce_cmds_test.go
@@ -47,6 +47,12 @@ func runOne(t *testing.T, gate func(r *strings.Reader, o, e *bytes.Buffer) int, 
 	origEnt := gateManagedEnterprise
 	gateManagedEnterprise = func() bool { return false }
 	t.Cleanup(func() { gateManagedEnterprise = origEnt })
+	// Same hermetic pin for the R-8.2 require_local_audit source: OFF unless a test
+	// overrides it, so every runOne-based parity test keeps the fire-and-forget
+	// contract regardless of the machine's real managed-settings file.
+	origRLA := gateRequireLocalAudit
+	gateRequireLocalAudit = func() bool { return false }
+	t.Cleanup(func() { gateRequireLocalAudit = origRLA })
 
 	var out, errb bytes.Buffer
 	code := gate(strings.NewReader(event), &out, &errb)
@@ -173,7 +179,7 @@ func TestEnforce_WritesOutboxRow(t *testing.T) {
 func TestEnforce_OutboxFailure_DecisionInvariant(t *testing.T) {
 	// Force the sink to panic on every call.
 	origSink := enforceOutboxSink
-	enforceOutboxSink = func(string, skillgate.InvocationRecord) { panic("outbox is on fire") }
+	enforceOutboxSink = func(string, skillgate.InvocationRecord) bool { panic("outbox is on fire") }
 	t.Cleanup(func() { enforceOutboxSink = origSink })
 
 	skillEvent := `{"tool_name":"Skill","tool_input":{"skill":"subject"},"session_id":"s"}`
@@ -203,7 +209,7 @@ func TestEnforce_OutboxFailure_DecisionInvariant(t *testing.T) {
 // outbox failure must not become a fail-open OR a spurious deny).
 func TestEnforce_OutboxFailure_StillDecidesAllow(t *testing.T) {
 	origSink := enforceOutboxSink
-	enforceOutboxSink = func(string, skillgate.InvocationRecord) { panic("boom") }
+	enforceOutboxSink = func(string, skillgate.InvocationRecord) bool { panic("boom") }
 	t.Cleanup(func() { enforceOutboxSink = origSink })
 
 	code, out, _ := runOne(t, hookViaEnforce, "subject",

--- a/cmd/skillctl/enforce_require_audit_test.go
+++ b/cmd/skillctl/enforce_require_audit_test.go
@@ -1,0 +1,181 @@
+package main
+
+// Tests for SPEC-0317 R-8.2 — require_local_audit, the OPT-IN inversion of the
+// SPEC-0255 fire-and-forget contract.
+//
+// When require_local_audit is set (managed settings, enterprise-gated), a skill
+// ALLOW whose evidence could not be durably recorded (outbox + spool both failed)
+// is escalated to a fail-closed deny (exit 26). Everything else is unchanged:
+//   - flag unset → decision-invariance preserved (covered by TestEnforce_OutboxFailure_*);
+//   - a DENY already stands (never re-escalated);
+//   - a non-Skill / no-skill passthrough allow is NOT audited → NOT escalated.
+//
+// These tests set the seams MANUALLY (not via runOne, which pins
+// gateRequireLocalAudit OFF for hermeticity and would clobber the value here).
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/outbox"
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+)
+
+// runEnforceGatedSkill sets up a managed skill on a fresh $HOME with the §7 chain
+// stubbed to (verifyCode, verifyReason) and the locked path pinned OFF, then runs
+// enforce for that skill. The require_local_audit source and the outbox durability
+// are left to the CALLER's seams (set before invoking).
+func runEnforceGatedSkill(t *testing.T, skill string, verifyCode int, verifyReason string) (int, string, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	mkManagedSkill(t, home, skill)
+	oe := gateManagedEnterprise
+	gateManagedEnterprise = func() bool { return false } // keep the R-7.2 locked rung inert
+	t.Cleanup(func() { gateManagedEnterprise = oe })
+	of, oo := verifyManagedFn, verifyManagedOfflineFn
+	verifyManagedFn = func(string, gatePolicy) (int, string) { return verifyCode, verifyReason }
+	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return verifyCode, verifyReason, true }
+	t.Cleanup(func() { verifyManagedFn, verifyManagedOfflineFn = of, oo })
+
+	var out, errb bytes.Buffer
+	code := runEnforce(strings.NewReader(
+		`{"tool_name":"Skill","tool_input":{"skill":"`+skill+`"},"session_id":"s"}`), &out, &errb)
+	return code, out.String(), errb.String()
+}
+
+func withRequireLocalAudit(t *testing.T, v bool) {
+	t.Helper()
+	orig := gateRequireLocalAudit
+	gateRequireLocalAudit = func() bool { return v }
+	t.Cleanup(func() { gateRequireLocalAudit = orig })
+}
+func withOutboxDurable(t *testing.T, ok bool) {
+	t.Helper()
+	orig := enforceOutboxSink
+	enforceOutboxSink = func(string, skillgate.InvocationRecord) bool { return ok }
+	t.Cleanup(func() { enforceOutboxSink = orig })
+}
+
+// Headline R-8.2: an allow that could not be durably recorded fails closed (26).
+func TestRequireLocalAudit_UnrecordableAllowFailsClosed(t *testing.T) {
+	withRequireLocalAudit(t, true)
+	withOutboxDurable(t, false) // outbox + spool both failed
+	code, _, se := runEnforceGatedSkill(t, "subject", exitOK, "")
+	if code != exitHookBlock {
+		t.Fatalf("require_local_audit + unrecordable allow: want exit %d, got %d (stderr=%s)", exitHookBlock, code, se)
+	}
+	if !strings.Contains(se, "exit 26") || !strings.Contains(se, "require_local_audit") {
+		t.Errorf("expected a local_audit_unavailable deny naming exit 26:\n%s", se)
+	}
+}
+
+// A durable write → the allow stands.
+func TestRequireLocalAudit_DurableAllowPasses(t *testing.T) {
+	withRequireLocalAudit(t, true)
+	withOutboxDurable(t, true) // recorded (outbox or spool)
+	code, out, _ := runEnforceGatedSkill(t, "subject", exitOK, "")
+	if code != exitOK {
+		t.Fatalf("durable allow must pass, got exit %d", code)
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("a passing allow must emit nothing, got %q", out)
+	}
+}
+
+// A DENY is never re-escalated — it keeps its own reason (not exit 26).
+func TestRequireLocalAudit_DenyIsUnchanged(t *testing.T) {
+	withRequireLocalAudit(t, true)
+	withOutboxDurable(t, false) // even with a failed write
+	code, _, se := runEnforceGatedSkill(t, "subject", 11, "author signature invalid")
+	if code != exitHookBlock {
+		t.Fatalf("deny should exit %d, got %d", exitHookBlock, code)
+	}
+	if strings.Contains(se, "local_audit_unavailable") || strings.Contains(se, "exit 26") {
+		t.Errorf("a real deny must keep its own reason, not the audit deny:\n%s", se)
+	}
+	if !strings.Contains(se, "author signature invalid") {
+		t.Errorf("expected the original deny reason:\n%s", se)
+	}
+}
+
+// THE critical false-positive guard: a non-Skill tool (Bash/Read/…) and a
+// no-skill-field event are passthrough allows — nothing is gated, so
+// require_local_audit must NOT escalate them even with a failing outbox.
+// Breaking this would deny every file op on an enterprise host.
+func TestRequireLocalAudit_PassthroughNotEscalated(t *testing.T) {
+	withRequireLocalAudit(t, true)
+	withOutboxDurable(t, false)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	for _, ev := range []string{
+		`{"tool_name":"Bash","tool_input":{"command":"ls"}}`,
+		`{"tool_name":"Skill","tool_input":{"args":"x"}}`, // Skill tool, no skill field
+	} {
+		var out, errb bytes.Buffer
+		code := runEnforce(strings.NewReader(ev), &out, &errb)
+		if code != exitOK {
+			t.Fatalf("passthrough %q must allow (exit %d), got %d (stderr=%s)", ev, exitOK, code, errb.String())
+		}
+	}
+}
+
+// F1 regression: a CORRUPT outbox.db on a WRITABLE dir must NOT spuriously deny.
+// The real sink spools directly (no db I/O) when Open fails → durable → the allow
+// stands, and the evidence lands — so a fail-closed deny can never coexist with a
+// trail that recorded the allow.
+func TestRequireLocalAudit_OpenFailSpoolsNotSpuriousDeny(t *testing.T) {
+	withRequireLocalAudit(t, true)
+	// NOTE: exercise the REAL enforceOutboxSink here — do NOT stub it.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	mkManagedSkill(t, home, "subject")
+	oe := gateManagedEnterprise
+	gateManagedEnterprise = func() bool { return false }
+	t.Cleanup(func() { gateManagedEnterprise = oe })
+	of, oo := verifyManagedFn, verifyManagedOfflineFn
+	verifyManagedFn = func(string, gatePolicy) (int, string) { return exitOK, "" }
+	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return exitOK, "", true }
+	t.Cleanup(func() { verifyManagedFn, verifyManagedOfflineFn = of, oo })
+
+	// Corrupt the db so outbox.Open fails, but keep the dir writable.
+	if err := os.MkdirAll(filepath.Dir(outbox.DBPath(home)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outbox.DBPath(home), []byte("not a sqlite database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errb bytes.Buffer
+	code := runEnforce(strings.NewReader(
+		`{"tool_name":"Skill","tool_input":{"skill":"subject"},"session_id":"s"}`), &out, &errb)
+	if code != exitOK {
+		t.Fatalf("corrupt db on a writable dir must NOT spuriously deny (F1): got exit %d stderr=%s", code, errb.String())
+	}
+	spool := filepath.Join(home, ".claude", "skillctl", "spool.jsonl")
+	if b, err := os.ReadFile(spool); err != nil || len(b) == 0 {
+		t.Fatalf("expected a spooled record after Open failure (durability = writable dir); read err=%v len=%d", err, len(b))
+	}
+}
+
+// F2: require_local_audit escalates UNMANAGED (default-allow) skill allows too —
+// on an unrecordable outbox it denies the plugin ecosystem. Documented posture.
+func TestRequireLocalAudit_UnmanagedAllowEscalated(t *testing.T) {
+	withRequireLocalAudit(t, true)
+	withOutboxDurable(t, false)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	oe := gateManagedEnterprise
+	gateManagedEnterprise = func() bool { return false }
+	t.Cleanup(func() { gateManagedEnterprise = oe })
+
+	var out, errb bytes.Buffer
+	code := runEnforce(strings.NewReader(
+		`{"tool_name":"Skill","tool_input":{"skill":"some-plugin:thing"},"session_id":"s"}`), &out, &errb)
+	if code != exitHookBlock || !strings.Contains(errb.String(), "exit 26") {
+		t.Fatalf("an unmanaged allow under require_local_audit + failed outbox must escalate to exit 26; got %d stderr=%s", code, errb.String())
+	}
+}

--- a/cmd/skillctl/pin_cmds.go
+++ b/cmd/skillctl/pin_cmds.go
@@ -72,11 +72,11 @@ func runPin(args []string, stdout, stderr io.Writer) int {
 const pinUsage = `Usage: skillctl pin <generate|status|install> [flags]
 
   generate   Print the Claude Code managed-settings.json that pins the trust gate.
-             Flags: --binary <path> (default: this skillctl), --strict, --harden, --enterprise, --out <file>
+             Flags: --binary <path> (default: this skillctl), --strict, --harden, --enterprise, --require-local-audit, --out <file>
   status     Report whether the gate is pinned in managed settings.
              Flags: --path <file> (override), --json
   install    Stage the file and print the sudo runbook (root+--confirm writes it).
-             Flags: --binary <path>, --strict, --harden, --enterprise, --path <target>, --confirm
+             Flags: --binary <path>, --strict, --harden, --enterprise, --require-local-audit, --path <target>, --confirm
 
 --strict adds "allowManagedHooksOnly: true" — the full CISO lockdown that also
 DISABLES every other user/project hook. Without it the gate is already
@@ -104,6 +104,7 @@ func runPinGenerate(args []string, stdout, stderr io.Writer) int {
 	strict := fs.Bool("strict", false, "add allowManagedHooksOnly:true (disables ALL user hooks)")
 	harden := fs.Bool("harden", false, "imply --strict and block --dangerously-skip-permissions")
 	enterprise := fs.Bool("enterprise", false, "add skillctlEnterprise:true — enables the R-7.2 offline `locked` state")
+	requireLocalAudit := fs.Bool("require-local-audit", false, "add skillctlRequireLocalAudit:true (implies --enterprise) — R-8.2 fail-closed on un-recordable allow")
 	out := fs.String("out", "", "write to file instead of stdout")
 	if err := fs.Parse(args); err != nil {
 		return pinExitError
@@ -112,7 +113,7 @@ func runPinGenerate(args []string, stdout, stderr io.Writer) int {
 	if bin == "" {
 		bin = defaultBinary()
 	}
-	b, err := pin.Generate(pin.GenerateOptions{BinaryPath: bin, Strict: *strict, Harden: *harden, Enterprise: *enterprise})
+	b, err := pin.Generate(pin.GenerateOptions{BinaryPath: bin, Strict: *strict, Harden: *harden, Enterprise: *enterprise, RequireLocalAudit: *requireLocalAudit})
 	if err != nil {
 		fmt.Fprintf(stderr, "skillctl pin generate: %v\n", err)
 		return pinExitError
@@ -217,6 +218,7 @@ func runPinInstall(args []string, stdout, stderr io.Writer) int {
 	strict := fs.Bool("strict", false, "add allowManagedHooksOnly:true (disables ALL user hooks)")
 	harden := fs.Bool("harden", false, "imply --strict and block --dangerously-skip-permissions")
 	enterprise := fs.Bool("enterprise", false, "add skillctlEnterprise:true — enables the R-7.2 offline `locked` state")
+	requireLocalAudit := fs.Bool("require-local-audit", false, "add skillctlRequireLocalAudit:true (implies --enterprise) — R-8.2 fail-closed on un-recordable allow")
 	pathOverride := fs.String("path", "", "target managed-settings path override")
 	confirm := fs.Bool("confirm", false, "when run as root, actually write the file")
 	if err := fs.Parse(args); err != nil {
@@ -226,7 +228,7 @@ func runPinInstall(args []string, stdout, stderr io.Writer) int {
 	if bin == "" {
 		bin = defaultBinary()
 	}
-	opts := pin.GenerateOptions{BinaryPath: bin, Strict: *strict, Harden: *harden, Enterprise: *enterprise}
+	opts := pin.GenerateOptions{BinaryPath: bin, Strict: *strict, Harden: *harden, Enterprise: *enterprise, RequireLocalAudit: *requireLocalAudit}
 	target := *pathOverride
 	if target == "" {
 		p, perr := pin.DefaultManagedSettingsPath()

--- a/cmd/skillctl/session_baseline_cmds.go
+++ b/cmd/skillctl/session_baseline_cmds.go
@@ -132,6 +132,7 @@ func runSessionBaseline(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "  trust basis present:  %s (SPEC-0188 roots OR self/ER1 roots OR .m3c-provenance)\n", yesNo(dec.TrustBasisPresent))
 	fmt.Fprintf(stdout, "  translog anchor:      %s\n", yesNo(dec.AnchorPresent))
 	fmt.Fprintf(stdout, "  enterprise profile:   %s\n", yesNo(dec.Enterprise))
+	fmt.Fprintf(stdout, "  require local audit:  %s  [ENFORCED (R-8.2) by enforce: an allow that can't be durably recorded fails closed, exit 26]\n", yesNo(gateRequireLocalAudit()))
 	fmt.Fprintf(stdout, "  online fallback:      %s  [INFORMATIONAL — posture only; state-gating the online fallback is R-1.4 P2, not yet wired: the runtime gate still falls back]\n", allowedBlocked(dec.AllowOnlineFallback))
 	fmt.Fprintf(stdout, "  high-risk fail-closed:%s\n", yesNoPad(dec.HighRiskFailsClosed))
 	fmt.Fprintf(stdout, "  deny all managed:     %s  [ENFORCED (R-7.2) by verify-hook/enforce when the gate is pinned: a locked host denies non-allowlisted managed skills, exit 28]\n", yesNo(dec.DenyAllManaged))

--- a/pkg/skillctl/exitcode/registry.go
+++ b/pkg/skillctl/exitcode/registry.go
@@ -120,17 +120,18 @@ var (
 )
 
 // ---------------------------------------------------------------------------
-// Tier 7 — offline state machine (SPEC-0317 R-7.2, P2; the runtime gate).
-// 28 is a fresh, uniquely-themed code carried in the signed refusal_code when the
-// `locked` state (enterprise opt-in via managed settings + NO trust basis at all)
-// denies a MANAGED skill. The PROCESS still exits 2 to block the PreToolUse call,
-// mirroring the guard-path/verify-hook convention. Reserved-but-not-yet-emitted:
-// 26 (local_audit_unavailable, R-8 require_local_audit) — registered when that
-// carve-out is wired, so it is NOT in AllCodes yet.
+// Tier 7 — offline state machine + audit-durability (SPEC-0317 R-7.2 / R-8.2, P2).
+// 28 `offline_locked`: the `locked` state (enterprise opt-in via managed settings
+// + NO trust basis) denies a managed skill. 26 `local_audit_unavailable`:
+// require_local_audit is set and an ALLOW's evidence could not be durably recorded
+// (outbox+spool both failed) → fail closed, inverting the SPEC-0255 fire-and-forget
+// default. Both ride the message + refusal_code; the PROCESS still exits 2 to block
+// the PreToolUse call, mirroring the guard-path/verify-hook convention.
 // ---------------------------------------------------------------------------
 
 var (
-	OfflineLocked = Code{28, "offline / no-policy-basis", "state-machine", "offline_locked"}
+	OfflineLocked         = Code{28, "offline / no-policy-basis", "state-machine", "offline_locked"}
+	LocalAuditUnavailable = Code{26, "evidence / audit-durability", "enforce", "local_audit_unavailable"}
 )
 
 // AllCodes returns every Code currently registered. Used by the
@@ -154,7 +155,7 @@ func AllCodes() []Code {
 		SyncIngestRejected,
 		// Tier 6 — guard-path side channel
 		GuardPathSidechannelDenied,
-		// Tier 7 — offline state machine (locked)
-		OfflineLocked,
+		// Tier 7 — offline state machine (locked) + audit-durability
+		OfflineLocked, LocalAuditUnavailable,
 	}
 }

--- a/pkg/skillctl/outbox/spool.go
+++ b/pkg/skillctl/outbox/spool.go
@@ -46,14 +46,30 @@ func (s *Store) SpoolPath() string { return filepath.Join(s.dir, "spool.jsonl") 
 // the fallback the caller invokes when Append fails; it performs no db I/O so it
 // cannot itself stall on the lock that made Append fail.
 func (s *Store) Spool(rec skillgate.InvocationRecord, payloadJSON, payloadHash string) error {
+	return spoolAppend(s.dir, rec, payloadJSON, payloadHash)
+}
+
+// SpoolTo appends one row to the home-anchored spool.jsonl WITHOUT opening the
+// SQLite db. It is the fallback for the case where Open ITSELF fails (a corrupt
+// outbox.db on an otherwise-writable dir): the row still lands durably in the
+// same 0700 dir the signed trail uses, so a later `skillctl sync` Reconcile drains
+// it — and, crucially for R-8.2, durability then tracks the same writable-dir
+// condition the trail write depends on (the two sinks fail together or succeed
+// together, so require_local_audit never fires a spurious deny while the trail
+// records the allow).
+func SpoolTo(home string, rec skillgate.InvocationRecord, payloadJSON, payloadHash string) error {
+	return spoolAppend(dirName(home), rec, payloadJSON, payloadHash)
+}
+
+func spoolAppend(dir string, rec skillgate.InvocationRecord, payloadJSON, payloadHash string) error {
 	line, err := json.Marshal(spoolEntry{Record: rec, PayloadJSON: payloadJSON, PayloadHash: payloadHash})
 	if err != nil {
 		return fmt.Errorf("outbox: spool marshal: %w", err)
 	}
-	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("outbox: spool mkdir: %w", err)
 	}
-	f, err := os.OpenFile(s.SpoolPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	f, err := os.OpenFile(filepath.Join(dir, "spool.jsonl"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return fmt.Errorf("outbox: spool open: %w", err)
 	}

--- a/pkg/skillctl/pin/pin.go
+++ b/pkg/skillctl/pin/pin.go
@@ -71,6 +71,19 @@ type GenerateOptions struct {
 	// create a trust basis (that conflation made `locked` unreachable). Claude
 	// Code ignores the unknown key (its schema is additive); skillctl reads it.
 	Enterprise bool
+	// RequireLocalAudit emits `skillctlRequireLocalAudit: true` — the SPEC-0317
+	// R-8.2 opt-in that inverts the SPEC-0255 fire-and-forget audit contract: when
+	// set, `skillctl enforce` fails CLOSED (exit 26) if an ALLOW's evidence cannot
+	// be durably recorded. It is ENTERPRISE-ONLY, so setting it also emits
+	// skillctlEnterprise:true. Same root-owned managed tier as Enterprise, so the
+	// two enterprise knobs share ONE source (closing the R-7.2 F3 split).
+	//
+	// SCOPE: this escalates EVERY audited Skill allow that can't be recorded —
+	// managed, UNMANAGED (default-allow plugins/namespaced skills), AND allowlisted.
+	// On a host with an unrecordable outbox it therefore denies the plugin ecosystem
+	// and the operator's allowlisted escapes too; that is the intended "no un-audited
+	// allow" posture, not a bug. Enable it deliberately.
+	RequireLocalAudit bool
 }
 
 // wire structs — field order here is the emitted JSON key order (encoding/json
@@ -92,6 +105,7 @@ type managedSettings struct {
 	AllowManagedHooksOnly        bool       `json:"allowManagedHooksOnly,omitempty"`
 	DisableBypassPermissionsMode string     `json:"disableBypassPermissionsMode,omitempty"`
 	SkillctlEnterprise           bool       `json:"skillctlEnterprise,omitempty"`
+	SkillctlRequireLocalAudit    bool       `json:"skillctlRequireLocalAudit,omitempty"`
 	Hooks                        hooksBlock `json:"hooks"`
 }
 
@@ -144,6 +158,10 @@ func Generate(opts GenerateOptions) ([]byte, error) {
 	ms := managedSettings{Hooks: gateHooks(opts.BinaryPath)}
 	if opts.Enterprise {
 		ms.SkillctlEnterprise = true
+	}
+	if opts.RequireLocalAudit {
+		ms.SkillctlEnterprise = true // require_local_audit is enterprise-only
+		ms.SkillctlRequireLocalAudit = true
 	}
 	if opts.Strict || opts.Harden {
 		ms.AllowManagedHooksOnly = true
@@ -231,6 +249,20 @@ func EnterpriseFromBytes(settings []byte) bool {
 		return false
 	}
 	return ms.SkillctlEnterprise
+}
+
+// RequireLocalAuditFromBytes reports whether managed settings enable the
+// SPEC-0317 R-8.2 require_local_audit posture. Enterprise-GATED: true only when
+// BOTH skillctlEnterprise AND skillctlRequireLocalAudit are set — the
+// decision-invariance carve-out cannot be enabled on a non-enterprise host (the
+// same floor verify.Load enforced for the trust-roots surface). Same conservative
+// contract as EnterpriseFromBytes: missing/malformed → false.
+func RequireLocalAuditFromBytes(settings []byte) bool {
+	var ms managedSettings
+	if json.Unmarshal(settings, &ms) != nil {
+		return false
+	}
+	return ms.SkillctlEnterprise && ms.SkillctlRequireLocalAudit
 }
 
 // Verify parses managed-settings bytes and reports the pinning level. It matches

--- a/pkg/skillctl/pin/pin_test.go
+++ b/pkg/skillctl/pin/pin_test.go
@@ -377,3 +377,30 @@ func TestGenerate_EnterpriseKey(t *testing.T) {
 		t.Errorf("default must NOT emit the enterprise key:\n%s", off)
 	}
 }
+
+// TestRequireLocalAuditFromBytes locks the R-8.2 reader: enterprise-GATED (both
+// flags), missing/malformed → false.
+func TestRequireLocalAuditFromBytes(t *testing.T) {
+	if !RequireLocalAuditFromBytes([]byte(`{"skillctlEnterprise":true,"skillctlRequireLocalAudit":true}`)) {
+		t.Error("both flags → require_local_audit on")
+	}
+	for _, neg := range []string{
+		`{"skillctlRequireLocalAudit":true}`, // enterprise missing → gated off
+		`{"skillctlEnterprise":true,"skillctlRequireLocalAudit":false}`,
+		`{"skillctlEnterprise":true}`,
+		`{}`,
+		`{ not json`,
+	} {
+		if RequireLocalAuditFromBytes([]byte(neg)) {
+			t.Errorf("must be off (enterprise-gated / conservative): %q", neg)
+		}
+	}
+	// round-trip via Generate: --require-local-audit implies enterprise.
+	b, _ := Generate(GenerateOptions{RequireLocalAudit: true})
+	if !RequireLocalAuditFromBytes(b) {
+		t.Error("Generate(RequireLocalAudit) must round-trip")
+	}
+	if !EnterpriseFromBytes(b) {
+		t.Error("--require-local-audit must also emit enterprise (enterprise-only)")
+	}
+}


### PR DESCRIPTION
Wires **R-8.2**: an enterprise opt-in that inverts the LANDED **SPEC-0255** decision-invariance contract. Default is unchanged (fire-and-forget); when `skillctlRequireLocalAudit: true` is pinned in the root-owned managed settings, `skillctl enforce` escalates a skill ALLOW whose evidence could not be durably recorded (outbox row AND spool line both failed) into a fail-closed deny (**exit 26** `local_audit_unavailable`).

## Design
- **Default path (flag unset) is byte-identical** to today — the override is short-circuited by `reqAudit`, so SPEC-0255 / AC-2a decision-invariance holds (the existing panicking-sink tests still pass unchanged).
- The outbox sink now returns whether the record **durably landed**; `runEnforce` captures it + `sinkCalled`. `sinkCalled` distinguishes a real skill decision from a non-Skill / no-skill passthrough allow → **a Bash/Read event is never escalated** (the critical false-positive that would deny every file op).
- **Single enterprise source**: require_local_audit reads from the same managed tier as the R-7.2 enterprise flag (`pin … --require-local-audit`, implies `--enterprise`) — closing the R-7.2 F3 two-source split.

## Adversarial gate — ran, findings applied
- **F1 (HIGH, fixed)**: on `outbox.Open` failure (corrupt db on a **writable** dir) the sink now spools directly via a new db-free `outbox.SpoolTo` instead of giving up. Durability now tracks the same writable-dir condition the signed trail write depends on → kills the **spurious deny** *and* the **evidence inconsistency** (a fail-closed deny can no longer coexist with a trail that recorded the allow). Regression test drives the REAL sink against a corrupt db.
- **F2 (documented + tested)**: require_local_audit escalates **every** audited Skill allow — managed, unmanaged (default-allow plugins), and allowlisted — so on an unrecordable outbox it denies the plugin ecosystem too. Intended "no un-audited allow" posture; documented + pinned by a test.
- Minors: extended the KNOWN-NON-ESCALATED gaps comment (home/key/sign/marshal refusal); added `exitLocalAuditUnavailable = 26` const for parity.

## Scope
Exit 26 wired. The signed trail stays a best-effort **projection** (the outbox is the load-bearing store for this carve-out). Remaining SPEC-0317 follow-ups: state-gating the online fallback (R-1.4 P2), translog per-batch anchoring, the P3 KafShield backend (aims-core).

Tests: AC-2a preserved · unrecordable-allow→26 · durable-allow→pass · deny-unchanged · passthrough-not-escalated · open-fail-spools-not-spurious-deny · unmanaged-escalated · pin reader — `-race` + vet + gofmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)