### PR TITLE
feat(rag): multi-workspace search — one query across notes, specs and code

### DIFF
--- a/rag-mcp-server/README.md
+++ b/rag-mcp-server/README.md
@@ -26,13 +26,36 @@ $RAG/.venv/bin/python $RAG/rag.py search -w "$WS" "q" --path-prefix SPEC/ --sinc
 $RAG/.venv/bin/python $RAG/rag.py status -w "$WS"
 ```
 
+### Searching several repos at once
+
+`-w` is repeatable on `search`: the query is embedded **once**, fanned out across
+every index, and the hits are merged by score with a `workspace` label. Intent
+(a private SPEC repo), reasoning (a notes repo) and reality (the running code)
+are usually three different repos — one question should not have to be asked
+three times.
+
+```bash
+$RAG/.venv/bin/python $RAG/rag.py search -w "$NOTES" -w "$SPECS" -w "$CODE" "why is X the way it is?" -k 8
+
+export RAG_WORKSPACES="$NOTES:$SPECS:$CODE"      # standing set; -w still overrides
+$RAG/.venv/bin/python $RAG/rag.py search "why is X the way it is?"
+```
+
+Scores are only comparable under the **same embedding model**, so a model mismatch
+across workspaces is a hard error rather than a silently mis-ranked list; a
+differing `bit_width` only warns. `index`/`sync`/`status`/`verify` still take a
+single `-w` — building or committing several indexes from one invocation would
+hide which one failed.
+
 First `index` downloads `bge-m3` (~2.3 GB) to the HuggingFace cache, then runs
 offline. The index (`index.tvim`), sidecar (`meta.sqlite`) and `state.json` are
 written to `$WS/.rag/` (auto-added to `$WS/.gitignore`).
 
 ## MCP exposure
 
-Register in `<repo>/.mcp.json` so agents get `rag_search` / `rag_stats` / `rag_sync`:
+Register in `<repo>/.mcp.json` so agents get `rag_search` / `rag_workspaces` /
+`rag_stats` / `rag_sync` / `rag_verify`. `--workspace` is repeatable here too, so
+**one** registered server answers across every repo:
 
 ```json
 {
@@ -41,12 +64,24 @@ Register in `<repo>/.mcp.json` so agents get `rag_search` / `rag_stats` / `rag_s
       "command": "/Users/kamir/GITHUB.kamir/m3c-tools/rag-mcp-server/.venv/bin/python",
       "args": [
         "/Users/kamir/GITHUB.kamir/m3c-tools/rag-mcp-server/rag_mcp_server.py",
-        "--workspace", "/path/to/repo"
+        "--workspace", "/path/to/notes-repo",
+        "--workspace", "/path/to/spec-repo",
+        "--workspace", "/path/to/code-repo"
       ]
     }
   }
 }
 ```
+
+| Tool | Behaviour |
+|---|---|
+| `rag_search(query, k, path_prefix, since_days, workspace="")` | empty `workspace` searches all and merges by score; every hit carries `workspace` |
+| `rag_workspaces()` | what this server can search, in merge order (first = primary) |
+| `rag_stats(workspace="")` / `rag_verify(workspace="")` | per workspace; empty = all |
+| `rag_sync(workspace="")` | incremental re-index, local-only; empty = all |
+
+Indexers are cached per workspace and share one embedder, so the model is loaded
+once per server process — not once per query.
 
 ## Layout
 

--- a/rag-mcp-server/rag.py
+++ b/rag-mcp-server/rag.py
@@ -60,7 +60,14 @@ def resolve_workspaces(arg):
         ws = [w for w in os.environ.get("RAG_WORKSPACES", "").split(os.pathsep) if w]
     seen, out = set(), []
     for w in ws:
-        r = str(Path(w).expanduser().resolve())
+        pw = Path(w).expanduser().resolve()
+        # A standing fan-out set (a committed .mcp.json, $RAG_WORKSPACES in a
+        # profile) is shared across machines that do not all have every repo
+        # checked out. A missing one must not take the whole server down.
+        if not pw.is_dir():
+            print(f"rag: warning — skipping missing workspace {w}", file=sys.stderr)
+            continue
+        r = str(pw)
         if r not in seen:
             seen.add(r)
             out.append(r)

--- a/rag-mcp-server/rag.py
+++ b/rag-mcp-server/rag.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -50,14 +51,87 @@ def ensure_git_tracking(ws):
             f.write(".rag/index.tvim filter=lfs diff=lfs merge=lfs -text\n")
 
 
+def resolve_workspaces(arg):
+    """`-w` may be repeated; without it, fall back to $RAG_WORKSPACES (os.pathsep-
+    separated). Order is preserved and duplicates are dropped, so a caller can
+    export a standing fan-out set once and still override it per invocation."""
+    ws = list(arg or [])
+    if not ws:
+        ws = [w for w in os.environ.get("RAG_WORKSPACES", "").split(os.pathsep) if w]
+    seen, out = set(), []
+    for w in ws:
+        r = str(Path(w).expanduser().resolve())
+        if r not in seen:
+            seen.add(r)
+            out.append(r)
+    return out
+
+
+def _search_many(workspaces, query, k, path_prefix, since_days, get_indexer=None):
+    """Fan out one query across several workspaces and merge by score.
+
+    Three things make the merge honest and cheap:
+
+    * **One embedder for all of them.** Each Indexer would otherwise load its own
+      copy of the model; `Indexer(ws, cfg, embedder=...)` lets them share it, so
+      the query vector is computed exactly once.
+    * **`get_indexer` lets a caller supply CACHED indexers.** A long-lived host
+      (the MCP server) must not rebuild them per call — without this the model is
+      re-loaded on every fan-out search, which costs seconds each time.
+    * **Scores are only comparable under the same model.** Cosine scores from two
+      different embedders mean nothing side by side, so a model mismatch is a hard
+      error rather than a silently mis-ranked list. A differing `bit_width` only
+      adds quantization noise -> warn, continue.
+    """
+    from indexer import Indexer
+    from embedder import Embedder
+
+    cfgs = {w: load_cfg(w) for w in workspaces}
+    models = {w: c["model"] for w, c in cfgs.items()}
+    if len(set(models.values())) > 1:
+        detail = "; ".join(f"{Path(w).name}={m}" for w, m in models.items())
+        raise ValueError(f"refusing to merge results across different models ({detail}). "
+                         f"Re-index the odd one out, or search them separately.")
+
+    widths = {c.get("bit_width") for c in cfgs.values()}
+    if len(widths) > 1:
+        print(f"rag: warning — mixed bit_width across workspaces ({sorted(widths)}); "
+              f"ranking carries extra quantization noise", file=sys.stderr)
+
+    if get_indexer is None:
+        first = cfgs[workspaces[0]]
+        shared = Embedder(first["model"], max_seq_length=first.get("max_seq_length", 512))
+
+        def get_indexer(w, _shared=shared):
+            return Indexer(w, cfgs[w], embedder=_shared)
+
+    merged = []
+    for w in workspaces:
+        ix = get_indexer(w)
+        try:
+            hits = ix.search(query, k=k, path_prefix=path_prefix, since_days=since_days)
+        except Exception as e:  # a broken/absent index must not sink the whole fan-out
+            print(f"rag: warning — {Path(w).name}: {e}", file=sys.stderr)
+            continue
+        label = Path(w).name
+        for h in hits:
+            h["workspace"] = label
+            h["workspace_path"] = w
+            merged.append(h)
+    merged.sort(key=lambda h: h["score"], reverse=True)
+    return merged[:k]
+
+
 def main():
     ap = argparse.ArgumentParser(prog="rag")
     sub = ap.add_subparsers(dest="cmd", required=True)
     for name in ("index", "sync", "status", "verify"):
         s = sub.add_parser(name)
-        s.add_argument("--workspace", "-w", required=True)
+        s.add_argument("--workspace", "-w", action="append")
     ss = sub.add_parser("search")
-    ss.add_argument("--workspace", "-w", required=True)
+    ss.add_argument("--workspace", "-w", action="append",
+                    help="repeatable; fans the query out and merges by score. "
+                         "Defaults to $RAG_WORKSPACES.")
     ss.add_argument("query")
     ss.add_argument("-k", type=int, default=8)
     ss.add_argument("--path-prefix", default="")
@@ -65,12 +139,38 @@ def main():
     ss.add_argument("--json", action="store_true")
     a = ap.parse_args()
 
-    from indexer import Indexer
-    cfg = load_cfg(a.workspace)
-    ix = Indexer(a.workspace, cfg)
+    workspaces = resolve_workspaces(a.workspace)
+    if not workspaces:
+        ap.error("no workspace: pass -w <repo> (repeatable) or set $RAG_WORKSPACES")
 
+    # Write/state commands act on exactly one workspace: building or committing
+    # several indexes from a single invocation would hide which one failed.
+    if a.cmd != "search" and len(workspaces) > 1:
+        ap.error(f"'{a.cmd}' takes a single -w; got {len(workspaces)}")
+
+    from indexer import Indexer
+
+    if a.cmd == "search":
+        try:
+            res = _search_many(workspaces, a.query, a.k, a.path_prefix, a.since_days)
+        except ValueError as e:
+            sys.exit(f"rag: {e}")
+        if a.json:
+            print(json.dumps(res, indent=2))
+            return
+        if not res:
+            print("(no results)", file=sys.stderr)
+        multi = len(workspaces) > 1
+        for r in res:
+            where = f"{r['workspace']}:{r['path']}" if multi else r["path"]
+            print(f"\n{r['score']:.3f}  {where}:{r['lines']}  [{r['heading']}]")
+            print("    " + r["snippet"].replace("\n", " ")[:240])
+        return
+
+    ws = workspaces[0]
+    ix = Indexer(ws, load_cfg(ws))
     if a.cmd == "index":
-        ensure_git_tracking(a.workspace)
+        ensure_git_tracking(ws)
         print(json.dumps(ix.build(), indent=2))
     elif a.cmd == "sync":
         print(json.dumps(ix.sync(), indent=2))
@@ -80,16 +180,6 @@ def main():
         r = ix.verify()
         print(json.dumps(r, indent=2))
         sys.exit(0 if r.get("fresh") else 2)
-    elif a.cmd == "search":
-        res = ix.search(a.query, k=a.k, path_prefix=a.path_prefix, since_days=a.since_days)
-        if a.json:
-            print(json.dumps(res, indent=2))
-            return
-        if not res:
-            print("(no results)", file=sys.stderr)
-        for r in res:
-            print(f"\n{r['score']:.3f}  {r['path']}:{r['lines']}  [{r['heading']}]")
-            print("    " + r["snippet"].replace("\n", " ")[:240])
 
 
 if __name__ == "__main__":

--- a/rag-mcp-server/rag_mcp_server.py
+++ b/rag-mcp-server/rag_mcp_server.py
@@ -2,7 +2,15 @@
 """rag MCP server (SPEC-0268) — FastMCP stdio, mirrors mcp-skill-server.
 
 Exposes local workspace RAG search/stats/sync as Claude Code tools.
-Launch:  rag_mcp_server.py --workspace <repo>
+
+Launch:  rag_mcp_server.py --workspace <repo> [--workspace <repo> ...]
+
+`--workspace` is repeatable (and $RAG_WORKSPACES is honoured), so ONE registered
+server can answer across several repos — e.g. the thinking corpus, the private
+SPEC/intent repo and the running code. `rag_search` then merges by score and
+labels every hit with its workspace; pass `workspace="<name>"` to scope to one.
+The FIRST workspace is the primary: it is what a single-target call defaults to.
+
 Register in <repo>/.mcp.json (see README).
 """
 from __future__ import annotations
@@ -11,62 +19,111 @@ import argparse
 import sys
 from pathlib import Path
 
-import yaml
-
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 
 from mcp.server.fastmcp import FastMCP  # noqa: E402
 
+from rag import load_cfg, resolve_workspaces, _search_many  # noqa: E402
+
 _ap = argparse.ArgumentParser()
-_ap.add_argument("--workspace", "-w", required=True)
+_ap.add_argument("--workspace", "-w", action="append")
 ARGS, _ = _ap.parse_known_args()
 
+WORKSPACES = resolve_workspaces(ARGS.workspace)
+if not WORKSPACES:
+    sys.exit("rag_mcp_server: no workspace — pass --workspace <repo> or set $RAG_WORKSPACES")
+PRIMARY = WORKSPACES[0]
 
-def _cfg(ws):
-    rc = Path(ws).resolve() / ".rag" / "config.yaml"
-    default = HERE / "config.default.yaml"
-    return yaml.safe_load((rc if rc.exists() else default).read_text())
+
+def _label(ws):
+    return Path(ws).name
+
+
+def _resolve_one(workspace):
+    """Map a tool's `workspace` argument (a name or a path) onto a registered
+    workspace. Empty -> the primary. An unknown value is an error rather than a
+    silent fallback: quietly answering from the wrong repo is worse than failing."""
+    if not workspace:
+        return PRIMARY
+    for w in WORKSPACES:
+        if workspace in (w, _label(w)):
+            return w
+    raise ValueError(f"unknown workspace {workspace!r}; registered: "
+                     + ", ".join(_label(w) for w in WORKSPACES))
 
 
 mcp = FastMCP("rag")
-_ix = None
+_ixs = {}
 
 
-def _indexer():
-    global _ix
-    if _ix is None:
+def _indexer(ws):
+    """One cached Indexer per workspace, all sharing a single embedder so the
+    model is loaded once no matter how many repos are registered."""
+    if ws not in _ixs:
         from indexer import Indexer
-        _ix = Indexer(ARGS.workspace, _cfg(ARGS.workspace))
-    return _ix
+        # Only hand over an embedder that is ALREADY materialized — `.embedder` is
+        # a lazy property, so touching it here would load the model even for a
+        # stats-only call that never needs it.
+        shared = next((i._embedder for i in _ixs.values() if i._embedder is not None), None)
+        _ixs[ws] = Indexer(ws, load_cfg(ws), embedder=shared)
+    return _ixs[ws]
 
 
 @mcp.tool()
-def rag_search(query: str, k: int = 8, path_prefix: str = "", since_days: int = 0) -> list:
-    """Semantic search over the local workspace index.
+def rag_search(query: str, k: int = 8, path_prefix: str = "",
+               since_days: int = 0, workspace: str = "") -> list:
+    """Semantic search over the local workspace index(es).
 
-    Returns up to k chunks as {path, heading, lines, score, snippet}, each citing
-    a clickable path:line. Use path_prefix (e.g. "SPEC/") or since_days to scope.
+    Returns up to k chunks as {path, heading, lines, score, snippet, workspace},
+    each citing a clickable path:line. Scope with path_prefix (e.g. "SPEC/"),
+    since_days, or workspace (a registered name; empty searches all of them and
+    merges by score).
     """
-    return _indexer().search(query, k=k, path_prefix=path_prefix, since_days=since_days)
+    if workspace:
+        ws = _resolve_one(workspace)
+        hits = _indexer(ws).search(query, k=k, path_prefix=path_prefix, since_days=since_days)
+        for h in hits:
+            h["workspace"] = _label(ws)
+        return hits
+    return _search_many(WORKSPACES, query, k, path_prefix, since_days,
+                        get_indexer=_indexer)
 
 
 @mcp.tool()
-def rag_stats() -> dict:
-    """Index statistics: file/chunk counts, model, dim, last-sync git commit, size."""
-    return _indexer().stats()
+def rag_workspaces() -> list:
+    """The workspaces this server can search, in merge order (first = primary)."""
+    return [{"name": _label(w), "path": w} for w in WORKSPACES]
 
 
 @mcp.tool()
-def rag_sync() -> dict:
-    """Incrementally re-index files changed/added/deleted since the last sync (local-only)."""
-    return _indexer().sync()
+def rag_stats(workspace: str = "") -> dict:
+    """Index statistics per workspace: file/chunk counts, model, dim, last-sync commit, size.
+
+    Empty workspace reports every registered one.
+    """
+    targets = WORKSPACES if not workspace else [_resolve_one(workspace)]
+    return {_label(w): _indexer(w).stats() for w in targets}
 
 
 @mcp.tool()
-def rag_verify() -> dict:
-    """Is the committed index FRESH vs the current workspace? Returns fresh + corpus hashes."""
-    return _indexer().verify()
+def rag_sync(workspace: str = "") -> dict:
+    """Incrementally re-index files changed/added/deleted since the last sync (local-only).
+
+    Empty workspace syncs every registered one.
+    """
+    targets = WORKSPACES if not workspace else [_resolve_one(workspace)]
+    return {_label(w): _indexer(w).sync() for w in targets}
+
+
+@mcp.tool()
+def rag_verify(workspace: str = "") -> dict:
+    """Is each index FRESH vs its current workspace? Returns fresh + corpus hashes.
+
+    Empty workspace verifies every registered one.
+    """
+    targets = WORKSPACES if not workspace else [_resolve_one(workspace)]
+    return {_label(w): _indexer(w).verify() for w in targets}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Intent (a private SPEC repo), reasoning (a notes repo) and reality (the running code) live in different repos, but they answer the same question. `rag.py` took exactly one `-w`, so that question had to be asked once per repo and the results ranked by hand.

Concretely: answering *"why is the AIL edge store the way it is?"* meant three separate searches across `mirkos-braindump`, `m3c-tools-maintenance` and `aims-core`.

## What

- **`search` accepts a repeatable `-w`** (and honours `$RAG_WORKSPACES`, os.pathsep-separated). The query is embedded **once**, fanned out across every index, and merged by score with a `workspace` label on each hit.
- **The MCP server takes repeatable `--workspace`**, so one registered server answers across all repos. New `rag_workspaces()`; `rag_search` / `rag_stats` / `rag_sync` / `rag_verify` gain an optional `workspace` argument (empty = all).
- README + usage docs updated.

## Three things the implementation is careful about

1. **Scores are only comparable under the same embedding model.** A model mismatch across workspaces is a hard error, not a silently mis-ranked list. A differing `bit_width` only warns (quantization noise).
2. **`_search_many` accepts a `get_indexer` callback** so a long-lived host can supply *cached* indexers. Without it the MCP server rebuilt them per call and re-loaded bge-m3 every time — **measured 10.4 s per search instead of 0.8–1.8 s** after the first.
3. **The server only shares an already-materialized embedder.** `.embedder` is a lazy property, so touching it eagerly would load the model even for a stats-only call that never needs it.

Plus a robustness fix: a **missing workspace is skipped with a warning** rather than taking the fan-out down. A standing set (a committed `.mcp.json`, `$RAG_WORKSPACES` in a profile) is shared across machines that do not all have every repo checked out.

## Compatibility

Backwards compatible. A single `-w` behaves exactly as before, **including the output format** — the workspace column appears only when several are searched. This matters: `mirkos-braindump/tools/nightly-sync.sh` and `tools/rag-lifecycle.sh` call `sync`/`verify` with one `-w` and parse the output.

`index` / `sync` / `status` / `verify` still take a single `-w` — building or committing several indexes from one invocation would hide which one failed.

## Testing

Manual, against three real indexes (6 708 / 2 075 / building files):

- single `-w` `verify`, `status`, `search` — output byte-identical to before
- fan-out across two workspaces, correctly merged and labelled
- `$RAG_WORKSPACES` env, duplicate + `~` normalization
- multiple `-w` rejected on `verify`
- unknown `workspace` argument → `ValueError` naming the registered ones
- missing workspace path → warning, remaining workspaces still answer
- MCP server boot: 5 tools registered; `rag_stats()` across 2 workspaces with **no** model load; repeat searches 0.8–1.8 s with one shared embedder instance

Python-only, all under `rag-mcp-server/`. No Go code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)