### PR TITLE
fix(rag-mcp-server): incremental sync self-heals interrupted index

### DIFF
--- a/rag-mcp-server/indexer.py
+++ b/rag-mcp-server/indexer.py
@@ -248,11 +248,32 @@ class Indexer:
             upd_files.append((rel, h, p.stat().st_mtime, len(frows)))
 
         if to_embed:
-            vecs = self.embedder.encode([r[5] for r in to_embed],
+            # Chunk ids are content-independent (sha1(path#ci)), so a changed
+            # file re-uses ids the idx.remove() above should have cleared. Two
+            # cases still leave an id resident when we go to add it: (a) two
+            # chunks in this batch hash to the same id (build() dedups these via
+            # its `seen` set; sync must too), and (b) an earlier sync was
+            # interrupted -- the store is written incrementally but index.tvim
+            # only at the end, so a killed run drops files from the store while
+            # their vectors survive in index.tvim, and they then look "added".
+            # add_with_ids() raises on a duplicate id, so dedup the batch and
+            # drop any already-resident id first. This makes the add idempotent
+            # and lets a plain `sync` self-heal an index left inconsistent by an
+            # interrupted run (no full rebuild needed).
+            batch, seen = [], set()
+            for r in to_embed:
+                if r[0] in seen:
+                    continue
+                seen.add(r[0])
+                batch.append(r)
+            for cid in seen:
+                if idx.contains(int(cid)):
+                    idx.remove(int(cid))
+            vecs = self.embedder.encode([r[5] for r in batch],
                                        batch_size=self.cfg.get("embed_batch_size", 16))
-            ids = np.array([r[0] for r in to_embed], dtype=np.uint64)
+            ids = np.array([r[0] for r in batch], dtype=np.uint64)
             idx.add_with_ids(vecs, ids)
-            self.store.insert_chunks(to_embed)
+            self.store.insert_chunks(batch)
         for fm in upd_files:
             self.store.upsert_file(*fm)
         idx.write(str(self.index_path))


### PR DESCRIPTION
## fix(rag-mcp-server): incremental sync self-heals an interrupted index

### Bug
Every `sync` crashed with:
```
ValueError: id <n> already present in index
  indexer.py:254  idx.add_with_ids(vecs, ids)
```

### Root cause
`sync()` writes `meta.sqlite` (the store) **incrementally** but `index.tvim` (the vector index)
**only at the end**. A killed run therefore leaves the store *ahead* of the vector index: files
the interrupted run had already `delete_file`'d are gone from the store, but their vectors survive
in `index.tvim`. The next sync then sees those files as **"added"**, re-chunks them, and calls
`add_with_ids()` with ids that are **still resident** → duplicate-id crash. Chunk ids are
content-independent (`sha1(path#ci)`), so this is deterministic once the state is inconsistent.

### Fix
Before `add_with_ids`, dedup the embed batch and drop any id already resident in the index,
using turbovec's `contains()` / `remove()`. This makes the add **idempotent** and lets a plain
`sync` **self-heal** an index left inconsistent by an interrupted run — no full rebuild needed.

### Verification
- Reproduced the exact `ValueError` in isolation (turbovec add of an existing id).
- `rm .rag/meta.sqlite` (rebuild from the committed, consistent JSONL) + `sync` on a real 5.5k-file
  workspace ran clean to `verify: FRESH`; previously-missing docs became searchable.

Single-file change (`rag-mcp-server/indexer.py`, +24/−3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
