### PR TITLE
fix(lint): clear golangci-lint debt (errcheck) — WF-001/W8

### DIFF
--- a/pkg/skillctl/artifact/conformance/conformance.go
+++ b/pkg/skillctl/artifact/conformance/conformance.go
@@ -135,7 +135,9 @@ func Run(t *testing.T, be artifact.Backend) {
 	revEv, _ := registry.BuildBundleRevokedEvent(registry.RevokedEventInput{
 		BundleDigest: digPdf2, ReasonCode: "deprecated", RevokedBy: "id:conformance", OccurredAt: time.Unix(1, 0).UTC(),
 	})
-	registry.SignEnvelopeSignature(priv, revEv)
+	if _, err := registry.SignEnvelopeSignature(priv, revEv); err != nil {
+		t.Fatalf("SignEnvelopeSignature(revoke): %v", err)
+	}
 	if _, err := be.Publish(ctx, artifact.PublishRequest{
 		Kind: artifact.KindRevoke, Event: revEv,
 		Meta: artifact.ArtifactMeta{Name: "pdf", Version: "1.2.0", Digest: digPdf2},


### PR DESCRIPTION
## What

Clears the last remaining `golangci-lint` failure so the **Lint & Vet** CI job goes green.

`pkg/skillctl/artifact/conformance/conformance.go:138` — **errcheck**: the return value of `registry.SignEnvelopeSignature(priv, revEv)` (`([]byte, error)`) was unchecked. The freshly-signed `revEv` envelope is consumed by the revoke `Publish` call immediately below, so a signing failure would silently produce an unsigned/invalid envelope and mis-assert the revoke path. The conformance harness has `*testing.T` in scope, so the fix checks the error and `t.Fatalf`s on failure — no silencing.

```go
if _, err := registry.SignEnvelopeSignature(priv, revEv); err != nil {
    t.Fatalf("SignEnvelopeSignature(revoke): %v", err)
}
```

## Context on the other originally-reported issues

The WF-001/W8 debt list also named `commands_shared.go` (SA4023) and `ignore_test.go` (QF1002). Both were already resolved on `master` by `cd9c95e` (`errors.Is(loopErr, context.Canceled)` + a tagged switch). Under the repo's actual `.golangci.yml`, the errcheck above was the **only** remaining `Lint & Vet` failure.

## Verification (all green)

- `golangci-lint run --timeout=5m` (exact CI command) → **0 issues**
- `go build ./...` → clean
- `go vet ./...` → clean
- `make test-unit` → PASS
- git + ER1 backend conformance harness (`conformance.Run`) exercised via `TestGitBackendConformance` → PASS

## Separate finding for the human — govulncheck (NOT addressed here)

`govulncheck ./...` flags **7 Go stdlib CVEs, every one "Fixed in go1.26.6"** (build toolchain is go1.26.5). These are a CI **toolchain bump** (setup-go → 1.26.6+), not a code change, and are intentionally left out of this PR:

| ID | Package | Summary |
|---|---|---|
| GO-2026-6218 | net/url | quadratic complexity in resolvePath |
| GO-2026-6091 | html/template | JS regexp context tracking |
| GO-2026-6090 | crypto/tls | limit post-handshake messages |
| GO-2026-6089 | net/http | ReadHeaderTimeout on h2c check |
| GO-2026-6088 | encoding/xml | recursion depth guard on decode |
| GO-2026-5972 | encoding/asn1 | max recursion depth |
| GO-2026-5026 | x/net/idna (via net/http) | ASCII-only Punycode label rejection |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
