### PR TITLE
feat(skillctl): close ER1↔GitLab parity gaps (show/emit-installed over git + --since on both)

### DIFF
--- a/cmd/skillctl/pull_cmds.go
+++ b/cmd/skillctl/pull_cmds.go
@@ -220,16 +220,67 @@ func runPull(args []string, stdout, stderr io.Writer) int {
 
 	if *emitInstalled {
 		if artifact.SchemeOf(*registryName) != "er1" {
-			// Do NOT silently write the install-ack into ER1 for a git registry.
-			// Routing BundleInstalledEvent to the active backend is a SPEC-0351
-			// follow-up; for now install completed but no installed-event is written.
-			fmt.Fprintf(stderr, "pull: --emit-installed is not yet routed to %q — install completed, but no BundleInstalledEvent was written (SPEC-0351 follow-up)\n", *registryName)
+			// Route the BundleInstalledEvent to the ACTIVE backend (git/GitLab),
+			// not silently into ER1 — cross-machine install visibility on the same
+			// carrier the bundle came from.
+			emitInstalledEventsViaBackend(stdout, stderr, res.Staged, *registryName, *keyPath, *identity, tr.Fingerprint)
 		} else {
 			emitInstalledEvents(stdout, stderr, results, res.Staged, *keyPath, *identity, *er1Target, *er1Context, tr.Fingerprint)
 		}
 	}
 	maybeCheckpoint(stdout, *noCheckpoint, *er1Target, *er1Context, fmt.Sprintf("installed %d bundle(s) under %s (trust-mode)", len(results), strOr(*installSkillsDir, "~/.claude/skills")))
 	return 0
+}
+
+// emitInstalledEventsViaBackend is the git/GitLab peer of emitInstalledEvents:
+// it builds + signs the SAME BundleInstalledEvent and appends it to the active
+// artifact backend via Publish(KindInstall) — ZERO signing changes, the git
+// backend commits it under events/<digesthex>/. Failures are non-fatal (the
+// install already succeeded); each is reported and the loop continues.
+func emitInstalledEventsViaBackend(stdout, stderr io.Writer, staged []*registry.StagedBundle, spec, keyPath, identity, trustRootsFP string) {
+	priv, err := signing.LoadPrivateKey(keyPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "    (emit-installed skipped: load key: %v)\n", err)
+		return
+	}
+	defer wipe(priv)
+	be, err := artifact.Open(spec, artifact.OpenOptions{Creds: artifactauth.New()})
+	if err != nil {
+		fmt.Fprintf(stderr, "    (emit-installed skipped: open %s: %v)\n", spec, err)
+		return
+	}
+	defer be.Close()
+	host := shortHostname()
+	ctx := context.Background()
+	for _, b := range staged {
+		ev, err := registry.BuildBundleInstalledEvent(registry.InstalledEventInput{
+			BundleDigest:          b.Digest,
+			Name:                  b.Name,
+			Version:               b.Version,
+			InstalledOnHost:       host,
+			InstalledAt:           time.Now().UTC(),
+			TrustRootsFingerprint: trustRootsFP,
+			Registry:              spec,
+		})
+		if err != nil {
+			fmt.Fprintf(stderr, "    (emit-installed %s: build event: %v)\n", b.Name, err)
+			continue
+		}
+		if _, err := registry.SignEnvelopeSignature(priv, ev); err != nil {
+			fmt.Fprintf(stderr, "    (emit-installed %s: sign envelope: %v)\n", b.Name, err)
+			continue
+		}
+		res, err := be.Publish(ctx, artifact.PublishRequest{
+			Kind:  artifact.KindInstall,
+			Event: ev,
+			Meta:  artifact.ArtifactMeta{Name: b.Name, Version: b.Version, Digest: b.Digest, AuthorIdentity: identity},
+		})
+		if err != nil {
+			fmt.Fprintf(stderr, "    (emit-installed %s: %v)\n", b.Name, err)
+			continue
+		}
+		fmt.Fprintf(stdout, "    ✉ emitted installed event: %s@%s on host=%s ref=%s\n", b.Name, b.Version, host, res.NativeID)
+	}
 }
 
 // emitInstalledEvents posts one BundleInstalledEvent per installed bundle so

