### PR TITLE
docs+test(skillctl): role playbooks + tenant ops in manual; kup-training onto ER1 self

### DIFF
--- a/demo/kup-training/02-mirko-publish.sh
+++ b/demo/kup-training/02-mirko-publish.sh
@@ -8,54 +8,41 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 require_skillctl
 
-header "02 — Mirko publishes to aims registry"
+header "02 — Mirko publishes to the ER1 self registry"
 
 if ! online_mode_available; then
-  warn "online mode not available — skipping POST /api/skills/bundles"
-  warn "the chain proof in steps 03–10 still runs end-to-end (offline)"
+  warn "online mode not available — skipping the ER1 self publish"
+  warn "the chain proof in steps 03–09 still runs end-to-end (offline)"
   exit 0
 fi
 
-DIGEST=$(cat "$ARTIFACTS_DIR/digest.txt")
 BUNDLE="$BUNDLES_DIR/${SKILL_NAME}-${SKILL_VERSION}.skb"
-SIG="${BUNDLE}.${DIGEST#sha256:}.author.sig"
 
-# 1) Register Mirko's identity (idempotent on the registry side)
-log "registering Mirko's identity"
-PUB_B64=$(base64 < "$KEYS_DIR/mirko.pub" | tr -d '\n')
-auth_curl "$MIRKO_ID" -- -X POST "$REGISTRY_URL/api/skills/identities" \
-    -d "{\"id\":\"$MIRKO_ID\",\"ed25519_pubkey_pem\":\"$PUB_B64\",\"tier\":\"user\",\"rationale\":\"KuP training demo\"}" \
-    -o "$LOG_DIR/identity-mirko.json" -w "HTTP %{http_code}\n" \
-  | tee -a "$LOG_DIR/full.log"
-
-# 2) POST the bundle (multipart: blob + raw 64-byte signature + identity_id)
-# Field names per server contract — flask/modules/skill_registry/api.py:458
-# admit_bundle() reads:
-#   - bundle      (file)  — the .skb tarball
-#   - signature   (file)  — raw 64-byte ed25519 signature over the bundle digest
-#   - identity_id (form)  — author identity (e.g. id:mirko@m3c)
-# An earlier version of this script sent author_sig + author_identity, which
-# the server rejected with HTTP 400 "Missing required field: signature (file)"
-# during the 2026-05-08 KuP release-gate run.
-log "POST $REGISTRY_URL/api/skills/bundles"
-HTTP=$(curl -sk \
-  -H "X-API-KEY: ${ER1_API_KEY}" \
-  -H "X-User-ID: $MIRKO_ID" \
-  -F "bundle=@$BUNDLE" \
-  -F "signature=@$SIG" \
-  -F "identity_id=$MIRKO_ID" \
-  -o "$LOG_DIR/admit.json" -w "%{http_code}" \
-  "$REGISTRY_URL/api/skills/bundles") || true
-echo "HTTP $HTTP" | tee -a "$LOG_DIR/full.log"
-
-if [[ "$HTTP" =~ ^(200|201)$ ]]; then
-  ok "registry accepted bundle"
-  note "$(head -3 "$LOG_DIR/admit.json")"
-elif [[ "$HTTP" == "409" ]]; then
-  warn "registry returned 409 (already admitted) — re-running is safe"
+# Re-pointed (SPEC-0246 convergence) from the HTTP /api/skills registry to the
+# ER1 `self` transport: `skillctl publish --registry self`. This exercises the
+# real ER1 publish code path (POST /upload_2, envelope-signing, tag schema).
+#
+# SINGLE-MACHINE SMOKE: the runner's ER1 login acts as the author, publishing
+# into their own <sub>___skills context. A true TWO-PERSON cross-principal run
+# (SPEC-0246 AC3) needs two ER1 accounts and is validated manually (§11).
+# Best-effort: any failure warns; the offline chain proof in 05 proves the trust
+# core regardless. Targets `local` by default so demo items never land in prod
+# ER1 — set ER1_TARGET=prod for a real run.
+ER1_TARGET="${ER1_TARGET:-local}"
+log "Mirko: skillctl publish $SKILL_NAME@$SKILL_VERSION --registry self --er1-target $ER1_TARGET"
+set +e
+HOME="$INSTALL_HOME" "$SKILLCTL" publish "$SKILL_NAME@$SKILL_VERSION" \
+    --bundle "$BUNDLE" --registry self \
+    --er1-target "$ER1_TARGET" --er1-context skills \
+    --key "$KEYS_DIR/mirko.priv" --identity "$MIRKO_ID" --yes \
+    >>"$LOG_DIR/full.log" 2>&1
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+  ok "published to ER1 self ($ER1_TARGET)"
 else
