### PR TITLE
chore(ci): supply-chain hardening — SHA-pin + pin-guard, hermetic, least-privilege (CD-T1..T7)

### DIFF
--- a/.github/workflows/archive-merged-branches.yml
+++ b/.github/workflows/archive-merged-branches.yml
@@ -29,7 +29,7 @@ jobs:
     name: Archive merged branches
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0   # full history needed to tag any commit
 

--- a/.github/workflows/boundary-gate.yml
+++ b/.github/workflows/boundary-gate.yml
@@ -7,11 +7,15 @@ on:
   push:
   pull_request:
 
+# CD-T6: least-privilege default GITHUB_TOKEN for the whole workflow.
+permissions:
+  contents: read
+
 jobs:
   boundary-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: Run boundary-gate

--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
 
+# CD-T6: least-privilege default GITHUB_TOKEN for the whole workflow.
+permissions:
+  contents: read
+
 jobs:
   check-branch-name:
     name: Validate branch name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,18 @@ on:
   pull_request:
     branches: [main, master]
 
+# CD-T6: least-privilege default GITHUB_TOKEN for the whole workflow.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Vet
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.6"
 
@@ -24,7 +28,7 @@ jobs:
         run: go vet ./...
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2
 
       - name: golangci-lint
         run: golangci-lint run --timeout=5m
@@ -33,9 +37,9 @@ jobs:
     name: Unit Tests
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.6"
 
@@ -59,9 +63,9 @@ jobs:
     name: skillctl Security Tests (-race)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.6"
 
@@ -83,9 +87,9 @@ jobs:
     name: govulncheck (reachable CVEs)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.6"
 
@@ -100,13 +104,13 @@ jobs:
       # regressing. Standalone (not in any build job's `needs`) so a fresh upstream
       # CVE blocks merge but never the release builds.
       - name: govulncheck ./...
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
 
   gitleaks:
     name: gitleaks (secret scan)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0 # full history for a complete secret scan
 
@@ -115,22 +119,46 @@ jobs:
       # gitleaks version validated locally; exits non-zero on any finding (blocks).
       - name: Install gitleaks
         run: |
+          # CD-T2: pin the tarball hash and verify integrity BEFORE extract/install
+          # (modeled on tools/skillctl-install.sh's sha256 gate). A swapped tarball
+          # at the release origin fails `sha256sum -c` and never reaches `install`.
+          GITLEAKS_SHA256="79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e"
           curl -fsSL -o /tmp/gitleaks.tar.gz \
             https://github.com/gitleaks/gitleaks/releases/download/v8.30.0/gitleaks_8.30.0_linux_x64.tar.gz
+          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           sudo install /tmp/gitleaks /usr/local/bin/gitleaks
 
       - name: Scan full history (config-aware)
         run: gitleaks git . --config .gitleaks.toml --no-banner --redact
 
+  # CD-T4: go.mod/go.sum must already be tidy in the repo. GoReleaser no longer
+  # runs `go mod tidy` at release time (that hook was removed), so an untidy
+  # module graph must be caught here at PR/push time, not papered over silently
+  # during a release build.
+  mod-tidy-check:
+    name: go mod tidy is a no-op
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.6"
+
+      - name: go mod tidy && git diff --exit-code
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
   build-macos:
     name: Build macOS (arm64 + amd64)
     runs-on: macos-latest
     needs: [lint, test]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.6"
 
@@ -165,9 +193,10 @@ jobs:
           go build -o build/poc-recorder ./cmd/poc-recorder
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: m3c-tools-macos
+          retention-days: 7
           path: |
             build/m3c-tools-darwin-arm64
             build/m3c-tools-darwin-amd64
@@ -177,9 +206,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.6"
 
@@ -199,9 +228,10 @@ jobs:
           build/m3c-tools-linux-amd64 help
 
       - name: Upload cross-platform artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: m3c-tools-cross
+          retention-days: 7
           path: |
             build/m3c-tools-linux-amd64
             build/m3c-tools-windows-amd64.exe