--- a/cmd/skillctl/registry_cmds.go
+++ b/cmd/skillctl/registry_cmds.go
@@ -11,6 +11,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
@@ -135,10 +136,7 @@ func runRegistryShow(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	if artifact.SchemeOf(*registrySpec) != "er1" {
-		// Do NOT silently target ER1 for a git spec. The full signed timeline is
-		// in the repo (events/<digesthex>/); a git-native `show` is a follow-up.
-		fmt.Fprintf(stderr, "registry show: not yet wired for %q — use `registry ls --registry %s`; the signed event timeline is in the repo under events/<digesthex>/\n", *registrySpec, *registrySpec)
-		return 2
+		return runRegistryShowBackend(*registrySpec, fs.Arg(0), stdout, stderr)
 	}
 	cfg, err := resolveER1Config(*er1Target)
 	if err != nil {
@@ -177,4 +175,126 @@ func runRegistryShow(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	return 0
+}
+
+// runRegistryShowBackend renders `registry show` for a SPEC-0356 artifact backend
+// (gitlab:// / github://) from its GovernanceLog event timeline — the git-native
+// peer of ShowSkill, sourced from events/<digesthex>/ in the repo. Read-only; no
+// verification (that is `pull`). Accepts a skill name or a sha256:<hex> digest.
+func runRegistryShowBackend(spec, key string, stdout, stderr io.Writer) int {
+	be, err := artifact.Open(spec, artifact.OpenOptions{Creds: artifactauth.New()})
+	if err != nil {
+		fmt.Fprintf(stderr, "registry show: open %s: %v\n", spec, err)
+		return 1
+	}
+	defer be.Close()
+	gl, ok := be.(artifact.GovernanceLog)
+	if !ok {
+		fmt.Fprintf(stderr, "registry show: backend %q exposes no signed event timeline\n", spec)
+		return 1
+	}
+	ctx := context.Background()
+	isDigest := strings.HasPrefix(key, "sha256:")
+
+	var filter artifact.ListFilter
+	if !isDigest {
+		filter.Name = key
+	}
+	page, err := gl.Events(ctx, filter, artifact.Page{})
+	if err != nil {
+		fmt.Fprintf(stderr, "registry show: %v\n", err)
+		return 1
+	}
+	evs := page.Events
+	if isDigest {
+		filtered := evs[:0:0]
+		for _, e := range evs {
+			if e.Digest == key {
+				filtered = append(filtered, e)
+			}
+		}
+		evs = filtered
+	}
+	if len(evs) == 0 {
+		fmt.Fprintf(stdout, "(no events for %q in %s)\n", key, spec)
+		return 0
+	}
+
+	// Header: name from the events; latest version/digest via Resolve (name query)
+	// or the pinned digest (digest query); status = revoked if a revoke event exists.
+	name := key
+	for _, e := range evs {
+		if n := envString(e.Envelope, "name"); n != "" {
+			name = n
+			break
+		}
+	}
+	latestVer, latestDig := "", key
+	if !isDigest {
+		latestDig = ""
+		if ref, rerr := be.Resolve(ctx, artifact.RefQuery{Name: key}); rerr == nil {
+			latestVer, latestDig = ref.Version, ref.Digest
+		}
+	}
+	sort.SliceStable(evs, func(i, j int) bool { return evs[i].OccurredAt.After(evs[j].OccurredAt) })
+	latestGov, revoked := "", false
+	for _, e := range evs {
+		if latestDig != "" && e.Digest != latestDig {
+			continue
+		}
+		if e.Kind == artifact.KindAttest && latestGov == "" && e.Governance != "" {
+			latestGov = e.Governance
+		}
+		if e.Kind == artifact.KindRevoke {
+			revoked = true
+		}
+	}
+
+	fmt.Fprintf(stdout, "skill:           %s\n", name)
+	fmt.Fprintf(stdout, "registry:        %s\n", spec)
+	if latestVer != "" {
+		fmt.Fprintf(stdout, "latest version:  %s\n", latestVer)
+	}
+	fmt.Fprintf(stdout, "latest digest:   %s\n", strOr(latestDig, "?"))
+	fmt.Fprintf(stdout, "latest gov:      %s\n", strOr(latestGov, "—"))
+	if revoked {
+		fmt.Fprintln(stdout, "status:          REVOKED")
+	} else {
+		fmt.Fprintln(stdout, "status:          ok")
+	}
+	fmt.Fprintln(stdout, "\nevents (newest first):")
+	fmt.Fprintln(stdout, strings.Repeat("-", 80))
+	for _, e := range evs {
+		occ := "?"
+		if !e.OccurredAt.IsZero() {
+			occ = e.OccurredAt.UTC().Format("2006-01-02T15:04:05Z")
+		}
+		fmt.Fprintf(stdout, "  %-20s  %-9s  %s\n", occ, e.Kind, shortDigest(e.Digest))
+		if e.Governance != "" {
+			fmt.Fprintf(stdout, "    governance: %s\n", e.Governance)
+		}
+		if e.Host != "" {
+			fmt.Fprintf(stdout, "    host:       %s\n", e.Host)
+		}
+		if e.Rationale != "" {
+			fmt.Fprintf(stdout, "    rationale:  %s\n", e.Rationale)
+		}
+	}
+	return 0
+}
+
+func envString(env map[string]any, k string) string {
+	if env == nil {
+		return ""
+	}
+	s, _ := env[k].(string)
+	return s
+}
+
+func shortDigest(d string) string {
+	h := strings.TrimPrefix(d, "sha256:")
+	if len(h) > 12 {
+		return "sha256:" + h[:12] + "…"
+	}
+	return d
 }

--- a/cmd/skillctl/registry_cmds.go
+++ b/cmd/skillctl/registry_cmds.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifactauth"
@@ -86,7 +87,7 @@ func runRegistryLs(args []string, stdout, stderr io.Writer) int {
 		if s.IsRevoked {
 			status = "REVOKED"
 		}
-		fmt.Fprintf(stdout, "%-32s %-10s %-72s %-8s %s\n", s.Name, strOr(s.LatestVersion, "?"), s.LatestDigest, strOr(s.LatestGovernance, "—"), status)
+		fmt.Fprintf(stdout, "%-32s %-10s %-72s %-8s %s\n", safeCell(s.Name), strOr(safeCell(s.LatestVersion), "?"), safeCell(s.LatestDigest), strOr(safeCell(s.LatestGovernance), "—"), status)
 	}
 	return 0
 }
@@ -117,7 +118,7 @@ func runRegistryLsBackend(spec, skillName string, latest bool, stdout, stderr io
 		if s.IsRevoked {
 			status = "REVOKED"
 		}
-		fmt.Fprintf(stdout, "%-32s %-10s %-72s %-8s %s\n", s.Name, strOr(s.LatestVersion, "?"), s.LatestDigest, strOr(s.LatestGovernance, "—"), status)
+		fmt.Fprintf(stdout, "%-32s %-10s %-72s %-8s %s\n", safeCell(s.Name), strOr(safeCell(s.LatestVersion), "?"), safeCell(s.LatestDigest), strOr(safeCell(s.LatestGovernance), "—"), status)
 	}
 	return 0
 }