-  warn "registry returned HTTP $HTTP — see $LOG_DIR/admit.json"
-  warn "demo continues offline; the chain proof does not depend on this step"
+  warn "publish --registry self exit $rc — ER1 transport not exercised"
+  warn "(needs an ER1 login + a reachable '$ER1_TARGET' target); offline chain in 05 is unaffected"
 fi
 
-header "02 — done (online attempt complete)"
+header "02 — done (ER1 self publish attempted)"

--- a/demo/kup-training/05-eric-install-and-run.sh
+++ b/demo/kup-training/05-eric-install-and-run.sh
@@ -16,22 +16,36 @@ BUNDLE="$BUNDLES_DIR/${SKILL_NAME}-${SKILL_VERSION}.skb"
 SIG="${BUNDLE}.${DIGEST#sha256:}.author.sig"
 
 if online_mode_available; then
-  log "Eric: skillctl install $SKILL_NAME@$SKILL_VERSION --registry $REGISTRY_URL"
+  # Re-pointed (SPEC-0246 AC3 convergence) from `skillctl install --registry
+  # .../api/skills` to the ER1 `self` pull path. Single-machine smoke (see 02's
+  # note). Eric pins Mirko's key via a HAND-WRITTEN self trust-roots.yaml — the
+  # ER1 `self` path uses ~/.claude/trust-roots.yaml, NOT `trust add`.
+  ER1_TARGET="${ER1_TARGET:-local}"
+  mkdir -p "$INSTALL_HOME/.claude"
+  PUB_B64=$(openssl pkey -pubin -in "$KEYS_DIR/mirko.pub" -outform DER 2>/dev/null | tail -c 32 | base64 | tr -d '\n')
+  cat > "$INSTALL_HOME/.claude/trust-roots.yaml" <<YAML
+registry: self
+pubkey_b64: $PUB_B64
+governance_minimum: green
+YAML
+  log "Eric: skillctl pull --registry self --er1-target $ER1_TARGET (G-23 dry-run then confirm)"
   set +e
-  HOME="$INSTALL_HOME" \
-    "$SKILLCTL" install "$SKILL_NAME@$SKILL_VERSION" \
-        --registry "$REGISTRY_URL/api/skills" \
-        --allow-yellow \
-        --verbose \
-      >>"$LOG_DIR/full.log" 2>&1
-  rc=$?
-  set -e
-  if [[ "$rc" -eq 0 ]]; then
-    ok "install exit 0 — full chain verified by registry"
+  TOKEN=$(HOME="$INSTALL_HOME" "$SKILLCTL" pull --registry self \
+       --er1-target "$ER1_TARGET" --er1-context skills --skill "$SKILL_NAME" \
+       --install --trust-mode --dry-run-install --no-checkpoint 2>>"$LOG_DIR/full.log" \
+       | sed -n 's/.*dry-run-install token (5-minute TTL): //p' | head -1)
+  if [[ -n "${TOKEN:-}" ]]; then
+    HOME="$INSTALL_HOME" "$SKILLCTL" pull --registry self \
+       --er1-target "$ER1_TARGET" --er1-context skills --skill "$SKILL_NAME" \
+       --install --trust-mode --confirm-install --dry-run-install-token "$TOKEN" \
+       --no-checkpoint >>"$LOG_DIR/full.log" 2>&1 \
+      && ok "pulled + installed via ER1 self ($ER1_TARGET) — full chain verified by pull's 5 gates" \
+      || warn "pull --confirm-install failed — ER1 transport not fully exercised"
   else
-    warn "install exit $rc — registry round-trip incomplete (likely missing identity registration)"
-    warn "falling back to offline chain proof"
+    warn "pull --registry self did not yield an install token — ER1 transport not exercised"
+    warn "(needs a live '$ER1_TARGET' ER1 with the skill published in step 02); falling back to offline proof"
   fi
+  set -e
 fi
 
 # OFFLINE / FALLBACK CHAIN PROOF — this is the load-bearing demonstration:

