### PR TITLE
docs: program, service, and component indexes

### DIFF
--- a/docs/component-index.md
+++ b/docs/component-index.md
@@ -1,0 +1,194 @@
+---
+layout: default
+title: Component Index
+---
+
+# Component Index
+
+**The building blocks.** Importable Go library packages (no `main`) that the
+[programs](program-index) and [services](service-index) are assembled from.
+Public packages live under `pkg/`; internal-only packages under `internal/`.
+
+Grouped by domain:
+[A. Capture & media](#a-capture--media-pipeline-pkg) ·
+[B. ER1 & session](#b-er1-knowledge-upload--session-pkg) ·
+[C. Capture sources](#c-capture-sources-pkg) ·
+[D. Config/infra/util](#d-config-infra--util-pkg) ·
+[E. Desktop UI](#e-desktop-ui-pkg) ·
+[F. skillctl trust subsystem](#f-skillctl-trust-subsystem-pkgskillctl-siblings) ·
+[G. Thinking Engine internals](#g-thinking-engine-internals-internalthinking)
+
+---
+
+## A. Capture & media pipeline (`pkg/`)
+
+| Package | Responsibility |
+|---------|----------------|
+| `transcript` | Pure-Go port of youtube-transcript-api (InnerTube, no API key). Video page → API key → caption XML → snippets; 4 output formats (Text/SRT/JSON/WebVTT); proxy configs; thumbnail fetch with size fallback. |
+| `impression` | Observation capture + composite-document builder + tag system. Combines video transcript + user commentary into a structured ER1 document; auto-tags by observation type. |
+| `whisper` | Speech-to-text via the `whisper` CLI subprocess (not C bindings); finds the binary, runs `--output_format json`, parses segments. |
+| `recorder` | PortAudio microphone recording via cgo. 16 kHz/16-bit PCM mono WAV (whisper-compatible). |
+| `screenshot` | Screen capture on macOS via the `screencapture` CLI. |
+| `draft` | Save/load capture drafts (in-progress observations). |
+| `importer` | Batch audio import: scan a folder, deduplicate, copy, and track. |
+| `bulkprogress` | Platform-neutral progress vocabulary for the audio pipeline. |
+
+## B. ER1, knowledge upload & session (`pkg/`)
+
+| Package | Responsibility |
+|---------|----------------|
+| `er1` | ER1 server config + multipart HTTP upload (`transcript_file_ext`/`audio_data_ext`/`image_data`, placeholder audio/image when absent) + JSON-backed retry queue with mutex sync. |
+| `er1login` | Runs the aims-core browser **device-pairing** flow and returns credentials. |
+| `session` | SPEC-0213 "session-state in ER1" — persist a working session as a machine-tagged memory item + checkpoint chain. |
+| `tracking` | SQLite-backed export tracking for ER1 uploads. |
+| `timetracking` | Local time tracking scoped to PLM project contexts. |
+| `m3cproject` | Resolves the PLM project context for the current working directory (`.m3c/project.yaml`). |
+| `auth` | Device-token storage and retrieval. |
+
+## C. Capture sources (`pkg/`)
+
+| Package | Responsibility |
+|---------|----------------|
+| `plaud` | API client for the **Plaud.ai** voice-recorder cloud. |
+| `pocket` | **Pocket** cloud API client (SPEC-0173). |
+
+## D. Config, infra & util (`pkg/`)
+
+| Package | Responsibility |
+|---------|----------------|
+| `config` | Init/config bootstrap (`.env` / `~/.m3c-tools.env`). |
+| `setup` | Foundation of the SPEC-0175 onboarding flow. |
+| `httpsafe` | Small, dependency-free HTTP hardening helpers shared across clients. |
+| `diag` | Diagnostic check types + rendering for the doctor/check surface. |
+| `testutil` | Shared test helpers. |
+
+## E. Desktop UI (`pkg/`)
+
+| Package | Responsibility |
+|---------|----------------|
+| `menubar` | Types, configuration, and callback interfaces for the menu bar app. |
+| `tray` | Cross-platform notifications via pure-Go `beeep`. |
+
+## F. skillctl trust subsystem (`pkg/skillctl/*` + siblings)
+
+The offline-verifiable skill **trust plane** — the library behind the
+[`skillctl`](program-index) CLI. 30 focused subpackages, grouped by role:
+
+**Inventory & parsing**
+
+| Package | Responsibility |
+|---------|----------------|
+| `skillctl/model` | Data types for the skill inventory system. |
+| `skillctl/parser` | Extracts YAML frontmatter from markdown skill files. |
+| `skillctl/scanner` | Walks directories to discover Claude Code skill sources. |
+| `skillctl/hasher` | Content hashing + duplicate detection. |
+
+**Cryptography & identity**
+
+| Package | Responsibility |
+|---------|----------------|
+| `skillctl/signing` | Phase-2 cryptographic primitives (SPEC-0188). |
+| `skillctl/verify` | Client-side verifier algorithm (SPEC-0188). |
+| `skillctl/device` | Per-machine DEVICE KEY that signs SPEC-0202 invocations. |
+| `skillctl/agentid` | Pure, stdlib-only core of SPEC-0277 agent-instance identity. |
+| `skillctl/translog` | L1 transparency log (SPEC-0278). |
+
+**Lifecycle, admission & install**
+
+| Package | Responsibility |
+|---------|----------------|
+| `skillctl/install` | SPEC-0188 §7 client install pipeline. |
+| `skillctl/importer` | Talks to the aims-core skill-profile API. |
+| `skillctl/registry` | HTTP client for the aims-core skill registry. |
+| `skillctl/awareness` | SPEC-0195 admission bridge. |
+| `skillctl/propose` | SPEC-0194 §6 ready-to-promote gate. |
+| `skillctl/pin` | SPEC-0247 §7.3 managed-settings pinning. |
+
+**Governance & evidence**
+
+| Package | Responsibility |
+|---------|----------------|
+| `skillctl/outbox` | SPEC-0317 (P0) transactional audit outbox. |
+| `skillctl/statemachine` | SPEC-0317 R-7 named offline state machine. |
+| `skillctl/govlevel` | The one canonical governance-level vocabulary. |
+| `skillctl/datascope` | Typed client-side contract for SPEC-0196. |
+| `skillctl/bodyscan` | SPEC-0246 §4 semantic danger-prose detector. |
+| `skillctl/exitcode` | Canonical registry of `skillctl` process exit codes. |
+
+**Analysis, reporting & UI**
+
+| Package | Responsibility |
+|---------|----------------|
+| `skillctl/audit` | Per-skill verdicts for `skillctl audit`. |
+| `skillctl/consolidate` | Duplicate/orphan analysis over an inventory. |
+| `skillctl/delta` | Diffs two inventories. |
+| `skillctl/report` | HTML + Markdown reports from inventories. |
+| `skillctl/review` | Local HTTP server for reviewing delta reports. |
+| `skillctl/browse` | Interactive D3.js skill-graph browser. |
+| `skillctl/menubar` | macOS menu bar app for monitoring skillctl state. |
+
+**Sibling top-level packages**
+
+| Package | Responsibility |
+|---------|----------------|
+| `skillgate` | SPEC-0202 cooperative invocation gateway. |
+| `skillbundle` | Deterministic packing of `.skb` skill bundles. |
+| `skillimport` | SPEC-0201 import-from-internet: `parser` (reference syntax), `policy` (source-policy files), `scanner` (pre-flight static scanner). |
+
+## G. Thinking Engine internals (`internal/thinking/*`)
+
+The 18 internal packages that make up the [Thinking Engine service](service-index).
+Grouped by role in the T→R→I→A→C pipeline:
+
+**Substrate**
+
+| Package | Responsibility |
+|---------|----------------|
+| `thinking/schema` | Go types for every message on every topic. |
+| `thinking/ctx` | Compile-time-safe wrapper around the user context / ctx hash. |
+| `thinking/store` | Local SQLite engine state. |
+| `thinking/kafka` | Kafka producer/consumer (in-memory bus, or franz-go under the `thinking_kafka` tag). |
+
+**Cognitive pipeline (R/I/A/C)**
+
+| Package | Responsibility |
+|---------|----------------|
+| `thinking/orchestrator` | Accepts a ProcessSpec; publishes lifecycle events. |
+| `thinking/processors` | The R/I/A/C cognitive-layer processors. |
+| `thinking/autoreflect` | Opt-in consumer that watches and triggers reflection. |
+| `thinking/feedback` | Closes the cognitive loop from the I-processor. |
+
+**LLM**
+
+| Package | Responsibility |
+|---------|----------------|
+| `thinking/llm` | LLM adapter surface (OpenAI / Ollama). |
+| `thinking/prompts` | Resolves prompt IDs to prompt bodies. |
+
+**Persistence to ER1**
+
+| Package | Responsibility |
+|---------|----------------|
+| `thinking/er1` | Thinking Engine's ER1 REST client. |
+| `thinking/sink` | D2 async ER1 sinker. |
+
+**Cost control**
+
+| Package | Responsibility |
+|---------|----------------|
+| `thinking/budget` | D4 two-layer spend cap. |
+| `thinking/ratelimit` | Keyed hourly limiter backed by the store. |
+
+**Control, ops & recovery**
+
+| Package | Responsibility |
+|---------|----------------|
+| `thinking/api` | Engine control surface (`/v1/*`). |
+| `thinking/observability` | P0 operational surface (metrics/health). |
+| `thinking/rebuild` | SPEC-0167 §Reconciler cold-start rebuild. |
+
+**Other internal**
+
+| Package | Responsibility |
+|---------|----------------|
+| `internal/dbdriver` | Shared database-driver support. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,9 @@ agent skills that act on it (sign, admit, verify, revoke — offline-verifiable)
 
 **Documentation:**
 
+- [Program Index](program-index) — every runnable binary, MCP server and entry point in the repo
+- [Service Index](service-index) — the long-running services and their runtime wrappers (`deploy/*`)
+- [Component Index](component-index) — the importable Go library packages under `pkg/` and `internal/`
 - [Quickstart: m3c-tools](quickstart-m3c-tools) — capture your first memory in 5 minutes
 - [Quickstart: skillctl](quickstart-skillctl) — sign, install and verify a skill in 5 minutes
 - [Manual: m3c-tools](manual-m3c-tools) — every command, flag and config variable

--- a/docs/program-index.md
+++ b/docs/program-index.md
@@ -1,0 +1,76 @@
+---
+layout: default
+title: Program Index
+---
+
+# Program Index
+
+**What you run.** Every buildable/runnable entry point in the `m3c-tools`
+repository — Go binaries, Python MCP servers, and the evaluation harness.
+
+> Go module: `github.com/kamir/m3c-tools`. All Go binaries build to `./build/`.
+> The bare executables checked out at the repo root (`m3c-tools`, `skillctl`,
+> `thinking-engine`, `m3c-tools.exe`) are git-ignored build artifacts, not sources.
+
+See also: [Service Index](service-index) (what stays running) ·
+[Component Index](component-index) (the libraries these programs are built from).
+
+## Go binaries (`cmd/`)
+
+| Program | Entry point | Build | What it is |
+|---------|-------------|-------|------------|
+| **m3c-tools** | `cmd/m3c-tools/` | `make build` | The main Multi-Modal-Memory CLI. Also launches the macOS menu bar app with `--menubar`. |
+| **skillctl** | `cmd/skillctl/` | `make build-skillctl` | The skill **trust** CLI — sign, admit, verify, revoke, audit skills (offline-verifiable). |
+| **skillctl-demo** | `cmd/skillctl-demo/` | `make build-skillctl-demo` | Self-contained offline demo that shows a CISO the trust plane *containing an attack live* (scenarios S1/S2A/S5, real exit codes). |
+| **thinking-engine** | `cmd/thinking-engine/` | `make thinking-build` | Per-user cognitive runtime (SPEC-0167). Runs as a service — see [Service Index](service-index). |
+| **poc-menubar** | `cmd/poc-menubar/` | `make build-all` | Reference POC: macOS menu bar via `menuet`. |
+| **poc-recorder** | `cmd/poc-recorder/` | `make build-all` | Reference POC: PortAudio microphone recording. |
+| **poc-transcript** | `cmd/poc-transcript/` | `make build-all` | Reference POC: YouTube transcript fetch (core library port). |
+| **poc-whisper** | `cmd/poc-whisper/` | `make build-all` | Reference POC: Whisper transcription via CLI subprocess. |
+
+> The four `poc-*` binaries are **validated reference implementations**, not
+> production code (see `CLAUDE.md`).
+
+### `m3c-tools` subcommands
+
+Manual `os.Args` parsing (no cobra/flag). The dispatched subcommands are:
+
+`transcript` · `upload` · `whisper` · `thumbnail` · `check-er1` · `record` ·
+`devices` · `screenshot` · `import` · `login` · `plaud` · `pocket` ·
+`session` · `progress` · `queue` · `tags` · `setup`
+
+Full reference: [Manual: m3c-tools](manual-m3c-tools).
+
+### `skillctl` verb surface
+
+The trust lifecycle CLI: signing (`keygen` / `sign` / `verify-sig`),
+`agentid` (SPEC-0277 agent-instance identity), `audit`, `install`, admission,
+revocation, and reporting. Full reference: [Manual: skillctl](manual-skillctl).
+
+## Python programs (MCP servers)
+
+| Program | Entry point | What it is |
+|---------|-------------|------------|
+| **mcp-skill-server** | `mcp-skill-server/server.py` | MCP (stdio) server exposing the skill lifecycle as Claude Code tools — wraps the `skillctl` Go CLI + aims-core REST. |
+| **rag-mcp-server** | `rag-mcp-server/rag_mcp_server.py` | MCP (stdio) server for local, air-gapped workspace RAG (SPEC-0268). Also ships a CLI (`rag.py`) and pipeline scripts (`indexer.py`, `embedder.py`, `chunker.py`, `distill_backfill.py`). |
+
+Both run as long-lived services — see [Service Index](service-index).
+
+## Evaluation harness
+
+| Program | Location | Build | What it is |
+|---------|----------|-------|------------|
+| **trust-layer evaluation** | `evaluation/` | `make eval` (`make eval-fast`) | SPEC-0280 measurement harness. Contains no production code; the measurable surface lives entirely in Go test files (`e1`…`e10`: verify latency, revocation scale, body-scan corpus, agent-authz, inclusion proof, freshness, …). |
+
+## Operational scripts (not primary programs, but runnable)
+
+| Area | Location | Purpose |
+|------|----------|---------|
+| Build & packaging | `scripts/build-all.sh`, `scripts/build-windows.sh`, `scripts/build-portaudio-universal.sh`, `scripts/make-dmg.sh`, `scripts/make-icns.sh` | Cross-platform builds, macOS bundle/DMG, Windows binary. |
+| Installers | `installer/` (`m3c-tools.nsi`, `build.sh`), `scripts/installer.nsi`, `tools/skillctl-install.sh`, `tools/skillctl-install.ps1` | NSIS installer, skillctl install one-liners. |
+| skillctl release/runbook | `tools/skillctl-release.sh`, `tools/skillctl-runbook.sh`, `tools/skillctl-runbook-publish.sh`, `scripts/publish-skb.sh` | Release + `.skb` publish + runbook automation. |
+| Thinking Engine launch | `tools/thinking-engine-start.sh` | Convenience launcher for a per-user engine stack. |
+| Capture-source login/checks | `tools/plaud-mcp-login.mjs`, `tools/plaud-e2e-check.sh`, `scripts/e2e-plaud-sync-local.sh` | Plaud OAuth login + E2E sync verification. |
+| CI / docs / review | `scripts/code-review.sh`, `scripts/check-docs.sh`, `scripts/e2e-device-token-proof.sh` | Local CI helpers. |
+
+Discover all build/test/run entry points with `make help`.

--- a/docs/service-index.md
+++ b/docs/service-index.md
@@ -1,0 +1,98 @@
+---
+layout: default
+title: Service Index
+---
+
+# Service Index
+
+**What stays running.** Long-lived processes in the `m3c-tools` ecosystem, each
+paired with its **runtime wrapper** — the `deploy/*` stack, Dockerfile, compose
+file, or MCP registration that turns a [program](program-index) into a running
+service.
+
+See also: [Program Index](program-index) · [Component Index](component-index).
+
+## 1. m3c Thinking Engine
+
+A per-user, event-driven **cognitive runtime** (SPEC-0167). Flask/aims-core does
+the *sensing* (capture); this engine owns the *thinking*: it takes raw thoughts
+off a stream and produces **Reflections → Insights → Artifacts** (the T→R→I→A→C
+model) via an LLM, with a replayable, auditable log.
+
+| Aspect | Detail |
+|--------|--------|
+| Program | `thinking-engine` (`cmd/thinking-engine/`) — see [Program Index](program-index) |
+| Runtime wrapper | `deploy/thinking-engine/` |
+| Listen / health | `:7140`, `GET /v1/health` |
+| Launch (local) | `make thinking-up` → `make thinking-topics` → `make thinking-build` and run; or `tools/thinking-engine-start.sh` |
+| Launch (container) | `docker compose -f deploy/thinking-engine/docker-compose.yml --profile engine up -d` |
+| Isolation | Refuses to start without `--user-context-id`; every topic/group/HMAC claim derives from its `ctx_hash`; a runtime guard panics on cross-context topic access. |
+| LLM backend | OpenAI, or **Ollama** for zero-cost local dev (`NewAdapterFromEnv`). |
+
+**Runtime wrapper contents** (`deploy/thinking-engine/`):
+
+| File | Role |
+|------|------|
+| `docker-compose.yml` | Phase-1 stack: Confluent `cp-*` broker set (zookeeper + broker + schema-registry + control-center, single broker RF=1) + the `engine` service (gated behind compose `profiles: [engine]`). Ports parameterized per user. |
+| `Dockerfile` | Multi-stage build of the engine binary with the `thinking_kafka` tag (wires the real **franz-go** Kafka driver); static `CGO_ENABLED=0`, non-root Alpine, `<30 MB`. |
+| `topic-bootstrap.sh` | Creates the **8 canonical topics** `m3c.<ctx_hash>.*` (thoughts.raw, reflections.generated, insights.generated, artifacts.created, process.commands, process.events, compilation.requests, context.snapshots). |
+| `.env.example` | Per-user config template: `CTX_HASH`, `M3C_USER_CONTEXT_ID`, `THINKING_ENGINE_SECRET` (HMAC), per-user port allocation. |
+
+Internals: [Component Index → Thinking Engine internals](component-index#g-thinking-engine-internals-internalthinking).
+
+## 2. skillctl Trust-Plane (container)
+
+The pure-Go skill **trust plane** packaged as an OCI image, and `.skb` skill
+bundles published to a registry (SPEC-0354). The capture-plane (recorder,
+menubar — cgo + macOS-only) is deliberately **excluded**.
+
+| Aspect | Detail |
+|--------|--------|
+| Program | `skillctl` (`cmd/skillctl/`) |
+| Runtime wrapper | `deploy/skillctl/` (`Dockerfile` + `README.md`) |
+| Build | `make skillctl-image` (`make skillctl-image-smoke` to verify) |
+
+## 3. mcp-skill-server (Claude Code MCP)
+
+Exposes the skill lifecycle as native Claude Code tools so the agent can browse,
+query, import, and track skills.
+
+| Aspect | Detail |
+|--------|--------|
+| Program | `mcp-skill-server/server.py` |
+| Transport | stdio |
+| Registration | `~/.claude/mcp.json` |
+| Wraps | the `skillctl` Go CLI + aims-core REST API |
+
+## 4. rag-mcp-server (Claude Code MCP)
+
+Local, air-gapped semantic search over a GitHub-backed workspace (SPEC-0268) —
+the local twin of the ER1/aims-core memory search.
+
+| Aspect | Detail |
+|--------|--------|
+| Program | `rag-mcp-server/rag_mcp_server.py` |
+| Transport | stdio (also a `rag.py` CLI) |
+| Engine | `turbovec` (TurboQuant) + local `BAAI/bge-m3` embedder — no data leaves the machine |
+| State | per-repo, gitignored `.rag/` |
+| Tools | `rag_search`, `rag_stats`, `rag_sync`, `rag_verify` |
+
+## 5. Menu Bar App (desktop-resident)
+
+A long-running macOS desktop service: the menu bar app with 4 capture channels,
+the Observation Window pipeline, and ER1 upload.
+
+| Aspect | Detail |
+|--------|--------|
+| Program | `m3c-tools --menubar` (production); `poc-menubar` (reference POC) |
+| Launch | `make menubar` / `make menubar-app` |
+| UI stack | `menuet` (menu bar) + native Cocoa via cgo |
+| Details | [Menu Bar App](menubar-app) |
+
+## External dependency — ER1 / aims-core
+
+Not built in this repo, but the **server every capture flows into**. `m3c-tools`
+uploads multimodal observations to it (`pkg/er1`), the Thinking Engine sinks
+Artifacts to it (`internal/thinking/er1`, `internal/thinking/sink`), and both
+MCP servers query it. Configure via `~/.m3c-tools.env`
+(`ER1_API_URL` / `ER1_API_KEY` / `ER1_CONTEXT_ID`).


### PR DESCRIPTION
Adds three cross-linked reference maps of the repository, wired into the docs home page (`docs/index.md`):

- **[program-index]** — every runnable binary, MCP server, and entry point (`cmd/*`, the two Python MCP servers, the SPEC-0280 eval harness) with build commands.
- **[service-index]** — long-running services and their runtime wrappers: the Thinking Engine + `deploy/thinking-engine/`, the skillctl trust-plane container (`deploy/skillctl/`), both MCP servers, and the menu bar app; ER1/aims-core noted as the external dependency.
- **[component-index]** — importable library packages under `pkg/` and `internal/`, grouped by domain (capture pipeline, ER1/session, capture sources, the 30-package skillctl trust subsystem, the 18-package thinking-engine internals).

Reference-only; no code changes. `make check-docs` passes (25 markdown files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)