@@ -250,13 +251,13 @@ func runRegistryShowBackend(spec, key string, stdout, stderr io.Writer) int {
 		}
 	}
 
-	fmt.Fprintf(stdout, "skill:           %s\n", name)
-	fmt.Fprintf(stdout, "registry:        %s\n", spec)
+	fmt.Fprintf(stdout, "skill:           %s\n", safeCell(name))
+	fmt.Fprintf(stdout, "registry:        %s\n", spec) // operator-provided, trusted
 	if latestVer != "" {
-		fmt.Fprintf(stdout, "latest version:  %s\n", latestVer)
+		fmt.Fprintf(stdout, "latest version:  %s\n", safeCell(latestVer))
 	}
-	fmt.Fprintf(stdout, "latest digest:   %s\n", strOr(latestDig, "?"))
-	fmt.Fprintf(stdout, "latest gov:      %s\n", strOr(latestGov, "—"))
+	fmt.Fprintf(stdout, "latest digest:   %s\n", strOr(safeCell(latestDig), "?"))
+	fmt.Fprintf(stdout, "latest gov:      %s\n", strOr(safeCell(latestGov), "—"))
 	if revoked {
 		fmt.Fprintln(stdout, "status:          REVOKED")
 	} else {
@@ -269,15 +270,15 @@ func runRegistryShowBackend(spec, key string, stdout, stderr io.Writer) int {
 		if !e.OccurredAt.IsZero() {
 			occ = e.OccurredAt.UTC().Format("2006-01-02T15:04:05Z")
 		}
-		fmt.Fprintf(stdout, "  %-20s  %-9s  %s\n", occ, e.Kind, shortDigest(e.Digest))
+		fmt.Fprintf(stdout, "  %-20s  %-9s  %s\n", occ, safeCell(string(e.Kind)), shortDigest(e.Digest))
 		if e.Governance != "" {
-			fmt.Fprintf(stdout, "    governance: %s\n", e.Governance)
+			fmt.Fprintf(stdout, "    governance: %s\n", safeCell(e.Governance))
 		}
 		if e.Host != "" {
-			fmt.Fprintf(stdout, "    host:       %s\n", e.Host)
+			fmt.Fprintf(stdout, "    host:       %s\n", safeCell(e.Host))
 		}
 		if e.Rationale != "" {
-			fmt.Fprintf(stdout, "    rationale:  %s\n", e.Rationale)
+			fmt.Fprintf(stdout, "    rationale:  %s\n", safeCell(e.Rationale))
 		}
 	}
 	return 0
@@ -292,9 +293,35 @@ func envString(env map[string]any, k string) string {
 }
 
 func shortDigest(d string) string {
-	h := strings.TrimPrefix(d, "sha256:")
+	h := strings.TrimPrefix(safeCell(d), "sha256:")
 	if len(h) > 12 {
 		return "sha256:" + h[:12] + "…"
 	}
-	return d
+	return "sha256:" + h
+}
+
+// safeCell strips control characters from a repo-sourced string and caps its
+// length before it reaches a terminal. The git host is UNTRUSTED (SPEC-0356 §6):
+// an event/bundle.json field (name, governance, host, rationale, digest) can
+// carry ANSI escape sequences that rewrite earlier output — e.g. overwrite a
+// printed `status: REVOKED` with `ok` in the operator's decide-what-to-pull view.
+// Display-only defense; the authoritative pull gauntlet re-verifies independently
+// of the terminal. Mirrors the install path's control-char rejection.
+func safeCell(s string) string {
+	const max = 200
+	var b strings.Builder
+	for _, r := range s {
+		if r == '\t' {
+			r = ' '
+		}
+		if unicode.IsControl(r) {
+			continue // drop C0/C1 incl. ESC, CR, LF, backspace
+		}
+		if b.Len() >= max {
+			b.WriteString("…")
+			break
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }

--- a/cmd/skillctl/sanitize_test.go
+++ b/cmd/skillctl/sanitize_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSafeCell — the git-registry render paths must strip terminal-escape and
+// control bytes from untrusted repo-sourced fields (challenge-gate finding:
+// a malicious rationale could rewrite `status: REVOKED` -> `ok`).
+func TestSafeCell(t *testing.T) {
+	// ANSI cursor-up + carriage-return spoof is neutralized (ESC + CR dropped).
+	spoof := "green\x1b[3A\r    status:          ok"
+	got := safeCell(spoof)
+	if strings.ContainsRune(got, '\x1b') || strings.ContainsRune(got, '\r') || strings.ContainsRune(got, '\n') {
+		t.Errorf("control chars survived: %q", got)
+	}
+	// The ESC + CR are dropped (so the cursor cannot move); the printable "[3A"
+	// remnant stays as inert text — that is the correct, safe outcome.
+	if got != "green[3A    status:          ok" {
+		t.Errorf("safeCell = %q", got)
+	}
+	// A tab becomes a space (kept printable, not a layout break).
+	if got := safeCell("a\tb"); got != "a b" {
+		t.Errorf("tab handling: %q", got)
+	}
+	// Length is capped.
+	if got := safeCell(strings.Repeat("x", 500)); len([]rune(got)) > 205 {
+		t.Errorf("safeCell did not cap length: %d runes", len([]rune(got)))
+	}
+	// Clean input is unchanged.
+	if got := safeCell("sha256:deadbeef"); got != "sha256:deadbeef" {
+		t.Errorf("clean input mutated: %q", got)
+	}
+}

--- a/pkg/skillctl/backend/git/git.go
+++ b/pkg/skillctl/backend/git/git.go
@@ -161,7 +161,7 @@ func (b *gitBackend) Describe() artifact.Descriptor {
 			CanAdmit: true, CanAttest: true, CanRevoke: true, CanInstall: true,
 			ServerEventLog: true,  // committed events/ tree, surfaced via GovernanceLog.Events
 			Paginated:      false, // single-shot: one clone returns the COMPLETE listing; Page.Cursor is not honored
-			HonoursSince:   false, // v1: no server-side since filter
+			HonoursSince:   true,  // Events applies ListFilter.Since on occurred_at
 			Governance:     artifact.GovFromEventLog,
 			LatestPolicy:   artifact.LatestSemverMax,
 			Rooms:          false,
@@ -521,14 +521,23 @@ func (b *gitBackend) Events(ctx context.Context, filter artifact.ListFilter, pag
 					Kind:       artifact.EventKind(kindFromEventFile(e.Name())),
 					Digest:     "sha256:" + dh,
 					Governance: strFromMap(env, "governance_level"),
+					Host:       strFromMap(env, "packed_on_host"),
 					Rationale:  strFromMap(env, "rationale"),
 					NativeID:   e.Name(),
 					Envelope:   env,
+				}
+				if rec.Host == "" {
+					rec.Host = strFromMap(env, "installed_on_host")
 				}
 				if ts := strFromMap(env, "occurred_at"); ts != "" {
 					if t, perr := time.Parse(time.RFC3339, ts); perr == nil {
 						rec.OccurredAt = t
 					}
+				}
+				// --since (ListFilter.Since): drop events older than the bound. A
+				// zero/unparseable timestamp is kept (best-effort, never a gate).
+				if !filter.Since.IsZero() && !rec.OccurredAt.IsZero() && rec.OccurredAt.Before(filter.Since) {
+					continue
 				}
 				recs = append(recs, rec)
 			}

--- a/pkg/skillctl/backend/git/parity_test.go
+++ b/pkg/skillctl/backend/git/parity_test.go
@@ -1,0 +1,89 @@
+package git
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+)
+
+// TestGitEventsSinceHostInstall covers the three ER1↔GitLab parity additions on
+// the git side in one lifecycle: (1) an installed event published OVER git
+// (Publish(KindInstall) appended under events/<digesthex>/ and surfaced by
+// Events); (2) EventRecord.Host populated from packed_on_host / installed_on_host;
+// (3) ListFilter.Since honored on occurred_at.
+func TestGitEventsSinceHostInstall(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	ctx := context.Background()
+	b := newGitBackend(bareRepo(t), "gitlab")
+	defer b.Close()
+	d := fdig('a')
+
+	// admit @ 2026-01-01 on host boxA
+	if _, err := b.Publish(ctx, artifact.PublishRequest{
+		Kind: artifact.KindAdmit,
+		Event: map[string]any{
+			"kind": "admitted", "name": "ev", "version": "1.0.0", "bundle_digest": d,
+			"occurred_at": "2026-01-01T00:00:00Z", "packed_on_host": "boxA",
+		},
+		Meta: artifact.ArtifactMeta{Name: "ev", Version: "1.0.0", Digest: d},
+		Blob: []byte("SKB:ev@1.0.0"),
+	}); err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+
+	// installed event OVER GIT @ 2026-06-01 on host boxB
+	if _, err := b.Publish(ctx, artifact.PublishRequest{
+		Kind: artifact.KindInstall,
+		Event: map[string]any{
+			"kind": "installed", "bundle_digest": d,
+			"occurred_at": "2026-06-01T00:00:00Z", "installed_on_host": "boxB",
+		},
+		Meta: artifact.ArtifactMeta{Name: "ev", Version: "1.0.0", Digest: d},
+	}); err != nil {
+		t.Fatalf("install-over-git: %v", err)
+	}
+
+	// No --since: both events, with Host + OccurredAt populated.
+	page, err := b.Events(ctx, artifact.ListFilter{Name: "ev"}, artifact.Page{})
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	if len(page.Events) != 2 {
+		t.Fatalf("got %d events, want 2 (admit + install): %+v", len(page.Events), page.Events)
+	}
+	var sawAdmitHost, sawInstall bool
+	for _, e := range page.Events {
+		switch e.Kind {
+		case artifact.KindAdmit:
+			if e.Host != "boxA" {
+				t.Errorf("admit Host = %q, want boxA", e.Host)
+			}
+			if e.OccurredAt.IsZero() {
+				t.Error("admit OccurredAt not parsed")
+			}
+			sawAdmitHost = true
+		case artifact.KindInstall:
+			if e.Host != "boxB" {
+				t.Errorf("install Host = %q, want boxB (installed_on_host)", e.Host)
+			}
+			sawInstall = true
+		}
+	}
+	if !sawAdmitHost || !sawInstall {
+		t.Errorf("missing admit-host (%v) or installed-over-git event (%v)", sawAdmitHost, sawInstall)
+	}
+
+	// --since 2026-03-01 excludes the Jan admit, keeps the Jun install.
+	page2, err := b.Events(ctx, artifact.ListFilter{Name: "ev", Since: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)}, artifact.Page{})
+	if err != nil {
+		t.Fatalf("Events --since: %v", err)
+	}
+	if len(page2.Events) != 1 || page2.Events[0].Kind != artifact.KindInstall {
+		t.Errorf("--since 2026-03 => want [installed], got %+v", page2.Events)
+	}
+}

--- a/pkg/skillctl/registry/backend_pull.go
+++ b/pkg/skillctl/registry/backend_pull.go
@@ -19,9 +19,49 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
 )
