### PR TITLE
feat(rag): hybride Suche — dichte + lexikalische Hälfte, per Rang fusioniert

### DIFF
--- a/rag-mcp-server/indexer.py
+++ b/rag-mcp-server/indexer.py
@@ -195,6 +195,7 @@ class Indexer:
         for fm in files_meta:
             self.store.upsert_file(*fm)
         self._export_jsonl()
+        self.store.rebuild_fts()
         corpus = self._corpus_hash([(fm[0], fm[1]) for fm in files_meta])
         n_chunks, n_files = self.store.counts()
         self._write_state(n_chunks, n_files, corpus)
@@ -278,6 +279,7 @@ class Indexer:
             self.store.upsert_file(*fm)
         idx.write(str(self.index_path))
         self._export_jsonl()
+        self.store.rebuild_fts()
         corpus = self._corpus_hash(list(self.store.all_files().items()))
         n_chunks, n_files = self.store.counts()
         self._write_state(n_chunks, n_files, corpus)
@@ -286,7 +288,21 @@ class Indexer:
                 "corpus_hash": corpus[:12]}
 
     # ---------- search ----------
-    def search(self, query, k=8, path_prefix="", since_days=0):
+    @staticmethod
+    def _rrf(ranked_lists, k0=60):
+        """Reciprocal Rank Fusion: score(d) = sum 1/(k0 + rank_i(d)).
+
+        Deliberately rank-based, not score-based. Cosine similarity and BM25 live
+        on incomparable scales; any attempt to normalise them needs per-corpus
+        tuning that goes stale. RRF needs neither and is the standard answer.
+        """
+        acc = {}
+        for lst in ranked_lists:
+            for rank, cid in enumerate(lst, 1):
+                acc[cid] = acc.get(cid, 0.0) + 1.0 / (k0 + rank)
+        return sorted(acc.items(), key=lambda x: -x[1])
+
+    def search(self, query, k=8, path_prefix="", since_days=0, mode="hybrid"):
         from turbovec import IdMapIndex
         if not self.index_path.exists():
             return []
@@ -306,9 +322,60 @@ class Indexer:
                 return []
             allow = np.array(sorted(common), dtype=np.uint64)
 
-        scores, ids = _tv_search(idx, qv, k, allow)
+        # HYBRID (default): dense + lexical, fused by rank.
+        #
+        # Why the lexical half is not optional: a question can carry a rare literal
+        # term that appears verbatim in the target and STILL be missed by dense
+        # retrieval, because the rest of the sentence dominates the embedding.
+        # Measured 2026-09-01 over 4 workspaces / ~125k chunks: the German question
+        # "Wird propose-by-default serverseitig erzwungen?" returned nothing from
+        # admission.py or SPEC-0350 in the top FIFTY — although `propose-by-default`
+        # occurs literally in both, and in 13 files overall. Not a ranking problem
+        # (reranking cannot fix what was never retrieved) but a recall problem.
+        deep = max(k * 5, 50) if mode == "hybrid" else k
+        dense_ids = []
+        if mode in ("hybrid", "dense"):
+            scores, ids = _tv_search(idx, qv, deep, allow)
+            dense_ids = [int(i) for i in ids]
+        lex_ids, n_ident = [], 0
+        if mode in ("hybrid", "lexical"):
+            lex_ids, n_ident = self.store.search_lexical(
+                query, k=deep, allow=set(allow.tolist()) if allow is not None else None)
+
+        rrf_score = {}
+        if mode == "hybrid" and lex_ids:
+            pairs = self._rrf([dense_ids, lex_ids])
+            rrf_score = dict(pairs)
+            fused = [cid for cid, _ in pairs][:k]
+            # EXAKTBEGRIFF HAT VORRANG. Traegt die Frage einen Identifier
+            # (`propose-by-default`, `ail_admission_hook`, `SPEC-0350`), dann ist
+            # der woertliche Treffer das staerkste Signal, das es gibt — staerker
+            # als jede Aehnlichkeit. Reines RRF verliert ihn trotzdem, weil es
+            # Treffer belohnt, die BEIDE Haelften finden: ist die dichte Haelfte
+            # fuer diese Frage falsch, gewinnen Rausch-Chunks, die zufaellig in
+            # beiden Listen stehen. Gemessen an genau diesem Fall.
+            if n_ident:
+                head = [c for c in lex_ids[:n_ident] if c not in ()][:max(1, k // 2)]
+                rest = [c for c in fused if c not in set(head)]
+                fused = (head + rest)[:k]
+                for r, c in enumerate(head, 1):
+                    rrf_score[c] = 1.0 / r          # vor jedem RRF-Wert (< 1/60)
+        elif mode == "lexical":
+            fused = lex_ids[:k]
+        else:
+            fused = dense_ids[:k]
+
+        dense_rank = {cid: r for r, cid in enumerate(dense_ids, 1)}
+        lex_rank = {cid: r for r, cid in enumerate(lex_ids, 1)}
+        # Der Score bleibt die Kosinus-Aehnlichkeit, wo es eine gibt — sonst waere
+        # die Ausgabe nicht mehr mit fruheren Laeufen vergleichbar. Woher ein
+        # Treffer kommt, sagt `via`.
+        dense_score = {int(i): float(s) for s, i in zip(*_tv_search(idx, qv, deep, allow))} \
+            if mode in ("hybrid", "dense") else {}
+
         out = []
-        for s, i in zip(scores, ids):
+        for i in fused:
+            s = dense_score.get(i, 0.0)
             row = self.store.get_chunk(int(i))
             if not row:
                 continue
@@ -317,6 +384,9 @@ class Indexer:
                 "heading": row["heading"],
                 "lines": f"{row['line_start']}-{row['line_end']}",
                 "score": round(float(s), 4),
+                "rrf": round(rrf_score.get(i, 0.0), 6),
+                "via": ("both" if i in dense_rank and i in lex_rank
+                        else "lexical" if i in lex_rank else "dense"),
                 "snippet": row["text"][:500],
             })
         return out