--- a/docs/acceptance-skillctl-lifecycle.md
+++ b/docs/acceptance-skillctl-lifecycle.md
@@ -244,8 +244,11 @@ The `demo/kup-training/` scripts are the **automated regression** for the trust 
   not the **ER1 `self`** path this procedure (and Eric, in the field) use. So it proves the
   trust core, but not the ER1 transport of AC3.
 - **Convergence plan (tracked):**
-  1. Re-point `02-mirko-publish.sh` / `05-eric-install-and-run.sh` at `publish`/`pull
-     --registry self` so the automated run exercises the ER1 transport of AC3.
+  1. **Done (best-effort):** `02-mirko-publish.sh` / `05-eric-install-and-run.sh` now attempt
+     the ER1 `self` transport (`publish` / `pull --registry self`, target `local` by default) as
+     a **single-machine smoke** — the runner's ER1 login acts as the author. It needs a live
+     local ER1 to actually exercise, and a true two-person cross-principal AC3 run needs two ER1
+     accounts (validated manually, §11). The offline chain + N1–N3 remain the automated bar.
   2. Add negative steps for **N4 (exit 10)**, **N5 (12)**, **N6 (13)**, **N7 (17)** (pull N7
      in from the Kata harness).
   3. Wire (or explicitly scope out) the orphaned demand-side steps `10-scan` / `11-use` /

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -1027,6 +1027,193 @@ Derived from each command's own usage output.
 
 ---
 
