### PR TITLE
feat(skillctl): FR-0090 — trust-event identity from the SIGNED envelope on every carrier

### DIFF
--- a/cmd/skillctl/gossip_revokes.go
+++ b/cmd/skillctl/gossip_revokes.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifactauth"
 	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+	"github.com/kamir/m3c-tools/pkg/skillctl/trustcore"
 )
 
 func gossipedRevokedPath(home string) string {
@@ -137,19 +138,36 @@ func gossipRevokedDigests(peers *registry.Peers) (map[string]struct{}, []peerGos
 }
 
 // unionVerifiedRevokes adds every SIGNED revoke digest in events (verified against
-// pub) into `into` and returns how many it added. Integrity fail-closed: an
-// unsigned/forged revoke, a non-revoke event, or a digest-less event is ignored.
+// pub) into `into` and returns how many NEW digests it added. Integrity fail-closed:
+// an unsigned/forged revoke, a non-revoke event, or an anchor-less event is ignored.
+//
+// FR-0090 IS-T2: the classification and the revoked-set KEY are taken from the
+// SIGNED envelope (trustcore.KindFromSignedEnvelope + SignedDigest), NEVER from the
+// EventRecord.Kind / .Digest carrier projection a hostile peer controls. Without
+// this, a peer could relabel a signed revoke of X as EventRecord{Digest:Y} to
+// revoke an innocent digest Y, or wrap a signed ATTEST in EventRecord{Kind:revoke}
+// to forge a revocation — both defeated here because the union only ever trusts the
+// bytes the peer's key actually signed.
 func unionVerifiedRevokes(events []artifact.EventRecord, pub ed25519.PublicKey, into map[string]struct{}) int {
 	n := 0
 	for _, ev := range events {
-		if ev.Kind != artifact.KindRevoke || ev.Envelope == nil || ev.Digest == "" {
+		if ev.Envelope == nil {
 			continue
+		}
+		if trustcore.KindFromSignedEnvelope(ev.Envelope) != artifact.KindRevoke {
+			continue // a signed non-revoke (e.g. an attest relabeled Kind:revoke) unions nothing
+		}
+		signedDigest := trustcore.SignedDigest(ev.Envelope)
+		if !trustcore.ValidDigest(signedDigest) {
+			continue // no well-formed signed anchor → cannot revoke anything
 		}
 		if registry.VerifyEnvelopeSignature(pub, ev.Envelope) != nil {
 			continue // an unsigned/forged revoke does not count
 		}
-		into[ev.Digest] = struct{}{}
-		n++
+		if _, seen := into[signedDigest]; !seen {
+			into[signedDigest] = struct{}{}
+			n++
+		}
 	}
 	return n
 }

--- a/cmd/skillctl/gossip_revokes_test.go
+++ b/cmd/skillctl/gossip_revokes_test.go
@@ -36,8 +36,29 @@ func signedRevoke(t *testing.T, priv ed25519.PrivateKey, digest string) map[stri
 	return ev
 }
 
+// signedAttestEvent is a genuinely-signed ATTESTATION (reviewer_id + governance_level,
+// no revoked_by) — used to prove a signed non-revoke unions nothing even when the
+// carrier relabels its EventRecord.Kind to revoke.
+func signedAttestEvent(t *testing.T, priv ed25519.PrivateKey, digest string) map[string]any {
+	t.Helper()
+	ev := map[string]any{
+		"schema_version":   registry.EventSchemaVersion,
+		"event_id":         "a-" + digest,
+		"occurred_at":      "2026-08-01T00:00:00Z",
+		"bundle_digest":    digest,
+		"reviewer_id":      "id:gov@org",
+		"governance_level": "green",
+	}
+	if _, err := registry.SignEnvelopeSignature(priv, ev); err != nil {
+		t.Fatal(err)
+	}
+	return ev
+}
+
 // TestUnionVerifiedRevokes: only revoke events that verify against the peer's key
-// are unioned; wrong-key/unsigned/non-revoke are dropped (integrity fail-closed).
+// are unioned; wrong-key/unsigned are dropped (integrity fail-closed). Classification
+// is by the SIGNED envelope shape (FR-0090 IS-T2), so a signed revoke is unioned on
+// its SIGNED bundle_digest regardless of how the carrier labelled EventRecord.Kind.
 func TestUnionVerifiedRevokes(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
 	_, wrongPriv, _ := ed25519.GenerateKey(rand.Reader)
@@ -46,9 +67,7 @@ func TestUnionVerifiedRevokes(t *testing.T) {
 
 	events := []artifact.EventRecord{
 		{Kind: artifact.KindRevoke, Digest: good, Envelope: signedRevoke(t, priv, good)},          // valid
-		{Kind: artifact.KindRevoke, Digest: forged, Envelope: signedRevoke(t, wrongPriv, forged)}, // wrong key
-		{Kind: artifact.KindAdmit, Digest: gd(3), Envelope: signedRevoke(t, priv, gd(3))},         // not a revoke
-		{Kind: artifact.KindRevoke, Digest: "", Envelope: signedRevoke(t, priv, good)},            // no digest
+		{Kind: artifact.KindRevoke, Digest: forged, Envelope: signedRevoke(t, wrongPriv, forged)}, // wrong key → dropped
 	}
 	into := map[string]struct{}{}
 	n := unionVerifiedRevokes(events, pub, into)
@@ -60,6 +79,39 @@ func TestUnionVerifiedRevokes(t *testing.T) {
 	}
 	if _, ok := into[forged]; ok {
 		t.Error("a revoke signed by the WRONG key must be dropped (integrity fail-closed)")
+	}
+}
+
+// TestUnionVerifiedRevokesSignedIdentity is the FR-0090 IS-T2 regression. A hostile
+// peer serves signed events whose EventRecord carrier fields (Kind/Digest) LIE:
+//
+//   - a genuinely-signed revoke of X wrapped in EventRecord{Kind:revoke, Digest:Y}
+//     must union X (the SIGNED bundle_digest), never the carrier Digest Y;
+//   - a genuinely-signed ATTEST relabelled EventRecord{Kind:revoke, Digest:Y}
+//     must union NOTHING (it is not a signed revoke).
+//
+// Against the old code (which keyed on ev.Digest and filtered on ev.Kind) BOTH
+// events would have unioned Y — revoking an innocent digest and honouring a forged
+// revocation. The signed-identity union defeats both.
+func TestUnionVerifiedRevokesSignedIdentity(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	x := gd(7) // the digest the SIGNED revoke actually targets
+	y := gd(8) // the digest the carrier LABELS both records with
+
+	events := []artifact.EventRecord{
+		// Signed revoke of X, but the carrier claims Digest:Y.
+		{Kind: artifact.KindRevoke, Digest: y, Envelope: signedRevoke(t, priv, x)},
+		// Signed attest of Y, but the carrier claims Kind:revoke.
+		{Kind: artifact.KindRevoke, Digest: y, Envelope: signedAttestEvent(t, priv, y)},
+	}
+	into := map[string]struct{}{}
+	unionVerifiedRevokes(events, pub, into)
+
+	if _, ok := into[x]; !ok {
+		t.Error("a signed revoke of X must union X (its SIGNED bundle_digest), not the carrier's Digest")
+	}
+	if _, ok := into[y]; ok {
+		t.Error("must NOT union Y: neither the carrier Digest of the revoke nor a relabelled signed attest may add a digest")
 	}
 }
 

--- a/pkg/skillctl/backend/git/git.go
+++ b/pkg/skillctl/backend/git/git.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+	"github.com/kamir/m3c-tools/pkg/skillctl/trustcore"
 )
 
 func init() {
@@ -517,13 +518,26 @@ func (b *gitBackend) Events(ctx context.Context, filter artifact.ListFilter, pag
 				if err := json.Unmarshal(data, &env); err != nil {
 					continue // a malformed file is untrusted → ignore (never influences a verdict)
 				}
+				// FR-0090 IS-T1: derive Kind + Digest from the SIGNED envelope, NEVER
+				// from the unsigned carrier projection. The file name ("<seq>-<kind>.json")
+				// and the events/<digesthex>/ directory are attacker-controllable path
+				// projections — a signed revoke of X committed at events/<Yhex>/NNNN-
+				// installed.json must surface as {revoke, X}, not {install, Y}, or a
+				// hostile registry could relabel a revoke to suppress it or rebind its
+				// digest onto an innocent skill. The filename is kept only as NativeID
+				// (advisory). See reference_git_event_signed_identity.
+				kind := trustcore.KindFromSignedEnvelope(env)
+				signedDigest := trustcore.SignedDigest(env)
+				if kind == "" || !trustcore.ValidDigest(signedDigest) {
+					continue // unclassifiable, or no well-formed signed anchor → drop
+				}
 				rec := artifact.EventRecord{
-					Kind:       artifact.EventKind(kindFromEventFile(e.Name())),
-					Digest:     "sha256:" + dh,
+					Kind:       kind,
+					Digest:     signedDigest,
 					Governance: strFromMap(env, "governance_level"),
 					Host:       strFromMap(env, "packed_on_host"),
 					Rationale:  strFromMap(env, "rationale"),
-					NativeID:   e.Name(),
+					NativeID:   e.Name(), // advisory only (the unsigned filename projection)
 					Envelope:   env,
 				}
 				if rec.Host == "" {
@@ -577,13 +591,13 @@ func (b *gitBackend) targetDigestHexes(dir, name string) ([]string, error) {
 	return out, nil
 }
 
-func kindFromEventFile(fn string) string {
-	fn = strings.TrimSuffix(fn, ".json")
-	if i := strings.Index(fn, "-"); i >= 0 {
-		return fn[i+1:]
-	}
-	return fn
-}
+// kindFromEventFile (the old filename-projection classifier) was removed in
+// FR-0090 IS-T1: Events() now classifies from the SIGNED envelope via
+// trustcore.KindFromSignedEnvelope, and the "<seq>-<kind>.json" name is advisory
+// (NativeID) only. isRevoked() below still reads the filename, but purely for the
+// List/Resolve DISPLAY status column — never for a trust decision (parity with the
+// OCI backend's advisory digestRevoked; the authoritative revoke gate is the pull
+// gauntlet's signed-envelope path).
 
 func strFromMap(m map[string]any, k string) string {
 	s, _ := m[k].(string)

--- a/pkg/skillctl/backend/git/git_signed_identity_test.go
+++ b/pkg/skillctl/backend/git/git_signed_identity_test.go
@@ -1,0 +1,123 @@
+package git
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+)
+
+// TestGitEventsSignedIdentity is the FR-0090 IS-T1 regression: a genuinely signed
+// revoke of digest X is committed at events/<Yhex>/0001-installed.json — the
+// FILENAME lies ("installed") and the DIRECTORY lies (Y). Events() must derive the
+// event identity from the SIGNED envelope: Kind = revoke, Digest = X. Against the
+// old code it would report {install, sha256:Y} (filename + dirname projections), so
+// a revoked/key-compromised bundle would slip through the pull gauntlet and the
+// revoke would be redirected onto the innocent digest Y.
+func TestGitEventsSignedIdentity(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	bare := bareRepo(t)
+
+	// A signed-SHAPED revoke of X. (The git backend's Events() surfaces the raw
+	// envelope for the §7 verifier to re-check later; it does not itself verify the
+	// signature, so the classification/anchor extraction is what IS-T1 pins.)
+	xHex := strings.Repeat("a", 64)
+	yHex := strings.Repeat("b", 64)
+	xDigest := "sha256:" + xHex
+
+	revEnv := map[string]any{
+		"schema_version":     "1.0.0",
+		"event_id":           "r-1",
+		"occurred_at":        "2026-01-01T00:00:00Z",
+		"bundle_digest":      xDigest, // the SIGNED anchor → the real target
+		"revoked_by":         "id:gov@org",
+		"reason_code":        "key-compromise",
+		"envelope_signature": "aGVsbG8=", // irrelevant to Events() derivation
+	}
+	data, err := json.MarshalIndent(revEnv, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed the mislabeled event into the bare repo via a working clone: place the
+	// revoke-of-X under events/<Yhex>/ with a "-installed.json" name.
+	work := t.TempDir()
+	mustGit(t, "", "clone", "--quiet", bare, work)
+	mustGit(t, work, "checkout", "-B", "main")
+	evDir := filepath.Join(work, "events", yHex)
+	if err := os.MkdirAll(evDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(evDir, "0001-installed.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, work, "add", "-A")
+	mustGit(t, work, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "seed mislabeled event")
+	mustGit(t, work, "push", "origin", "main")
+
+	b := newGitBackend(bare, "local")
+	defer b.Close()
+
+	ep, err := b.Events(context.Background(), artifact.ListFilter{}, artifact.Page{})
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	if len(ep.Events) != 1 {
+		t.Fatalf("Events returned %d records, want 1: %+v", len(ep.Events), ep.Events)
+	}
+	got := ep.Events[0]
+	if got.Kind != artifact.KindRevoke {
+		t.Errorf("Kind = %q, want %q (from the SIGNED revoked_by, NOT the -installed.json filename)", got.Kind, artifact.KindRevoke)
+	}
+	if got.Digest != xDigest {
+		t.Errorf("Digest = %q, want %q (from the SIGNED bundle_digest X, NOT the events/<Yhex> dirname)", got.Digest, xDigest)
+	}
+	if got.NativeID != "0001-installed.json" {
+		t.Errorf("NativeID = %q, want the advisory filename 0001-installed.json", got.NativeID)
+	}
+}
+
+// TestGitEventsDropsAnchorlessEnvelope: an envelope with no signed discriminator
+// (or no well-formed bundle_digest) is DROPPED — it can never influence a verdict.
+func TestGitEventsDropsAnchorlessEnvelope(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	bare := bareRepo(t)
+	yHex := strings.Repeat("c", 64)
+
+	// No discriminator field and a junk digest → unclassifiable + invalid anchor.
+	junk := map[string]any{"schema_version": "1.0.0", "bundle_digest": "not-a-digest", "note": "hi"}
+	data, _ := json.MarshalIndent(junk, "", "  ")
+
+	work := t.TempDir()
+	mustGit(t, "", "clone", "--quiet", bare, work)
+	mustGit(t, work, "checkout", "-B", "main")
+	evDir := filepath.Join(work, "events", yHex)
+	if err := os.MkdirAll(evDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(evDir, "0001-revoked.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, work, "add", "-A")
+	mustGit(t, work, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "seed junk event")
+	mustGit(t, work, "push", "origin", "main")
+
+	b := newGitBackend(bare, "local")
+	defer b.Close()
+	ep, err := b.Events(context.Background(), artifact.ListFilter{}, artifact.Page{})
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	if len(ep.Events) != 0 {
+		t.Errorf("anchor-less/unclassifiable envelope must be dropped; got %d records: %+v", len(ep.Events), ep.Events)
+	}
+}

--- a/pkg/skillctl/backend/git/parity_test.go
+++ b/pkg/skillctl/backend/git/parity_test.go
@@ -27,8 +27,11 @@ func TestGitEventsSinceHostInstall(t *testing.T) {
 	if _, err := b.Publish(ctx, artifact.PublishRequest{
 		Kind: artifact.KindAdmit,
 		Event: map[string]any{
+			// admitted_by_identity is the SIGNED admit discriminator (FR-0090 IS-T1):
+			// Events() now classifies from it, exactly as BuildBundleAdmittedEvent sets it.
 			"kind": "admitted", "name": "ev", "version": "1.0.0", "bundle_digest": d,
-			"occurred_at": "2026-01-01T00:00:00Z", "packed_on_host": "boxA",
+			"admitted_by_identity": "id:test@m3c",
+			"occurred_at":          "2026-01-01T00:00:00Z", "packed_on_host": "boxA",
 		},
 		Meta: artifact.ArtifactMeta{Name: "ev", Version: "1.0.0", Digest: d},
 		Blob: []byte("SKB:ev@1.0.0"),

--- a/pkg/skillctl/backend/oci/helpers.go
+++ b/pkg/skillctl/backend/oci/helpers.go
@@ -109,37 +109,10 @@ func strFromMap(m map[string]any, k string) string {
 }
 func parseRFC3339(s string) (time.Time, error) { return time.Parse(time.RFC3339, s) }
 
-// kindFromSignedEnvelope classifies a lifecycle event from fields that are inside
-// the SIGNED SPEC-0190 envelope — never from the registry-controlled OCI annotation.
-// A malicious registry can relabel/strip a referrer's annKind, but it cannot alter
-// `revoked_by`/`reviewer_id`/… without breaking the ed25519 signature the gauntlet
-// re-verifies. The builders are mutually exclusive (event.go), so field presence is
-// an unambiguous discriminator. Returns "" for an unclassifiable envelope (dropped).
-func kindFromSignedEnvelope(env map[string]any) artifact.EventKind {
-	switch {
-	case envHas(env, "revoked_by"):
-		return artifact.KindRevoke
-	case envHas(env, "reviewer_id"):
-		return artifact.KindAttest
-	case envHas(env, "installed_on_host"):
-		return artifact.KindInstall
-	case envHas(env, "admitted_by_identity"):
-		return artifact.KindAdmit
-	}
-	return ""
-}
-
-func envHas(m map[string]any, k string) bool {
-	if m == nil {
-		return false
-	}
-	v, ok := m[k]
-	if !ok || v == nil {
-		return false
-	}
-	s, isStr := v.(string)
-	return !isStr || s != ""
-}
+// kindFromSignedEnvelope / the signed-envelope classifier now lives in the shared
+// pkg/skillctl/trustcore (FR-0090 IS-T0) so the OCI, git, and ER1 backends plus the
+// gossip + gauntlet paths derive event identity from ONE audited definition. Events()
+// calls trustcore.KindFromSignedEnvelope + trustcore.SignedDigest directly.
 
 // isLoopbackOrPrivate reports whether host (possibly host:port) resolves to a
 // loopback or RFC1918/ULA address — the only place a bearer token may ride plain

--- a/pkg/skillctl/backend/oci/oci.go
+++ b/pkg/skillctl/backend/oci/oci.go
@@ -476,8 +476,8 @@ func (b *ociBackend) Events(ctx context.Context, filter artifact.ListFilter, pag
 			// annotation is advisory display only. See reference_git_event_signed_identity.
 			kind := trustcore.KindFromSignedEnvelope(env)
 			signedDigest := trustcore.SignedDigest(env)
-			if kind == "" || signedDigest == "" {
-				continue // unclassifiable/anchor-less signed envelope → ignore
+			if kind == "" || !trustcore.ValidDigest(signedDigest) {
+				continue // unclassifiable / no well-formed signed anchor → never a verdict (parity with git/er1)
 			}
 			rec := artifact.EventRecord{
 				Kind:       kind,

--- a/pkg/skillctl/backend/oci/oci.go
+++ b/pkg/skillctl/backend/oci/oci.go
@@ -29,6 +29,7 @@ import (
 	"oras.land/oras-go/v2/registry"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+	"github.com/kamir/m3c-tools/pkg/skillctl/trustcore"
 )
 
 const (
@@ -473,8 +474,8 @@ func (b *ociBackend) Events(ctx context.Context, filter artifact.ListFilter, pag
 			// malicious registry relabel a signed revoke ("revoked"→"installed") to
 			// SUPPRESS it, or rebind its digest to revoke an innocent skill. The
 			// annotation is advisory display only. See reference_git_event_signed_identity.
-			kind := kindFromSignedEnvelope(env)
-			signedDigest := strFromMap(env, "bundle_digest")
+			kind := trustcore.KindFromSignedEnvelope(env)
+			signedDigest := trustcore.SignedDigest(env)
 			if kind == "" || signedDigest == "" {
 				continue // unclassifiable/anchor-less signed envelope → ignore
 			}

--- a/pkg/skillctl/backend/oci/oci_test.go
+++ b/pkg/skillctl/backend/oci/oci_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact/conformance"
+	"github.com/kamir/m3c-tools/pkg/skillctl/trustcore"
 )
 
 // ociStore builds an offline OCI layout in t.TempDir() — a real content store
@@ -225,7 +226,8 @@ func TestOpenOCISchemeMapping(t *testing.T) {
 }
 
 // TestOCIKindFromSignedEnvelope pins the classifier: kind comes from the signed
-// discriminator field, and the function never even sees an annotation.
+// discriminator field, and the function never even sees an annotation. The OCI
+// backend now derives this from the shared trustcore helper (FR-0090 IS-T0).
 func TestOCIKindFromSignedEnvelope(t *testing.T) {
 	cases := []struct {
 		env  map[string]any
@@ -239,8 +241,8 @@ func TestOCIKindFromSignedEnvelope(t *testing.T) {
 		{map[string]any{"revoked_by": ""}, ""},     // empty discriminator → not present
 	}
 	for _, c := range cases {
-		if got := kindFromSignedEnvelope(c.env); got != c.want {
-			t.Errorf("kindFromSignedEnvelope(%v) = %q, want %q", c.env, got, c.want)
+		if got := trustcore.KindFromSignedEnvelope(c.env); got != c.want {
+			t.Errorf("trustcore.KindFromSignedEnvelope(%v) = %q, want %q", c.env, got, c.want)
 		}
 	}
 }

--- a/pkg/skillctl/registry/attest_quorum.go
+++ b/pkg/skillctl/registry/attest_quorum.go
@@ -91,6 +91,18 @@ func (a *AttestAccumulator) OfferAttest(ev map[string]any) {
 	if digest == "" {
 		return
 	}
+	// FR-0090 IS-T3: an attestation MUST carry BOTH signed discriminator fields —
+	// reviewer_id (who) and governance_level (what). A revoke/admit/install envelope
+	// (no reviewer_id) can therefore never occupy a governance slot, even if it
+	// verifies against a pinned key. The identity of a signed event is its signed
+	// SHAPE, not merely "it verifies". BuildAttestationPublishedEvent always sets
+	// both, so legitimate attestations are unaffected.
+	if rid, _ := ev["reviewer_id"].(string); rid == "" {
+		return
+	}
+	if lvl, _ := ev["governance_level"].(string); lvl == "" {
+		return
+	}
 	for _, s := range a.signers {
 		if VerifyEnvelopeSignature(s.pub, ev) != nil {
 			continue // not this signer's key
@@ -123,6 +135,14 @@ func (a *AttestAccumulator) OfferAttest(ev map[string]any) {
 func (a *AttestAccumulator) OfferRevoke(ev map[string]any) {
 	digest, _ := ev["bundle_digest"].(string)
 	if digest == "" {
+		return
+	}
+	// FR-0090 IS-T3: a revoke MUST carry the signed revoked_by discriminator. Without
+	// this guard, ANY envelope that merely verifies against a pinned key — an admit or
+	// an attestation for `digest` — would mark `digest` revoked (a signed-but-wrong-
+	// shape confusion). revoked_by is the field BuildBundleRevokedEvent sets and the
+	// only thing that makes a signed envelope a revocation.
+	if rb, _ := ev["revoked_by"].(string); rb == "" {
 		return
 	}
 	for _, s := range a.signers {

--- a/pkg/skillctl/registry/attest_quorum_test.go
+++ b/pkg/skillctl/registry/attest_quorum_test.go
@@ -215,3 +215,94 @@ func TestAccumulatorRevoke(t *testing.T) {
 		t.Error("a verified revoke must mark the digest revoked")
 	}
 }
+
+// signedAdmit is a genuinely-signed ADMIT envelope (admitted_by_identity, no
+// revoked_by, no reviewer_id) — a signed event of the WRONG shape for a revoke or an
+// attestation, used to prove the accumulator gates on signed shape, not "it verifies".
+func signedAdmit(t *testing.T, priv ed25519.PrivateKey, digest string) map[string]any {
+	t.Helper()
+	ev := map[string]any{
+		"schema_version":       EventSchemaVersion,
+		"event_id":             "adm-" + digest,
+		"occurred_at":          "2026-08-01T00:00:00Z",
+		"bundle_digest":        digest,
+		"admitted_by_identity": "id:kamir@m3c",
+	}
+	if _, err := SignEnvelopeSignature(priv, ev); err != nil {
+		t.Fatal(err)
+	}
+	return ev
+}
+
+// TestOfferRevokeRequiresSignedRevokedBy is the FR-0090 IS-T3 regression: an
+// admit/attest envelope — correctly signed by the pinned key — must NOT mark its
+// digest revoked when fed to OfferRevoke. A revoke is the SIGNED revoked_by shape,
+// not merely a signature that verifies. Against the old code (which revoked on any
+// verifying envelope with a bundle_digest) both cases below would have revoked qd,
+// letting an attacker suppress a good bundle by replaying a signed admit/attest into
+// the revoke path.
+func TestOfferRevokeRequiresSignedRevokedBy(t *testing.T) {
+	priv, pub := genEd(t)
+	tr := &SelfTrustRoots{GovernanceMinimum: "green", pub: pub}
+
+	// A signed ATTEST (reviewer_id + governance_level, no revoked_by) → not a revoke.
+	attest := signedAttest(t, priv, "id:kamir@m3c", qd, "green", "2026-08-01T00:00:00Z", nil)
+	accA := NewAttestAccumulator(tr, qnow)
+	accA.OfferRevoke(attest)
+	if accA.IsRevoked(qd) {
+		t.Error("a signed ATTEST fed to OfferRevoke must NOT revoke (no signed revoked_by)")
+	}
+
+	// A signed ADMIT (admitted_by_identity, no revoked_by) → not a revoke.
+	accB := NewAttestAccumulator(tr, qnow)
+	accB.OfferRevoke(signedAdmit(t, priv, qd))
+	if accB.IsRevoked(qd) {
+		t.Error("a signed ADMIT fed to OfferRevoke must NOT revoke (no signed revoked_by)")
+	}
+
+	// Sanity: a genuine signed revoke still revokes (the guard did not over-reject).
+	rev := map[string]any{"schema_version": EventSchemaVersion, "event_id": "r", "occurred_at": "2026-08-01T00:00:00Z", "bundle_digest": qd, "revoked_by": "id:gov@org"}
+	if _, err := SignEnvelopeSignature(priv, rev); err != nil {
+		t.Fatal(err)
+	}
+	accC := NewAttestAccumulator(tr, qnow)
+	accC.OfferRevoke(rev)
+	if !accC.IsRevoked(qd) {
+		t.Error("a genuine signed revoke must still mark the digest revoked")
+	}
+}
+
+// TestOfferAttestRequiresSignedReviewerAndLevel is the attestation half of IS-T3: a
+// signed revoke/admit envelope must never occupy a governance slot. Against the old
+// code a signed revoke (which has a bundle_digest and verifies) would be recorded as
+// an attestation with an empty governance_level — a shape-confusion the floor should
+// never see.
+func TestOfferAttestRequiresSignedReviewerAndLevel(t *testing.T) {
+	priv, pub := genEd(t)
+	tr := &SelfTrustRoots{GovernanceMinimum: "green", pub: pub}
+
+	// A signed revoke fed to OfferAttest → no reviewer_id → must not qualify.
+	rev := map[string]any{"schema_version": EventSchemaVersion, "event_id": "r", "occurred_at": "2026-08-01T00:00:00Z", "bundle_digest": qd, "revoked_by": "id:gov@org"}
+	if _, err := SignEnvelopeSignature(priv, rev); err != nil {
+		t.Fatal(err)
+	}
+	accA := NewAttestAccumulator(tr, qnow)
+	accA.OfferAttest(rev)
+	if len(accA.Qualifying(qd)) != 0 || accA.HasBelowFloor(qd) {
+		t.Error("a signed revoke fed to OfferAttest must occupy NO governance slot")
+	}
+
+	// A signed admit fed to OfferAttest → no reviewer_id → must not qualify.
+	accB := NewAttestAccumulator(tr, qnow)
+	accB.OfferAttest(signedAdmit(t, priv, qd))
+	if len(accB.Qualifying(qd)) != 0 {
+		t.Error("a signed admit fed to OfferAttest must occupy NO governance slot")
+	}
+
+	// Sanity: a real attestation still qualifies.
+	accC := NewAttestAccumulator(tr, qnow)
+	accC.OfferAttest(signedAttest(t, priv, "id:kamir@m3c", qd, "green", "2026-08-01T00:00:00Z", nil))
+	if len(accC.Qualifying(qd)) != 1 {
+		t.Error("a genuine signed attestation must still qualify")
+	}
+}

--- a/pkg/skillctl/registry/backend_pull.go
+++ b/pkg/skillctl/registry/backend_pull.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+	"github.com/kamir/m3c-tools/pkg/skillctl/trustcore"
 )
 
 // parsePullSince turns the --since flag into a lower bound on occurred_at.
@@ -101,7 +102,13 @@ func PullBundlesFromBackend(ctx context.Context, be artifact.Backend, tr *SelfTr
 		if ev == nil {
 			continue
 		}
-		switch rec.Kind {
+		// FR-0090 IS-T3: dispatch on the SIGNED envelope shape, never the carrier's
+		// rec.Kind (an unsigned projection the backend's Events() derived from a
+		// filename/annotation/tag). This is defense-in-depth atop OfferRevoke /
+		// OfferAttest, which independently require the signed revoked_by /
+		// reviewer_id+governance_level — so a mislabeled event is routed by what it
+		// actually IS and then re-checked by the accumulator.
+		switch trustcore.KindFromSignedEnvelope(ev) {
 		case artifact.KindAdmit:
 			admits = append(admits, ev)
 		case artifact.KindRevoke:

--- a/pkg/skillctl/registry/er1_backend.go
+++ b/pkg/skillctl/registry/er1_backend.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/kamir/m3c-tools/pkg/er1"
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+	"github.com/kamir/m3c-tools/pkg/skillctl/trustcore"
 )
 
 // ER1Backend is the artifact.Backend view of one ER1 self-tenant context.
@@ -202,10 +203,19 @@ func (b *ER1Backend) Events(ctx context.Context, filter artifact.ListFilter, pag
 			if err != nil {
 				continue
 			}
-			d, _ := ev["bundle_digest"].(string)
+			// FR-0090 IS-T4 (parity with git/oci Events): Kind + Digest come from the
+			// SIGNED envelope, never the skill-event:<kind> TAG (the `kind` loop var is
+			// only the coarse search prefilter). A hostile ER1 item could otherwise
+			// relabel a signed revoke as skill-event:installed to suppress it. Digest was
+			// already envelope-sourced; classifying Kind here closes the tag projection.
+			signedKind := trustcore.KindFromSignedEnvelope(ev)
+			d := trustcore.SignedDigest(ev)
+			if signedKind == "" || !trustcore.ValidDigest(d) {
+				continue // unclassifiable / no well-formed anchor → never a verdict
+			}
 			lvl, _ := ev["governance_level"].(string)
 			rec := artifact.EventRecord{
-				Kind: artifact.EventKind(kind), Digest: d, Governance: lvl,
+				Kind: signedKind, Digest: d, Governance: lvl,
 				Host:      strOrEmpty(ev["packed_on_host"], ev["installed_on_host"]),
 				Rationale: strOrEmpty(ev["rationale"]),
 				Envelope:  ev,

--- a/pkg/skillctl/registry/er1_backend.go
+++ b/pkg/skillctl/registry/er1_backend.go
@@ -205,9 +205,15 @@ func (b *ER1Backend) Events(ctx context.Context, filter artifact.ListFilter, pag
 			}
 			// FR-0090 IS-T4 (parity with git/oci Events): Kind + Digest come from the
 			// SIGNED envelope, never the skill-event:<kind> TAG (the `kind` loop var is
-			// only the coarse search prefilter). A hostile ER1 item could otherwise
-			// relabel a signed revoke as skill-event:installed to suppress it. Digest was
-			// already envelope-sourced; classifying Kind here closes the tag projection.
+			// only the coarse search prefilter). This closes the tag projection for every
+			// item the search FETCHES — an intra-set retag (revoked<->attested) can no
+			// longer flip a verdict. RESIDUAL (tracked, IS-T4b): discovery is still gated
+			// on the skill-event:<kind> tag, so a hostile ER1 tenant retagging a signed
+			// revoke to skill-event:installed (or stripping the tag) can drop it from the
+			// search BEFORE it reaches this classifier. Full parity with git (which
+			// enumerates every event file structurally) needs de-gating the search off
+			// skill-event:<kind>; until then the freshness ceiling (IS-T5) is the
+			// compensating control for managed roots.
 			signedKind := trustcore.KindFromSignedEnvelope(ev)
 			d := trustcore.SignedDigest(ev)
 			if signedKind == "" || !trustcore.ValidDigest(d) {

--- a/pkg/skillctl/registry/er1_pull.go
+++ b/pkg/skillctl/registry/er1_pull.go
@@ -41,6 +41,8 @@ import (
 	"time"
 
 	"github.com/kamir/m3c-tools/pkg/er1"
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+	"github.com/kamir/m3c-tools/pkg/skillctl/trustcore"
 )
 
 // ─── Errors ────────────────────────────────────────────────────────────────
@@ -508,16 +510,25 @@ func loadAttestRevoke(cfg *er1.Config, ctxID, onlySkill string, pub ed25519.Publ
 			if err := VerifyEnvelopeSignature(pub, ev); err != nil {
 				continue
 			}
-			if kind == EventKindRevoked {
+			// FR-0090 IS-T4: classify by the SIGNED envelope SHAPE, not the
+			// skill-event:<kind> TAG. The tag was only a coarse SEARCH prefilter (the
+			// `kind` loop variable above); an ER1 item's tags are carrier metadata a
+			// writer controls, so a signed revoke re-tagged skill-event:attested (to
+			// SUPPRESS the revoke) or an attestation re-tagged skill-event:revoked (to
+			// forge a revocation) must be judged by what the SIGNED bytes actually are.
+			switch trustcore.KindFromSignedEnvelope(ev) {
+			case artifact.KindRevoke:
 				revokedDigests[digest] = struct{}{}
-				continue
-			}
-			level, _ := ev["governance_level"].(string)
-			ts, _ := ev["occurred_at"].(string)
-			if prev, ok := attestTS[digest]; !ok || ts > prev {
-				attestByDigest[digest] = level
-				attestTS[digest] = ts
-				attestEventByDigest[digest] = ev // keep the SIGNED event for the install-time stash
+			case artifact.KindAttest:
+				level, _ := ev["governance_level"].(string)
+				ts, _ := ev["occurred_at"].(string)
+				if prev, ok := attestTS[digest]; !ok || ts > prev {
+					attestByDigest[digest] = level
+					attestTS[digest] = ts
+					attestEventByDigest[digest] = ev // keep the SIGNED event for the install-time stash
+				}
+			default:
+				// admit/install/unclassifiable → never a governance verdict here.
 			}
 		}
 	}
@@ -544,10 +555,18 @@ func loadAttestAccumulator(cfg *er1.Config, ctxID, onlySkill string, tr *SelfTru
 			if err != nil {
 				continue
 			}
-			if kind == EventKindRevoked {
+			// FR-0090 IS-T4: route by the SIGNED envelope shape, not the skill-event
+			// TAG (the `kind` loop variable is only the coarse search prefilter). The
+			// accumulator's OfferRevoke/OfferAttest re-check the signed discriminator
+			// fields (IS-T3), so a re-tagged event is both routed and gated by what it
+			// actually IS — a revoke re-tagged attested still reaches OfferRevoke.
+			switch trustcore.KindFromSignedEnvelope(ev) {
+			case artifact.KindRevoke:
 				acc.OfferRevoke(ev)
-			} else {
+			case artifact.KindAttest:
 				acc.OfferAttest(ev)
+			default:
+				// admit/install/unclassifiable → not a governance verdict.
 			}
 		}
 	}

--- a/pkg/skillctl/registry/er1_pull.go
+++ b/pkg/skillctl/registry/er1_pull.go
@@ -516,6 +516,10 @@ func loadAttestRevoke(cfg *er1.Config, ctxID, onlySkill string, pub ed25519.Publ
 			// writer controls, so a signed revoke re-tagged skill-event:attested (to
 			// SUPPRESS the revoke) or an attestation re-tagged skill-event:revoked (to
 			// forge a revocation) must be judged by what the SIGNED bytes actually are.
+			// RESIDUAL (tracked, IS-T4b): the search only returns items still tagged with
+			// one of the searched skill-event:<kind> values, so a revoke retagged to an
+			// UNsearched value (e.g. skill-event:installed) or stripped of the tag is
+			// dropped at DISCOVERY, before this classifier — de-gating the search closes it.
 			switch trustcore.KindFromSignedEnvelope(ev) {
 			case artifact.KindRevoke:
 				revokedDigests[digest] = struct{}{}

--- a/pkg/skillctl/registry/er1_pull_signed_identity_test.go
+++ b/pkg/skillctl/registry/er1_pull_signed_identity_test.go
@@ -1,0 +1,91 @@
+package registry
+
+import (
+	"crypto/ed25519"
+	"strings"
+	"testing"
+)
+
+// TestER1LoadAttestRevokeSignedIdentity is the FR-0090 IS-T4 regression. ER1 item
+// tags are carrier metadata a writer controls, so loadAttestRevoke must classify by
+// the SIGNED envelope shape, treating the skill-event:<kind> tag as a coarse SEARCH
+// prefilter only:
+//
+//   - a genuinely-signed REVOKE re-tagged skill-event:attested must STILL revoke
+//     (and must NOT be counted as an attestation) — otherwise a writer could hide a
+//     revocation among the attestations and keep a compromised bundle installable;
+//   - a genuinely-signed ATTEST re-tagged skill-event:revoked must NOT revoke (and
+//     must be counted as the attestation it is) — otherwise a writer could suppress a
+//     good bundle by forging a revocation from a re-tagged attestation.
+//
+// Against the old code (which trusted the skill-event:<kind> tag) the revoke would
+// have been recorded as an empty-level attestation and the attest would have revoked
+// its digest — exactly inverted from the signed truth.
+func TestER1LoadAttestRevokeSignedIdentity(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	f := newPullFake(t)
+
+	revDigest := "sha256:" + strings.Repeat("a", 64)
+	attDigest := "sha256:" + strings.Repeat("b", 64)
+
+	// A signed REVOKE, but the ER1 item is TAGGED skill-event:attested.
+	revEv, err := BuildBundleRevokedEvent(RevokedEventInput{
+		BundleDigest: revDigest, ReasonCode: "key-compromise", RevokedBy: "id:test@m3c", OccurredAt: testTime(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SignEnvelopeSignature(priv, revEv); err != nil {
+		t.Fatal(err)
+	}
+	f.addItem(map[string]any{
+		"doc_id": "sneaky-revoke-tagged-attested",
+		"tags": strings.Join([]string{
+			"m3c-skill-bundle", "skill-registry:self",
+			"skill:pdf", "skill-digest:" + revDigest,
+			"skill-event:" + EventKindAttested, // THE LIE
+		}, ","),
+		"transcript": renderTestEventBody(revEv, "attested"),
+	})
+
+	// A signed ATTEST, but the ER1 item is TAGGED skill-event:revoked.
+	attEv, err := BuildAttestationPublishedEvent(AttestedEventInput{
+		BundleDigest: attDigest, ReviewerID: "id:test@m3c", GovernanceLevel: "green", OccurredAt: testTime(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SignEnvelopeSignature(priv, attEv); err != nil {
+		t.Fatal(err)
+	}
+	f.addItem(map[string]any{
+		"doc_id": "sneaky-attest-tagged-revoked",
+		"tags": strings.Join([]string{
+			"m3c-skill-bundle", "skill-registry:self",
+			"skill:pdf", "skill-digest:" + attDigest,
+			"skill-event:" + EventKindRevoked, // THE LIE
+		}, ","),
+		"transcript": renderTestEventBody(attEv, "revoked"),
+	})
+
+	attestByDigest, revoked, _, err := loadAttestRevoke(f.cfg(), "skills", "", pub)
+	if err != nil {
+		t.Fatalf("loadAttestRevoke: %v", err)
+	}
+
+	// The re-tagged revoke: revokes, and is NOT an attestation.
+	if _, ok := revoked[revDigest]; !ok {
+		t.Error("a signed revoke re-tagged skill-event:attested must STILL revoke (classified by signed shape)")
+	}
+	if _, ok := attestByDigest[revDigest]; ok {
+		t.Error("a signed revoke must NOT be counted as an attestation, whatever its skill-event tag")
+	}
+
+	// The re-tagged attest: does NOT revoke, and IS an attestation.
+	if _, ok := revoked[attDigest]; ok {
+		t.Error("a signed attestation re-tagged skill-event:revoked must NOT revoke")
+	}
+	if lvl, ok := attestByDigest[attDigest]; !ok || lvl != "green" {
+		t.Errorf("a signed attestation must be counted (level %q, ok=%v); want green", lvl, ok)
+	}
+}

--- a/pkg/skillctl/trustcore/trustcore.go
+++ b/pkg/skillctl/trustcore/trustcore.go
@@ -1,0 +1,87 @@
+// Package trustcore holds the SIGNED-envelope trust primitives shared by every
+// artifact backend and by the pull / gossip / gauntlet paths (FR-0090).
+//
+// THE PRINCIPLE (reference_git_event_signed_identity): a trust decision may only
+// read a lifecycle event's KIND and DIGEST from fields INSIDE the signed SPEC-0190
+// envelope — never from an unsigned carrier projection (a git filename/dirname, an
+// OCI referrer annotation, an ER1 skill-event tag). A hostile carrier can relabel
+// those projections at will without breaking the ed25519 signature the §7 verifier
+// re-checks; the signed discriminator fields (`revoked_by`, `reviewer_id`,
+// `installed_on_host`, `admitted_by_identity`, `bundle_digest`) it CANNOT forge.
+// Sourcing kind/digest from a projection would let a registry relabel a signed
+// revoke ("revoked"→"installed") to SUPPRESS it, or rebind its digest to revoke an
+// innocent skill. Centralising the derivation here means one audited definition,
+// used identically by the OCI, git, and ER1 backends, the gossip union, and the
+// pull gauntlet — so the carriers cannot drift.
+//
+// This package imports ONLY pkg/skillctl/artifact (itself a leaf), so it is safe
+// for every backend and the registry/gossip layers to import without a cycle.
+package trustcore
+
+import (
+	"regexp"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+)
+
+// digestRe pins the canonical bundle-digest shape: "sha256:" + 64 lowercase hex.
+// It matches the per-backend validators (backend/git, backend/oci, registry/event)
+// so a trust decision keys only on a well-formed digest.
+var digestRe = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// KindFromSignedEnvelope classifies a lifecycle event purely from the SIGNED
+// discriminator fields SPEC-0190's event builders set (event.go). The builders are
+// mutually exclusive — an admit carries `admitted_by_identity`, an attestation
+// `reviewer_id`(+`governance_level`), a revoke `revoked_by`, an install
+// `installed_on_host` — so field presence is an unambiguous discriminator on any
+// well-formed envelope.
+//
+// `revoked_by` is checked FIRST deliberately: a revoke takes precedence, so a
+// degenerate/adversarial envelope that somehow carries a revoke field alongside
+// another is treated as a revocation (fail-safe toward DENY, never toward trust).
+// An envelope with NONE of the discriminators is unclassifiable and returns ""
+// (the caller drops it — it never influences a verdict).
+func KindFromSignedEnvelope(env map[string]any) artifact.EventKind {
+	switch {
+	case envHas(env, "revoked_by"):
+		return artifact.KindRevoke
+	case envHas(env, "reviewer_id"):
+		return artifact.KindAttest
+	case envHas(env, "installed_on_host"):
+		return artifact.KindInstall
+	case envHas(env, "admitted_by_identity"):
+		return artifact.KindAdmit
+	}
+	return ""
+}
+
+// SignedDigest returns the `bundle_digest` carried INSIDE the signed envelope, or
+// "" when absent/blank/non-string. This is the ONLY digest a trust decision may
+// key on — never a carrier-supplied dir/tag/annotation digest. Callers that gate
+// on it should additionally require ValidDigest.
+func SignedDigest(env map[string]any) string {
+	if env == nil {
+		return ""
+	}
+	s, _ := env["bundle_digest"].(string)
+	return s
+}
+
+// ValidDigest reports whether s is a well-formed sha256:<64 lowercase hex> digest.
+func ValidDigest(s string) bool { return digestRe.MatchString(s) }
+
+// envHas reports whether m carries a present, non-nil key k whose value — when it
+// is a string — is non-empty. A present non-string value counts as present (the
+// discriminators are always strings in practice; this only guards the empty-string
+// carrier case so `{"revoked_by": ""}` is treated as ABSENT, not a revoke).
+func envHas(m map[string]any, k string) bool {
+	if m == nil {
+		return false
+	}
+	v, ok := m[k]
+	if !ok || v == nil {
+		return false
+	}
+	s, isStr := v.(string)
+	return !isStr || s != ""
+}

--- a/pkg/skillctl/trustcore/trustcore_test.go
+++ b/pkg/skillctl/trustcore/trustcore_test.go
@@ -1,0 +1,75 @@
+package trustcore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+)
+
+// TestKindFromSignedEnvelope pins the classifier over the four signed shapes plus
+// the unclassifiable (empty / no-discriminator) case. The kind is derived ONLY
+// from the signed discriminator field — the classifier never sees a carrier tag,
+// filename, or annotation.
+func TestKindFromSignedEnvelope(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]any
+		want artifact.EventKind
+	}{
+		{"revoke", map[string]any{"revoked_by": "id:gov", "bundle_digest": "sha256:x"}, artifact.KindRevoke},
+		{"attest", map[string]any{"reviewer_id": "id:rev", "governance_level": "green"}, artifact.KindAttest},
+		{"install", map[string]any{"installed_on_host": "host-1"}, artifact.KindInstall},
+		{"admit", map[string]any{"admitted_by_identity": "id:a", "signatures": []any{}}, artifact.KindAdmit},
+		// Unclassifiable / "ambiguous" in the sense of carrying no discriminator: a
+		// bare envelope with only anchor/metadata fields is unknown ("") and dropped.
+		{"empty", map[string]any{}, ""},
+		{"no-discriminator", map[string]any{"bundle_digest": "sha256:x", "occurred_at": "2026-01-01T00:00:00Z"}, ""},
+		// An empty-string discriminator is treated as ABSENT (carrier can't neuter a
+		// classification by blanking the field either — it just becomes unknown).
+		{"blank-revoked_by", map[string]any{"revoked_by": ""}, ""},
+		{"nil-env", nil, ""},
+		// revoke takes precedence (fail-safe toward DENY) if a degenerate envelope
+		// carries a revoke field alongside another discriminator.
+		{"revoke-precedence", map[string]any{"revoked_by": "id:gov", "reviewer_id": "id:rev"}, artifact.KindRevoke},
+	}
+	for _, c := range cases {
+		if got := KindFromSignedEnvelope(c.env); got != c.want {
+			t.Errorf("%s: KindFromSignedEnvelope(%v) = %q, want %q", c.name, c.env, got, c.want)
+		}
+	}
+}
+
+func TestSignedDigest(t *testing.T) {
+	if got := SignedDigest(map[string]any{"bundle_digest": "sha256:abc"}); got != "sha256:abc" {
+		t.Errorf("SignedDigest = %q, want sha256:abc", got)
+	}
+	if got := SignedDigest(map[string]any{}); got != "" {
+		t.Errorf("SignedDigest(no digest) = %q, want empty", got)
+	}
+	if got := SignedDigest(nil); got != "" {
+		t.Errorf("SignedDigest(nil) = %q, want empty", got)
+	}
+	if got := SignedDigest(map[string]any{"bundle_digest": 42}); got != "" {
+		t.Errorf("SignedDigest(non-string) = %q, want empty", got)
+	}
+}
+
+func TestValidDigest(t *testing.T) {
+	good := "sha256:" + strings.Repeat("a", 64)
+	if !ValidDigest(good) {
+		t.Errorf("ValidDigest(%q) = false, want true", good)
+	}
+	for _, bad := range []string{
+		"",
+		"sha256:short",
+		"sha256:" + strings.Repeat("a", 63),
+		"sha256:" + strings.Repeat("A", 64), // uppercase not allowed
+		"md5:" + strings.Repeat("a", 64),
+		strings.Repeat("a", 64), // missing prefix
+	} {
+		if ValidDigest(bad) {
+			t.Errorf("ValidDigest(%q) = true, want false", bad)
+		}
+	}
+}

--- a/pkg/skillctl/verify/freshness.go
+++ b/pkg/skillctl/verify/freshness.go
@@ -31,6 +31,17 @@ import (
 // defaultCacheTTL is the shipped sweep cadence used when cache_ttl is unset.
 const defaultCacheTTL = 12 * time.Hour
 
+// managedDefaultMaxStaleness is the FR-0090 IS-T5 fail-closed staleness ceiling a
+// MANAGED (enterprise) trust root receives when max_staleness is unset — as both a
+// Go duration (used by EvaluateFreshness as the effective ceiling) and its string
+// form (stamped by the trust-roots loader's applyManagedDefaults). A managed host
+// must never trust an unbounded-age revocation snapshot: past this ceiling a
+// high-risk invocation of a since-revoked digest fails closed.
+const (
+	managedDefaultMaxStaleness    = 48 * time.Hour
+	managedDefaultMaxStalenessStr = "48h"
+)
+
 // maxFutureClockSkew is how far a snapshot's issued_at may sit in the FUTURE
 // (relative to the verifier's clock) before it is treated as DISHONEST. A small
 // skew (NTP jitter, sub-second rounding) is tolerated; anything beyond it is a
@@ -72,9 +83,18 @@ const (
 // strings are parsed once at Load).
 type FreshnessPolicy struct {
 	// MaxStaleness is the staleness ceiling. Zero means "no ceiling" — the
-	// pre-SPEC-0279 behaviour (a synced snapshot is trusted at any age). When
-	// non-zero, a snapshot older than this triggers the fail-policy.
+	// pre-SPEC-0279 behaviour (a synced snapshot is trusted at any age) — but ONLY
+	// for a non-managed root (see Managed below). When non-zero, a snapshot older
+	// than this triggers the fail-policy.
 	MaxStaleness time.Duration
+
+	// Managed marks this policy as belonging to an enterprise-MANAGED trust root
+	// (TrustRoot.IsManaged, FR-0090 IS-T5). A managed policy NEVER has "no ceiling":
+	// if MaxStaleness is 0, EvaluateFreshness applies the fail-closed managed default
+	// (48h) instead of trusting the snapshot at any age. This is belt-and-suspenders
+	// to the loader, which already defaults max_staleness to 48h for a managed root —
+	// so even a hand-constructed managed policy cannot dodge the ceiling.
+	Managed bool
 
 	// CacheTTL is the local revocation-cache lifetime (default 12h).
 	CacheTTL time.Duration
@@ -138,6 +158,12 @@ func (t *TrustRoot) Freshness() (FreshnessPolicy, error) {
 		return FreshnessPolicy{}, err
 	}
 	p.FailPolicy = fp
+
+	// FR-0090 IS-T5: a managed (enterprise) root's freshness contract always has a
+	// ceiling. The loader already defaults max_staleness to 48h for such a root, so
+	// p.MaxStaleness is non-zero here in practice; carrying the flag lets
+	// EvaluateFreshness fail closed even on a hand-constructed managed policy.
+	p.Managed = t.IsManaged()
 
 	if len(t.FailPolicyByRisk) > 0 {
 		p.byRisk = make(map[ActionRisk]FailPolicy, len(t.FailPolicyByRisk))
@@ -324,11 +350,20 @@ type FreshnessDecision struct {
 // verifier's clock, and a high-risk action past the ceiling is denied no matter
 // what the list claims.
 func EvaluateFreshness(epoch int, issuedAt string, policy FreshnessPolicy, risk ActionRisk, now time.Time) (FreshnessDecision, error) {
+	// FR-0090 IS-T5: a MANAGED (enterprise) policy never has "no ceiling". If
+	// max_staleness is unset (0) on a managed root, apply the fail-closed managed
+	// default (48h). The trust-roots loader already stamps 48h for a managed root, so
+	// this only bites a hand-constructed managed policy — the "no ceiling" allow below
+	// is thereby reachable ONLY for non-managed roots.
+	effectiveMax := policy.MaxStaleness
+	if effectiveMax == 0 && policy.Managed {
+		effectiveMax = managedDefaultMaxStaleness
+	}
 	dec := FreshnessDecision{
 		Epoch:               epoch,
 		IssuedAt:            strings.TrimSpace(issuedAt),
 		Risk:                risk,
-		MaxStalenessSeconds: int64(policy.MaxStaleness / time.Second),
+		MaxStalenessSeconds: int64(effectiveMax / time.Second),
 	}
 
 	staleness, parsedOK := snapshotStaleness(issuedAt, now)
@@ -345,7 +380,9 @@ func EvaluateFreshness(epoch int, issuedAt string, policy FreshnessPolicy, risk 
 	dec.StalenessSeconds = int64(staleness / time.Second)
 
 	// No ceiling configured → freshness is not enforced (pre-SPEC-0279 default).
-	if policy.MaxStaleness == 0 {
+	// Reachable ONLY for non-managed roots: a managed root's effectiveMax is forced
+	// to the 48h fail-closed default above (FR-0090 IS-T5).
+	if effectiveMax == 0 {
 		dec.FailPolicy = policy.PolicyFor(risk)
 		dec.Allowed = true
 		dec.Reason = "no_staleness_ceiling"
@@ -359,7 +396,7 @@ func EvaluateFreshness(epoch int, issuedAt string, policy FreshnessPolicy, risk 
 		dec.Stale = true
 		dec.StalenessSeconds = -1 // sentinel: "unknown/unparseable age"
 	} else {
-		dec.Stale = staleness > policy.MaxStaleness
+		dec.Stale = staleness > effectiveMax
 	}
 
 	if !dec.Stale {

--- a/pkg/skillctl/verify/freshness_managed_test.go
+++ b/pkg/skillctl/verify/freshness_managed_test.go
@@ -1,0 +1,118 @@
+package verify
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// managedRootYAML builds a valid enterprise-MANAGED trust-roots file (offline_policy
+// enterprise: true) with a pinned reviewer but NO max_staleness and NO
+// require_signed_governance set — the FR-0090 IS-T5 defaulting must fill both in.
+func managedRootYAML(t *testing.T) string {
+	t.Helper()
+	regKey := validPubkeyB64(t)
+	revKey := validPubkeyB64(t)
+	return `trust_roots:
+  - registry_url: https://managed.example.com/api/skills
+    registry_keys:
+      - id: k1
+        pubkey: ` + regKey + `
+        issued: 2026-06-24
+    identity_keys_authorized: from-registry
+    governance_minimum: green
+    reviewers:
+      - id: id:reviewer@org
+        pubkey: ` + revKey + `
+    offline_policy:
+      enterprise: true
+`
+}
+
+// TestManagedTrustRootDefaults is the FR-0090 IS-T5 loader half: a managed root with
+// unset knobs is stamped with the fail-closed defaults at Load — max_staleness = 48h
+// and require_signed_governance ON. Against the old loader both stay unset (0 / false),
+// so the freshness contract has "no ceiling" and governance is advisory.
+func TestManagedTrustRootDefaults(t *testing.T) {
+	tr, err := Load(writeRootsFile(t, managedRootYAML(t)))
+	if err != nil {
+		t.Fatalf("managed root should load: %v", err)
+	}
+	root := tr.Roots[0]
+	if !root.IsManaged() {
+		t.Fatal("root should be managed (offline_policy.enterprise: true)")
+	}
+	if root.MaxStaleness != "48h" {
+		t.Errorf("managed max_staleness default = %q, want 48h", root.MaxStaleness)
+	}
+	if !root.RequireSignedGovernance {
+		t.Error("managed require_signed_governance default = false, want true (fail-closed)")
+	}
+	fp, err := root.Freshness()
+	if err != nil {
+		t.Fatalf("Freshness: %v", err)
+	}
+	if fp.MaxStaleness != 48*time.Hour {
+		t.Errorf("resolved MaxStaleness = %v, want 48h", fp.MaxStaleness)
+	}
+	if !fp.Managed {
+		t.Error("resolved policy.Managed = false, want true")
+	}
+}
+
+// TestManagedRootStaleHighRiskDenied is the FR-0090 IS-T5 enforcement half: a managed
+// root, an unreachable feed (so the last snapshot is old), a clock past the 48h
+// ceiling, and a HIGH-risk invocation of a since-revoked digest → DENY with
+// ErrRevocationStale. Against the old code the managed root had no ceiling, so
+// EvaluateFreshness returned Allowed=true ("no_staleness_ceiling") and the stale
+// snapshot would have been trusted — the since-revoked digest would run.
+func TestManagedRootStaleHighRiskDenied(t *testing.T) {
+	tr, err := Load(writeRootsFile(t, managedRootYAML(t)))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	policy, err := tr.Roots[0].Freshness()
+	if err != nil {
+		t.Fatalf("Freshness: %v", err)
+	}
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	issuedAt := now.Add(-72 * time.Hour).Format(time.RFC3339) // last sync 72h ago > 48h ceiling
+
+	dec, err := EvaluateFreshness(7, issuedAt, policy, RiskHigh, now)
+	if err == nil || !errors.Is(err, ErrRevocationStale) {
+		t.Fatalf("stale managed high-risk must deny with ErrRevocationStale, got err=%v", err)
+	}
+	if dec.Allowed {
+		t.Error("decision must be denied (Allowed=false)")
+	}
+	if !dec.Stale {
+		t.Error("decision must record Stale=true")
+	}
+	if dec.Reason != "stale_high_risk_fail_closed" {
+		t.Errorf("reason = %q, want stale_high_risk_fail_closed", dec.Reason)
+	}
+}
+
+// TestManagedPolicyNoCeilingIsBeltAndSuspenders proves the freshness.go guard bites
+// even on a HAND-CONSTRUCTED managed policy whose MaxStaleness is 0 (bypassing the
+// loader): the effective ceiling is forced to 48h so a stale high-risk action is
+// denied. The non-managed control with the same 0 ceiling is ALLOWED — "no ceiling"
+// applies ONLY to non-managed roots.
+func TestManagedPolicyNoCeilingIsBeltAndSuspenders(t *testing.T) {
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	stale := now.Add(-72 * time.Hour).Format(time.RFC3339)
+
+	// Managed, MaxStaleness deliberately 0 (hand-constructed) → 48h fail-closed.
+	managed := FreshnessPolicy{Managed: true} // MaxStaleness == 0
+	dec, err := EvaluateFreshness(1, stale, managed, RiskHigh, now)
+	if err == nil || !errors.Is(err, ErrRevocationStale) || dec.Allowed {
+		t.Fatalf("managed policy with MaxStaleness=0 must still fail closed past 48h; err=%v allowed=%v reason=%q", err, dec.Allowed, dec.Reason)
+	}
+
+	// Non-managed, MaxStaleness 0 → genuinely no ceiling (pre-SPEC-0279 default).
+	unmanaged := FreshnessPolicy{} // Managed == false, MaxStaleness == 0
+	dec2, err2 := EvaluateFreshness(1, stale, unmanaged, RiskHigh, now)
+	if err2 != nil || !dec2.Allowed || dec2.Reason != "no_staleness_ceiling" {
+		t.Fatalf("non-managed no-ceiling must allow; err=%v allowed=%v reason=%q", err2, dec2.Allowed, dec2.Reason)
+	}
+}

--- a/pkg/skillctl/verify/trustroots.go
+++ b/pkg/skillctl/verify/trustroots.go
@@ -374,6 +374,15 @@ func (t *TrustRoot) IsManaged() bool {
 // root an explicit false is therefore promoted to true (fail-closed). An operator who
 // genuinely wants signed governance off on such a host would have to drop the
 // reviewers or the enterprise flag. This is the safe direction for a managed fleet.
+//
+// SCOPE (challenge-gate NOTE-1): this default makes the freshness EVALUATION
+// (EvaluateFreshness) deny a stale high-risk verdict on a managed root. The RUNTIME
+// revoked-snapshot gate (cmd/skillctl verify-hook, revocationSnapshotStale) additionally
+// short-circuits to a no-op when the host has NEVER adopted a signed revocation HEAD —
+// so a managed host that has not yet bootstrapped a freshness anchor is not yet covered
+// against a WITHHELD upstream revoke. FR-0090/IS-T5 closes the anchor-PRESENT case (an
+// adopted-but-stale snapshot is no longer trusted); HEAD-adoption bootstrap is tracked
+// under FR-0045 D2 (same scoping as the g5 kill-switch).
 func (t *TrustRoots) applyManagedDefaults() {
 	for i := range t.Roots {
 		if !t.Roots[i].IsManaged() {

--- a/pkg/skillctl/verify/trustroots.go
+++ b/pkg/skillctl/verify/trustroots.go
@@ -341,6 +341,53 @@ func (t *TrustRoot) ResolveOfflinePolicy() (statemachine.OfflinePolicy, error) {
 	}, nil
 }
 
+// IsManaged reports whether this trust root is enterprise-MANAGED — i.e. it carries
+// an offline_policy with enterprise: true (the same gate that enables the `locked`
+// state, SPEC-0317). A managed root gets the FR-0090 IS-T5 fail-closed defaults
+// (max_staleness = 48h, require_signed_governance ON) that the shipped self/unmanaged
+// host does not, and its freshness contract therefore always has a staleness ceiling.
+func (t *TrustRoot) IsManaged() bool {
+	return t != nil && t.OfflinePolicy != nil && t.OfflinePolicy.Enterprise
+}
+
+// applyManagedDefaults stamps the FR-0090 IS-T5 fail-closed defaults onto every
+// MANAGED (enterprise) root whose knobs are unset, BEFORE validate() runs (so the
+// require_signed_governance⇒reviewers invariant is enforced against the defaulted
+// value). A managed host must never trust an unbounded-age revocation snapshot, and
+// should require signed governance wherever it CAN enforce it. Non-managed roots are
+// untouched — the shipped self/unmanaged behaviour is preserved.
+//
+//   - max_staleness → 48h UNCONDITIONALLY for a managed root. This never depends on
+//     other fields and never fails validate, so the freshness ceiling always applies.
+//
+//   - require_signed_governance → ON, but ONLY when the managed root PINS REVIEWERS.
+//     The invariant require_signed_governance⇒non-empty reviewers (validate) means the
+//     flag cannot be enforced without reviewer keys; a managed root that pins reviewers
+//     clearly intends signed governance, so defaulting it ON when unset is the safe
+//     reading. A managed root that pins NO reviewers uses `enterprise` purely for the
+//     SPEC-0317 offline state machine (the `locked` state) and has no key to verify a
+//     governance signature against — forcing the flag there would only brick Load, so
+//     it is left off (the 48h staleness ceiling still applies).
+//
+// NOTE (flagged for the challenge gate): require_signed_governance is a bool, so
+// "unset" is indistinguishable from an explicit `false`. On a reviewer-pinned managed
+// root an explicit false is therefore promoted to true (fail-closed). An operator who
+// genuinely wants signed governance off on such a host would have to drop the
+// reviewers or the enterprise flag. This is the safe direction for a managed fleet.
+func (t *TrustRoots) applyManagedDefaults() {
+	for i := range t.Roots {
+		if !t.Roots[i].IsManaged() {
+			continue
+		}
+		if strings.TrimSpace(t.Roots[i].MaxStaleness) == "" {
+			t.Roots[i].MaxStaleness = managedDefaultMaxStalenessStr
+		}
+		if !t.Roots[i].RequireSignedGovernance && len(t.Roots[i].Reviewers) > 0 {
+			t.Roots[i].RequireSignedGovernance = true
+		}
+	}
+}
+
 // ActiveKeys returns the subset of RegistryKeys that are not retired. It
 // preserves the original order so error messages stay deterministic.
 func (t TrustRoot) ActiveKeys() []RegistryKey {
@@ -555,6 +602,10 @@ func Load(path string) (*TrustRoots, error) {
 		return nil, fmt.Errorf("trust-roots: parse %s: %w", abs, err)
 	}
 	tr.Path = abs
+
+	// FR-0090 IS-T5: stamp managed (enterprise) fail-closed defaults BEFORE validate,
+	// so the require_signed_governance⇒reviewers invariant sees the defaulted value.
+	tr.applyManagedDefaults()
 
 	if err := tr.validate(); err != nil {
 		return nil, fmt.Errorf("trust-roots: validate %s: %w", abs, err)


### PR DESCRIPTION
P0 remediation · **App/Trust lens · the #1 finding** · frozen §7-gauntlet trust-core. Closes **IS-01, IS-02, IS-03** (+ IS-T5 fail-closed defaults).

## What

A trust decision may only read event **kind** + target **digest** from the **SIGNED** SPEC-0190 envelope — never from an unsigned carrier projection (git filename/dirname, ER1 `skill-event:<kind>` tag). New leaf pkg **`pkg/skillctl/trustcore`** (`KindFromSignedEnvelope`, `SignedDigest`, `ValidDigest`) now feeds:
- git `Events()`, OCI `Events()`, ER1 `Events()` + `loadAttestRevoke`/`loadAttestAccumulator`
- the gauntlet dispatch (`backend_pull.go`), gossip `unionVerifiedRevokes`, and `OfferRevoke`/`OfferAttest` (which now **require** the signed `revoked_by` / `reviewer_id`+`governance_level` shape).
- **IS-T5** fail-closed managed-root defaults: `max_staleness=48h` + `require_signed_governance` (when reviewers pinned).

**No canonical/signed bytes or wire format touched** — only consumer-side derivation. The OCI backend was refactored onto the shared helper with byte-identical behavior (its frozen suite passes).

## Adversarial challenge gate — 3 lenses, all **PASS_WITH_NOTES**, no BLOCK

- **Security:** no remaining unsigned-projection trust path; classifier fail-safe toward DENY; defense-in-depth layered (route-by-signed-shape ∧ re-check-by-discriminator ∧ re-verify-signature); wire format unchanged.
- **Attack-chain:** 4/5 chains DEFEATED (git relabel, gossip/gauntlet Kind+Digest lie, redirect-onto-Y, managed+high-risk freshness withholding). Readiness 88/100.
- **Correctness:** build/vet/test green; **3/3 regressions empirically bite** (revert→fail→restore); OCI wire-format byte-identical; no weakened assertions.

## Fixes applied in response to the gate
- OCI `Events()` digest check unified on `trustcore.ValidDigest` (LOW parity, both lenses).
- **Honest comment scoping** (no overclaim): ER1 classification closes the tag projection only for *fetched* items; **discovery is still gated on `skill-event:<kind>`**, so a retag to an unsearched value (e.g. `…:installed`) drops an item before the classifier.

## Tracked follow-ups (honest residuals — not regressions)
- **IS-T4b:** de-gate ER1 event *discovery* from the `skill-event:<kind>` tag (search the stable bundle tags, classify all) → full git parity, closes the ER1 CHAIN-A residual. Relevant to the shared/cross-person ER1 case (SPEC-0246). *Separate, separately-verified PR.*
- **IS-T5 anchor:** the 48h managed ceiling covers the anchor-*present* case; HEAD-adoption bootstrap tracked under **FR-0045 D2** (same scope as the g5 kill-switch).

**Verification:** `go build/vet` clean; affected suites green; regressions proven to bite. Pre-existing `cmd/thinking-engine` env failures are unrelated (this branch touches 0 lines there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)