--- a/rag-mcp-server/rag.py
+++ b/rag-mcp-server/rag.py
@@ -150,7 +150,7 @@ def resolve_workspaces(arg):
     return out
 
 
-def _search_many(workspaces, query, k, path_prefix, since_days, get_indexer=None):
+def _search_many(workspaces, query, k, path_prefix, since_days, get_indexer=None, mode="hybrid"):
     """Fan out one query across several workspaces and merge by score.
 
     Three things make the merge honest and cheap:
@@ -192,7 +192,13 @@ def _search_many(workspaces, query, k, path_prefix, since_days, get_indexer=None
     for w in workspaces:
         ix = get_indexer(w)
         try:
-            hits = ix.search(query, k=k, path_prefix=path_prefix, since_days=since_days)
+            # TIEFER als k je Workspace holen. Sonst liefert jeder nur seine
+            # Spitze, die Fusion interleavt round-robin, und der eine Workspace,
+            # der die Antwort WIRKLICH hat, kommt mit Rang 5 nie durch.
+            # Gemessen: admission.py steht in aims-core auf Rang 5 und fehlte im
+            # Verbund-Top-10 vollstaendig.
+            hits = ix.search(query, k=max(k * 3, 30), path_prefix=path_prefix,
+                             since_days=since_days, mode=mode)
         except Exception as e:  # a broken/absent index must not sink the whole fan-out
             print(f"rag: warning — {Path(w).name}: {e}", file=sys.stderr)
             continue
@@ -201,7 +207,18 @@ def _search_many(workspaces, query, k, path_prefix, since_days, get_indexer=None
             h["workspace"] = label
             h["workspace_path"] = w
             merged.append(h)
-    merged.sort(key=lambda h: h["score"], reverse=True)
+    # Bei hybrid tragen rein-lexikalische Treffer keinen Kosinus-Score. Nach score
+    # zu sortieren wuerde sie ans Ende schieben und den Fan-out um genau die
+    # Treffer bringen, wegen derer die lexikalische Haelfte existiert. Deshalb
+    # wird ueber die Workspaces erneut per RRF fusioniert.
+    # Global nach dem Fusionswert sortieren, den jeder Workspace SELBST vergeben
+    # hat — nicht die Workspaces gegeneinander round-robin interleaven. Ein stark
+    # fusionierter Treffer aus einem Repo schlaegt damit die schwache Spitze eines
+    # anderen, was der ganze Punkt des Verbundes ist.
+    if any(h.get("rrf") for h in merged):
+        merged.sort(key=lambda h: (h.get("rrf", 0.0), h["score"]), reverse=True)
+    else:
+        merged.sort(key=lambda h: h["score"], reverse=True)
     return merged[:k]
 
 
@@ -223,6 +240,9 @@ def main():
     ss.add_argument("-k", type=int, default=8)
     ss.add_argument("--path-prefix", default="")
     ss.add_argument("--since-days", type=int, default=0)
+    ss.add_argument("--mode", choices=["hybrid", "dense", "lexical"], default="hybrid",
+                    help="hybrid (default): dense + BM25, fused by rank. dense: wie bisher. "
+                         "lexical: nur BM25 — nuetzlich, um einen exakten Begriff zu pruefen.")
     ss.add_argument("--json", action="store_true")
     a = ap.parse_args()
 
@@ -239,7 +259,7 @@ def main():
 
     if a.cmd == "search":
         try:
-            res = _search_many(workspaces, a.query, a.k, a.path_prefix, a.since_days)
+            res = _search_many(workspaces, a.query, a.k, a.path_prefix, a.since_days, mode=a.mode)
         except ValueError as e:
             sys.exit(f"rag: {e}")
         if a.json:
@@ -250,7 +270,9 @@ def main():
         multi = len(workspaces) > 1
         for r in res:
             where = f"{r['workspace']}:{r['path']}" if multi else r["path"]
-            print(f"\n{r['score']:.3f}  {where}:{r['lines']}  [{r['heading']}]")
+            via = r.get("via", "")
+            tag = {"both": " ‡", "lexical": " ¶"}.get(via, "")
+            print(f"\n{r['score']:.3f}{tag}  {where}:{r['lines']}  [{r['heading']}]")
             print("    " + r["snippet"].replace("\n", " ")[:240])
         return
 

--- a/rag-mcp-server/store.py
+++ b/rag-mcp-server/store.py
@@ -39,6 +39,13 @@ class Store:
             );
             CREATE TABLE IF NOT EXISTS meta(k TEXT PRIMARY KEY, v TEXT);
             CREATE INDEX IF NOT EXISTS idx_chunks_path ON chunks(path);
+            -- Lexical half of hybrid retrieval. FTS5 ships with SQLite, so this
+            -- costs no new dependency and no second model. Derived like the rest
+            -- of meta.sqlite: dropped and rebuilt with the index, never committed.
+            CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+                text, heading, path, content='chunks', content_rowid='id',
+                tokenize='unicode61 remove_diacritics 2'
+            );
             """
         )
         self.conn.commit()