+## Roles & playbooks
+
+Skill governance is a separation-of-duties system: no single role can both create and bless a
+skill. Each role below lists *what you own* and the current `skillctl` commands you actually run.
+For the HTTP-registry vs ER1-`self` split, see
+[Trust roots & registries — which file, when](#trust-roots--registries--which-file-when); for
+the exit codes every role branches on, see [Exit codes](#exit-codes).
+
+### Author / Skill-Steward
+
+You write the skill and put the first signature on it; you never bless your own governance
+verdict. Keep your private key local — only the `.pub` ever leaves your machine.
+
+```bash
+skillctl keygen --out ~/.config/m3c/skill-keys/author            # -> author.priv + author.pub
+skillctl pack --skill ~/.claude/skills/my-skill -o my-skill.skb \
+  --name my-skill --version 1.0.0 --summary "…" \
+  --data-scopes '{"id":"ds:fs/cwd","kind":"local_fs","access":"write","scope":"<cwd>/out/**","reason":"…"}'
+skillctl sign my-skill.skb --key ~/.config/m3c/skill-keys/author.priv
+skillctl verify-sig my-skill.skb --pubkey ~/.config/m3c/skill-keys/author.pub   # offline self-check
+```
+
+You may **not** attest your own skill (reviewer≠author is enforced — SPEC-0246) and `--author-intent`
+is advisory only; imported bundles are capped at yellow.
+
+### Reviewer
+
+You own the binding governance verdict. Read the bundle, verify the author signature offline,
+then post a signed attestation on the digest — as a *different* identity than the author.
+
+```bash
+skillctl verify --bundle my-skill.skb --trust-roots ./roots.yaml --json   # inspect offline, no install
+skillctl attest sha256:<hex> --level green \
+  --rationale "activation gate passed; intent matches data-scopes" \
+  --reviewer-id id:reviewer@m3c --author-id id:author@m3c \
+  --key ~/.config/m3c/skill-keys/reviewer.priv \
+  --registry https://aims.example.com/api/skills
+skillctl attest sha256:<hex> --level red --rationale "…" --reviewer-id id:reviewer@m3c --key …   # demote / retract
+```
+
+Passing `--author-id` triggers the offline reviewer≠author check. The most-recent qualified
+attestation wins; a `red` re-attest is how a verdict is retracted.
+
+### Registry Operator
+
+You own the registry signing key and the trust distribution. In the ER1 `self` model *you are*
+the registry — you admit and sign; in the HTTP model you run the server, hand out its pubkey,
+register author identities, and drive the revocation feed.
+
+```bash
+# ER1 self: admit a bundle into your own context
+skillctl publish my-skill --bundle my-skill.skb --version 1.0.0 \
+  --registry self --er1-target prod --er1-context skills \
+  --key ~/.config/m3c/skill-registry-self.priv --identity id:op@m3c
+skillctl registry ls                                             # inspect the self registry
+skillctl revoke sha256:<hex> --reason key_compromise --registry https://aims.example.com/api/skills
+skillctl revoke feed --refresh --registry https://aims.example.com/api/skills   # roll the signed kill-switch HEAD
+```
+
+`--er1-context skills` is auto-prefixed to `<your-sub>___skills`; you can publish **only** into
+your own context (403 / BUG-0165 otherwise). Registering an *author's* identity on an HTTP
+registry is a server-side admin operation (see [Tenant operations](#tenant-operations)), not a
+`skillctl` verb.
+
+### Tenant Admin
+
+You own the fleet's trust posture: which registry keys the machines pin, the `governance_minimum`
+floor, and the tenant scope. That lives in the trust-roots file you distribute.
+
+```bash
+# HTTP fleet: pin the registry the whole tenant trusts (writes ~/.claude/skill-trust-roots.yaml)
+skillctl trust add --registry https://aims.example.com/api/skills --pubkey registry.pub --id aims-prod
+skillctl trust list
+skillctl install my-skill@1.0.0 --tenant kup-berlin              # installs respect tenant scope + floor
+```
+
+Set `governance_minimum` (default green) in the distributed trust-roots file; a CISO-console
+tenant block surfaces to consumers as exit `16`.
+
+### CISO (Tenant Security Officer)
+
+You authorize what runs inside your tenant and pull the trigger when something turns hostile.
+The `skillctl`-side levers are revocation, the kill-switch feed, audit, and demotion.
+
+```bash
+skillctl revoke feed --status --registry https://aims.example.com/api/skills   # inspect the signed revocation HEAD
+skillctl revoke sha256:<hex> --reason governance_retraction --actor-identity governance_reviewer --key reviewer.priv
+skillctl audit --format json                                     # fleet inventory verdicts
+```
+
+A revoked digest fails install/verify with exit `17`; a stale revocation snapshot fails **closed**
+with exit `22`.
+
+### End-User / Consumer
+
+You pin trust once, install verified skills, and let the runtime gate enforce the chain on every
+invocation. You never publish.
+
+```bash
+# HTTP path — pin, install, verify
+skillctl trust add --registry https://aims.example.com/api/skills --pubkey registry.pub --id aims-prod
+skillctl install didactic-session@1.0.0 --tenant kup-berlin
+skillctl verify didactic-session
+
+# ER1 self path — hand-written ~/.claude/trust-roots.yaml (fingerprint checked out-of-band), then pull
+skillctl pull --registry self --er1-target prod --er1-context <publisher-sub>___skills \
+  --install --trust-mode --dry-run-install                       # G-23 step 1 (plan + token)
+skillctl audit                                                   # OK | UNVERIFIED | BROKEN | BELOW_MIN
+```
+
+Wire the fail-closed gate so nothing runs unverified — it denies if it cannot verify:
+
+```json
+{ "hooks": { "PreToolUse": [ { "matcher": "Skill",
+  "hooks": [ { "type": "command", "command": "skillctl verify-hook" } ] } ] } }
+```
+
+Don't hand-edit an installed skill under `~/.claude/skills/` — `skillctl audit` flags the drift
+as `BROKEN`. See **[Acceptance & Handover: the skill lifecycle](acceptance-skillctl-lifecycle.md)**
+for the two-person hand-off procedure over ER1.
+
+---
+
+## Tenant operations
+
+Operator-side procedures. Each notes whether it applies to an **HTTP `/api/skills` registry** or
+the **ER1 `self`** registry — they pin trust in different files (see
+[Trust roots & registries](#trust-roots--registries--which-file-when)).
+
+### Provision a tenant
+
+**ER1 `self` (personal / small-team).** Nothing to stand up: your tenant *is* your ER1 login's
+`<sub>___skills` context. Mint a registry key, publish into your own context, and hand consumers
+the pubkey fingerprint out-of-band.
+
+```bash
+skillctl keygen --out ~/.config/m3c/skill-registry-self          # -> .priv + .pub
+skillctl publish my-skill --bundle my-skill.skb --version 1.0.0 \
+  --registry self --er1-target prod --er1-context skills \
+  --key ~/.config/m3c/skill-registry-self.priv --identity id:op@m3c
+# consumers hand-write ~/.claude/trust-roots.yaml (registry: self, pubkey_b64, fingerprint,
+# governance_minimum) and pull from <your-sub>___skills — NOT `trust add`.
+```
+
+**HTTP `/api/skills` registry (fleet / regulated).** The server side — bucket, namespace,
+per-tenant registry key — is provisioned by aims-core infrastructure, *not* by `skillctl`. Once
+it exists, every consumer machine pins it and installs scoped to the tenant:
+
+```bash
+skillctl trust add --registry https://aims.example.com/api/skills --pubkey registry.pub --id aims-prod
+skillctl install my-skill@1.0.0 --tenant <tenant-id>
+```
+
+### Rotate the registry key (overlap-publish window)
+
+Never swap keys abruptly. Run an **overlap window** where both keys are accepted, re-sign under
+the new key, then drop the old.
+
+**HTTP registry** — `skill-trust-roots.yaml` holds multiple keys per registry, so pin the new key
+alongside the old for the window:
+
+```bash
+skillctl keygen --out ~/.config/m3c/skill-registry-v2                       # 1) new keypair
+skillctl trust add --registry https://aims.example.com/api/skills \
+  --pubkey ~/.config/m3c/skill-registry-v2.pub --id aims-prod-v2            # 2) pin new (old still pinned)
+# 3) re-admit / re-sign current bundles under the new key during the window
+skillctl trust remove --registry https://aims.example.com/api/skills        # 4) after cutover, re-pin new-only
+```
+
+**ER1 `self`** — the flat `~/.claude/trust-roots.yaml` pins a single `pubkey_b64`, so re-publish
+current bundles under the v2 key during the window, then have each consumer swap their
+`pubkey_b64` / `fingerprint` (carried out-of-band) before you retire v1. Attestations bind to the
+`bundle_digest`, not the signing key, so they generally survive a rotation.
+
+### Register an author identity
+
+**ER1 `self`.** Identity is the `id:you@m3c` you stamp into events plus the keypair behind it —
+no self-serve endpoint. Generate the keypair, stamp `--identity` on publish (and `--identity-id`
+on `sign`), and give consumers the `.pub` fingerprint out-of-band.
+
+**HTTP registry.** Registering an author's public key is a **server-side admin operation** on the
+aims-core registry (`POST /api/skills/identities` with an operator bearer token) — not a
+`skillctl` verb. The author sends their `.pub`; the operator registers it; consumers' `verify` /
+`install` then check the author signature (exit `11` on mismatch) against that identity.
+
+---
+
 ## Files & locations
 
 | Path | Contents |


### PR DESCRIPTION
The two consolidation follow-ups.

## 1. Manual — role playbooks + tenant operations (`docs/manual-skillctl.md`)
Forward-ports the unique, still-valid content from the superseded legacy `USER-MANUAL.md`, updated to **current** commands:
- **Roles & playbooks** — Author/Steward, Reviewer, Registry Operator, Tenant Admin, CISO, End-User; each with *what you own* + the 3–6 commands that role runs.
- **Tenant operations** — provision a tenant, rotate the registry key (overlap window), register an author identity — each split HTTP-registry vs ER1-`self`.
- Legacy key paths (`skillctl-keys/author.key` → `skill-keys/*.priv`), trust-root files, and exit codes corrected to current truth.

## 2. Harness — re-point `demo/kup-training/` 02/05 onto ER1 `self`
Steps 02 (publish) and 05 (pull+install) now attempt the **ER1 `self` transport** (`publish`/`pull --registry self`) instead of the older HTTP `/api/skills` registry — so the automated run exercises the SPEC-0246 ER1 transport of AC3.
- **Best-effort single-machine smoke:** the runner's ER1 login acts as the author; target **`local`** by default (never writes to prod ER1); the **offline crypto chain — the load-bearing assertion — is unchanged and always runs**.
- A true two-person cross-principal AC3 run needs two ER1 accounts (validated manually, SPEC-0246 §11).
- Flags + the `--dry-run-install` token parse were **verified against `cmd/skillctl/{publish,pull}_cmds.go`**; `bash -n` clean.
- Acceptance doc §8 convergence note updated (step 1 → done).

⚠️ **Honest caveat:** the ER1 round-trip could **not be executed in-session** (no live local ER1 + login here). It needs a validation run on a box with a local aims-core + `skillctl login` to confirm the transport actually round-trips. Until then the offline chain + N1–N3 remain the automated bar (as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)