### PR TITLE
feat(skillctl): local-folder skill registry (local:// scheme, SPEC-0359 D1)

### DIFF
--- a/cmd/skillctl/registry_cmds.go
+++ b/cmd/skillctl/registry_cmds.go
@@ -30,6 +30,10 @@ func runRegistry(args []string, stdout, stderr io.Writer) int {
 		return runRegistryLs(args[1:], stdout, stderr)
 	case "show":
 		return runRegistryShow(args[1:], stdout, stderr)
+	case "init":
+		return runRegistryInit(args[1:], stdout, stderr)
+	case "export":
+		return runRegistryExport(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
 		printRegistryUsage(stdout)
 		return 0
@@ -41,12 +45,18 @@ func runRegistry(args []string, stdout, stderr io.Writer) int {
 }
 
 func printRegistryUsage(w io.Writer) {
-	fmt.Fprintln(w, "Usage: skillctl registry <ls|show> [flags]")
+	fmt.Fprintln(w, "Usage: skillctl registry <ls|show|init|export> [flags]")
 	fmt.Fprintln(w, "")
-	fmt.Fprintln(w, "  ls    [--latest] [--skill <name>] [--er1-target ...] [--er1-context ...]")
-	fmt.Fprintln(w, "        List bundles in the `self` registry, grouped by skill.")
-	fmt.Fprintln(w, "  show  <name | sha256:<hex>>  [--er1-target ...] [--er1-context ...]")
-	fmt.Fprintln(w, "        Show the full event timeline for one skill or one digest.")
+	fmt.Fprintln(w, "  ls     [--latest] [--skill <name>] [--registry <spec>]")
+	fmt.Fprintln(w, "         List bundles in a registry, grouped by skill.")
+	fmt.Fprintln(w, "  show   <name | sha256:<hex>>  [--registry <spec>]")
+	fmt.Fprintln(w, "         Show the full event timeline for one skill or one digest.")
+	fmt.Fprintln(w, "  init   --registry local://<path>")
+	fmt.Fprintln(w, "         Create a BARE local git registry (a folder you can publish into,")
+	fmt.Fprintln(w, "         offline). Push to a central GitLab/GitHub later with `git push`.")
+	fmt.Fprintln(w, "  export --registry local://<path> --out <file.bundle>")
+	fmt.Fprintln(w, "         Write a portable, verifiable one-file snapshot (git bundle) — the")
+	fmt.Fprintln(w, "         offline handoff: a peer runs `pull --registry local://<file.bundle>`.")
 }
 
 func runRegistryLs(args []string, stdout, stderr io.Writer) int {

--- a/cmd/skillctl/registry_local_cmds.go
+++ b/cmd/skillctl/registry_local_cmds.go
@@ -1,0 +1,65 @@
+package main
+
+// `skillctl registry init` + `registry export` — SPEC-0359 local-folder registry.
+// Manage a skill registry in a local folder with NO remote service; push to a
+// central GitLab/GitHub later (plain `git push`), or hand off a verifiable
+// snapshot (git bundle) for someone to review/request.
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+	backendgit "github.com/kamir/m3c-tools/pkg/skillctl/backend/git"
+)
+
+func runRegistryInit(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("registry init", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	spec := fs.String("registry", "", "Local registry to create: local://<path> (a bare git repo).")
+	if err := fs.Parse(reorderFlagArgs(fs, args)); err != nil {
+		return 2
+	}
+	if artifact.SchemeOf(*spec) != "local" {
+		fmt.Fprintf(stderr, "registry init: only local:// registries are created locally (got %q).\n  For gitlab://github:// create the project on the server; for ER1 use the self tenant.\n", *spec)
+		return 2
+	}
+	path, err := backendgit.InitLocalRegistry(*spec)
+	if err != nil {
+		fmt.Fprintf(stderr, "registry init: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "initialized local skill registry: %s\n", path)
+	fmt.Fprintf(stdout, "  publish:  skillctl publish <skill> --registry %s ...\n", *spec)
+	fmt.Fprintf(stdout, "  pull:     skillctl pull --registry %s\n", *spec)
+	fmt.Fprintf(stdout, "  push up:  git -C %s push --mirror <gitlab-or-github-url>\n", path)
+	return 0
+}
+
+func runRegistryExport(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("registry export", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	spec := fs.String("registry", "", "Local registry to export: local://<path>.")
+	out := fs.String("out", "", "Output bundle file, e.g. skills.bundle.")
+	if err := fs.Parse(reorderFlagArgs(fs, args)); err != nil {
+		return 2
+	}
+	if artifact.SchemeOf(*spec) != "local" {
+		fmt.Fprintf(stderr, "registry export: --registry must be local://<path> (got %q)\n", *spec)
+		return 2
+	}
+	if *out == "" {
+		fmt.Fprintln(stderr, "registry export: --out <file.bundle> is required")
+		return 2
+	}
+	if err := backendgit.ExportBundle(*spec, *out); err != nil {
+		fmt.Fprintf(stderr, "registry export: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "exported registry snapshot: %s\n", *out)
+	fmt.Fprintf(stdout, "  hand it to a peer; they review + verify with:\n")
+	fmt.Fprintf(stdout, "    skillctl registry ls --registry local://%s\n", *out)
+	fmt.Fprintf(stdout, "    skillctl pull --registry local://%s   # §7 gauntlet verifies against THEIR trust roots\n", *out)
+	return 0
+}

--- a/pkg/skillctl/backend/git/local.go
+++ b/pkg/skillctl/backend/git/local.go
@@ -80,12 +80,58 @@ func InitLocalRegistry(spec string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// `git init --bare` is safe to re-run on an existing bare repo.
+	if err := ensureInitTarget(path); err != nil {
+		return "", err
+	}
+	// `git init --bare` is safe to re-run on an existing bare repo (idempotent).
 	out, err := exec.Command("git", "-c", "init.defaultBranch=main", "init", "--bare", path).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git init --bare %s: %w: %s", path, err, strings.TrimSpace(string(out)))
 	}
 	return path, nil
+}
+
+// ensureInitTarget refuses to `git init --bare` over an existing NON-EMPTY,
+// NON-REPO directory — the classic `local://~` / `local://.` dropped-subpath typo
+// that would otherwise scatter bare-repo plumbing (HEAD/config/objects/refs)
+// across $HOME or the cwd. Allowed: the path is absent, an empty dir, or already a
+// git repo (so idempotent re-init still works).
+func ensureInitTarget(path string) error {
+	fi, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil // absent → git init creates it fresh
+	}
+	if err != nil {
+		return err
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("local: %q exists and is not a directory", path)
+	}
+	if isGitRepo(path) {
+		return nil // already a registry → idempotent re-init
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+	if len(entries) > 0 {
+		return fmt.Errorf("local: refusing to init a registry over the non-empty directory %q (it is not a git repo) — point --registry at a new or empty path, e.g. local://%s", path, filepath.Join(path, "skills.git"))
+	}
+	return nil
+}
+
+// isGitRepo reports whether path is already a git repository — a bare repo (HEAD
+// + objects/ at the root) or a working repo (a .git directory).
+func isGitRepo(path string) bool {
+	if _, err := os.Stat(filepath.Join(path, "objects")); err == nil {
+		if _, err := os.Stat(filepath.Join(path, "HEAD")); err == nil {
+			return true
+		}
+	}
+	if fi, err := os.Stat(filepath.Join(path, ".git")); err == nil && fi.IsDir() {
+		return true
+	}
+	return false
 }
 
 // ExportBundle writes a single-file git bundle of the local registry's full ref
@@ -100,6 +146,11 @@ func ExportBundle(spec, outPath string) error {
 	}
 	if outPath == "" {
 		return fmt.Errorf("local: export needs an output path (--out)")
+	}
+	if strings.HasPrefix(outPath, "-") {
+		// outPath is the only caller-controlled arg (--all is a fixed literal);
+		// rejecting a leading '-' closes git-flag injection into bundle create.
+		return fmt.Errorf("local: --out path may not start with '-' (%q)", outPath)
 	}
 	out, err := exec.Command("git", "-C", path, "bundle", "create", outPath, "--all").CombinedOutput()
 	if err != nil {

--- a/pkg/skillctl/backend/git/local.go
+++ b/pkg/skillctl/backend/git/local.go
@@ -1,0 +1,109 @@
+package git
+
+// SPEC-0359 D1: the `local://` scheme — a git skill registry on the LOCAL
+// filesystem, no remote service required. The FOLDER is the registry.
+//
+//   local://<path>       a bare git repo (read-write): publish/list/pull/attest/revoke
+//   local://<file.bundle> a git bundle (read-only snapshot): the offline "request" —
+//                         a peer pulls + verifies from it, but cannot publish into it.
+//
+// It reuses the provider-neutral gitBackend verbatim (clone-then-write, the
+// core.symlinks=false + lstat symlink defense, the SEC-M9 validators, the §7
+// verifying pull) — only the remote is a path instead of an https URL. Because
+// the wire format is frozen and byte-exact, "work locally, push to a central
+// GitLab/GitHub later" is a plain `git push` (digests + signatures survive).
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+)
+
+func init() {
+	artifact.Register("local", openLocal)
+}
+
+// openLocal maps local://<path> to a gitBackend whose "remote" is a local path.
+// The path must already exist (a bare repo made by `registry init`, or a .bundle);
+// git treats both as valid clone sources.
+func openLocal(spec string, opts artifact.OpenOptions) (artifact.Backend, error) {
+	path, err := resolveLocalPath(spec)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("local: registry path %q not found — run `skillctl registry init --registry %s` first (or check the .bundle path): %w", path, spec, err)
+	}
+	b := newGitBackend(path, "local")
+	b.applyCreds(opts) // no-op for local (no token), kept for symmetry
+	return b, nil
+}
+
+// resolveLocalPath turns local://<path> into an absolute filesystem path.
+// Accepts local:///abs/path, local://~/under-home, local://relative. Rejects a
+// leading '-' (would be parsed as a git flag) and an empty path.
+func resolveLocalPath(spec string) (string, error) {
+	if !strings.HasPrefix(spec, "local://") {
+		return "", fmt.Errorf("local: expected local://<path>, got %q", spec)
+	}
+	p := strings.TrimPrefix(spec, "local://")
+	if p == "" {
+		return "", fmt.Errorf("local: empty path in %q", spec)
+	}
+	if strings.HasPrefix(p, "-") {
+		return "", fmt.Errorf("local: path may not start with '-' (%q)", p)
+	}
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		p = filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(p, "~"), "/"))
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+// InitLocalRegistry creates (or re-initializes, idempotently) a BARE git repo at
+// the local:// path so it can be published into. Returns the resolved path.
+// Bare is required: the backend pushes to it, and git refuses a push to the
+// checked-out branch of a non-bare repo.
+func InitLocalRegistry(spec string) (string, error) {
+	path, err := resolveLocalPath(spec)
+	if err != nil {
+		return "", err
+	}
+	// `git init --bare` is safe to re-run on an existing bare repo.
+	out, err := exec.Command("git", "-c", "init.defaultBranch=main", "init", "--bare", path).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git init --bare %s: %w: %s", path, err, strings.TrimSpace(string(out)))
+	}
+	return path, nil
+}
+
+// ExportBundle writes a single-file git bundle of the local registry's full ref
+// set (--all: every branch + tag). The bundle is a portable, verifiable,
+// READ-ONLY snapshot — the decentralized "pull request" / air-gap handoff: a peer
+// runs `skillctl pull --registry local://<bundle>` and the §7 gauntlet verifies
+// it against their own pinned trust roots.
+func ExportBundle(spec, outPath string) error {
+	path, err := resolveLocalPath(spec)
+	if err != nil {
+		return err
+	}
+	if outPath == "" {
+		return fmt.Errorf("local: export needs an output path (--out)")
+	}
+	out, err := exec.Command("git", "-C", path, "bundle", "create", outPath, "--all").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git bundle create %s: %w: %s", outPath, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/pkg/skillctl/backend/git/local_test.go
+++ b/pkg/skillctl/backend/git/local_test.go
@@ -1,0 +1,110 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+)
+
+func TestResolveLocalPath(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	cases := []struct {
+		spec, want string
+		err        bool
+	}{
+		{"local:///abs/reg.git", "/abs/reg.git", false},
+		{"local://~/reg.git", filepath.Join(home, "reg.git"), false},
+		{"local://-oops", "", true},  // leading '-' rejected (git-flag injection)
+		{"local://", "", true},       // empty
+		{"gitlab://h/g/p", "", true}, // wrong scheme
+	}
+	for _, c := range cases {
+		got, err := resolveLocalPath(c.spec)
+		if c.err {
+			if err == nil {
+				t.Errorf("resolveLocalPath(%q) = %q, want error", c.spec, got)
+			}
+			continue
+		}
+		if err != nil || got != c.want {
+			t.Errorf("resolveLocalPath(%q) = %q / %v, want %q", c.spec, got, err, c.want)
+		}
+	}
+}
+
+// TestLocalRegistryEndToEnd: init a bare local registry, publish + read through
+// artifact.Open("local://…"), export a git-bundle snapshot, and prove a peer can
+// list+fetch from the READ-ONLY bundle — the offline handoff flow, no remote.
+func TestLocalRegistryEndToEnd(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	ctx := context.Background()
+	regPath := filepath.Join(t.TempDir(), "reg.git")
+	spec := "local://" + regPath
+
+	// init → bare repo exists.
+	if _, err := InitLocalRegistry(spec); err != nil {
+		t.Fatalf("InitLocalRegistry: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(regPath, "HEAD")); err != nil {
+		t.Fatalf("init did not create a bare repo (no HEAD): %v", err)
+	}
+
+	// Open via the factory (proves the local:// scheme is registered) + publish.
+	be, err := artifact.Open(spec, artifact.OpenOptions{})
+	if err != nil {
+		t.Fatalf("Open(%q): %v", spec, err)
+	}
+	defer be.Close()
+	if be.Describe().Scheme != "local" {
+		t.Errorf("scheme = %q, want local", be.Describe().Scheme)
+	}
+	d := fdig('a')
+	if _, err := be.Publish(ctx, admitEvent("localskill", "1.0.0", d)); err != nil {
+		t.Fatalf("publish to local registry: %v", err)
+	}
+
+	// Read back through the local registry.
+	lst, err := be.List(ctx, artifact.ListFilter{}, artifact.Page{})
+	if err != nil || len(lst.Skills) != 1 || lst.Skills[0].Name != "localskill" {
+		t.Fatalf("List local = %+v / %v", lst, err)
+	}
+	ref, err := be.Resolve(ctx, artifact.RefQuery{Name: "localskill"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	blob, err := be.Fetch(ctx, *ref)
+	if err != nil || string(blob) != "SKB:localskill@1.0.0" {
+		t.Fatalf("Fetch local = %q / %v", blob, err)
+	}
+
+	// export → a portable read-only bundle snapshot (the offline "request").
+	bundlePath := filepath.Join(t.TempDir(), "skills.bundle")
+	if err := ExportBundle(spec, bundlePath); err != nil {
+		t.Fatalf("ExportBundle: %v", err)
+	}
+	if fi, err := os.Stat(bundlePath); err != nil || fi.Size() == 0 {
+		t.Fatalf("bundle not written: %v", err)
+	}
+
+	// A PEER opens the bundle as a read-only registry and lists + fetches from it.
+	bspec := "local://" + bundlePath
+	pbe, err := artifact.Open(bspec, artifact.OpenOptions{})
+	if err != nil {
+		t.Fatalf("Open bundle %q: %v", bspec, err)
+	}
+	defer pbe.Close()
+	plst, err := pbe.List(ctx, artifact.ListFilter{}, artifact.Page{})
+	if err != nil || len(plst.Skills) != 1 || plst.Skills[0].Name != "localskill" {
+		t.Fatalf("List from bundle = %+v / %v", plst, err)
+	}
+	pblob, err := pbe.Fetch(ctx, artifact.ArtifactRef{Name: "localskill", Version: "1.0.0", Digest: d})
+	if err != nil || string(pblob) != "SKB:localskill@1.0.0" {
+		t.Fatalf("Fetch from bundle = %q / %v", pblob, err)
+	}
+}

--- a/pkg/skillctl/backend/git/local_test.go
+++ b/pkg/skillctl/backend/git/local_test.go
@@ -36,6 +36,42 @@ func TestResolveLocalPath(t *testing.T) {
 	}
 }
 
+// TestInitLocalRegistryGuards: init must refuse to scatter bare-repo plumbing over
+// a non-empty non-repo directory (the local://~ / local://. typo footgun), while
+// still allowing an absent path, an empty dir, and idempotent re-init of a repo.
+func TestInitLocalRegistryGuards(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	// Non-empty NON-repo dir → REFUSE (the footgun).
+	danger := t.TempDir()
+	if err := os.WriteFile(filepath.Join(danger, "my-important.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InitLocalRegistry("local://" + danger); err == nil {
+		t.Errorf("init over a non-empty non-repo dir must be refused")
+	}
+	if _, err := os.Stat(filepath.Join(danger, "HEAD")); err == nil {
+		t.Errorf("init wrote bare-repo plumbing into a user directory — footgun not guarded")
+	}
+
+	// Empty dir → OK.
+	empty := t.TempDir()
+	if _, err := InitLocalRegistry("local://" + empty); err != nil {
+		t.Errorf("init over an empty dir should succeed: %v", err)
+	}
+	// Idempotent re-init of the now-bare repo → OK.
+	if _, err := InitLocalRegistry("local://" + empty); err != nil {
+		t.Errorf("re-init of an existing bare repo should be idempotent: %v", err)
+	}
+
+	// Absent path → OK (git creates it).
+	absent := filepath.Join(t.TempDir(), "new", "reg.git")
+	if _, err := InitLocalRegistry("local://" + absent); err != nil {
+		t.Errorf("init over an absent path should succeed: %v", err)
+	}
+}
+
 // TestLocalRegistryEndToEnd: init a bare local registry, publish + read through
 // artifact.Open("local://…"), export a git-bundle snapshot, and prove a peer can
 // list+fetch from the READ-ONLY bundle — the offline handoff flow, no remote.


### PR DESCRIPTION
**The folder is the registry** — no remote service or account needed to start. SPEC-0359 D1, on top of the merged SPEC-0356 backend.

## What
- **`local://<path>` scheme** — a bare git repo is a read-write registry (publish/list/pull/attest/revoke, offline); a `.bundle` file is a read-only snapshot. Reuses the provider-neutral `gitBackend` verbatim (same clone-then-write, `core.symlinks=false`+`lstat` symlink defense, SEC-M9 validators, §7 verifying pull) — only the "remote" is a path. `SchemeOf` unchanged.
- **`registry init --registry local://<path>`** → `git init --bare` (idempotent).
- **`registry export --registry local://<path> --out skills.bundle`** → `git bundle create --all`: a portable, verifiable, **read-only** snapshot (the offline "request"/air-gap handoff). Peer runs `pull --registry local://skills.bundle`; the §7 gauntlet verifies against **their** roots.
- **Push-to-central-later** = `git push --mirror` — byte-exact frozen wire format ⇒ digests + signatures survive, nothing to migrate.
- Path validation: reject leading `-` (git-flag injection) + empty; absolutize.

## Tests
`TestLocalRegistryEndToEnd` (init → publish → list/resolve/fetch → export → peer lists+fetches from the read-only bundle), `TestResolveLocalPath`. Full offline suite + vet clean; CLI smoke (`init`/`ls`/`help`) verified.

## Status
**Draft** — trust-plane code, so a focused challenge gate runs before it's marked ready. SPEC + infographic: m3c-tools-maintenance PR (SPEC-0359).

🤖 Generated with [Claude Code](https://claude.com/claude-code)