+
+// parsePullSince turns the --since flag into a lower bound on occurred_at.
+// Accepts RFC3339, a date (YYYY-MM-DD), or a Go duration ("168h" => now-168h).
+// Empty => zero time (no bound). Shared by PullBundles (ER1) and
+// PullBundlesFromBackend (git) so --since behaves identically on both carriers.
+func parsePullSince(s string) (time.Time, error) {
+	if strings.TrimSpace(s) == "" {
+		return time.Time{}, nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t, nil
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		return time.Now().Add(-d), nil
+	}
+	return time.Time{}, fmt.Errorf("bad --since %q (want RFC3339, YYYY-MM-DD, or a duration like 168h)", s)
+}
+
+// eventOlderThan reports whether a signed event's occurred_at is strictly before
+// cutoff. An absent/unparseable timestamp is treated as NOT older (kept): --since
+// is a best-effort scope narrowing, never a security gate. Callers apply it only
+// AFTER the envelope signature verifies, so the timestamp is authenticated.
+func eventOlderThan(ev map[string]any, cutoff time.Time) bool {
+	if cutoff.IsZero() {
+		return false
+	}
+	ts, _ := ev["occurred_at"].(string)
+	if ts == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return false
+	}
+	return t.Before(cutoff)
+}
 
 // PullBundlesFromBackend runs the SPEC-0188 §7 gauntlet over be and stages the
 // bundles that pass. The governance floor requires a SIGNED AttestationPublished
