### PR TITLE
fix(menubar): run the .app inner binary so `make menubar` stops crashing on macOS 14+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,10 +286,18 @@ uninstall:
 run: build
 	$(BUILD_DIR)/$(BINARY) $(ARGS)
 
-# Run the menu bar app
+# Run the menu bar app (foreground: live stdout logs, Ctrl-C to quit).
+# menuet unconditionally touches [UNUserNotificationCenter currentNotificationCenter]
+# at startup (createAndRunApplication -> initNotifications). On macOS 14+ that API
+# HARD-ASSERTS ("bundleProxyForCurrentProcess is nil") unless the running executable
+# lives inside a .app bundle — so the old bare-binary run ($(BUILD_DIR)/$(BINARY))
+# aborts on launch. Running the bundle's INNER executable directly gives a valid
+# bundle proxy (verified: notification init succeeds) while keeping the foreground
+# stdout dev workflow — unlike `menubar-app`, which detaches via `open`.
 .PHONY: menubar
-menubar: build
-	$(BUILD_DIR)/$(BINARY) menubar $(ARGS)
+menubar: check-not-root build-app
+	@echo "Running $(APP_NAME).app (foreground; Ctrl-C to quit). Logs also at: ~/.m3c-tools/m3c-tools.log"
+	$(APP_BUNDLE)/Contents/MacOS/$(BINARY) menubar $(ARGS)
 
 # Guard: the menu bar app MUST run as the logged-in user, never as root. A GUI
 # menu-bar app launched via `sudo` renders a broken menu — no Quit, no Sign-In
@@ -597,8 +605,8 @@ help:
 	@echo "  release-patch  Release with patch version bump"
 	@echo "  release-minor  Release with minor version bump"
 	@echo "  release-major  Release with major version bump"
-	@echo "  menubar        Build and launch the menu bar app (bare binary — CLI debugging)"
-	@echo "  menubar-app    Build + launch the BUNDLED .app (icon + notifications work here)"
+	@echo "  menubar        Build + run the menu bar .app in the FOREGROUND (stdout logs, Ctrl-C)"
+	@echo "  menubar-app    Build + launch the .app DETACHED via 'open' (background, quit from menu)"
 	@echo "  build-windows  Cross-compile CLI + tray for Windows (amd64)"
 	@echo "  installer-windows  Build NSIS installer (requires nsis)"
 	@echo "  snapshot       Build with GoReleaser (local snapshot, no publish)"


### PR DESCRIPTION
## Problem

`make menubar` aborts on launch on macOS 14+ (Sonoma/Sequoia):

```
*** Assertion failure in +[UNUserNotificationCenter currentNotificationCenter]
reason: 'bundleProxyForCurrentProcess is nil: mainBundle.bundleURL file:///…/m3c-tools/build/'
   initNotifications + 40  ←  createAndRunApplication + 76
```

`menuet`'s `createAndRunApplication` unconditionally calls `initNotifications()` → `[UNUserNotificationCenter currentNotificationCenter]` (menuet.m:230-231). On macOS 14+ that API **hard-asserts unless the process lives inside a `.app` bundle** — and `make menubar` ran the bare `build/m3c-tools`. The exception is thrown from inside a `dispatch_once` C callout, so it is **not catchable** — there is no menuet opt-out; the bundle is mandatory.

## Fix

`make menubar` now depends on `build-app` and runs the bundle's **inner executable** directly:
`build/M3C-Tools.app/Contents/MacOS/m3c-tools menubar`.

**Verified with an isolated probe** of the exact crashing API in three launch modes:

| Launch mode | `bundleProxyForCurrentProcess` | Result |
|---|---|---|
| Bare binary | nil | **crash** (reproduces the bug) |
| Inner exec inside `.app`, run **directly** | valid | **OK** |
| `.app` via `open` | valid | OK |

So the binary only needs to *live inside* a `.app` (Info.plist with a `CFBundleIdentifier`); running its inner binary directly gives a valid bundle proxy — which keeps `make menubar`'s dev-friendly **foreground + stdout + Ctrl-C** workflow, unlike `menubar-app` (which detaches via `open`). Also adds the `check-not-root` guard (BUG-0192) and fixes the help text.

`make build-app` + `make -n menubar` confirm the wiring; `menubar-app` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)