### PR TITLE
feat(skillctl): Windows runtime hardening — DPAPI creds, NTFS DACLs, PATH/exec (WIN-T5/6/7/9)

### DIFF
--- a/cmd/skillctl/publish_cmds.go
+++ b/cmd/skillctl/publish_cmds.go
@@ -40,6 +40,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -924,12 +925,20 @@ func resolveAPIKeyFromKeychain() string {
 	if k := os.Getenv("ER1_API_KEY"); k != "" {
 		return k
 	}
+	// The Keychain (`security`) exists only on macOS. On Windows/Linux there is no
+	// such binary, so skip the lookup rather than spawn — or PATH-resolve — a
+	// non-existent `security`. Callers fall back to ER1_API_KEY / other config.
+	if runtime.GOOS != "darwin" {
+		return ""
+	}
 	u, _ := user.Current()
 	uname := "kamir"
 	if u != nil && u.Username != "" {
 		uname = u.Username
 	}
-	out, err := exec.Command("security", "find-generic-password", "-s", "aims-core-er1", "-a", uname, "-w").Output()
+	// Absolute /usr/bin/security (macOS ships it there), not a bare-name PATH
+	// lookup that a planted `security` could hijack.
+	out, err := exec.Command("/usr/bin/security", "find-generic-password", "-s", "aims-core-er1", "-a", uname, "-w").Output()
 	if err != nil {
 		return ""
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/sashabaranov/go-openai v1.42.0
 	github.com/twmb/franz-go v1.21.6
 	github.com/zalando/go-keyring v0.2.8
+	golang.org/x/sys v0.47.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.57.0
 	oras.land/oras-go/v2 v2.6.2
@@ -49,7 +50,6 @@ require (
 	github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.13.1 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	modernc.org/libc v1.74.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/pkg/skillctl/artifactauth/creds.go
+++ b/pkg/skillctl/artifactauth/creds.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
@@ -44,21 +45,35 @@ func (r *Resolver) Credential(ctx context.Context, scheme, host string) (artifac
 	if v := strings.TrimSpace(os.Getenv(m.env)); v != "" {
 		return artifact.Credential{Scheme: scheme, Token: v, User: m.user}, nil
 	}
-	if v := keychain(m.kcService, host); v != "" {
+	// macOS Keychain — only on darwin. keychain() shells out to `security`, which
+	// exists only on macOS; guarding the call keeps a Windows/Linux box from
+	// spawning (or, worse, PATH-resolving) a non-existent `security` binary.
+	if runtime.GOOS == "darwin" {
+		if v := keychain(m.kcService, host); v != "" {
+			return artifact.Credential{Scheme: scheme, Token: v, User: m.user}, nil
+		}
+	}
+	// Per-OS credential store (Windows DPAPI in creds_windows.go; no-op elsewhere).
+	// Lets a Windows user keep a write-capable PAT out of a plaintext env var.
+	if v := osCredStore(m.kcService, host); v != "" {
 		return artifact.Credential{Scheme: scheme, Token: v, User: m.user}, nil
 	}
 	return artifact.Credential{}, nil // anonymous
 }
 
-// keychain reads a generic-password from the macOS Keychain (read-only). Returns
-// empty on any error or on non-macOS platforms. Store one with:
+// keychain reads a generic-password from the macOS Keychain (read-only). It is
+// only ever CALLED on darwin (see Credential). Returns empty on any error. Store
+// one with:
 //
 //	security add-generic-password -s m3c-skillctl-gitlab -a <host> -w '<PAT>' -U
+//
+// The binary is the absolute /usr/bin/security (macOS ships it there) rather than
+// a bare-name PATH lookup, so a `security` planted on PATH cannot be run instead.
 func keychain(service, account string) string {
 	if account == "" {
 		return ""
 	}
-	out, err := exec.Command("security", "find-generic-password", "-s", service, "-a", account, "-w").Output()
+	out, err := exec.Command("/usr/bin/security", "find-generic-password", "-s", service, "-a", account, "-w").Output()
 	if err != nil {
 		return ""
 	}

--- a/pkg/skillctl/artifactauth/creds_other.go
+++ b/pkg/skillctl/artifactauth/creds_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package artifactauth
+
+// osCredStore has no OS credential store on non-Windows platforms here: macOS
+// resolves through the Keychain (creds.go:keychain, gated on runtime.GOOS), and
+// Linux relies on the env override or ambient git credentials. Returning "" keeps
+// the resolver's fail-soft-to-anonymous contract. The real Windows DPAPI store is
+// in creds_windows.go (WIN-T6).
+func osCredStore(service, account string) string { return "" }

--- a/pkg/skillctl/artifactauth/creds_windows.go
+++ b/pkg/skillctl/artifactauth/creds_windows.go
@@ -1,0 +1,159 @@
+//go:build windows
+
+package artifactauth
+
+// Windows credential store for the write-capable backend PATs (WIN-T6).
+//
+// The macOS path reads the token from the Keychain (creds.go:keychain). Windows
+// has no Keychain, so without this a Windows user's only option is the plaintext
+// env var (M3C_GITHUB_TOKEN / M3C_GITLAB_TOKEN) — a WRITE-scoped registry token
+// sitting in the process environment, inherited by every child process and dumped
+// into crash reports. Instead we persist it as a DPAPI-protected blob: the
+// ciphertext is bound to the current user account (CryptProtectData), so even a
+// world-readable copy of the file is useless to another user or on another machine.
+//
+// StoreCred writes it once; osCredStore is the read side the Resolver consults
+// after the env override and (on macOS only) the Keychain.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// osCredStore returns the token stored for (service, account) via StoreCred, or ""
+// if none is stored / it cannot be decrypted (fail-soft to anonymous, exactly like
+// the macOS keychain reader). account is the registry host, mirroring keychain().
+func osCredStore(service, account string) string {
+	if account == "" {
+		return ""
+	}
+	p, err := credPath(service, account)
+	if err != nil {
+		return ""
+	}
+	enc, err := os.ReadFile(p)
+	if err != nil {
+		return ""
+	}
+	plain, err := dpapiUnprotect(enc)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(plain))
+}
+
+// StoreCred DPAPI-protects secret and writes it under the per-user credential dir
+// for (service, account). This is the write side of the Windows credential store —
+// the analogue of `security add-generic-password` on macOS — so an operator can
+// keep a write-capable PAT out of the environment. The ciphertext is user-bound by
+// DPAPI; the 0600 is best-effort belt-and-braces (Windows ignores the perm bits).
+func StoreCred(service, account, secret string) error {
+	if account == "" {
+		return errors.New("artifactauth: StoreCred needs a non-empty account (registry host)")
+	}
+	p, err := credPath(service, account)
+	if err != nil {
+		return err
+	}
+	enc, err := dpapiProtect([]byte(secret))
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(p, enc, 0o600); err != nil {
+		return err
+	}
+	return nil
+}
+
+// credDir is %LOCALAPPDATA%\m3c\artifactauth (created 0700 if absent).
+func credDir() (string, error) {
+	base := os.Getenv("LOCALAPPDATA")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		base = filepath.Join(home, "AppData", "Local")
+	}
+	dir := filepath.Join(base, "m3c", "artifactauth")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+func credPath(service, account string) (string, error) {
+	dir, err := credDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, safeCredName(service)+"_"+safeCredName(account)+".dpapi"), nil
+}
+
+// safeCredName reduces service/host to a safe single filename component (the host
+// may carry ':' for host:port, etc.). Non [A-Za-z0-9._-] becomes '_'.
+func safeCredName(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "_"
+	}
+	return b.String()
+}
+
+// --- DPAPI (CryptProtectData / CryptUnprotectData) via golang.org/x/sys/windows ---
+
+func dpapiProtect(plain []byte) ([]byte, error) {
+	in := windows.DataBlob{Size: uint32(len(plain))}
+	if len(plain) > 0 {
+		in.Data = &plain[0]
+	}
+	var out windows.DataBlob
+	// CRYPTPROTECT_UI_FORBIDDEN: never pop UI (works headless/in a service).
+	if err := windows.CryptProtectData(&in, nil, nil, 0, nil, windows.CRYPTPROTECT_UI_FORBIDDEN, &out); err != nil {
+		return nil, err
+	}
+	defer localFree(out.Data)
+	return blobBytes(out), nil
+}
+
+func dpapiUnprotect(enc []byte) ([]byte, error) {
+	in := windows.DataBlob{Size: uint32(len(enc))}
+	if len(enc) > 0 {
+		in.Data = &enc[0]
+	}
+	var out windows.DataBlob
+	if err := windows.CryptUnprotectData(&in, nil, nil, 0, nil, windows.CRYPTPROTECT_UI_FORBIDDEN, &out); err != nil {
+		return nil, err
+	}
+	defer localFree(out.Data)
+	return blobBytes(out), nil
+}
+
+// blobBytes copies a DPAPI output blob into a Go-owned slice before it is freed.
+func blobBytes(b windows.DataBlob) []byte {
+	if b.Data == nil || b.Size == 0 {
+		return nil
+	}
+	return append([]byte(nil), unsafe.Slice(b.Data, b.Size)...)
+}
+
+// localFree releases a LocalAlloc'd DPAPI output buffer.
+func localFree(p *byte) {
+	if p != nil {
+		_, _ = windows.LocalFree(windows.Handle(unsafe.Pointer(p)))
+	}
+}

--- a/pkg/skillctl/backend/git/git.go
+++ b/pkg/skillctl/backend/git/git.go
@@ -12,11 +12,41 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
 	"github.com/kamir/m3c-tools/pkg/skillctl/trustcore"
 )
+
+// gitExe resolves the `git` binary ONCE to a validated absolute path. A bare
+// exec.Command("git", …) re-runs a PATH lookup on every call, and on Windows a
+// `git.exe` dropped in the current working directory (or a writable PATH entry)
+// could be executed instead of the real one (the classic cwd/relative-resolution
+// hijack). We resolve via exec.LookPath, reject anything that is not an absolute
+// path (Go ≥1.19 already refuses a cwd-relative result with exec.ErrDot; the
+// IsAbs check makes that guarantee explicit and fail-closed), and cache it.
+var (
+	gitExeOnce sync.Once
+	gitExe     string
+	gitExeErr  error
+)
+
+func resolveGit() (string, error) {
+	gitExeOnce.Do(func() {
+		p, err := exec.LookPath("git")
+		if err != nil {
+			gitExeErr = fmt.Errorf("git: cannot locate a git executable on PATH: %w", err)
+			return
+		}
+		if !filepath.IsAbs(p) {
+			gitExeErr = fmt.Errorf("git: refusing to run non-absolute git path %q (possible cwd/relative-resolution hijack)", p)
+			return
+		}
+		gitExe = p
+	})
+	return gitExe, gitExeErr
+}
 
 func init() {
 	artifact.Register("gitlab", openGitLab)
@@ -177,7 +207,11 @@ func (b *gitBackend) Close() error { return nil }
 // --- git exec plumbing ---
 
 func (b *gitBackend) git(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+	gitBin, err := resolveGit()
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command(gitBin, args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -473,7 +507,14 @@ func (b *gitBackend) Fetch(ctx context.Context, ref artifact.ArtifactRef) ([]byt
 		if err := validateVersion(ver); err != nil {
 			return err
 		}
-		d, err := os.ReadFile(filepath.Join(dir, bundleSkbPath(name, ver)))
+		// The clone is untrusted (SPEC-0356 §6). lstatRegular fails closed on a
+		// symlinked blob path so a malicious repo cannot redirect the read outside
+		// the clone (defense-in-depth behind the core.symlinks=false clone).
+		bp := filepath.Join(dir, bundleSkbPath(name, ver))
+		if _, lerr := lstatRegular(bp); lerr != nil {
+			return fmt.Errorf("git: read blob %s@%s: %w", name, ver, lerr)
+		}
+		d, err := os.ReadFile(bp)
 		if err != nil {
 			return fmt.Errorf("git: read blob %s@%s: %w", name, ver, err)
 		}
@@ -510,7 +551,14 @@ func (b *gitBackend) Events(ctx context.Context, filter artifact.ListFilter, pag
 				if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 					continue
 				}
-				data, err := os.ReadFile(filepath.Join(edir, e.Name()))
+				// Untrusted clone: skip a symlinked/irregular event file rather than
+				// follow it (lstatRegular fails closed on a symlink). A skipped file
+				// simply never influences a verdict — the same as a malformed one.
+				ep := filepath.Join(edir, e.Name())
+				if ok, lerr := lstatRegular(ep); lerr != nil || !ok {
+					continue
+				}
+				data, err := os.ReadFile(ep)
 				if err != nil {
 					continue
 				}
@@ -640,7 +688,12 @@ func (b *gitBackend) isRevoked(dir, digest string) bool {
 
 func (b *gitBackend) readBundleJSON(dir, name, ver string) (bundleJSON, error) {
 	var bj bundleJSON
-	data, err := os.ReadFile(filepath.Join(dir, bundleJSONPath(name, ver)))
+	// Untrusted clone: fail closed on a symlinked manifest path (see lstatRegular).
+	mp := filepath.Join(dir, bundleJSONPath(name, ver))
+	if _, lerr := lstatRegular(mp); lerr != nil {
+		return bj, lerr
+	}
+	data, err := os.ReadFile(mp)
 	if err != nil {
 		return bj, err
 	}

--- a/pkg/skillctl/backend/git/layout.go
+++ b/pkg/skillctl/backend/git/layout.go
@@ -34,6 +34,16 @@ var (
 	digestRe  = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 )
 
+// NOTE (WIN-T9, NTFS case-insensitivity): the name/version validated here become
+// filesystem path components under skills/<name>/<version>/ in a CLONE. NTFS (and
+// APFS by default) are case-INSENSITIVE but case-PRESERVING, so two names that
+// differ only in case — "Foo" vs "foo" — are distinct tags/annotations but collide
+// onto the SAME directory when the repo is checked out on Windows/macOS. Whatever
+// was written last wins; the other silently reads back the wrong bytes. The regexp
+// below intentionally does NOT fold case (git storage is case-sensitive and the
+// authoritative identity is the recomputed .skb digest, which a collision does not
+// forge). If a future storage layer relies on the on-disk name being unique, it
+// must dedup names case-INSENSITIVELY, not rely on this validator.
 func validateName(s string) error {
 	if s == "" || s == "." || strings.HasPrefix(s, "-") || strings.Contains(s, "..") || !nameRe.MatchString(s) {
 		return fmt.Errorf("git: invalid skill name %q (allowed [A-Za-z0-9._-], no '..', no leading '-')", s)

--- a/pkg/skillctl/registry/install_trust_mode.go
+++ b/pkg/skillctl/registry/install_trust_mode.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/kamir/m3c-tools/pkg/skillbundle"
+	"github.com/kamir/m3c-tools/pkg/skillctl/secfile"
 )
 
 // MaxExtractedBytes / MaxExtractedFiles are the registry-package spelling of the
@@ -332,7 +333,16 @@ func installTokenKey() ([]byte, error) {
 	}
 	installTokenKeyValue = key
 	_ = os.MkdirAll(dir, 0o700)
-	_ = os.WriteFile(keyPath, installTokenKeyValue, 0o600)
+	if err := os.WriteFile(keyPath, installTokenKeyValue, 0o600); err == nil {
+		// WIN-T7: 0600 is advisory on Windows/NTFS (inherited ACEs win). Lock the
+		// on-disk HMAC key to owner+SYSTEM only. This key guards the G-23
+		// destructive-overwrite token, so if hardening fails we DELETE the cache
+		// rather than leave the secret inheritable — the in-memory key still serves
+		// this process; the next run re-mints and re-caches. No-op on Unix.
+		if derr := secfile.SecureFileDACL(keyPath); derr != nil {
+			_ = os.Remove(keyPath)
+		}
+	}
 	return installTokenKeyValue, nil
 }
 

--- a/pkg/skillctl/secfile/acl_other.go
+++ b/pkg/skillctl/secfile/acl_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package secfile
+
+// SecureFileDACL is a no-op on non-Windows platforms: the callers already create
+// these files with mode 0600, which the Unix kernel enforces directly. The DACL
+// hardening in acl_windows.go exists only because Windows/NTFS does not honour the
+// Unix perm bits (see the package doc there).
+func SecureFileDACL(path string) error { return nil }

--- a/pkg/skillctl/secfile/acl_windows.go
+++ b/pkg/skillctl/secfile/acl_windows.go
@@ -1,0 +1,91 @@
+//go:build windows
+
+// Package secfile hardens the on-disk permissions of security-sensitive files
+// (trust-roots, HMAC/token caches) to owner-only.
+//
+// On Unix the callers already create these files with mode 0600, which the
+// kernel enforces. On Windows the Go os package largely IGNORES the Unix perm
+// bits (only the read-only attribute is honoured): an NTFS file created with
+// 0600 still inherits the parent directory's DACL, so a trust-root/token/cache
+// file can end up readable (or writable) by other principals via inheritance.
+// SecureFileDACL is the Windows enforcement of the 0600 intent (WIN-T7); on
+// every other OS it is a no-op (see acl_other.go) because 0600 already holds.
+//
+// It lives in its own leaf package — not in pkg/skillctl/verify — because verify
+// already imports pkg/skillctl/registry, and the registry install path is one of
+// the callers; a setter in verify called from registry would be an import cycle.
+package secfile
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+// SecureFileDACL replaces the DACL on path with a PROTECTED (inheritance-disabled)
+// DACL that grants FULL control to exactly two trustees — the current user (whom
+// it also sets as the OWNER) and the local SYSTEM account — and to no one else.
+// PROTECTED_DACL strips any ACEs inherited from the parent directory, so the file
+// no longer leaks read/write access through inheritance. Fail-closed: any Win32
+// error is returned so the caller can treat a failed hardening as a failed write.
+func SecureFileDACL(path string) error {
+	if path == "" {
+		return fmt.Errorf("secfile: empty path")
+	}
+
+	// Owner = the current process user (a real, closeable token).
+	tok, err := windows.OpenCurrentProcessToken()
+	if err != nil {
+		return fmt.Errorf("secfile: open process token: %w", err)
+	}
+	defer tok.Close()
+	tu, err := tok.GetTokenUser()
+	if err != nil {
+		return fmt.Errorf("secfile: query token user: %w", err)
+	}
+	ownerSID := tu.User.Sid
+
+	// SYSTEM keeps full access (backup/AV/indexing, and so an elevated repair can
+	// still touch the file); the protected DACL excludes everyone else.
+	systemSID, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return fmt.Errorf("secfile: build SYSTEM sid: %w", err)
+	}
+
+	entries := []windows.EXPLICIT_ACCESS{
+		fullControlFor(ownerSID, windows.TRUSTEE_IS_USER),
+		fullControlFor(systemSID, windows.TRUSTEE_IS_WELL_KNOWN_GROUP),
+	}
+	dacl, err := windows.ACLFromEntries(entries, nil)
+	if err != nil {
+		return fmt.Errorf("secfile: assemble DACL: %w", err)
+	}
+
+	// DACL_SECURITY_INFORMATION           — replace the DACL,
+	// PROTECTED_DACL_SECURITY_INFORMATION — and DROP inherited ACEs (no inheritance),
+	// OWNER_SECURITY_INFORMATION          — pin ownership to the current user.
+	secInfo := windows.SECURITY_INFORMATION(
+		windows.DACL_SECURITY_INFORMATION |
+			windows.PROTECTED_DACL_SECURITY_INFORMATION |
+			windows.OWNER_SECURITY_INFORMATION)
+	if err := windows.SetNamedSecurityInfo(
+		path, windows.SE_FILE_OBJECT, secInfo,
+		ownerSID, nil, dacl, nil); err != nil {
+		return fmt.Errorf("secfile: SetNamedSecurityInfo %q: %w", path, err)
+	}
+	return nil
+}
+
+// fullControlFor returns a non-inheritable "grant full control" ACE for sid.
+func fullControlFor(sid *windows.SID, ttype windows.TRUSTEE_TYPE) windows.EXPLICIT_ACCESS {
+	return windows.EXPLICIT_ACCESS{
+		AccessPermissions: windows.GENERIC_ALL,
+		AccessMode:        windows.SET_ACCESS,
+		Inheritance:       windows.NO_INHERITANCE,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  ttype,
+			TrusteeValue: windows.TrusteeValueFromSID(sid),
+		},
+	}
+}

--- a/pkg/skillctl/verify/trustroots.go
+++ b/pkg/skillctl/verify/trustroots.go
@@ -30,6 +30,7 @@ import (
 	"crypto/sha256"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/govlevel"
+	"github.com/kamir/m3c-tools/pkg/skillctl/secfile"
 	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
 	"github.com/kamir/m3c-tools/pkg/skillctl/statemachine"
 	"gopkg.in/yaml.v3"
@@ -684,6 +685,13 @@ func (t *TrustRoots) Save() error {
 	if err := os.Rename(tmp, t.Path); err != nil {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("trust-roots: rename %s → %s: %w", tmp, t.Path, err)
+	}
+	// WIN-T7: on Windows the 0600 above is advisory (NTFS honours inherited ACEs,
+	// not the Unix perm bits). Enforce an owner+SYSTEM-only, non-inheriting DACL so
+	// this machine's trust policy can't be read or silently rewritten by another
+	// local principal. No-op on Unix (0600 already holds). Fail closed.
+	if err := secfile.SecureFileDACL(t.Path); err != nil {
+		return fmt.Errorf("trust-roots: harden permissions on %s: %w", t.Path, err)
 	}
 	return nil
 }

--- a/tools/skillctl-install.ps1
+++ b/tools/skillctl-install.ps1
@@ -9,10 +9,12 @@
 
   Provenance has two tracks, exactly like the shell installer:
     TRACK 1 (PRIMARY) -- keyless cosign / GitHub OIDC (SPEC-0253). cosign is the
-      primary path and is AUTO-FETCHED (pinned + self-verified) when not on PATH.
-      A cosign bundle that is present but does NOT verify is a HARD FAIL (an
-      attacker must not be able to force a downgrade). A fully ABSENT bundle falls
-      through to track 2.
+      primary path. The cosign we run must ALWAYS match the pinned SHA-256 --
+      including one found on PATH -- so a planted cosign.exe cannot rubber-stamp an
+      unsigned manifest (WIN-T5); the pinned build is auto-fetched and a PATH cosign
+      is used only if it byte-matches the pin. A cosign bundle that is present but
+      does NOT verify is a HARD FAIL (an attacker must not be able to force a
+      downgrade). A fully ABSENT bundle falls through to track 2.
     TRACK 2 (FALLBACK) -- pinned ed25519 (SEC-M2), used only when track 1 did not
       verify AND openssl.exe is available. Windows does not ship openssl, so unlike
       the shell installer this is a conditional fallback, not a hard prerequisite;
@@ -202,6 +204,39 @@ function Invoke-Native([scriptblock]$Command) {
     }
 }
 
+# Resolve a native helper tool to an ABSOLUTE path from a TRUSTED location instead
+# of a bare-name PATH lookup. A bare `Get-Command openssl` returns whatever comes
+# first on PATH -- which an attacker can influence via a writable PATH entry or the
+# current working directory, letting a planted openssl.exe run in our place
+# (WIN-T5). We first probe a fixed list of known-good ABSOLUTE install paths; only
+# if none exist do we consult PATH, and then we ACCEPT the result solely when it is
+# an absolute path rooted under a system / Program Files directory (never the cwd,
+# a temp dir, or a user-writable %LOCALAPPDATA%). Returns $null when nothing
+# trustworthy is found (the caller then fails closed).
+function Resolve-TrustedTool {
+    param([string]$Name, [string[]]$KnownPaths)
+    foreach ($p in $KnownPaths) {
+        if ($p -and (Test-Path -LiteralPath $p -PathType Leaf)) {
+            return (Resolve-Path -LiteralPath $p).Path
+        }
+    }
+    $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($cmd -and $cmd.Source) {
+        $src = $cmd.Source
+        try { $src = (Resolve-Path -LiteralPath $src -ErrorAction Stop).Path } catch { $src = $null }
+        if ($src -and [System.IO.Path]::IsPathRooted($src)) {
+            $trustedRoots = @($env:SystemRoot, $env:ProgramFiles, ${env:ProgramFiles(x86)}) |
+                Where-Object { $_ }
+            foreach ($root in $trustedRoots) {
+                $prefix = ($root.TrimEnd('\') + '\').ToLower()
+                if ($src.ToLower().StartsWith($prefix)) { return $src }
+            }
+            $host.UI.WriteErrorLine("ignoring ${Name} at ${src}: not under a trusted system/Program Files directory")
+        }
+    }
+    return $null
+}
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -233,41 +268,58 @@ $hint
     $verified = $false
 
     # === Provenance track 1 (PRIMARY): keyless cosign / GitHub OIDC (SPEC-0253). ===
-    # cosign is the primary path. If it is not on PATH we auto-fetch a PINNED cosign
-    # and verify its own SHA-256 before using it. When cosign is available AND the
-    # release carries a cosign bundle, verify SHA256SUMS against the EXPECTED workflow
-    # OIDC identity (no key to trust -- the signer is the release workflow itself).
-    # A present-but-invalid bundle is a HARD FAIL (no silent downgrade); a fully
-    # ABSENT bundle falls through to the pinned-ed25519 track below.
+    # cosign is the primary path. WIN-T5: the pinned SHA-256 gate applies to EVERY
+    # cosign we might run -- INCLUDING one already on PATH. A cosign.exe planted on a
+    # writable PATH entry (or dropped in the cwd) could otherwise print "Verified OK"
+    # for an UNSIGNED SHA256SUMS and silently bypass provenance. So we never trust a
+    # PATH cosign implicitly: we build a candidate list (PATH cosign first, then the
+    # auto-fetched pinned download) and accept the FIRST candidate whose SHA-256
+    # equals the pinned $COSIGN_SHA256. A candidate that does not match is refused.
+    # When a trusted cosign AND a cosign bundle are present, verify SHA256SUMS
+    # against the EXPECTED workflow OIDC identity (no key to trust -- the signer is
+    # the release workflow itself). A present-but-invalid bundle is a HARD FAIL (no
+    # silent downgrade); a fully ABSENT bundle falls through to the ed25519 track.
     $cosignExe = $null
-    $cmd = Get-Command cosign -ErrorAction SilentlyContinue
-    if (-not $cmd) { $cmd = Get-Command cosign.exe -ErrorAction SilentlyContinue }
-    if ($cmd) { $cosignExe = $cmd.Source }
+    if ($COSIGN_SHA256 -eq 'REPLACE_WITH_PINNED_SHA256') {
+        # SEC: never run an UNPINNED cosign. If the pin is unset we cannot vouch for
+        # ANY cosign (PATH or downloaded) -- skip the cosign track entirely.
+        Write-Info "cosign pin is not set (COSIGN_SHA256) -- refusing to run unverified cosign; skipping cosign track"
+    } else {
+        $candidates = New-Object System.Collections.Generic.List[string]
 
-    if (-not $cosignExe) {
-        Write-Info "cosign not on PATH -- fetching pinned cosign $COSIGN_VERSION (windows/amd64)"
+        # Candidate 1: a cosign already on PATH -- UNTRUSTED until it hash-matches the
+        # pin (a bare-name PATH resolution is attacker-influenceable).
+        $pathCmd = Get-Command cosign -ErrorAction SilentlyContinue
+        if (-not $pathCmd) { $pathCmd = Get-Command cosign.exe -ErrorAction SilentlyContinue }
+        if ($pathCmd -and $pathCmd.Source) { [void]$candidates.Add($pathCmd.Source) }
+
+        # Candidate 2: the pinned auto-fetch. Always downloaded so a non-matching (or
+        # absent) PATH cosign still has the pinned build to fall back to.
+        Write-Info "Obtaining a pin-verified cosign $COSIGN_VERSION (windows/amd64)"
         $cosignDl = Join-Path $tmp 'cosign.exe'
         if (Invoke-Download -Url $COSIGN_URL -OutFile $cosignDl -Optional) {
-            if ($COSIGN_SHA256 -eq 'REPLACE_WITH_PINNED_SHA256') {
-                # SEC: never run an UNPINNED cosign. If the pin is unset, we cannot
-                # trust the downloaded cosign -- skip the cosign track entirely.
-                Write-Info "cosign pin is not set (COSIGN_SHA256) -- refusing to run unverified cosign; skipping cosign track"
-            } else {
-                $dlHash = Get-Sha256Hex $cosignDl
-                if ($dlHash -ieq $COSIGN_SHA256) {
-                    Unblock-File -LiteralPath $cosignDl -ErrorAction SilentlyContinue
-                    $cosignExe = $cosignDl
-                    Write-Ok "pinned cosign verified ($COSIGN_SHA256)"
-                } else {
-                    # SEC: never USE a cosign whose hash != pin. Do not set $cosignExe;
-                    # fall through to the ed25519 track (as if cosign were absent).
-                    $host.UI.WriteErrorLine("downloaded cosign SHA-256 does not match the pin -- refusing to use it")
-                    $host.UI.WriteErrorLine("  expected: $COSIGN_SHA256")
-                    $host.UI.WriteErrorLine("  got:      $dlHash")
-                }
-            }
+            [void]$candidates.Add($cosignDl)
         } else {
-            Write-Info "could not download pinned cosign -- will try the ed25519 fallback"
+            Write-Info "could not download pinned cosign -- a PATH cosign is used ONLY if it matches the pin"
+        }
+
+        foreach ($cand in $candidates) {
+            if (-not (Test-Path -LiteralPath $cand)) { continue }
+            $h = Get-Sha256Hex $cand
+            if ($h -ieq $COSIGN_SHA256) {
+                Unblock-File -LiteralPath $cand -ErrorAction SilentlyContinue
+                $cosignExe = $cand
+                Write-Ok "pinned cosign verified ($COSIGN_SHA256)"
+                break
+            } else {
+                # SEC: never USE a cosign whose hash != pin. Try the next candidate.
+                $host.UI.WriteErrorLine("ignoring cosign at ${cand}: SHA-256 does not match the pin")
+                $host.UI.WriteErrorLine("  expected: $COSIGN_SHA256")
+                $host.UI.WriteErrorLine("  got:      $h")
+            }
+        }
+        if (-not $cosignExe) {
+            Write-Info "no pin-matching cosign available -- will try the ed25519 fallback"
         }
     }
 
@@ -304,11 +356,26 @@ expected workflow identity; refusing to install (no silent downgrade to ed25519)
     # Windows does not ship openssl, so this track is CONDITIONAL on openssl.exe being
     # present (the shell installer can hard-require openssl; here we cannot).
     if (-not $verified) {
-        $osslCmd = Get-Command openssl.exe -ErrorAction SilentlyContinue
-        if (-not $osslCmd) { $osslCmd = Get-Command openssl -ErrorAction SilentlyContinue }
+        # WIN-T5: resolve openssl to an ABSOLUTE, trusted path -- never a bare-name
+        # PATH lookup that a planted openssl.exe (cwd / writable PATH) could hijack.
+        # Windows does not ship openssl; it typically arrives with Git-for-Windows or
+        # an OpenSSL install, so probe those known-good absolute locations first.
+        $osslKnown = @()
+        foreach ($base in @($env:ProgramFiles, ${env:ProgramFiles(x86)})) {
+            if ($base) {
+                $osslKnown += (Join-Path $base 'Git\usr\bin\openssl.exe')
+                $osslKnown += (Join-Path $base 'Git\mingw64\bin\openssl.exe')
+                $osslKnown += (Join-Path $base 'OpenSSL-Win64\bin\openssl.exe')
+                $osslKnown += (Join-Path $base 'OpenSSL-Win32\bin\openssl.exe')
+                $osslKnown += (Join-Path $base 'OpenSSL\bin\openssl.exe')
+            }
+        }
+        if ($env:SystemRoot) { $osslKnown += (Join-Path $env:SystemRoot 'System32\openssl.exe') }
 
-        if ($osslCmd) {
-            $openssl = $osslCmd.Source
+        $openssl = Resolve-TrustedTool -Name 'openssl.exe' -KnownPaths $osslKnown
+        if (-not $openssl) { $openssl = Resolve-TrustedTool -Name 'openssl' -KnownPaths @() }
+
+        if ($openssl) {
             $haveSig   = Fetch 'SHA256SUMS.sig' -Optional
             $havePubDl = Fetch 'skillctl-release.pub' -Optional
 
@@ -374,7 +441,7 @@ RELEASE KEY FINGERPRINT MISMATCH -- refusing to install
                 Write-Info "ed25519 fallback unavailable (missing signature or public key at the release)"
             }
         } else {
-            Write-Info "openssl.exe not found -- cannot use the ed25519 fallback"
+            Write-Info "openssl not found in a trusted location -- cannot use the ed25519 fallback"
         }
     }
 


### PR DESCRIPTION
P0 remediation · **Windows lens** (code-only track; the Authenticode signing track is cert-gated and separate).

- **WIN-T5** (`tools/skillctl-install.ps1`): the pinned cosign SHA-256 gate now applies to a cosign found on **PATH** too (candidate list, accept only the hash-matching one) — a planted `cosign.exe` can no longer bypass provenance. `openssl` resolved to an absolute trusted path.
- **WIN-T6**: new `artifactauth/creds_windows.go` — DPAPI (`CryptProtectData`) per-user credential store so a write-capable PAT is never left only in a plaintext env var; macOS `keychain()`/`security` calls now `runtime.GOOS=="darwin"`-guarded + absolute `/usr/bin/security`. (`creds_other.go` stub.)
- **WIN-T7**: new leaf pkg `pkg/skillctl/secfile` — `SecureFileDACL` sets an owner+SYSTEM, no-inheritance NTFS DACL; called after writing the trust-roots file (fail-closed) and the install-token key (delete-on-failure). (Placed in a leaf pkg to avoid a verify→registry import cycle.)
- **WIN-T9** (`backend/git`): `git` resolved once to a validated **absolute** path; the `lstatRegular` symlink guard applied **uniformly** to blob/event/bundle.json reads; NTFS case-collision note added.

**Verified:** `GOOS=windows go build ./...` **and** `GOOS=darwin go build ./...` both green; `go test`/`go vet` on the changed packages green; `golang.org/x/sys` promoted to a direct dep.
**Validated only by `windows-gate` CI** (cannot run on the macOS host): the DPAPI round-trip, the `SetNamedSecurityInfo` DACL path, and the PowerShell install script's runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)