### PR TITLE
fix: repair master red — Windows test portability + Go 1.26.6 staticcheck

### DIFF
--- a/cmd/m3c-tools/commands_shared.go
+++ b/cmd/m3c-tools/commands_shared.go
@@ -137,7 +137,10 @@ func cmdRetry(args []string) {
 		cancel()
 	}()
 
-	if loopErr := runner.Run(ctx, time.Duration(interval)*time.Second); loopErr != nil && !errors.Is(loopErr, context.Canceled) {
+	// RetryRunner.Run only returns on context cancellation (never nil), so a bare
+	// `!= nil` is always-true (SA4023); the meaningful check is whether it was a
+	// clean context-cancel vs a real error worth surfacing.
+	if loopErr := runner.Run(ctx, time.Duration(interval)*time.Second); !errors.Is(loopErr, context.Canceled) {
 		fmt.Fprintf(os.Stderr, "Retry loop error: %v\n", loopErr)
 		os.Exit(1)
 	}

--- a/cmd/skillctl/gossip_revokes_test.go
+++ b/cmd/skillctl/gossip_revokes_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -84,9 +85,11 @@ func TestGossipedRevokedGrowOnly(t *testing.T) {
 			t.Errorf("digest %s missing after grow-only merge", d)
 		}
 	}
-	// Perms: 0600.
-	if fi, err := os.Stat(gossipedRevokedPath(home)); err == nil && fi.Mode().Perm() != 0o600 {
-		t.Errorf("gossip cache perms = %o, want 600", fi.Mode().Perm())
+	// Perms: 0600 (POSIX only — Windows does not model unix mode bits).
+	if runtime.GOOS != "windows" {
+		if fi, err := os.Stat(gossipedRevokedPath(home)); err == nil && fi.Mode().Perm() != 0o600 {
+			t.Errorf("gossip cache perms = %o, want 600", fi.Mode().Perm())
+		}
 	}
 }
 

