### PR TITLE
feat(gate): SPEC-0358 id-only cross-reference lint (W4)

### DIFF
--- a/tools/id-xref-lint.sh
+++ b/tools/id-xref-lint.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# tools/id-xref-lint.sh — SPEC-0358 id-only cross-reference lint (WF-001 W4)
+# The companion to tools/boundary-gate.sh ("ship the code, keep the reasoning").
+#
+# The boundary-gate blocks private PATHS + secrets + internal endpoints from leaking
+# into the public plane. This lint enforces the OTHER half of SPEC-0358 §3.2 / §4:
+#
+#     A public-plane file may cite the private intent plane ONLY by a bare id-marker
+#     (`implements SPEC-0342`, `see ADR-0007`) — never a path or URL into the private
+#     repo, and the id must actually RESOLVE to a real SPEC/ADR on the private plane.
+#
+# It catches typos (`SPEC-0432` for `SPEC-0342`), dangling refs (a SPEC that was never
+# written / was renumbered), private-only ids pasted as text, and the "id-not-alone"
+# leak where an identifier is glued into a path/URL or embeds the private doc filename.
+#
+# Two checks
+# ----------
+#   A. id-not-alone  (format-only — ALWAYS runs, no registry needed)
+#        A marker glued to a path or URL, or one that embeds a private doc filename:
+#            SPEC-0342/SPEC-0342-foo.md   see ../SPEC/SPEC-0342-x.md   SPEC-0167-slug.md
+#        A bare compound shorthand (`SPEC-0279/0278`), a second id after a slash
+#        (`SPEC-0247/SPEC-0251`) or an intra-spec sub-ref (`SPEC-0246/RC2`) is NOT a
+#        path — the identifier still stands alone — and passes.
+#
+#   B. resolution    (needs the private SPEC/ADR registry)
+#        Every `SPEC-NNNN` / `ADR-NNNN` marker must resolve to a real registry file in
+#        the maintenance repo's SPEC/ and ADR/ directories. A non-resolving marker is a
+#        typo, a dangling/renumbered ref, or a private-only id leaking as text.
+#
+# Locating the private registry
+# -----------------------------
+#   $M3C_MAINTENANCE_DIR   (same convention the demo build + skills use), else the
+#   sibling checkout ../m3c-tools-maintenance. When the registry is ABSENT — the normal
+#   case in the PUBLIC repo's CI, where the private plane is never checked out — check B
+#   is SKIPPED with a clear notice and only the format-only check A runs. The lint is
+#   therefore safe to wire into open-source CI: it degrades, it does not error.
+#
+# Output (identical shape to boundary-gate):  file:line: <reason>: <text>
+# Exit 1 on any violation, else print a clean line and exit 0.
+#
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+fail=0
+emit() { printf '%s\n' "$1"; fail=1; }
+
+# match_exact PATH ITEM...  -> 0 if PATH equals any ITEM
+match_exact() { local p=$1; shift; local x; for x in "$@"; do [ "$p" = "$x" ] && return 0; done; return 1; }
+
+# ---- Allowlist: files that DEFINE / DOCUMENT the convention itself, with placeholder
+#      ids (SPEC-1234) and deliberately-bad path examples. Skipped by BOTH checks —
+#      they are reviewed on purpose and their example markers must not resolve. -------
+XREF_EXEMPT_EXACT=(
+  tools/id-xref-lint.sh          # this lint — its comments carry example bad patterns
+  tools/id-xref-lint.test.sh     # its self-test — fixtures embed dangling + glued ids
+  tools/boundary-gate.sh         # docstring cites SPEC-1234 / ADR-1234 as placeholders
+  CONTENT-TOPOLOGY.md            # the public topology doc: placeholder ids + rule examples
+)
+
+# ---- Marker + violation patterns (ERE) -----------------------------------------
+# NOTE: scope is SPEC + ADR per SPEC-0358 §4 (the resolvable design/decision plane).
+# FR / CR / BUG live in PLM/ER1 (no file registry) and are an explicit non-goal here;
+# add them to MARKER + a registry source when a file registry for them exists.
+MARKER='(SPEC|ADR)-[0-9]{4}'
+
+# A marker glued to a real path/URL: a separator (/ or :) followed by a tail that
+# still contains a further path char (. or /). The trailing "[./]" is what separates a
+# genuine path/URL/filename from a bare compound id or a sub-ref:
+#   SPEC-0342/SPEC-0342-foo.md  -> tail "SPEC-0342-foo.md" has a "." -> HIT
+#   SPEC-0342/a/b               -> tail "a/b"              has a "/" -> HIT
+#   SPEC-0342:../SPEC/x.md      -> tail "../SPEC/x.md"     has "." /  -> HIT
+#   SPEC-0279/0278 (compound)   -> tail "0278"            no "." "/" -> ok
+#   SPEC-0247/SPEC-0251 (2 ids) -> tail "SPEC-0251"       no "." "/" -> ok
+#   SPEC-0246/RC2  (sub-ref)    -> tail "RC2"             no "." "/" -> ok
+PAT_PATH='(SPEC|ADR)-[0-9]{4}[/:][^[:space:]),]*[./][^[:space:]),]*'
+
+# A marker used as the HEAD of a PRIVATE doc filename (SPEC-0167-thinking-engine.md).
+# The extension anchor keeps prose compounds ("a SPEC-0276-style list") from matching.
+PAT_FILE='(SPEC|ADR)-[0-9]{4}-[A-Za-z0-9._-]*\.(md|markdown|txt|adoc|rst|pdf|html|htm|yaml|yml|json)'
+
+# ---- Locate the private registry (env, else sibling checkout) -------------------
+MAINT="${M3C_MAINTENANCE_DIR:-$(dirname "$PWD")/m3c-tools-maintenance}"
+REGISTRY_PRESENT=0
+REAL_SET="|"
+n_spec=0 n_adr=0
+if [ -d "$MAINT/SPEC" ]; then
+  REGISTRY_PRESENT=1
+  # Enumerate real ids from the registry filenames (SPEC-NNNN-*.md / ADR-NNNN-*.md).
+  # Globs (not ls|grep) so odd filenames can't break the parse; the id is the fixed
+  # "<PREFIX>-NNNN" head of the basename (SPEC-=9 chars, ADR-=8).
+  for p in "$MAINT"/SPEC/SPEC-[0-9][0-9][0-9][0-9]*; do
+    [ -e "$p" ] || continue
+    b=${p##*/}; id=${b:0:9}
+    case "$REAL_SET" in *"|$id|"*) : ;; *) REAL_SET="${REAL_SET}${id}|"; n_spec=$((n_spec + 1)) ;; esac
+  done
+  for p in "$MAINT"/ADR/ADR-[0-9][0-9][0-9][0-9]*; do
+    [ -e "$p" ] || continue
+    b=${p##*/}; id=${b:0:8}
+    case "$REAL_SET" in *"|$id|"*) : ;; *) REAL_SET="${REAL_SET}${id}|"; n_adr=$((n_adr + 1)) ;; esac
+  done
+fi
+
+# scan_pattern FILE REASON PATTERN — emit "file:line: reason: text" per matching line
+scan_pattern() {
+  local f=$1 reason=$2 pat=$3 m ln txt
+  while IFS= read -r m; do
+    [ -z "$m" ] && continue
+    ln=${m%%:*}
+    txt=${m#*:}
+    txt=${txt#"${txt%%[![:space:]]*}"}          # left-trim
+    emit "$f:$ln: $reason: $txt"
+  done < <(grep -InE "$pat" "$f" 2>/dev/null || true)
+}
+
+# resolve_scan FILE — emit one finding per marker that does not resolve in the registry
+resolve_scan() {
+  local f=$1 m ln mk
+  while IFS= read -r m; do
+    [ -z "$m" ] && continue
+    ln=${m%%:*}
+    mk=${m#*:}
+    case "$REAL_SET" in
+      *"|$mk|"*) : ;;                                   # resolves — fine
+      *) emit "$f:$ln: dangling reference (no such id in private registry): $mk" ;;
+    esac
+  done < <(grep -InoE "$MARKER" "$f" 2>/dev/null || true)
+}
+
+check() {
+  local f=$1
+  match_exact "$f" "${XREF_EXEMPT_EXACT[@]}" && return 0
+  grep -Iq . "$f" 2>/dev/null || return 0             # skip binary / empty files
+
+  # A — id-not-alone (always checked; no registry needed)
+  scan_pattern "$f" 'id-not-alone (id glued to a path/URL)'      "$PAT_PATH"
+  scan_pattern "$f" 'id-not-alone (embeds private doc filename)' "$PAT_FILE"
+
+  # B — resolution (only when the private registry is present)
+  if [ "$REGISTRY_PRESENT" -eq 1 ]; then resolve_scan "$f"; fi
+  return 0                                              # never let set -e kill the loop
+}
+
+if [ "$REGISTRY_PRESENT" -eq 1 ]; then
+  printf 'id-xref-lint: registry %s (%d SPEC, %d ADR)\n' "$MAINT" "$n_spec" "$n_adr" >&2
+else
+  printf 'id-xref-lint: resolution skipped (private registry not present at %s); format-only checks running\n' "$MAINT" >&2
+fi
+
+while IFS= read -r f; do
+  [ -n "$f" ] && check "$f"
+done < <(git ls-files)
+
+if [ "$fail" -ne 0 ]; then
+  echo "id-xref-lint: FAIL — public-plane cross-reference violates SPEC-0358 (id-only + resolvable)" >&2
+  exit 1
+fi
+echo "id-xref-lint: clean"
+exit 0

--- a/tools/id-xref-lint.test.sh
+++ b/tools/id-xref-lint.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# tools/id-xref-lint.test.sh — self-contained fixtures for tools/id-xref-lint.sh
+# (SPEC-0358 WF-001 W4). Builds a throwaway git repo + a fake private registry, then
+# asserts the lint's three behaviours: resolvable→pass, dangling→fail, path-glued→fail,
+# plus the public-CI degrade mode (registry absent → resolution skipped).
+#
+# No network, no deps beyond git + grep. Exit 0 = all assertions passed.
+#
+set -euo pipefail
+
+LINT="$(cd "$(dirname "$0")" && pwd)/id-xref-lint.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- a fake private registry: real ids are SPEC-0001, SPEC-0342, ADR-0007 -----------
+mkdir -p "$TMP/registry/SPEC" "$TMP/registry/ADR"
+: > "$TMP/registry/SPEC/SPEC-0001-alpha.md"
+: > "$TMP/registry/SPEC/SPEC-0342-content-topology.md"
+: > "$TMP/registry/ADR/ADR-0007-example-decision.md"
+
+# --- a throwaway public repo with fixtures ------------------------------------------
+REPO="$TMP/repo"
+mkdir -p "$REPO/docs"
+cd "$REPO"
+git init -q
+git config user.email t@t; git config user.name t
+
+# resolvable + id-only + benign compounds/sub-refs  -> PASS (no finding)
+cat > docs/good.md <<'EOF'
+This module implements SPEC-0342 and follows ADR-0007.
+It also builds on SPEC-0342/0001 (compound), SPEC-0001/ADR-0007 (two ids)
+and the SPEC-0342/RC2 sub-requirement. Prose like a SPEC-0342-style guard is fine.
+EOF
+
+# dangling id -> FAIL (resolution)
+cat > docs/dangling.md <<'EOF'
+This references SPEC-9999 which does not exist, and a typo SPEC-0432.
+EOF
+
+# path-glued + private filename -> FAIL (id-not-alone, even with no registry)
+cat > docs/pathglued.md <<'EOF'
+See SPEC-0342/SPEC-0342-content-topology.md for the detail.
+Also see ../registry/SPEC/SPEC-0342-content-topology.md.
+EOF
+
+git add -A
+
+pass=0; failc=0
+ok()  { printf '  ok   %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL %s\n' "$1"; failc=$((failc+1)); }
+contains()   { printf '%s' "$1" | grep -q "$2"; }
+
+# ============ 1. full run: registry present ==========================================
+echo "[1] registry present (full run)"
+set +e
+OUT="$(M3C_MAINTENANCE_DIR="$TMP/registry" bash "$LINT" 2>/dev/null)"; RC=$?
+set -e
+[ "$RC" -eq 1 ]                                   && ok "exit 1 (violations found)"        || bad "expected exit 1, got $RC"
+contains "$OUT" 'docs/dangling.md:.*SPEC-9999'    && ok "flags dangling SPEC-9999"          || bad "missed SPEC-9999"
+contains "$OUT" 'docs/dangling.md:.*SPEC-0432'    && ok "flags typo SPEC-0432"              || bad "missed SPEC-0432"
+contains "$OUT" 'docs/pathglued.md:.*id-not-alone' && ok "flags path-glued reference"       || bad "missed path-glued ref"
+! contains "$OUT" 'docs/good.md:'                 && ok "resolvable/id-only file is clean"  || bad "false positive on good.md"
+
+# ============ 2. degrade mode: registry absent (public CI) ===========================
+echo "[2] registry absent (public-CI degrade)"
+set +e
+OUT2="$(M3C_MAINTENANCE_DIR="$TMP/does-not-exist" bash "$LINT" 2>&1)"; RC2=$?
+set -e
+contains "$OUT2" 'resolution skipped'             && ok "prints resolution-skipped notice" || bad "no skip notice"
+[ "$RC2" -eq 1 ]                                  && ok "still exit 1 (format-only caught path-glued)" || bad "expected exit 1, got $RC2"
+contains "$OUT2" 'docs/pathglued.md:.*id-not-alone' && ok "path-glued still caught with no registry" || bad "missed path-glued in degrade"
+! contains "$OUT2" 'SPEC-9999'                    && ok "dangling NOT flagged (resolution skipped)"   || bad "flagged dangling without registry"
+
+echo
+if [ "$failc" -ne 0 ]; then
+  echo "id-xref-lint.test: FAIL ($pass passed, $failc failed)"; exit 1
+fi
+echo "id-xref-lint.test: OK ($pass assertions passed)"


### PR DESCRIPTION
## What & why

Builds the **SPEC-0358 id-only cross-reference lint** (WF-001 **W4**) — the companion
to `tools/boundary-gate.sh`. The gate blocks private-repo **paths + secrets** from
leaking into the public plane. W4 adds the other half of SPEC-0358 §3.2/§4: a
public-plane file may cite the private intent plane **only by a bare id-marker**
(`implements SPEC-0342`, `see ADR-0007`) that must actually **resolve** to a real
SPEC/ADR — catching typos, dangling/renumbered refs, private-only ids pasted as text,
and ids glued into a path/URL.

> Isolated PR — **do not merge**. It reports current findings; it does not fix them.

## Home & why

`tools/id-xref-lint.sh` in **m3c-tools** (Option A — cross-repo). Rationale:
- The lint scans the **public** tracked files, so it belongs beside the code it guards
  and beside its sibling `tools/boundary-gate.sh` (same style, same output shape).
- Resolution needs the **private** SPEC/ADR registry, which lives in the sibling
  `m3c-tools-maintenance` checkout — so the lint is *cross-repo by discovery*, not by
  vendoring anything private into the public repo. No private path is baked in.

## How resolution works (and the public-CI degrade)

- Registry located via `$M3C_MAINTENANCE_DIR` (the convention the demo build + skills
  already use), else the sibling checkout `../m3c-tools-maintenance`.
- Present → enumerate real ids from `SPEC/SPEC-NNNN-*.md` + `ADR/ADR-NNNN-*.md`
  (today: **353 SPEC, 10 ADR**); every `SPEC-NNNN`/`ADR-NNNN` marker in the public
  tree must be one of them.
- **Absent** (the normal case in *this* repo's CI, where the private plane is never
  checked out) → resolution is **skipped with a clear notice** and only the
  format-only check runs. The lint degrades; it never errors for lack of the registry.

Two checks, `file:line: reason: text`, exit 1 on any hit (identical to boundary-gate):
- **A. id-not-alone** (always) — a marker glued to a path/URL, or embedding a private
  doc filename (`SPEC-0167-slug.md`). Calibrated against the real corpus so the benign
  forms pass: compound shorthand `SPEC-0279/0278`, two-id `SPEC-0247/SPEC-0251`, and
  intra-spec sub-refs `SPEC-0246/RC2`.
- **B. resolution** (registry present) — non-resolving markers are flagged as dangling.

A documented `XREF_EXEMPT_EXACT` allowlist covers the files that *define* the
convention with placeholder ids (this lint, its test, `boundary-gate.sh`,
`CONTENT-TOPOLOGY.md`).

## Tests

`tools/id-xref-lint.test.sh` — self-contained (git + grep only), builds a throwaway
repo + fake registry and asserts: resolvable→pass, dangling `SPEC-9999`/typo→fail,
path-glued→fail, plus the public-CI degrade path. **9/9 assertions pass.** The test
already earned its keep: it caught a real `set -e` bug where `check()` returned the
false `[registry present]` test as its exit status, aborting the scan after the first
file in degrade mode — fixed here.

## Findings on m3c-tools today (reported, NOT auto-fixed)

- **0 dangling refs** — every real `SPEC`/`ADR` marker resolves. (The only
  non-resolving ids in the tree — `SPEC-1234`/`ADR-1234`/`ADR-0007` — are placeholder
  examples in the convention docs, allowlisted.)
- **2 id-not-alone findings** (private doc filenames embedded in public files):
  - `cmd/thinking-engine/README.md:87` — ``See `SPEC-0167-m3c-thinking-engine.md` ...``
  - `pkg/skillctl/registry/types.go:20` — `... the S5 brief in PLAN-SPEC-0188-parallel-execution.md`

Both leak a private-plane filename where an id-only marker (`SPEC-0167`, `SPEC-0188`)
would do. Left as findings for a human to resolve. **Because of these, the lint is NOT
wired into CI in this PR** — that's the natural follow-up once the two lines are
converted to id-only form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)