--- a/.github/workflows/pin-guard.yml
+++ b/.github/workflows/pin-guard.yml
@@ -1,0 +1,109 @@
+name: Pin Guard (supply-chain)
+
+# CD-T1 keystone + CD-T2/T6/T7 drift guard. Modeled on the drift-guard grep
+# block in windows-gate.yml. Four cheap, robust checks keep the supply-chain
+# hardening honest on every push/PR:
+#
+#   1. CD-T1  every remote `uses:` must be pinned to a full 40-hex commit SHA.
+#   2. CD-T2  no `@latest` ref may appear in any workflow (pin tool versions).
+#   3. CD-T6  every workflow must declare a top-level `permissions:` block.
+#   4. CD-T7  every actions/upload-artifact step must set `retention-days:`.
+#
+# Self-reference: this file necessarily contains the tokens it searches for
+# ("uses:", "@latest", "upload-artifact"). The uses/retention checks anchor to a
+# real YAML `uses:` key (optional "- " then `uses:` at line start) after
+# stripping comments, so the grep/awk PROGRAM lines here (which have other
+# leading text) never match. The @latest check excludes this file by name.
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  pin-guard:
+    name: Enforce pinning + least-privilege + retention
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # (1) CD-T1 — every remote action ref must be a 40-hex commit SHA.
+      - name: Guard — all `uses:` refs are pinned to a 40-hex SHA
+        run: |
+          set -euo pipefail
+          bad=""
+          for f in .github/workflows/*.yml; do
+            # Strip trailing comments, keep only real step-level `uses:` keys,
+            # drop local (./) and docker:// refs, then drop anything already
+            # pinned to @<40 hex>. Whatever survives is an unpinned violation.
+            v="$(sed 's/#.*$//' "$f" \
+                  | grep -nE '^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]' \
+                  | grep -vE 'uses:[[:space:]]+(\.|docker://)' \
+                  | grep -vE '@[0-9a-f]{40}[[:space:]]*$' || true)"
+            if [ -n "$v" ]; then
+              bad="$bad$(printf '%s\n' "$v" | sed "s|^|$f:|")"$'\n'
+            fi
+          done
+          if [ -n "$bad" ]; then
+            echo "::error::Unpinned action ref(s) — pin to a full 40-char commit SHA (e.g. actions/checkout@<sha> # v7):"
+            printf '%s\n' "$bad"
+            exit 1
+          fi
+          echo "OK: every 'uses:' ref is pinned to a 40-hex commit SHA."
+
+      # (2) CD-T2 — no floating @latest anywhere in the workflows.
+      - name: Guard — no @latest refs
+        run: |
+          set -euo pipefail
+          # Exclude this guard file: it contains the literal token by necessity.
+          hits="$(grep -rnE '@latest' .github/workflows/ | grep -v 'pin-guard.yml' || true)"
+          if [ -n "$hits" ]; then
+            echo "::error::@latest ref(s) found — pin to a fixed version (CD-T2):"
+            printf '%s\n' "$hits"
+            exit 1
+          fi
+          echo "OK: no @latest refs."
+
+      # (3) CD-T6 — every workflow declares a top-level permissions block.
+      - name: Guard — top-level permissions present
+        run: |
+          set -euo pipefail
+          missing=""
+          for f in .github/workflows/*.yml; do
+            grep -qE '^permissions:' "$f" || missing="$missing $f"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Workflow(s) missing a top-level 'permissions:' block (CD-T6):$missing"
+            exit 1
+          fi
+          echo "OK: every workflow declares a top-level permissions block."
+
+      # (4) CD-T7 — every upload-artifact step sets retention-days.
+      - name: Guard — upload-artifact steps set retention-days
+        run: |
+          set -euo pipefail
+          bad=""
+          for f in .github/workflows/*.yml; do
+            # For each real `uses: …upload-artifact…` step key, scan its block
+            # (until the next `- ` step item) for a retention-days: key.
+            out="$(awk '
+              /^[ \t]*(-[ \t]+)?uses:[ \t].*upload-artifact/ { inblk=1; has=0; ln=NR; next }
+              inblk {
+                if ($0 ~ /retention-days:/) has=1
+                if ($0 ~ /^[ \t]*-[ \t]/) {
+                  if (!has) print FILENAME ":" ln ": upload-artifact step missing retention-days"
+                  inblk=0
+                }
+              }
+              END { if (inblk && !has) print FILENAME ":" ln ": upload-artifact step missing retention-days" }
+            ' "$f")"
+            if [ -n "$out" ]; then bad="$bad$out"$'\n'; fi
+          done
+          if [ -n "$bad" ]; then
+            echo "::error::upload-artifact step(s) without retention-days (CD-T7):"
+            printf '%s\n' "$bad"
+            exit 1
+          fi
+          echo "OK: every upload-artifact step sets retention-days."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,15 @@ on:
     tags:
       - 'v*'
 
+# CD-T6: least-privilege default — read-only for the whole workflow; the single
+# job that creates the GitHub Release elevates to contents: write per-job below.
 permissions:
-  contents: write
+  contents: read
 
 env:
   GO_VERSION: "1.26.6"
+  # CD-T4: builds must use go.sum as-is; never mutate the module graph mid-build.
+  GOFLAGS: -mod=readonly
 
 jobs:
   # -----------------------------------------------------------------------
@@ -19,9 +23,9 @@ jobs:
     name: Build macOS (arm64 + amd64)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -85,9 +89,10 @@ jobs:
           tar czf skillctl-darwin-amd64.tar.gz skillctl-darwin-amd64
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: macos-binaries
+          retention-days: 7
           path: |
             m3c-tools-darwin-arm64.tar.gz
             m3c-tools-darwin-amd64.tar.gz
@@ -101,16 +106,16 @@ jobs:
     name: Build Linux + Windows (GoReleaser)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           install-only: true
           version: "~> v2"
@@ -121,9 +126,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload GoReleaser artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: goreleaser-binaries
+          retention-days: 7
           path: |
             dist/m3c-tools-linux-*.tar.gz
             dist/skillctl-linux-*.tar.gz
@@ -140,9 +146,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-linux-windows]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -166,9 +172,10 @@ jobs:
         run: makensis scripts/installer.nsi
 
       - name: Upload installer
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: windows-installer
+          retention-days: 7
           path: build/M3C-Tools-Setup.exe
 
   # -----------------------------------------------------------------------
@@ -178,11 +185,13 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [build-macos, build-linux-windows, build-windows-installer]
+    permissions:
+      contents: write # create the GitHub Release + upload its assets
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
           merge-multiple: true
@@ -197,8 +206,16 @@ jobs:
           echo "=== checksums.txt ==="
           cat checksums.txt
 
+      # CD-T3 (RETIRE): the UNSIGNED skillctl CLI binaries no longer ship on the
+      # v* product release. The ONLY skillctl distribution is the signed
+      # (cosign/OIDC + SLSA provenance) skillctl/v* path built by
+      # skillctl-release.yml. Do NOT re-add skillctl-{darwin,linux,windows} assets
+      # to the files list below — a second, unsigned download channel defeats the
+      # pinned verification in tools/skillctl-install.sh. (skillctl-demo, a
+      # separate offline demo binary, is not part of the signed CLI channel and
+      # stays.)
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3
         with:
           generate_release_notes: true
           files: |
@@ -207,11 +224,6 @@ jobs:
             artifacts/m3c-tools-linux-amd64.tar.gz
             artifacts/m3c-tools-linux-arm64.tar.gz
             artifacts/m3c-tools-windows-amd64.zip
-            artifacts/skillctl-darwin-arm64.tar.gz
-            artifacts/skillctl-darwin-amd64.tar.gz
-            artifacts/skillctl-linux-amd64.tar.gz
-            artifacts/skillctl-linux-arm64.tar.gz
-            artifacts/skillctl-windows-amd64.zip
             artifacts/skillctl-demo-linux-amd64.tar.gz
             artifacts/skillctl-demo-linux-arm64.tar.gz
             artifacts/skillctl-demo-windows-amd64.zip

--- a/.github/workflows/skillctl-release.yml
+++ b/.github/workflows/skillctl-release.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # CD-T4: builds use go.sum as-is; never mutate the module graph mid-build.
+  GOFLAGS: -mod=readonly
+
 jobs:
   release:
     name: Build · cosign-sign · draft
@@ -32,9 +36,9 @@ jobs:
       id-token: write # OIDC for keyless cosign + build provenance
       attestations: write # SLSA build-provenance attestation
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.6" # patched toolchain (SPEC-0251 §5) — CVE-free binaries (GO-2026-5856)
 
@@ -71,7 +75,7 @@ jobs:
       # never block a release cut.
       - name: Generate SBOM (CycloneDX)
         continue-on-error: true
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           path: .
           format: cyclonedx-json
@@ -79,7 +83,7 @@ jobs:
           artifact-name: skillctl.sbom.cdx.json
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Keyless-sign SHA256SUMS (GitHub OIDC)
         working-directory: dist
@@ -96,7 +100,7 @@ jobs:
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 
       - name: SLSA build provenance (binaries + manifest)
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: |
             dist/skillctl-darwin-arm64
@@ -133,7 +137,7 @@ jobs:
       # SHA256SUMS.sig, and promotes. A broken cosign flow yields a draft, never
       # a published release.
       - name: Create draft release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3
         with:
           draft: true
           make_latest: false

--- a/.github/workflows/skillctl-windows-smoke.yml
+++ b/.github/workflows/skillctl-windows-smoke.yml
@@ -22,14 +22,18 @@ on:
       - "tools/skillctl-install.ps1"
       - ".github/workflows/skillctl-windows-smoke.yml"
 
+# CD-T6: least-privilege default GITHUB_TOKEN for the whole workflow.
+permissions:
+  contents: read
+
 jobs:
   quickstart-smoke:
     name: Quickstart Smoke (windows-latest)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.6"
           cache: true
@@ -60,7 +64,7 @@ jobs:
     name: Installer under Windows PowerShell 5.1 (BUG-0193)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install under Windows PowerShell 5.1 (from published release)
         shell: powershell

--- a/.github/workflows/windows-gate.yml
+++ b/.github/workflows/windows-gate.yml
@@ -41,15 +41,19 @@ on:
   pull_request:
     branches: [main, master]
 
+# CD-T6: least-privilege default GITHUB_TOKEN for the whole workflow.
+permissions:
+  contents: read
+
 jobs:
   # ── Phase 1+2: Cross-compile check (fast, ubuntu runner) ──────────────────
   windows-compile:
     name: Windows Cross-Compile (ubuntu)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.6"
           cache: true
@@ -99,7 +103,7 @@ jobs:
           echo "m3c-tools.exe: ${SIZE} bytes OK"
 
       - name: Upload Windows binaries
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: windows-binaries-${{ github.sha }}
           retention-days: 7
@@ -116,9 +120,9 @@ jobs:
     name: Trust Surface (windows-latest)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.6"
           cache: true
@@ -147,7 +151,7 @@ jobs:
 
       - name: Upload Windows test report (for drift parity)
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: win-trust-json-${{ github.sha }}
           retention-days: 7
@@ -167,9 +171,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: windows-trust
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.6"
           cache: true
@@ -206,7 +210,7 @@ jobs:
         continue-on-error: true
 
       - name: Download Windows test report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: win-trust-json-${{ github.sha }}
 
@@ -220,15 +224,15 @@ jobs:
     runs-on: windows-latest
     needs: windows-compile
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.6"
           cache: true
 
       - name: Download Windows binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: windows-binaries-${{ github.sha }}
           path: build/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,10 +11,9 @@ version: 2
 
 project_name: m3c-tools
 
-before:
-  hooks:
-    - go mod tidy
-
+# CD-T4: no `before: hooks: - go mod tidy`. A release build must never mutate
+# go.mod/go.sum; module tidiness is enforced by the mod-tidy-check job in ci.yml,
+# and every build below runs with GOFLAGS=-mod=readonly.
 builds:
   # --- m3c-tools: Linux + Windows only (CGO_ENABLED=0, CLI-only mode via main_other.go) ---
   - id: m3c-tools
@@ -22,6 +21,7 @@ builds:
     main: ./cmd/m3c-tools
     env:
       - CGO_ENABLED=0
+      - GOFLAGS=-mod=readonly
     ldflags:
       - -s -w
       - -X main.version={{.Version}}
@@ -44,6 +44,7 @@ builds:
     main: ./cmd/skillctl
     env:
       - CGO_ENABLED=0
+      - GOFLAGS=-mod=readonly
     ldflags:
       - -s -w
       - -X main.version={{.Version}}
@@ -68,6 +69,7 @@ builds:
     main: ./cmd/skillctl-demo
     env:
       - CGO_ENABLED=0
+      - GOFLAGS=-mod=readonly
     ldflags:
       - -s -w
       - -X main.version={{.Version}}

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ m3c-tools doctor                        # verify connectivity & config
 ### `skillctl` — sign and verify your first skill
 
 ```bash
-# macOS (Apple Silicon)
-curl -sL https://github.com/kamir/m3c-tools/releases/latest/download/skillctl-darwin-arm64.tar.gz | tar xz \
-  && sudo mv skillctl-darwin-arm64 /usr/local/bin/skillctl
+# macOS / Linux / Windows — signed installer: fetches the right binary from the
+# signed skillctl/v* release and verifies cosign/OIDC provenance + SHA-256 first.
+curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/master/tools/skillctl-install.sh | bash
 
 skillctl keygen --out ~/.config/m3c/skill-keys/mykey            # ed25519 → mykey.priv + mykey.pub
 skillctl pack --skill ./my-skill -o my-skill.skb --name my-skill --version 1.0.0

--- a/docs/illustration-prompt.md
+++ b/docs/illustration-prompt.md
@@ -109,8 +109,8 @@ else should be "no text"):
 - Real commands only: `keygen`, `pack`, `sign`, `verify-sig`, `trust`, `install`, `verify`,
   `publish`, `pull`, `registry`, `agentid`, `revoke` — **never** `search`, `init`, `build`, `run`.
 - Repo URL (footer): `github.com/kamir/m3c-tools`  — **not** `skillctl/skillctl`.
-- Install line (if shown): `curl -sL github.com/kamir/m3c-tools/releases/latest/download/skillctl-darwin-arm64.tar.gz | tar xz`
-  — **not** `get.skillctl.dev`.
+- Install line (if shown): `curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/master/tools/skillctl-install.sh | bash`
+  (the signed installer — skillctl ships **only** from the signed `skillctl/v*` release) — **not** `get.skillctl.dev`.
 - License (footer, correct): `Apache-2.0`.
 - Trust phrasing: *offline-verifiable — no hosted CA in the verification path* (evidence-led, no overclaim).
 - Do **not** invent a public skill marketplace or named skills (no `pdf-extract`, `web-search`, `skillhub`).

--- a/docs/quickstart-skillctl.md
+++ b/docs/quickstart-skillctl.md
@@ -44,28 +44,21 @@ curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/master/tools/skillc
 
 Override the target dir or the release with `INSTALL_DIR=…` / `RELEASE_BASE=…`.
 
-**Interim (unsigned — until the signed `skillctl/v0.3.x` release is published):** the scripted
-installers above verify a *signed* release, so until that release is live they report a missing
-download. For a quick Windows install *today* you can pull the unsigned binary from the current
-product release — this does **not** verify provenance, so prefer the signed one-liner once it
-ships:
-```powershell
-$d="$env:LOCALAPPDATA\Programs\skillctl"
-New-Item -ItemType Directory -Force -Path $d | Out-Null
-Invoke-WebRequest "https://github.com/kamir/m3c-tools/releases/latest/download/skillctl-windows-amd64.zip" -OutFile "$env:TEMP\skillctl.zip"
-Expand-Archive "$env:TEMP\skillctl.zip" $d -Force   # the zip already contains skillctl.exe — no rename needed
-$u=[Environment]::GetEnvironmentVariable("PATH","User"); if($u -notlike "*$d*"){[Environment]::SetEnvironmentVariable("PATH","$u;$d","User")}
-& "$d\skillctl.exe" version
-```
-
-**Manual install (raw tarball):**
+**Manual install (signed release, raw binary):** the **only** skillctl distribution channel is
+the signed `skillctl/v*` release (cosign/OIDC + SLSA provenance, plus a pinned ed25519 fallback).
+The unsigned per-arch skillctl assets that used to ride along on the `v*` product release have
+been **retired** — don't look for them there. To install by hand, pull the raw binary and its
+`SHA256SUMS` from the signed release and verify integrity *before* moving it onto your `PATH`:
 ```bash
-curl -sL https://github.com/kamir/m3c-tools/releases/latest/download/skillctl-darwin-arm64.tar.gz | tar xz \
-  && sudo mv skillctl-darwin-arm64 /usr/local/bin/skillctl
+BASE="https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.3.1"   # latest signed tag
+curl -sLO "$BASE/skillctl-darwin-arm64"     # or darwin-amd64 / linux-amd64 / linux-arm64 / windows-amd64.exe
+curl -sLO "$BASE/SHA256SUMS"
+grep ' skillctl-darwin-arm64$' SHA256SUMS | shasum -a 256 -c -     # integrity gate — fails closed on mismatch
+sudo install skillctl-darwin-arm64 /usr/local/bin/skillctl
 ```
 
-Swap `darwin-arm64` for `darwin-amd64`, `linux-amd64`, `linux-arm64`, or use the
-`skillctl-windows-amd64.zip`. Or build from source: `go build -o build/skillctl ./cmd/skillctl`.
+For full provenance verification (cosign bundle / ed25519 signature), prefer the one-liner
+installers above — they do it for you. Or build from source: `go build -o build/skillctl ./cmd/skillctl`.
 
 ```bash
 skillctl version


### PR DESCRIPTION
P0 remediation · **Cloud/DevOps lens** · toward SLSA-ready, non-forgeable provenance.

- **CD-T1 (keystone)**: every `uses:` in all 8 workflows pinned to a **full commit SHA** (with `# <tag>` comment); new **`pin-guard.yml`** fails closed on any non-SHA `uses:`. Extended to also fail on `@latest` in `run:` (CD-T2), any workflow missing a top-level `permissions:` (CD-T6), and any `upload-artifact` without `retention-days` (CD-T7). Each check verified to **bite** a synthetic violation.
- **CD-T2**: `golangci-lint`/`govulncheck` pinned to fixed versions; the gitleaks tarball verified against a pinned SHA-256 before install.
- **CD-T4**: hermetic build — dropped `go mod tidy` from `.goreleaser.yml`, `GOFLAGS=-mod=readonly`, new `mod-tidy-check` job.
- **CD-T6**: `permissions: contents: read` on the 5 workflows that lacked it; `release.yml` converted to per-job elevation.
- **CD-T7**: `retention-days: 7` on the unretained `upload-artifact` steps.
- **CD-T3** (decision = **retire**): removed the duplicate **unsigned** skillctl CLI assets from the `v*` product release; users now go solely to the signed `skillctl/v*` path.

All 9 workflows + `.goreleaser.yml` parse; resolved action→SHA table in the commit. (Pushed via SSH — workflow scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)