@@ -46,6 +53,80 @@ class Store:
     def reset(self):
         self.conn.executescript("DELETE FROM chunks; DELETE FROM files; DELETE FROM meta;")
         self.conn.commit()
+
+    def rebuild_fts(self):
+        """(Re)populate the FTS mirror from `chunks`. Cheap — it is a scan, no model."""
+        with self.conn:
+            self.conn.execute("INSERT INTO chunks_fts(chunks_fts) VALUES('delete-all')")
+            self.conn.execute(
+                "INSERT INTO chunks_fts(rowid, text, heading, path) "
+                "SELECT id, text, COALESCE(heading,''), path FROM chunks")
+
+    def search_lexical(self, query, k=50, allow=None):
+        """BM25 over the chunk text. Returns `(chunk_ids, n_from_identifier_pass)`.
+
+        The query is reduced to bare terms OR-ed together: a user question is a
+        sentence, not an FTS expression, and one stray quote would otherwise be a
+        syntax error. Rare terms still dominate — that is exactly what BM25 is for
+        and exactly what the dense side loses.
+        """
+        import re
+        terms = [w for w in re.findall(r"[\w][\w.\-/]{2,}", query.lower()) if not w.isdigit()]
+        if not terms:
+            return []
+
+        # Identifier-artige Begriffe zuerst, und zwar in einem EIGENEN Durchlauf.
+        #
+        # Ein blosses OR ueber alle Woerter geht hier schief, und nicht subtil:
+        # BM25 belohnt Seltenheit, und in einem ueberwiegend englischen Korpus ist
+        # ein deutsches Prosawort ("serverseitig") seltener als der gesuchte
+        # Fachbegriff. Gemessen: die Frage "Wird propose-by-default serverseitig
+        # erzwungen?" lieferte per OR sync_session.py und corps_album — der Begriff
+        # ALLEIN findet admission.py auf Rang 2. Die Prosa uebertoent das Signal.
+        #
+        # Identifier erkennt man an ihrer FORM: Bindestrich, Punkt, Unterstrich,
+        # Slash. Bewusst KEINE Laengenregel — "serverseitig" hat 12 Zeichen und
+        # waere damit als Identifier durchgegangen, genau das deutsche Prosawort
+        # also, das den Fachbegriff ueberstimmt hat. Interpunktion ist das
+        # verlaessliche Signal, Laenge ist es nicht.
+        def _ident(w):
+            return any(c in w for c in "-._/")
+        idents = [w for w in terms if _ident(w)]
+
+        def _run(ws, limit):
+            if not ws:
+                return []
+            expr = " OR ".join(f'"{w}"' for w in ws)
+            try:
+                return [int(r[0]) for r in self.conn.execute(
+                    "SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ? "
+                    "ORDER BY bm25(chunks_fts, 1.0, 2.0, 0.5) LIMIT ?", (expr, limit)).fetchall()]
+            except Exception:  # noqa: BLE001 — kein FTS (alter Index) oder unlesbarer Ausdruck
+                return []
+
+        ident_hits = _run(idents, k * 4)
+        ordered = ident_hits + _run(terms, k * 4)
+        n_ident = len(ident_hits)
+        out, seen = [], set()
+        for cid in ordered:
+            if cid in seen:
+                continue
+            seen.add(cid)
+            if allow is not None and cid not in allow:
+                continue
+            out.append(cid)
+            if len(out) >= k:
+                break
+        # Wieviele der zurueckgegebenen Treffer stammen aus dem Identifier-Durchlauf?
+        idset = set(ident_hits)
+        return out, sum(1 for c in out if c in idset)
+
+    def has_fts(self):
+        try:
+            return bool(self.conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE name='chunks_fts'").fetchone())
+        except Exception:      # noqa: BLE001
+            return False
 
     def insert_chunks(self, rows):
         # rows: (id, path, heading, line_start, line_end, text)


### PR DESCRIPTION
## Der gemessene Fehler

Über 4 Workspaces / ~125k Chunks lieferte die Frage

> *„Wird propose-by-default serverseitig erzwungen?"*

**nichts** aus `admission.py` oder `SPEC-0350` — nicht in den Top-5, **nicht in den Top-50**. Obwohl `propose-by-default` wörtlich in beiden steht und in 13 Dateien insgesamt vorkommt.

Das ist **kein Ranking-Problem**. Reranking kann nicht sortieren, was nie abgerufen wurde. Es ist ein **Recall-Problem**: die deutsche Satzform dominiert die Einbettung und schwemmt den seltenen Fachbegriff weg.

## Die Lösung

FTS5 liegt in SQLite, der Chunk-Store hält den Volltext ohnehin — **kein zweites Modell, keine neue Abhängigkeit.** 125 200 Chunks sind in 6 Sekunden indiziert, rein per Scan. Dense- und BM25-Liste werden per **Reciprocal Rank Fusion** vereinigt (rangbasiert, weil Kosinus und BM25 auf unvergleichbaren Skalen leben und jede Normalisierung Tuning bräuchte, das veraltet).

## Drei Dinge, die beim Bauen nicht funktioniert haben

Sie erklären, warum der Code aussieht wie er aussieht:

**1. Ein blosses OR über alle Frageworte geht schief.** BM25 belohnt Seltenheit — und in einem überwiegend englischen Korpus ist ein deutsches Prosawort (`serverseitig`) seltener als der gesuchte Fachbegriff. Ergebnis waren `sync_session.py` und `corps_album`. Deshalb ein eigener Durchlauf für Identifier, erkennbar an Interpunktion (`-._/`) — **nicht an Länge**: `serverseitig` hat 12 Zeichen und war mit einer Längenregel prompt als Identifier eingestuft.

**2. Reines RRF verliert den Exaktbegriff trotzdem**, weil es Treffer belohnt, die *beide* Hälften finden. Ist die dichte Hälfte für eine Frage falsch, gewinnen Rausch-Chunks, die zufällig in beiden Listen stehen. Deshalb hat ein wörtlicher Identifier-Treffer Vorrang vor der Fusion.

**3. Der Fan-out holte nur `k` je Workspace und interleavte round-robin.** Damit kam der eine Workspace, der die Antwort *wirklich* hatte, mit seinem Rang 5 nie durch: `admission.py` stand in aims-core auf Rang 5 und fehlte im Verbund-Top-10 vollständig.

## Messung

Fünf Fragen, Treffer in den Top-10:

| | dense | hybrid |
|---|---|---|
| Fragen mit Treffer | 3/5 | **4/5** |
| mittlerer bester Rang | **2,0** | 2,8 |

Die Auslöser-Frage geht von 0 auf 2 Treffer, *„Wie werden AIL-Kanten gespeichert?"* von 2 auf 6. Der Preis ist ehrlich: bei einer Frage, die dense schon konnte, rutscht der beste Treffer von #1 auf #2. Mehr Abdeckung, minimal unschärfere Spitze.

## Was bewusst NICHT gelöst ist

Eine Frage bleibt in **beiden** Modi ohne Treffer: *„Wo wird die Kohorten-Landing-Vorlage gegen Injection geprüft?"* — eine reine deutsche Konzeptfrage ohne einen einzigen gemeinsamen Token mit dem Ziel. Dagegen hilft weder die dichte noch die lexikalische Hälfte. Das braucht eine **Begriffsschicht** (Query-Expansion über ein Glossar), und die ist hier nicht mitgebaut.

## Kompatibilität

`--mode dense` verhält sich wie bisher. Ein Index ohne FTS-Tabelle fällt still auf dense zurück. Die FTS-Tabelle lebt in `meta.sqlite` — abgeleitet, gitignored, mit dem Index neu gebaut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)