### PR TITLE
fix(lint): clear the 3 pre-existing staticcheck issues failing Lint & Vet

### DIFF
--- a/cmd/m3c-tools/commands_shared.go
+++ b/cmd/m3c-tools/commands_shared.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -136,7 +137,7 @@ func cmdRetry(args []string) {
 		cancel()
 	}()
 
-	if loopErr := runner.Run(ctx, time.Duration(interval)*time.Second); loopErr != nil && loopErr != context.Canceled {
+	if loopErr := runner.Run(ctx, time.Duration(interval)*time.Second); loopErr != nil && !errors.Is(loopErr, context.Canceled) {
 		fmt.Fprintf(os.Stderr, "Retry loop error: %v\n", loopErr)
 		os.Exit(1)
 	}
@@ -381,7 +382,6 @@ func cmdCancel(args []string) {
 
 	fmt.Printf("Cancelled entry: %s\n", entryID)
 }
-
 
 func cmdUpload(args []string) {
 	if len(args) == 0 {

--- a/pkg/menubar/image_darwin.go
+++ b/pkg/menubar/image_darwin.go
@@ -83,8 +83,8 @@ func RegisterImage(name, filePath string) bool {
 	return C.registerImageFromFile(cName, cPath, isTemplate) == 1
 }
 
-// RegisterImageBytes registers an in-memory image (e.g. a PNG embedded via
-// go:embed) as a named NSImage, so menuet can reference it by name in
+// RegisterImageBytes registers an in-memory image (e.g. a PNG embedded with a
+// build-time go:embed) as a named NSImage, so menuet can reference it by name in
 // MenuState.Image / MenuItem.Image without any on-disk file. Pass template=true
 // for menu-bar template icons (monochrome, auto dark/light). Returns false if
 // the bytes are empty or cannot be decoded.

--- a/pkg/skillbundle/ignore_test.go
+++ b/pkg/skillbundle/ignore_test.go
@@ -42,8 +42,8 @@ func TestIgnoreSkbignore(t *testing.T) {
 	rules := append(parseIgnore(defaultIgnorePatterns),
 		parseIgnore([]string{
 			"# a comment",
-			"*.tmp",     // add
-			"!dist/",    // re-include a default-ignored dir
+			"*.tmp",      // add
+			"!dist/",     // re-include a default-ignored dir
 			"docs/build", // anchored (interior slash): only this exact path
 		})...)
 
@@ -93,14 +93,14 @@ func packNames(t *testing.T, dir string) map[string]bool {
 // real skill source does.
 func TestPackExcludesArtifacts(t *testing.T) {
 	dir := mustWriteSkill(t, map[string]string{
-		"SKILL.md":                          "---\nname: x\n---\n",
-		"src/main.py":                       "print(1)\n",
-		"references/data.json":              "{}\n",
-		"node_modules/left-pad/index.js":    "module.exports=1\n",
-		"dist/app":                          "BINARY",
-		"__pycache__/mod.cpython-313.pyc":   "PYC",
-		"scratch.pyc":                       "PYC",
-		"nested/.DS_Store":                  "junk",
+		"SKILL.md":                        "---\nname: x\n---\n",
+		"src/main.py":                     "print(1)\n",
+		"references/data.json":            "{}\n",
+		"node_modules/left-pad/index.js":  "module.exports=1\n",
+		"dist/app":                        "BINARY",
+		"__pycache__/mod.cpython-313.pyc": "PYC",
+		"scratch.pyc":                     "PYC",
+		"nested/.DS_Store":                "junk",
 	})
 	names := packNames(t, dir)
 
@@ -111,10 +111,8 @@ func TestPackExcludesArtifacts(t *testing.T) {
 		}
 	}
 	for n := range names {
-		switch {
-		case n == "dist/app",
-			n == "scratch.pyc",
-			n == "nested/.DS_Store":
+		switch n {
+		case "dist/app", "scratch.pyc", "nested/.DS_Store":
 			t.Errorf("artifact %q leaked into bundle", n)
 		}
 		if len(n) >= 13 && n[:13] == "node_modules/" {
@@ -130,11 +128,11 @@ func TestPackExcludesArtifacts(t *testing.T) {
 // default-ignored file; the .skbignore file itself does not ship.
 func TestPackSkbignore(t *testing.T) {
 	dir := mustWriteSkill(t, map[string]string{
-		"SKILL.md":     "---\nname: x\n---\n",
-		"keep.txt":     "keep\n",
-		"drop.tmp":     "drop\n",
-		"vendor.pyc":   "PYC", // default-ignored…
-		".skbignore":   "*.tmp\n!vendor.pyc\n",
+		"SKILL.md":   "---\nname: x\n---\n",
+		"keep.txt":   "keep\n",
+		"drop.tmp":   "drop\n",
+		"vendor.pyc": "PYC", // default-ignored…
+		".skbignore": "*.tmp\n!vendor.pyc\n",
 	})
 	names := packNames(t, dir)
 	if !names["keep.txt"] {


### PR DESCRIPTION
Clears the three staticcheck issues that fail **Lint & Vet on every open PR** (#100, #104, #105) — none is introduced by those PRs; they're pre-existing debt in unrelated files.

| Check | File | Fix |
|---|---|---|
| SA4023 (always-true) | `cmd/m3c-tools/commands_shared.go:139` | `loopErr != context.Canceled` → `!errors.Is(loopErr, context.Canceled)` (also unwraps) |
| SA9009 (ineffectual directive) | `pkg/menubar/image_darwin.go:87` | a wrapped comment line began with `go:embed`, read as a stray `//go:embed`; reworded off the line-start |
| QF1002 (tagged switch) | `pkg/skillbundle/ignore_test.go:114` | tagless `switch { case n == … }` → `switch n { case … }` |

Behavior-preserving. `go build ./...`, `go vet`, `go test ./pkg/skillbundle` green; staticcheck reports none of the three.

**The other red check on those PRs — `govulncheck` — is separate and not a code fix:** all 7 vulns are Go **standard-library** CVEs marked *Fixed in go1.26.6* (`net/url`, `net/http`, `crypto/tls`, `html/template`, `encoding/xml`, `encoding/asn1`, `x/net/idna`). It clears by bumping the CI Go toolchain (`setup-go` → 1.26.6+) in `.github/workflows/*.yml` — which needs the `workflow` token scope to push, so I've left it for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)