--- a/internal/thinking/llm/llm.go
+++ b/internal/thinking/llm/llm.go
@@ -43,12 +43,12 @@ type Request struct {
 
 // Response is one completion.
 type Response struct {
-	Content      string
-	Model        string  // actual model reported by the provider
-	TokensIn     int     // prompt tokens
-	TokensOut    int     // completion tokens
-	CostUSD      float64 // provider-derived USD cost for this call
-	DurationMS   int
+	Content    string
+	Model      string  // actual model reported by the provider
+	TokensIn   int     // prompt tokens
+	TokensOut  int     // completion tokens
+	CostUSD    float64 // provider-derived USD cost for this call
+	DurationMS int
 }
 
 // Adapter is the common surface every provider implements.
@@ -106,8 +106,9 @@ func (a *openaiAdapter) Complete(ctx context.Context, req Request) (Response, er
 		msgs = append(msgs, openai.ChatCompletionMessage{Role: m.Role, Content: m.Content})
 	}
 	in := openai.ChatCompletionRequest{
-		Model:       model,
-		Messages:    msgs,
+		Model:    model,
+		Messages: msgs,
+		//nolint:staticcheck // MaxTokens is retained deliberately: MaxCompletionTokens is incompatible with the non-o1 chat models this path targets.
 		MaxTokens:   req.MaxTokens,
 		Temperature: req.Temperature,
 	}
@@ -134,7 +135,7 @@ func (a *openaiAdapter) Complete(ctx context.Context, req Request) (Response, er
 		Content:    body,
 		Model:      out.Model,
 		TokensIn:   tokensIn,
-		TokensOut: tokensOut,
+		TokensOut:  tokensOut,
 		CostUSD:    cost,
 		DurationMS: dur,
 	}, nil
@@ -170,9 +171,9 @@ func (a *openaiAdapter) EstimateCost(req Request) (int, float64) {
 //
 //  1. If OPENAI_API_KEY is set → OpenAI adapter.
 //     - If OLLAMA_URL is also set AND M3C_LLM_FALLBACK=ollama, the
-//       returned adapter wraps OpenAI as primary and Ollama as
-//       fallback on 5xx responses. Lets a prod-configured engine
-//       degrade to local inference during transient outages.
+//     returned adapter wraps OpenAI as primary and Ollama as
+//     fallback on 5xx responses. Lets a prod-configured engine
+//     degrade to local inference during transient outages.
 //  2. Else if OLLAMA_URL is set → Ollama adapter (local, zero cost).
 //  3. Else → error. The engine refuses to start without a configured
 //     LLM path rather than silently no-op. Matches the Week-1
@@ -259,9 +260,10 @@ func isTransientLLMError(err error) bool {
 // gating and trace records.
 //
 // Rates are per-1M-tokens, approximate as of 2026-Q1:
-//   gpt-4o-mini: $0.15 / $0.60
-//   gpt-4o:      $2.50 / $10.00
-//   default:     $1.00 / $3.00
+//
+//	gpt-4o-mini: $0.15 / $0.60
+//	gpt-4o:      $2.50 / $10.00
+//	default:     $1.00 / $3.00
 func EstimateOpenAICost(model string, inTok, outTok int) float64 {
 	var inRate, outRate float64 // per 1M tokens
 	m := strings.ToLower(model)
@@ -346,7 +348,7 @@ func (m *MockAdapter) Complete(ctx context.Context, req Request) (Response, erro
 		Content:    body,
 		Model:      model,
 		TokensIn:   tokensIn,
-		TokensOut: tokensOut,
+		TokensOut:  tokensOut,
 		CostUSD:    0, // mock calls are free
 		DurationMS: 1,
 	}, nil

--- a/pkg/skillctl/backend/git/local_test.go
+++ b/pkg/skillctl/backend/git/local_test.go
@@ -12,11 +12,14 @@ import (
 
 func TestResolveLocalPath(t *testing.T) {
 	home, _ := os.UserHomeDir()
+	// Expected values are computed via filepath.Abs so they match resolveLocalPath
+	// on every OS (on Windows "/abs/reg.git" absolutizes to a drive-lettered path).
+	absSlash, _ := filepath.Abs("/abs/reg.git")
 	cases := []struct {
 		spec, want string
 		err        bool
 	}{
-		{"local:///abs/reg.git", "/abs/reg.git", false},
+		{"local:///abs/reg.git", absSlash, false},
 		{"local://~/reg.git", filepath.Join(home, "reg.git"), false},
 		{"local://-oops", "", true},  // leading '-' rejected (git-flag injection)
 		{"local://", "", true},       // empty


### PR DESCRIPTION
`master` went red on **Trust Surface (windows-latest)** and **Lint & Vet** after the Go 1.26.6 bump (#110) — blocking every open PR (#111, dependabot). None is a real defect; all four are portability/linter-version hygiene:

| Check | Fix |
|---|---|
| `SA4023` `commands_shared.go` | `RetryRunner.Run` never returns nil (returns only on ctx-cancel) → `loopErr != nil` is provably always-true. Dropped it; kept the `!errors.Is(…Canceled)` guard. (My #108 `errors.Is` touched the wrong sub-expression.) |
| `SA1019` `llm.go` | `openai.MaxTokens` deprecation — retained deliberately (`MaxCompletionTokens` is incompatible with the non-o1 models this path targets); targeted `//nolint` with rationale. |
| `TestResolveLocalPath` (Windows) | POSIX-shaped expected paths → computed via `filepath.Abs` (matches `resolveLocalPath` on Windows; no skip, full coverage). |
| `TestGossipedRevokedGrowOnly` (Windows) | 0600 perms assertion is POSIX-only → `runtime.GOOS != "windows"` guard. |

Behavior-preserving. `go build` + `vet` + `staticcheck` (no SA4023/SA1019) + full offline suite green. Merging this turns Trust Surface + Lint & Vet **green repo-wide**; #111 then goes green on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)