@@ -92,6 +132,11 @@ func PullBundlesFromBackend(ctx context.Context, be artifact.Backend, tr *SelfTr
 		return nil, fmt.Errorf("pull: mkdir cache: %w", err)
 	}
 
+	sinceCutoff, serr := parsePullSince(opts.Since)
+	if serr != nil {
+		return nil, serr
+	}
+
 	res := &PullResult{}
 	for _, event := range admits {
 		name, _ := event["name"].(string)
@@ -104,6 +149,10 @@ func PullBundlesFromBackend(ctx context.Context, be artifact.Backend, tr *SelfTr
 		// Gate 1: envelope_signature (admit).
 		if err := VerifyEnvelopeSignature(pub, event); err != nil {
 			res.Skipped = append(res.Skipped, &PullSkip{Name: name, Version: ver, Digest: digest, Gate: ErrGateEnvelope, Detail: err.Error()})
+			continue
+		}
+		// --since: best-effort scope narrowing on the now-AUTHENTICATED occurred_at.
+		if eventOlderThan(event, sinceCutoff) {
 			continue
 		}
 		// Gate 5: revoked?

--- a/pkg/skillctl/registry/backend_pull.go
+++ b/pkg/skillctl/registry/backend_pull.go
@@ -39,6 +39,11 @@ func parsePullSince(s string) (time.Time, error) {
 		return t, nil
 	}
 	if d, err := time.ParseDuration(s); err == nil {
+		if d < 0 {
+			// A negative duration would invert --since into a FUTURE lower bound
+			// (now-(-d)), silently excluding everything. Reject it instead.
+			return time.Time{}, fmt.Errorf("bad --since %q (duration must be non-negative, e.g. 168h)", s)
+		}
 		return time.Now().Add(-d), nil
 	}
 	return time.Time{}, fmt.Errorf("bad --since %q (want RFC3339, YYYY-MM-DD, or a duration like 168h)", s)

--- a/pkg/skillctl/registry/er1_backend.go
+++ b/pkg/skillctl/registry/er1_backend.go
@@ -43,7 +43,7 @@ func (b *ER1Backend) Describe() artifact.Descriptor {
 			CanAdmit: true, CanAttest: true, CanRevoke: true, CanInstall: true,
 			ServerEventLog: true,                      // via GovernanceLog.Events
 			Paginated:      false,                     // single-shot list today (the known limit=500 fetch)
-			HonoursSince:   false,                     // --since is not yet honored
+			HonoursSince:   true,                      // Events applies ListFilter.Since on occurred_at
 			Governance:     artifact.GovFromEventLog,  // newest signed attestation
 			LatestPolicy:   artifact.LatestMostRecent, // admit-time newest (NOT semver-max — a real ER1↔git difference)
 			Rooms:          false,                     // TODO: expose er1_room.go via Roomer (rooms are an ER1-only feature)
@@ -53,6 +53,16 @@ func (b *ER1Backend) Describe() artifact.Descriptor {
 }
 
 func (b *ER1Backend) Close() error { return nil }
+
+// strOrEmpty returns the first non-empty string among vals (each may be any).
+func strOrEmpty(vals ...any) string {
+	for _, v := range vals {
+		if s, ok := v.(string); ok && s != "" {
+			return s
+		}
+	}
+	return ""
+}
 
 func (b *ER1Backend) skillMeta(m artifact.ArtifactMeta) SkillMeta {
 	return SkillMeta{
@@ -194,9 +204,23 @@ func (b *ER1Backend) Events(ctx context.Context, filter artifact.ListFilter, pag
 			}
 			d, _ := ev["bundle_digest"].(string)
 			lvl, _ := ev["governance_level"].(string)
-			out.Events = append(out.Events, artifact.EventRecord{
-				Kind: artifact.EventKind(kind), Digest: d, Governance: lvl, Envelope: ev,
-			})
+			rec := artifact.EventRecord{
+				Kind: artifact.EventKind(kind), Digest: d, Governance: lvl,
+				Host:      strOrEmpty(ev["packed_on_host"], ev["installed_on_host"]),
+				Rationale: strOrEmpty(ev["rationale"]),
+				Envelope:  ev,
+			}
+			if ts, _ := ev["occurred_at"].(string); ts != "" {
+				if t, perr := time.Parse(time.RFC3339, ts); perr == nil {
+					rec.OccurredAt = t
+				}
+			}
+			// --since (ListFilter.Since): drop events older than the bound; a
+			// zero/unparseable timestamp is kept (best-effort, never a gate).
+			if !filter.Since.IsZero() && !rec.OccurredAt.IsZero() && rec.OccurredAt.Before(filter.Since) {
+				continue
+			}
+			out.Events = append(out.Events, rec)
 		}
 	}
 	return out, nil

--- a/pkg/skillctl/registry/er1_pull.go
+++ b/pkg/skillctl/registry/er1_pull.go
@@ -285,6 +285,11 @@ func PullBundles(cfg *er1.Config, ctxID string, tr *SelfTrustRoots, opts PullOpt
 		return nil, fmt.Errorf("pull: mkdir cache: %w", err)
 	}
 
+	sinceCutoff, serr := parsePullSince(opts.Since)
+	if serr != nil {
+		return nil, serr
+	}
+
 	res := &PullResult{}
 	for _, item := range admits {
 		docID, _ := item["doc_id"].(string)
@@ -304,6 +309,10 @@ func PullBundles(cfg *er1.Config, ctxID string, tr *SelfTrustRoots, opts PullOpt
 		// Gate 1: envelope_signature.
 		if err := VerifyEnvelopeSignature(tr.PubKey(), event); err != nil {
 			res.Skipped = append(res.Skipped, &PullSkip{Name: name, Version: ver, Digest: digest, DocID: docID, Gate: ErrGateEnvelope, Detail: err.Error()})
+			continue
+		}
+		// --since: best-effort scope narrowing on the now-AUTHENTICATED occurred_at.
+		if eventOlderThan(event, sinceCutoff) {
 			continue
 		}
 		// Gate 5: revoked? (cheapest non-cryptographic gate; check before fetching bytes)

--- a/pkg/skillctl/registry/since_test.go
+++ b/pkg/skillctl/registry/since_test.go
@@ -1,0 +1,50 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// TestParsePullSince covers the --since parser shared by both pull carriers.
+func TestParsePullSince(t *testing.T) {
+	if got, err := parsePullSince(""); err != nil || !got.IsZero() {
+		t.Errorf("empty => zero/no-error, got %v / %v", got, err)
+	}
+	if got, err := parsePullSince("2026-08-01T00:00:00Z"); err != nil || got.Year() != 2026 || got.Month() != 8 {
+		t.Errorf("RFC3339 parse: %v / %v", got, err)
+	}
+	if got, err := parsePullSince("2026-08-01"); err != nil || got.Year() != 2026 || got.Day() != 1 {
+		t.Errorf("date parse: %v / %v", got, err)
+	}
+	if got, err := parsePullSince("168h"); err != nil || time.Since(got) < 167*time.Hour {
+		t.Errorf("duration parse: %v / %v", got, err)
+	}
+	if _, err := parsePullSince("not-a-time"); err == nil {
+		t.Error("garbage should error")
+	}
+}
+
+// TestEventOlderThan covers the best-effort admit-timestamp filter: only a
+// parseable occurred_at strictly before the cutoff is dropped; everything else
+// (zero cutoff, absent/unparseable timestamp) is kept — it is never a gate.
+func TestEventOlderThan(t *testing.T) {
+	cutoff := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	older := map[string]any{"occurred_at": "2026-07-01T00:00:00Z"}
+	newer := map[string]any{"occurred_at": "2026-09-01T00:00:00Z"}
+
+	if !eventOlderThan(older, cutoff) {
+		t.Error("2026-07 event should be older than the 2026-08 cutoff")
+	}
+	if eventOlderThan(newer, cutoff) {
+		t.Error("2026-09 event should NOT be older than the 2026-08 cutoff")
+	}
+	if eventOlderThan(older, time.Time{}) {
+		t.Error("a zero cutoff must keep every event")
+	}
+	if eventOlderThan(map[string]any{}, cutoff) {
+		t.Error("an absent occurred_at must be kept (best-effort, not a gate)")
+	}
+	if eventOlderThan(map[string]any{"occurred_at": "nonsense"}, cutoff) {
+		t.Error("an unparseable occurred_at must be kept")
+	}
+}

--- a/pkg/skillctl/registry/since_test.go
+++ b/pkg/skillctl/registry/since_test.go
@@ -22,6 +22,14 @@ func TestParsePullSince(t *testing.T) {
 	if _, err := parsePullSince("not-a-time"); err == nil {
 		t.Error("garbage should error")
 	}
+	// A negative duration would invert --since into a future cutoff — reject it.
+	if _, err := parsePullSince("-24h"); err == nil {
+		t.Error("negative duration must error (would silently exclude everything)")
+	}
+	// A positive duration still yields a PAST cutoff.
+	if got, err := parsePullSince("1h"); err != nil || !got.Before(time.Now()) {
+		t.Errorf("positive duration => past cutoff, got %v / %v", got, err)
+	}
 }
 
 // TestEventOlderThan covers the best-effort admit-timestamp filter: only a


### PR DESCRIPTION
Closes the three true ER1↔GitLab **parity gaps** (same feature, one side missing) identified by the parity challenge, each now symmetric across both carriers. Builds on #99 (merged).

## Changes
1. **`registry show` over git** — `runRegistryShowBackend` renders the signed event timeline from the backend's `GovernanceLog` (`events/<digesthex>/`), the git-native peer of ER1 `ShowSkill`. Name or `sha256:<hex>`. Read-only. git `Events` now also fills `EventRecord.Host`.
2. **`--emit-installed` over git** — `emitInstalledEventsViaBackend` builds + signs the **same** `BundleInstalledEvent` and appends it via `be.Publish(KindInstall)` (git commits it under `events/<digesthex>/`) instead of no-op'ing on a non-ER1 registry. Zero signing changes.
3. **`--since` honored on BOTH** — was passed but never read. `parsePullSince` (RFC3339 / `YYYY-MM-DD` / Go duration) + `eventOlderThan` applied in `PullBundles` (ER1) and `PullBundlesFromBackend` (git) **after the envelope-signature gate** (authenticated `occurred_at`), best-effort (absent/unparseable kept). `ListFilter.Since` honored in git + ER1Backend `Events`; `Capabilities.HonoursSince` flipped true on both.

## Trust note
The verification gauntlet gates are **unchanged**. `--since` is a subtractive filter placed **after gate 1 (envelope signature)** — it only *excludes* older events, never admits or installs anything extra. `emit-installed` reuses the existing signed-event build verbatim.

## Tests
`TestParsePullSince`, `TestEventOlderThan`, `TestGitEventsSinceHostInstall` (installed-over-git + Host + `--since` in one lifecycle). Full offline suite green, vet clean. A focused adversarial challenge gate is being run on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)