### PR TITLE
docs(skillctl): consolidated acceptance/handover procedure + manual trust-root convergence

### DIFF
--- a/docs/acceptance-skillctl-lifecycle.md
+++ b/docs/acceptance-skillctl-lifecycle.md
@@ -1,0 +1,294 @@
+---
+layout: default
+title: "Acceptance & Handover: the skillctl skill lifecycle (Mirko → Eric)"
+---
+
+# Acceptance & Handover — the skillctl skill lifecycle
+
+**Audience:** Eric's team (a second organisation taking over `skillctl`).
+**Goal:** validate the *full tool + skill lifecycle* end-to-end across **two people** —
+Mirko authors, signs and publishes a skill; Eric trusts, pulls, verifies and uses it —
+and prove that invalid skills are refused. Functionality and the skill lifecycle come
+first; performance and scale are out of scope for this pass.
+
+**Backend:** this procedure runs on the **ER1 `self` registry** (the field-proven path,
+[SPEC-0246](https://github.com/kamir/m3c-tools-maintenance/blob/master/SPEC/SPEC-0246-skill-exchange-trust-layer-asm-compat.md)).
+The **only** two commands that are backend-specific are `publish` and `pull`; everything
+else is identical when the registry is later swapped for the skill-repo backend
+(see [§7 Backend swap point](#7-backend-swap-point-er1--skill-repo)).
+
+> **Canonical reference:** every command below is documented in full in
+> [manual-skillctl.md](manual-skillctl.md). This page is the *procedure*; the manual is the
+> *reference*. Where they ever disagree, the manual wins.
+
+---
+
+## 1. The lifecycle at a glance
+
+```
+  MIRKO (author / supply)                 ERIC (consumer / demand)
+  ─────────────────────────               ─────────────────────────
+  keygen                                   (receive Mirko's public key
+  pack        ─┐ trust core                 out-of-band + verify fingerprint)
+  sign         │ (backend-agnostic)         trust root  ─┐ trust core
+  verify-sig  ─┘                            pull         │ (5 gates)
+  publish  ───┐ ER1 transport               verify      ─┘
+  attest      │ (backend-SPECIFIC)          use the skill
+  share-room ─┘                             audit
+  …                                         …
+  revoke (retire)  ← G-23 two-step
+```
+
+The trust decisions (and their exit codes) are pure functions of the bundle bytes + the
+pinned key + the trust-roots file — the transport is invisible to them. Only `publish`
+and `pull` know it is ER1.
+
+---
+
+## 2. Roles, machines, prerequisites
+
+| Role | Who | Machine | Holds |
+|------|-----|---------|-------|
+| **Author / publisher** | Mirko | Machine A | author key `~/.config/m3c/skill-registry-self.priv`, ER1 login |
+| **Consumer** | Eric | Machine B | Mirko's **public** key, ER1 login, a trust-roots file |
+| **Reviewer** (governance) | a third identity | any | reviewer key; signs the green attestation |
+
+Prerequisites on **both** machines (see [manual §Installation](manual-skillctl.md#installation)):
+
+```bash
+# Install skillctl (signed one-liner; verifies cosign provenance + SHA-256):
+#   macOS/Linux:
+curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/master/tools/skillctl-install.sh | bash
+#   Windows (PowerShell):
+#   irm https://raw.githubusercontent.com/kamir/m3c-tools/master/tools/skillctl-install.ps1 | iex
+
+skillctl version          # MUST print a real skillctl/vX.Y.Z — NOT "dev" (see Troubleshooting)
+skillctl login --base-url https://onboarding.guide   # ER1 device pairing (FR-0043)
+skillctl login --status
+```
+
+### The trust-root file — pick the right one (this is the #1 source of confusion)
+
+| You are using… | Trust-roots file | How it's created | Read by |
+|----------------|------------------|------------------|---------|
+| **ER1 `self`** (this procedure) | `~/.claude/trust-roots.yaml` | **hand-written / carried out-of-band** (flat: `registry: self`, `pubkey_b64`, `fingerprint`, `governance_minimum`) | `pull` (default) |
+| HTTP `/api/skills` registry | `~/.claude/skill-trust-roots.yaml` | `skillctl trust add --registry <URL> --pubkey <path>` | `install`, `verify` |
+
+For this ER1 procedure, Eric uses **`~/.claude/trust-roots.yaml`** and does **not** run
+`skillctl trust add` (that is the HTTP-registry path). Do not mix the two files.
+
+---
+
+## 3. Part A — Mirko's lane (author → publish over ER1 `self`)
+
+```bash
+# A1. One-time: generate the author keypair.
+skillctl keygen --out ~/.config/m3c/skill-registry-self
+#   → ~/.config/m3c/skill-registry-self.priv (0600) + .pub (0644)
+#   Keep .priv secret. .pub is what Eric will pin.
+
+# A2. Pack the skill directory into a sealed .skb bundle (deterministic).
+skillctl pack --skill ~/.claude/skills/<name> -o <name>@<ver>.skb \
+              --name <name> --version <ver> \
+              --author-intent green \
+              --author-intent-rationale "Writes one local file. No network. No subprocess."
+#   Determinism check (acceptance): pack a second time and diff — MUST be byte-identical.
+
+# A3. Sign the bundle (detached ed25519 author signature over the digest).
+skillctl sign <name>@<ver>.skb --key ~/.config/m3c/skill-registry-self.priv --identity-id id:mirko@m3c
+#   → sidecar <bundle>.<hex>.author.sig ; prints digest sha256:<hex>
+
+# A4. Local self-check BEFORE publishing.
+skillctl verify-sig <name>@<ver>.skb --pubkey ~/.config/m3c/skill-registry-self.pub
+#   → EXIT 0 expected.
+
+# --- HUMAN CHECKPOINT: admit (publishing to the registry) ---
+# A5. Publish (admit) into your own ER1 context, sharing it into a co-learning room.
+skillctl publish <name>@<ver> --bundle <name>@<ver>.skb --registry self \
+              --er1-target prod --er1-context skills \
+              --key ~/.config/m3c/skill-registry-self.priv --identity id:mirko@m3c \
+              --share-room aims-basics
+#   NOTE: --er1-context skills is auto-prefixed to <your-sub>___skills (BUG-0165).
+#   Re-publishing the same digest is an idempotent no-op.
+
+# --- HUMAN CHECKPOINT: attest (signing a governance verdict) ---
+# A6. Post the reviewer's green attestation (reviewer ≠ author; SPEC-0246 §5).
+skillctl publish --attest <name>@<ver> --level green \
+              --rationale "Reviewed; activation gate satisfied." \
+              --registry self --er1-target prod --er1-context skills \
+              --identity id:reviewer@m3c --key ~/.config/m3c/reviewer.priv
+```
+
+**Hand-off to Eric (out-of-band).** Give Eric (a) your **public** key `skill-registry-self.pub`,
+(b) your ER1 **context** `<your-sub>___skills`, and (c) the **fingerprint** so he can verify it
+by voice/Signal (never trust a key that arrived over the same channel as the bundle):
+
+```bash
+# fingerprint of your raw ed25519 public key:
+openssl pkey -pubin -in ~/.config/m3c/skill-registry-self.pub -outform DER | tail -c 32 | shasum -a 256
+# base64 of the same raw key (goes into Eric's trust-roots.yaml → pubkey_b64):
+openssl pkey -pubin -in ~/.config/m3c/skill-registry-self.pub -outform DER | tail -c 32 | base64
+```
+
+---
+
+## 4. Part B — Eric's lane (consumer: trust → pull → verify → use over ER1 `self`)
+
+```bash
+# B1. Verify the fingerprint OUT-OF-BAND first (SPEC-0246 R6.3) — read it back to Mirko.
+
+# B2. Hand-write the self trust-roots file (NOT `trust add`).
+cat > ~/.claude/trust-roots.yaml <<'YAML'
+registry: self
+pubkey_b64: <base64 of Mirko's raw ed25519 public key>
+fingerprint: sha256:<hex you verified out-of-band>
+governance_minimum: green
+YAML
+
+# B3. G-23 step 1 — dry-run the install to review the plan + get a 5-min token.
+skillctl pull --registry self --er1-target prod --er1-context <mirko-sub>___skills \
+              --dry-run-install
+#   Reads ~/.claude/trust-roots.yaml by default. Prints the create/overwrite plan + token.
+
+# --- HUMAN CHECKPOINT: review the plan, then confirm ---
+# B4. G-23 step 2 — read-only consumer install (no --key, no --emit-installed).
+skillctl pull --registry self --er1-target prod --er1-context <mirko-sub>___skills \
+              --install --trust-mode \
+              --confirm-install --dry-run-install-token <tok> --no-checkpoint
+#   The 5 ER1 gates run: envelope-sig → not-revoked → governance-floor → digest → bundle-sigs.
+#   Installs under ~/.claude/skills/<name>/ with a .m3c-provenance.json sidecar.
+#   Read-only ⇒ NO write-back to Mirko's registry (SPEC-0246 R6.4).
+
+# B5. Re-verify the installed skill.
+skillctl verify <name>          # → EXIT 0 expected
+
+# B6. USE the skill (the load-bearing proof it actually works for Eric).
+#   Invoke the skill through Claude Code / run its entrypoint; confirm it produces its output.
+
+# B7. Antivirus-style audit of everything installed.
+skillctl audit --source all --minimum-governance green --format table   # → EXIT 0 expected
+```
+
+---
+
+## 5. Part C — Negative acceptance (invalid skills MUST be refused)
+
+Fail-closed is the whole point. Each case has a **specific** expected exit code (the full
+table is in [manual §Exit codes](manual-skillctl.md#exit-codes)):
+
+| # | Attack | Command | Expect |
+|---|--------|---------|--------|
+| N1 | Tampered bundle (flip a byte) | `skillctl verify-sig --pubkey mirko.pub tampered.skb` | **exit 11** (author_sig_invalid) |
+| N2 | Wrong key / impersonation | `skillctl verify-sig --pubkey mirko.pub attacker.skb` | **exit 11** (control vs attacker.pub = 0) |
+| N3 | No signature | `skillctl verify-sig --pubkey mirko.pub no-sig.skb` | **non-zero** (11 or 1 — never 0) |
+| N4 | Digest mismatch | installed bundle modified after signing | **exit 10** |
+| N5 | Registry not trusted / forged root | pull with an unpinned registry key | **exit 12** |
+| N6 | Governance below minimum | pull a skill with no green attestation | **exit 13** |
+| N7 | **Revoked author/bundle** | `skillctl verify <name> --revocations <signed-list>` | **exit 17** (SPEC-0198) |
+
+**Coverage today (honest):** N1–N3 are automated in `demo/kup-training/` (steps 06/07/08).
+N4–N7 are **not** in that harness — N7 (revoke) lives in the separate CISO Kata demo
+(`skillctl-demo --kata K5`), and N4/N5/N6 are asserted by unit tests, not the two-person
+script. Closing N4–N7 in the acceptance harness is a tracked gap (see §8).
+
+---
+
+## 6. Success criteria (the pass bar)
+
+Cross-person acceptance is defined by **SPEC-0246 §10 (AC1–AC5)**. A handover run **PASSES** iff:
+
+| AC | Criterion | Evidence / expected result |
+|----|-----------|----------------------------|
+| **AC1** | Author can pack+sign+publish into their own ER1 context | A2–A5 succeed; `verify-sig` → 0; publish returns admitted/already-admitted |
+| **AC2** | Reviewer (≠ author) attestation is required and honoured | A6 green attestation present; governance floor `green` enforced |
+| **AC3** | **A *different principal* (Eric) completes a read-only consumer install end-to-end, all 5 gates pass, no write-back** | B3–B5: `pull --install --trust-mode` (no `--key`, no `--emit-installed`) → skill under `~/.claude/skills/<name>/`; `verify` → 0; Mirko's registry unchanged |
+| **AC4** | The installed skill actually runs for Eric | B6 produces the skill's expected output |
+| **AC5** | Invalid skills are refused with the correct exit code | Part C: N1–N3 (min bar) refuse; N4–N7 as coverage lands |
+
+**Minimum pass bar for the first handover:** AC1–AC4 green **and** N1–N3 refuse. AC5's
+full matrix (N4–N7) is the target as the harness converges (§8). Field status: the Eric
+consumer path was proven live on **2026-06-09** (SPEC-0246 §11).
+
+---
+
+## 7. Backend swap point (ER1 → skill-repo)
+
+Only the **transport** changes when ER1 is replaced by the skill-repo backend. This is the
+seam `IsER1Registry` already draws in code, and the invariant SPEC-0248 §4 asserts.
+
+| Stays **identical** (trust core) | Changes (transport only) |
+|----------------------------------|--------------------------|
+| `keygen`, `pack`, `sign`, `verify-sig` | `publish` mechanics (`POST /upload_2`) |
+| `attest`, `trust`, the trust-roots file | `pull` mechanics (`GET /memory/<ctx>`) |
+| `install` (G-23, provenance, `~/.claude/skills/`) | the `<sub>___skills` context convention |
+| The **verification gauntlet + exit codes (0/10–17)** | the `m3c-skill-bundle` tag schema + inline `.skb` |
+| `audit` (0/2/3), `revoke` (G-23) | `--registry` / `--er1-target` / `--er1-context` / `--share-room` flags |
+| | room-based read authorization (SPEC-0096) |
+
+> The skill-repo backend is **not yet a written spec** — today it is the architectural
+> decision in SPEC-0188 §8 **D3** plus the `IsER1Registry` seam. A named `Backend` interface
+> (and a real SPEC — 0356 is unallocated) is the planned formalisation. When it lands, this
+> procedure is edited in exactly one place: Parts A5 and B3–B4 (the `publish`/`pull` flags).
+
+---
+
+## 8. Relationship to the automated harness — and the convergence plan
+
+The `demo/kup-training/` scripts are the **automated regression** for the trust core:
+
+- **What they prove today:** the offline cryptographic chain (keygen→pack→sign→verify),
+  the Mirko→Eric transfer (G3 → `artifacts/eric-home/output/hello.txt`), and the negative
+  tests N1–N3 (G4) — driven by `run-and-prove.sh` (exit 0 iff every check passes, `--json`
+  summary) and `run-all.sh` (the four release gates G1–G4).
+- **The divergence:** that harness uses the older **HTTP `/api/skills/*` admission registry**,
+  not the **ER1 `self`** path this procedure (and Eric, in the field) use. So it proves the
+  trust core, but not the ER1 transport of AC3.
+- **Convergence plan (tracked):**
+  1. Re-point `02-mirko-publish.sh` / `05-eric-install-and-run.sh` at `publish`/`pull
+     --registry self` so the automated run exercises the ER1 transport of AC3.
+  2. Add negative steps for **N4 (exit 10)**, **N5 (12)**, **N6 (13)**, **N7 (17)** (pull N7
+     in from the Kata harness).
+  3. Wire (or explicitly scope out) the orphaned demand-side steps `10-scan` / `11-use` /
+     `12-decay` (not run by either driver today; `12`'s decay path is unimplemented).
+  4. Remove the Mac-only assumptions (macOS keychain for credentials, `pandoc`+`xelatex`
+     for the PDF gate, `shasum` naming, hard-coded source paths) so Eric's team can run it
+     on Linux/Windows.
+
+Until convergence, the acceptance bar for the ER1 transport (AC3) is met by **running Part
+B manually** and recording the result; the harness covers the trust core and negatives.
+
+---
+
+## 9. Handover checklist for Eric's team
+
+- [ ] `skillctl` installed on both machines; `skillctl version` prints a real tag (not `dev`).
+- [ ] ER1 login works on both (`skillctl login --status`), against the correct `--base-url`.
+- [ ] Mirko's public key received **and fingerprint verified out-of-band**.
+- [ ] `~/.claude/trust-roots.yaml` written on Eric's box (self format), `governance_minimum: green`.
+- [ ] Part A (author) completes: `verify-sig` → 0, publish admitted, green attestation posted.
+- [ ] Part B (consumer) completes: `pull --install --trust-mode` → 0 gates, `verify` → 0, skill runs, `audit` → 0.
+- [ ] Part C: N1–N3 refuse with the expected exit codes.
+- [ ] No write-back appears in Mirko's registry (AC3/R6.4).
+- [ ] Result recorded (a `run-and-prove.sh --json` file, or the checklist above signed off).
+
+---
+
+## 10. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `skillctl version` prints `dev` | a stale binary earlier on `PATH` (e.g. `~/go/bin/skillctl` shadowing `~/.local/bin/skillctl`) | remove/rebuild the stale one; `which -a skillctl` to find shadows |
+| `403 not authorized for this context` on publish | publishing into a context whose `<sub>` ≠ your Google login (BUG-0165) | publish only into **your own** `<your-sub>___skills`; Eric *reads* Mirko's context |
+| `pull` rejects the trust-roots file | wrong file/schema — used `skill-trust-roots.yaml` (hosted) for the self path | use `~/.claude/trust-roots.yaml` (flat self format); see §2 table |
+| install one-liner 404s | targeting a release that isn't published yet | check the release is published; or set `RELEASE_BASE` to a published tag |
+| `exit 12` on install | registry key not pinned | pin it (HTTP path: `trust add`; self path: fix `trust-roots.yaml`) |
+| `exit 13` | no attestation meets the `green` floor | author must post a green attestation (A6), or lower the floor deliberately |
+
+---
+
+## See also
+
+- [manual-skillctl.md](manual-skillctl.md) — the full command/flag/exit-code reference.
+- [quickstart-skillctl.md](quickstart-skillctl.md) — the author happy-path in 5 minutes.
+- [quickstart-skillctl-demo.md](quickstart-skillctl-demo.md) — the offline Kata demo.
+- SPEC-0246 (cross-person exchange, AC1–AC5), SPEC-0248 (lifecycle umbrella), SPEC-0188 (trust chain + exit codes).

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ agent skills that act on it (sign, admit, verify, revoke — offline-verifiable)
 - [Quickstart: skillctl](quickstart-skillctl) — sign, install and verify a skill in 5 minutes
 - [Manual: m3c-tools](manual-m3c-tools) — every command, flag and config variable
 - [Manual: skillctl](manual-skillctl) — the full trust lifecycle, command by command
+- [Acceptance & Handover: skill lifecycle](acceptance-skillctl-lifecycle) — the two-person (Mirko → Eric) procedure over ER1, with success criteria
 - [Menu Bar App](menubar-app) — channels, Observation Window, menu items
 - [Setup & Operations — Intel Mac & Windows](setup-target-devices) — zero-to-operating runbook for fresh target devices
 - [Platform differences](PLATFORM-DIFFERENCES) — what works where

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -53,7 +53,7 @@ transparency log. Run any command with `--help` for its flags.
 |------|---------|
 | **`.skb` bundle** | A sealed skill bundle: a `SKILL.md`-bearing skill directory packed with a signed manifest (`bundle.json`). Its SHA-256 digest is the bundle's stable identity. |
 | **Author signature (detached)** | An ed25519 signature over the bundle's 32-byte digest, written *next to* the bundle as `<bundle>.<digest_hex>.author.sig`. Anyone with the author's public key can verify it offline. |
-| **Trust roots** | `~/.claude/skill-trust-roots.yaml`: the registry public keys *you* have pinned. The verifier trusts only these. Multiple keys per registry support rotation overlap windows. |
+| **Trust roots** | The registry public keys *you* have pinned; the verifier trusts only these. There are **two files, one per registry model** — `~/.claude/skill-trust-roots.yaml` (HTTP registries, managed by `trust`) and `~/.claude/trust-roots.yaml` (the ER1 `self` registry, hand-written). See [Trust roots & registries — which file, when](#trust-roots--registries--which-file-when). |
 | **Registry** | Where admitted bundles and their governance events live. Can be a `self` ER1 registry (personal) or an HTTP registry. The registry is a *distribution + audit* surface — it is **not** in the cryptographic verification path. |
 | **Admit / attest** | *Admit* publishes a bundle to a registry. *Attest* posts a signed governance verdict on an admitted digest. Attestations — not author intent — are what bind governance. |
 | **Governance level (green/yellow/red)** | The verdict carried by an attestation. Install/verify enforce a configurable minimum (default green). Author *intent* is advisory; the verifier ignores it. |
@@ -61,6 +61,29 @@ transparency log. Run any command with `--help` for its flags.
 | **AgentID** | An owner-signed *mandate* stating that a specific agent instance may use these skills for these intents. It verifies **offline** against pinned owner/approver keys — no authority in the path. |
 | **Transparency log (translog)** | A local RFC-6962 Merkle log (SPEC-0278, "L1"). It makes equivocation and withholding **detectable**, and emits offline inclusion receipts. It does not gate installs; L2 (BFT ledger) and L3 (public anchoring) are deferred. |
 | **The fail-closed gate** | `verify-hook` is a Claude Code `PreToolUse(Skill)` hook. It verifies the trust chain before any skill runs and emits allow/deny. If it cannot read or verify, it **denies** — fail-closed. |
+
+---
+
+## Trust roots & registries — which file, when
+
+skillctl has **two** trust-roots files, one per registry model. Using the wrong one is the
+most common setup error, so pick deliberately:
+
+| You are using… | Trust-roots file | Created by | Read by |
+|----------------|------------------|------------|---------|
+| **ER1 `self`** (`publish` / `pull --registry self`) | `~/.claude/trust-roots.yaml` — flat: `registry: self`, `pubkey_b64`, `fingerprint`, `governance_minimum` | **hand-written / carried out-of-band** | `pull` |
+| **HTTP `/api/skills` registry** | `~/.claude/skill-trust-roots.yaml` | `skillctl trust add --registry <URL> --pubkey <path>` | `install`, `verify`, `audit` |
+
+- `skillctl trust add --registry` takes a **URL** (e.g. `https://aims.example.com/api/skills`),
+  **never** an ER1 context id. It writes `skill-trust-roots.yaml`.
+- The ER1 `self` consumer path does **not** use `trust add` — hand-write `trust-roots.yaml`
+  and verify its `fingerprint` out-of-band before the first `pull`.
+- **Keys:** `keygen --out P` writes `P.priv` + `P.pub`. Pass the private key explicitly to
+  `sign` / `publish` as `--key P.priv`; the `self` default `~/.config/m3c/skill-registry-self.key`
+  applies only when `--key` is omitted.
+
+For the full two-person walkthrough over ER1, see
+**[Acceptance & Handover: the skill lifecycle](acceptance-skillctl-lifecycle.md)**.
 
 ---
 
@@ -1008,7 +1031,8 @@ Derived from each command's own usage output.
 
 | Path | Contents |
 |------|----------|
-| `~/.claude/skill-trust-roots.yaml` | Pinned registry public keys (managed by `trust`). The root of the offline verification chain. |
+| `~/.claude/skill-trust-roots.yaml` | Pinned **HTTP-registry** public keys (managed by `trust`). Read by `install` / `verify` / `audit`. |
+| `~/.claude/trust-roots.yaml` | The **ER1 `self`** trust root (flat `registry: self` + `pubkey_b64`), hand-written / carried out-of-band. Read by `pull`. See [Trust roots & registries](#trust-roots--registries--which-file-when). |
 | `~/.claude/skills/<name>/` | Installed skills (`install`, `pull --install`). Installs are atomic. |
 | `<stem>.priv` (mode `0600`) / `<stem>.pub` (mode `0644`) | ed25519 keypair written by `keygen`, PEM PKCS#8 / SPKI. |
 | `<bundle>.<digest_hex>.author.sig` | Detached author signature written by `sign` (64 raw bytes, mode `0644`). |
@@ -1023,7 +1047,21 @@ ER1 credentials for registry-backed commands resolve via Keychain → Secret Man
 
 ---
 
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `skillctl version` prints `dev` | a stale binary earlier on `PATH` (e.g. `~/go/bin/skillctl` shadowing `~/.local/bin/skillctl`) | `which -a skillctl`; remove or rebuild the stale copy |
+| `403 not authorized for this context` on `publish` | publishing into a context whose `<sub>` ≠ your login (BUG-0165) | publish only into your own `<sub>___skills` |
+| `pull` rejects the trust-roots file | used `skill-trust-roots.yaml` (hosted) for the `self` path | use `~/.claude/trust-roots.yaml` (see [Trust roots & registries](#trust-roots--registries--which-file-when)) |
+| `exit 12` (`registry_not_trusted`) | registry key not pinned | pin it — HTTP: `trust add`; self: fix `trust-roots.yaml` |
+| `exit 13` (`governance_below_min`) | no attestation meets the floor | post a green attestation, or lower the floor deliberately |
+
+---
+
 ## See also
 
 - **[Quickstart: skillctl](quickstart-skillctl.md)** — the happy path in five minutes.
+- **[Acceptance & Handover: the skill lifecycle](acceptance-skillctl-lifecycle.md)** — the two-person (Mirko → Eric) acceptance procedure over ER1, with success criteria.
+- **[Quickstart: the offline demo](quickstart-skillctl-demo.md)** — the `skillctl-demo` Kata walkthrough (CISO/booth).
 - **[Manual: m3c-tools](manual-m3c-tools.md)** — the memory-capture toolkit `skillctl` ships alongside.


### PR DESCRIPTION
Consolidates the scattered skillctl lifecycle docs into a **clear procedure** + a **converged manual**, so the tool can be handed to Eric's team. First half (source `docs/`); the maintenance-repo half (one `ONBOARDING/` infographic + supersede banners on the stale HTMLs) follows.

## New — the acceptance/handover procedure
`docs/acceptance-skillctl-lifecycle.md`: the two-person **Mirko (author) → Eric (consumer)** skill-lifecycle validation over the **ER1 `self` registry**:
- Part A (author: keygen→pack→sign→verify-sig→publish→attest), Part B (consumer: out-of-band fingerprint→hand-write `trust-roots.yaml`→`pull --install --trust-mode` G-23→verify→use→audit), Part C (negative tests with **expected exit codes**).
- **Success criteria = SPEC-0246 §10 (AC1–AC5)** as a PASS/FAIL table + a stated minimum pass bar.
- The **ER1 → skill-repo backend swap point** (only `publish`/`pull` change; the trust core + exit codes are identical) and the **convergence plan** vs the `demo/kup-training` automated harness (which today proves the trust core over the *HTTP* registry, not ER1).

## Manual convergence — `docs/manual-skillctl.md`
Resolves the highest-impact contradictions the review found:
- New **'Trust roots & registries — which file, when'** decision table: `~/.claude/trust-roots.yaml` (ER1 self, hand-written, read by `pull`) vs `~/.claude/skill-trust-roots.yaml` (`trust add --registry <URL>`, read by `install`/`verify`). `trust add --registry` takes a **URL, not a context id**.
- Key-path clarification (`keygen --out P` → `P.priv`/`P.pub`; pass `--key P.priv`).
- **Troubleshooting** section (`dev` PATH-shadow binary, 403 context/BUG-0165, exit 12/13).
- Self trust-root added to Files & locations; cross-links; index.md updated.

Backed by a three-part read-only review of every skillctl doc, the `demo/kup-training` scenario, and the lifecycle/backend source. (Note surfaced by the review: **SPEC-0356 does not exist as a file** — the skill-repo backend is SPEC-0188 §8 D3 + the `IsER1Registry` code seam; 0356 is unallocated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)