### PR TITLE
P1 · Trust/Authz — signed-mandate scope enforcement (IS-T4b/T6/T7)

### DIFF
--- a/cmd/skillctl/agentid_gate.go
+++ b/cmd/skillctl/agentid_gate.go
@@ -155,14 +155,17 @@ func authorizeAgentForSkill(home, skill string) agentAuthzResult {
 	// whose signed manifest exceeds the mandate's granted scope is DENIED even though
 	// it is named in the grant. Fail-closed by construction.
 	req, resolved := skillRequirementsFn(home, skill)
-	if !resolved && grantIsRestricting(doc.Payload.Grant) {
-		// A bundle digest IS on record for this skill, but its signed manifest could
-		// not be read + digest-verified (missing/unreadable stashed .skb, or a digest
-		// mismatch). For a RESTRICTING grant that is a fail-closed DENY: a same-uid
-		// actor could otherwise `rm ~/.claude/skills/<skill>/*.skb` to strip scope
-		// enforcement down to name-only and slip an over-scoped skill through. We refuse
-		// to authorize a scope we cannot confirm — mirroring the IS-T6 deleted-mandate
-		// → deny posture. A NON-restricting grant keeps the name-only never-brick path.
+	if !resolved && grantIsRestricting(doc.Payload.Grant) && doc.Payload.Grant.AllowsSkill(skill) {
+		// A managed bundle demonstrably exists for this IN-GRANT skill, but its signed
+		// scope could not be resolved + digest-verified (no provenance basis at all, a
+		// missing/unreadable stashed .skb, or a digest mismatch). For a RESTRICTING
+		// grant that is a fail-closed DENY: a same-uid actor could otherwise delete the
+		// provenance files (`.m3c-provenance.json` / `.skillctl-offline.json`) or the
+		// stashed `*.skb` to strip scope enforcement down to name-only and slip an
+		// over-scoped skill through. We refuse to authorize a scope we cannot confirm —
+		// mirroring the IS-T6 deleted-mandate → deny posture. A NON-restricting grant
+		// keeps the name-only never-brick path; a skill NOT named in the grant falls
+		// through to the AuthorizeSkillScoped name check below (skill_not_in_grant).
 		res.Allowed = false
 		res.Reason = "skill_requirements_unresolved"
 		return res
@@ -205,20 +208,29 @@ var skillRequirementsFn = resolveInstalledSkillRequirements
 // provenance sidecar's recorded bundle_digest before returning the manifest map — a
 // tampered manifest breaks the digest and yields nothing.
 //
-// The (req, resolved) contract distinguishes two "empty" cases the gate must treat
-// differently:
-//   - NO digest on record (a genuine legacy/unmanaged skill, or the gate's fake-skb
-//     test fixtures) → (empty, TRUE): name-only enforcement is correct; never-brick.
-//   - a digest IS on record but the .skb is absent/unreadable, or the manifest fails
-//     the digest check → (empty, FALSE): the code KNOWS a bundle should exist but
-//     cannot confirm its scope. The gate fails this CLOSED for a restricting grant
-//     (a same-uid actor must not be able to delete the .skb to escape enforcement).
+// The (req, resolved) contract distinguishes the "empty" cases the gate must treat
+// differently. The anchor is whether a MANAGED BASIS exists — a stashed .skb — and
+// whether its digest is resolvable from any recorded basis (provenance sidecar OR
+// the `skillctl install` offline stash, see installedSkillDigest):
+//   - NO managed basis at all (no stashed .skb, no digest on record) → a genuine
+//     legacy/unmanaged skill → (empty, TRUE): name-only is correct; never-brick.
+//   - a stashed .skb IS present but NO digest resolves from any basis (both the
+//     provenance sidecar and the offline stash are absent/unreadable — e.g. a
+//     same-uid actor deleted them to strip enforcement) → (empty, FALSE): a bundle
+//     demonstrably exists but its scope cannot be confirmed.
+//   - a digest IS on record but the .skb is absent/unreadable, or the manifest
+//     fails the digest check → (empty, FALSE): same "cannot confirm scope".
+// The gate fails every (empty, FALSE) case CLOSED for a restricting grant, so a
+// same-uid actor cannot delete provenance to downgrade enforcement to name-only.
 func resolveInstalledSkillRequirements(home, skill string) (agentid.SkillRequirements, bool) {
 	digest := installedSkillDigest(home, skill)
-	if digest == "" {
-		return agentid.SkillRequirements{}, true // genuine legacy/unmanaged → name-only, never-brick
-	}
 	skbPath := stashedSkbPath(home, skill)
+	if digest == "" {
+		if skbPath == "" {
+			return agentid.SkillRequirements{}, true // no managed basis → name-only, never-brick
+		}
+		return agentid.SkillRequirements{}, false // managed .skb present but no resolvable digest → unconfirmable
+	}
 	if skbPath == "" {
 		return agentid.SkillRequirements{}, false // digest on record but no .skb → scope unconfirmable
 	}
@@ -300,7 +312,7 @@ func requirementsFromManifest(m map[string]any) agentid.SkillRequirements {
 		if net, _ := intent["network"].(bool); net {
 			addIntent("network:write") // a skill asserting outbound network needs the network:write capability
 		}
-		if sp, ok := intent["subprocess"].([]any); ok && len(sp) > 0 {
+		if subprocessDeclared(intent["subprocess"]) {
 			addIntent("subprocess:exec")
 		}
 		if d, _ := intent["destructive"].(bool); d {
@@ -320,14 +332,43 @@ func requirementsFromManifest(m map[string]any) agentid.SkillRequirements {
 	return req
 }
 
+// subprocessDeclared reports whether a signed intent.subprocess value declares a
+// subprocess/shell capability in ANY of its encodings: a non-empty argv list (the
+// documented form), a bool true, a non-empty command string, or a non-empty
+// object. Only an absent / false / empty value means "no subprocess"; every other
+// non-empty shape is treated as declared (fail-closed), so a skill cannot dodge
+// the subprocess:exec requirement by encoding its declaration as a scalar or map.
+func subprocessDeclared(v any) bool {
+	switch t := v.(type) {
+	case nil:
+		return false
+	case bool:
+		return t
+	case string:
+		return strings.TrimSpace(t) != ""
+	case []any:
+		return len(t) > 0
+	case map[string]any:
+		return len(t) > 0
+	default:
+		return true // an unexpected non-empty encoding → fail-closed, treat as declared
+	}
+}
+
 // intentForKindAccess maps a signed data_dependency (SPEC-0196 kind + access) to
 // the "<category>:<action>" capability-intent token a mandate grant uses, so the
 // skill's signed data access is checked in the grant's own vocabulary
-// (http read → "network:read"; local_fs write → "fs:write"). An unknown kind maps
-// to "" (contributes no intent). An unknown access surfaces verbatim so it fails
-// set-membership unless the operator granted exactly it (fail-closed).
+// (http read → "network:read"; local_fs write → "fs:write"). An unknown kind is
+// carried VERBATIM as its own category (fail-closed): it fails set-membership
+// unless the operator granted exactly it, rather than silently contributing no
+// intent (pack-time already rejects unknown kinds, so this is defense-in-depth).
+// An empty kind contributes nothing. An unknown access likewise surfaces verbatim.
 func intentForKindAccess(kind, access string) string {
-	cat := ""
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		return "" // no declared kind → no derived intent
+	}
+	var cat string
 	switch kind {
 	case "local_fs":
 		cat = "fs"
@@ -342,7 +383,7 @@ func intentForKindAccess(kind, access string) string {
 	case "secrets_store":
 		cat = "secrets"
 	default:
-		return "" // unknown kind → no derived intent
+		cat = kind // unknown kind → verbatim category, fails membership unless granted
 	}
 	act := "read"
 	switch strings.TrimSpace(access) {

--- a/cmd/skillctl/agentid_gate.go
+++ b/cmd/skillctl/agentid_gate.go
@@ -154,7 +154,19 @@ func authorizeAgentForSkill(home, skill string) agentAuthzResult {
 	// declares in its DIGEST-VERIFIED bundle.json (SPEC-0277 IS-04 / IS-T7). A skill
 	// whose signed manifest exceeds the mandate's granted scope is DENIED even though
 	// it is named in the grant. Fail-closed by construction.
-	req := skillRequirementsFn(home, skill)
+	req, resolved := skillRequirementsFn(home, skill)
+	if !resolved && grantIsRestricting(doc.Payload.Grant) {
+		// A bundle digest IS on record for this skill, but its signed manifest could
+		// not be read + digest-verified (missing/unreadable stashed .skb, or a digest
+		// mismatch). For a RESTRICTING grant that is a fail-closed DENY: a same-uid
+		// actor could otherwise `rm ~/.claude/skills/<skill>/*.skb` to strip scope
+		// enforcement down to name-only and slip an over-scoped skill through. We refuse
+		// to authorize a scope we cannot confirm — mirroring the IS-T6 deleted-mandate
+		// → deny posture. A NON-restricting grant keeps the name-only never-brick path.
+		res.Allowed = false
+		res.Reason = "skill_requirements_unresolved"
+		return res
+	}
 	if r, ok := doc.Payload.Grant.AuthorizeSkillScoped(skill, req); !ok {
 		res.Allowed = false
 		res.Reason = r // skill_not_in_grant | intent_not_in_grant | data_scope_not_in_grant | limit_exceeded
@@ -164,41 +176,57 @@ func authorizeAgentForSkill(home, skill string) agentAuthzResult {
 	return res
 }
 
+// grantIsRestricting reports whether the grant bounds anything BEYOND the skill
+// name — i.e. it names capability intents, data-scopes, or resource limits. When it
+// does, an UNRESOLVABLE signed manifest (a digest is on record but its .skb can't be
+// read) must fail closed rather than silently degrade to name-only enforcement.
+func grantIsRestricting(g agentid.Grant) bool {
+	return len(g.Intents) > 0 || len(g.DataScopes) > 0 || len(g.Limits) > 0
+}
+
 // skillRequirementsFn resolves an installed skill's author-signed declared
 // requirements (intents / data-scopes / limits) from its digest-verified
-// bundle.json. Seam so tests can drive the scope-enforcement branch without minting
-// a real .skb; production points it at resolveInstalledSkillRequirements.
+// bundle.json. The second result is `resolved`: true when the requirements are
+// authoritative (either a genuine legacy/unmanaged skill with NO digest on record →
+// empty req → name-only, OR a successful digest-verified read), false ONLY when a
+// bundle digest IS on record but its signed manifest could not be read+verified.
+// Seam so tests can drive the scope-enforcement branch without minting a real .skb;
+// production points it at resolveInstalledSkillRequirements.
 var skillRequirementsFn = resolveInstalledSkillRequirements
 
 // resolveInstalledSkillRequirements resolves an installed skill's author-signed
 // declared requirements from its DIGEST-VERIFIED bundle.json:
-//   - the capability intents its data_dependencies imply (kind+access →
-//     "<category>:<action>", the SAME vocabulary a mandate grant uses),
+//   - the capability intents its data_dependencies + signed `intent` block imply,
 //   - the data-scope ids it declares (data_dependencies[].id),
 //   - any declared resource ceilings (a `limits` block; forward-compatible).
 //
 // The bytes are trustworthy ONLY because verify.ReadDigestVerifiedManifest
 // recomputes the on-disk .skb digest and constant-time-compares it against the
 // provenance sidecar's recorded bundle_digest before returning the manifest map — a
-// tampered manifest breaks the digest and yields nothing. When the digest or the
-// stashed .skb cannot be resolved (e.g. a legacy sidecar-only install with no .skb
-// on disk, or the gate's fake-skb test fixtures), we return an EMPTY requirement
-// set: the gate then enforces skill-NAME membership only (the pre-IS-T7 P1
-// behaviour), and NEVER a fabricated scope.
-func resolveInstalledSkillRequirements(home, skill string) agentid.SkillRequirements {
+// tampered manifest breaks the digest and yields nothing.
+//
+// The (req, resolved) contract distinguishes two "empty" cases the gate must treat
+// differently:
+//   - NO digest on record (a genuine legacy/unmanaged skill, or the gate's fake-skb
+//     test fixtures) → (empty, TRUE): name-only enforcement is correct; never-brick.
+//   - a digest IS on record but the .skb is absent/unreadable, or the manifest fails
+//     the digest check → (empty, FALSE): the code KNOWS a bundle should exist but
+//     cannot confirm its scope. The gate fails this CLOSED for a restricting grant
+//     (a same-uid actor must not be able to delete the .skb to escape enforcement).
+func resolveInstalledSkillRequirements(home, skill string) (agentid.SkillRequirements, bool) {
 	digest := installedSkillDigest(home, skill)
 	if digest == "" {
-		return agentid.SkillRequirements{}
+		return agentid.SkillRequirements{}, true // genuine legacy/unmanaged → name-only, never-brick
 	}
 	skbPath := stashedSkbPath(home, skill)
 	if skbPath == "" {
-		return agentid.SkillRequirements{}
+		return agentid.SkillRequirements{}, false // digest on record but no .skb → scope unconfirmable
 	}
 	manifest, err := verify.ReadDigestVerifiedManifest(skbPath, digest)
 	if err != nil {
-		return agentid.SkillRequirements{}
+		return agentid.SkillRequirements{}, false // digest on record but manifest unverifiable
 	}
-	return requirementsFromManifest(manifest)
+	return requirementsFromManifest(manifest), true
 }
 
 // stashedSkbPath returns the path to the first stashed .skb inside an installed
@@ -222,8 +250,21 @@ func stashedSkbPath(home, skill string) string {
 // agentid.SkillRequirements the grant is checked against.
 func requirementsFromManifest(m map[string]any) agentid.SkillRequirements {
 	var req agentid.SkillRequirements
+	seenIntent := map[string]struct{}{}
+	addIntent := func(tok string) {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			return
+		}
+		if _, dup := seenIntent[tok]; dup {
+			return
+		}
+		seenIntent[tok] = struct{}{}
+		req.Intents = append(req.Intents, tok)
+	}
+
+	// (1) Intents the signed data_dependencies imply (kind+access), plus their ids.
 	if deps, ok := m["data_dependencies"].([]any); ok {
-		seenIntent := map[string]struct{}{}
 		for _, d := range deps {
 			dm, ok := d.(map[string]any)
 			if !ok {
@@ -234,15 +275,40 @@ func requirementsFromManifest(m map[string]any) agentid.SkillRequirements {
 			}
 			kind, _ := dm["kind"].(string)
 			access, _ := dm["access"].(string)
-			if intent := intentForKindAccess(kind, access); intent != "" {
-				if _, dup := seenIntent[intent]; !dup {
-					seenIntent[intent] = struct{}{}
-					req.Intents = append(req.Intents, intent)
+			addIntent(intentForKindAccess(kind, access))
+		}
+	}
+
+	// (2) The SIGNED `intent` block is ITSELF a capability declaration — the exact
+	// class operators most want to restrict (network egress, subprocess/shell,
+	// destructive ops, arbitrary side-effects). A skill can declare these with NO
+	// data_dependencies entry (e.g. an http-egress or shell-spawning skill whose only
+	// declared "data" is read-shaped), so reading data_dependencies ALONE let such a
+	// skill pass a grant that never granted those capabilities — a false-security
+	// overclaim. Union the intent block's declared tokens into the required intents so
+	// the grant must cover them. side_effects are the authoritative SPEC-0196 §5
+	// vocabulary ("fs:write", "network:outbound", "subprocess", "llm:call", …); the
+	// network/subprocess/destructive flags are folded to stable capability tokens.
+	if intent, ok := m["intent"].(map[string]any); ok {
+		if ses, ok := intent["side_effects"].([]any); ok {
+			for _, s := range ses {
+				if t, _ := s.(string); strings.TrimSpace(t) != "" {
+					addIntent(strings.TrimSpace(t))
 				}
 			}
 		}
+		if net, _ := intent["network"].(bool); net {
+			addIntent("network:write") // a skill asserting outbound network needs the network:write capability
+		}
+		if sp, ok := intent["subprocess"].([]any); ok && len(sp) > 0 {
+			addIntent("subprocess:exec")
+		}
+		if d, _ := intent["destructive"].(bool); d {
+			addIntent("destructive")
+		}
 	}
-	// Declared resource ceilings (forward-compatible: today's bundle.json carries
+
+	// (3) Declared resource ceilings (forward-compatible: today's bundle.json carries
 	// none; a future `limits` block is enforced against the grant's caps). Values are
 	// stringified so a JSON number (float64) and a JSON string compare identically.
 	if lim, ok := m["limits"].(map[string]any); ok && len(lim) > 0 {
@@ -280,8 +346,8 @@ func intentForKindAccess(kind, access string) string {
 	}
 	act := "read"
 	switch strings.TrimSpace(access) {
-	case "write", "transform":
-		act = "write"
+	case "write", "transform", "egress":
+		act = "write" // any mutating / outbound-egress access is the "write" capability
 	case "", "read", "passthrough":
 		act = "read"
 	default:

--- a/cmd/skillctl/agentid_gate.go
+++ b/cmd/skillctl/agentid_gate.go
@@ -390,7 +390,7 @@ func intentForKindAccess(kind, access string) string {
 	case "write", "transform", "egress":
 		act = "write" // any mutating / outbound-egress access is the "write" capability
 	case "", "read", "passthrough":
-		act = "read"
+		// keep the "read" default (read/passthrough/unspecified access is read-only)
 	default:
 		act = strings.TrimSpace(access) // unknown → verbatim, fails membership unless granted
 	}

--- a/cmd/skillctl/agentid_gate.go
+++ b/cmd/skillctl/agentid_gate.go
@@ -23,10 +23,13 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/agentid"
+	"github.com/kamir/m3c-tools/pkg/skillctl/pin"
 	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
 )
 
@@ -78,6 +81,25 @@ type agentAuthzResult struct {
 // at verifyActiveAgentID.
 var agentIDVerifyForGateFn = verifyActiveAgentID
 
+// gateRequireAgentMandate reports whether the ROOT-OWNED managed settings engage
+// the SPEC-0277 IS-06 require-mandate floor (`skillctlRequireAgentMandate: true`).
+// When set, a MISSING ~/.claude/skillctl/agentid.json is a DENY at the gate rather
+// than the silent opt-out default — a non-privileged user cannot delete the mandate
+// to escape agent authorization. Same conservative, never-brick contract as
+// gateManagedEnterprise: a missing/unreadable/malformed managed file → false (an
+// unreadable managed file must never itself deny every skill). Seam: tests set it.
+var gateRequireAgentMandate = func() bool {
+	path, err := pin.DefaultManagedSettingsPath()
+	if err != nil {
+		return false
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return pin.RequireAgentMandateFromBytes(b)
+}
+
 // authorizeAgentForSkill is the gate's AgentID authorization entry point. It
 // loads the active mandate (if any), verifies it offline, attributes the actor,
 // and decides whether `skill` is within the grant. Fail-closed by construction:
@@ -97,8 +119,15 @@ func authorizeAgentForSkill(home, skill string) agentAuthzResult {
 	}
 	doc, err := loadAgentIDFile(activeAgentIDPath(home))
 	if err != nil {
-		// No mandate configured (the common case) → opt-in: not engaged.
+		// No mandate configured (the common case).
 		if errors.Is(err, os.ErrNotExist) {
+			// SPEC-0277 IS-06: a root-owned require-mandate floor turns the MISSING
+			// mandate from a silent opt-OUT into a hard DENY, so a non-privileged user
+			// cannot delete agentid.json to escape agent authorization. Absent the
+			// floor, keep the opt-in default (no mandate → skill chain only).
+			if gateRequireAgentMandate() {
+				return agentAuthzResult{Configured: true, Allowed: false, Reason: "agent_mandate_required"}
+			}
 			return agentAuthzResult{Configured: false}
 		}
 		// A PRESENT-but-unreadable mandate is suspicious: the operator clearly
@@ -120,14 +149,145 @@ func authorizeAgentForSkill(home, skill string) agentAuthzResult {
 		return res
 	}
 
-	// Mandate verified → authorize the skill against the grant (fail-closed).
-	if r, ok := doc.Payload.Grant.AuthorizeSkill(skill, nil); !ok {
+	// Mandate verified → authorize the skill against the grant, enforcing not just
+	// the skill NAME but the capability intents / data-scopes / limits the skill
+	// declares in its DIGEST-VERIFIED bundle.json (SPEC-0277 IS-04 / IS-T7). A skill
+	// whose signed manifest exceeds the mandate's granted scope is DENIED even though
+	// it is named in the grant. Fail-closed by construction.
+	req := skillRequirementsFn(home, skill)
+	if r, ok := doc.Payload.Grant.AuthorizeSkillScoped(skill, req); !ok {
 		res.Allowed = false
-		res.Reason = r // "skill_not_in_grant"
+		res.Reason = r // skill_not_in_grant | intent_not_in_grant | data_scope_not_in_grant | limit_exceeded
 		return res
 	}
 	res.Allowed = true
 	return res
+}
+
+// skillRequirementsFn resolves an installed skill's author-signed declared
+// requirements (intents / data-scopes / limits) from its digest-verified
+// bundle.json. Seam so tests can drive the scope-enforcement branch without minting
+// a real .skb; production points it at resolveInstalledSkillRequirements.
+var skillRequirementsFn = resolveInstalledSkillRequirements
+
+// resolveInstalledSkillRequirements resolves an installed skill's author-signed
+// declared requirements from its DIGEST-VERIFIED bundle.json:
+//   - the capability intents its data_dependencies imply (kind+access →
+//     "<category>:<action>", the SAME vocabulary a mandate grant uses),
+//   - the data-scope ids it declares (data_dependencies[].id),
+//   - any declared resource ceilings (a `limits` block; forward-compatible).
+//
+// The bytes are trustworthy ONLY because verify.ReadDigestVerifiedManifest
+// recomputes the on-disk .skb digest and constant-time-compares it against the
+// provenance sidecar's recorded bundle_digest before returning the manifest map — a
+// tampered manifest breaks the digest and yields nothing. When the digest or the
+// stashed .skb cannot be resolved (e.g. a legacy sidecar-only install with no .skb
+// on disk, or the gate's fake-skb test fixtures), we return an EMPTY requirement
+// set: the gate then enforces skill-NAME membership only (the pre-IS-T7 P1
+// behaviour), and NEVER a fabricated scope.
+func resolveInstalledSkillRequirements(home, skill string) agentid.SkillRequirements {
+	digest := installedSkillDigest(home, skill)
+	if digest == "" {
+		return agentid.SkillRequirements{}
+	}
+	skbPath := stashedSkbPath(home, skill)
+	if skbPath == "" {
+		return agentid.SkillRequirements{}
+	}
+	manifest, err := verify.ReadDigestVerifiedManifest(skbPath, digest)
+	if err != nil {
+		return agentid.SkillRequirements{}
+	}
+	return requirementsFromManifest(manifest)
+}
+
+// stashedSkbPath returns the path to the first stashed .skb inside an installed
+// skill's directory (~/.claude/skills/<skill>/), or "" if none. This is the same
+// on-disk .skb whose bytes carry the author-signature-covered bundle.json.
+func stashedSkbPath(home, skill string) string {
+	dir := filepath.Join(home, ".claude", "skills", skill)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".skb") {
+			return filepath.Join(dir, e.Name())
+		}
+	}
+	return ""
+}
+
+// requirementsFromManifest projects a digest-verified bundle.json map into the
+// agentid.SkillRequirements the grant is checked against.
+func requirementsFromManifest(m map[string]any) agentid.SkillRequirements {
+	var req agentid.SkillRequirements
+	if deps, ok := m["data_dependencies"].([]any); ok {
+		seenIntent := map[string]struct{}{}
+		for _, d := range deps {
+			dm, ok := d.(map[string]any)
+			if !ok {
+				continue
+			}
+			if id, _ := dm["id"].(string); strings.TrimSpace(id) != "" {
+				req.DataScopes = append(req.DataScopes, strings.TrimSpace(id))
+			}
+			kind, _ := dm["kind"].(string)
+			access, _ := dm["access"].(string)
+			if intent := intentForKindAccess(kind, access); intent != "" {
+				if _, dup := seenIntent[intent]; !dup {
+					seenIntent[intent] = struct{}{}
+					req.Intents = append(req.Intents, intent)
+				}
+			}
+		}
+	}
+	// Declared resource ceilings (forward-compatible: today's bundle.json carries
+	// none; a future `limits` block is enforced against the grant's caps). Values are
+	// stringified so a JSON number (float64) and a JSON string compare identically.
+	if lim, ok := m["limits"].(map[string]any); ok && len(lim) > 0 {
+		req.Limits = make(map[string]string, len(lim))
+		for k, v := range lim {
+			req.Limits[k] = fmt.Sprint(v)
+		}
+	}
+	return req
+}
+
+// intentForKindAccess maps a signed data_dependency (SPEC-0196 kind + access) to
+// the "<category>:<action>" capability-intent token a mandate grant uses, so the
+// skill's signed data access is checked in the grant's own vocabulary
+// (http read → "network:read"; local_fs write → "fs:write"). An unknown kind maps
+// to "" (contributes no intent). An unknown access surfaces verbatim so it fails
+// set-membership unless the operator granted exactly it (fail-closed).
+func intentForKindAccess(kind, access string) string {
+	cat := ""
+	switch kind {
+	case "local_fs":
+		cat = "fs"
+	case "http_endpoint":
+		cat = "network"
+	case "er1_collection":
+		cat = "er1"
+	case "firestore_collection":
+		cat = "firestore"
+	case "gcs_bucket":
+		cat = "gcs"
+	case "secrets_store":
+		cat = "secrets"
+	default:
+		return "" // unknown kind → no derived intent
+	}
+	act := "read"
+	switch strings.TrimSpace(access) {
+	case "write", "transform":
+		act = "write"
+	case "", "read", "passthrough":
+		act = "read"
+	default:
+		act = strings.TrimSpace(access) // unknown → verbatim, fails membership unless granted
+	}
+	return cat + ":" + act
 }
 
 // verifyActiveAgentID runs the offline AgentID verification against the SAME

--- a/cmd/skillctl/agentid_gate_test.go
+++ b/cmd/skillctl/agentid_gate_test.go
@@ -112,6 +112,30 @@ func (e gateEnv) revokeAgent(t *testing.T, agentID string) {
 	}
 }
 
+// installMandateWithSpendCap writes an active mandate granting `grantSkills` with
+// intents network:read AND a hard spend ceiling (--limit spend_eur_max=<cap>).
+func (e gateEnv) installMandateWithSpendCap(t *testing.T, agentID, grantSkills, cap string) {
+	t.Helper()
+	out := filepath.Join(e.home, ".claude", "skillctl", "agentid.json")
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{
+		"--owner", e.f.ownerID, "--owner-key", e.f.ownerKeyPath,
+		"--agent-id", agentID,
+		"--skills", grantSkills,
+		"--intents", "network:read",
+		"--limit", "spend_eur_max=" + cap,
+		"--trust-root", e.f.regURL,
+		"--expires", "2099-12-31T00:00:00Z",
+		"--out", out,
+	}
+	var so, se strings.Builder
+	if code := runAgentIDIssue(args, &so, &se); code != exitOK {
+		t.Fatalf("install mandate: exit %d %s", code, se.String())
+	}
+}
+
 func hookEventFor(skill string) string {
 	ev := map[string]any{
 		"hook_event_name": "PreToolUse",
@@ -212,6 +236,96 @@ func TestGate_InvocationEventCarriesAgentIdentity(t *testing.T) {
 	if tv.Verified == 0 {
 		t.Fatal("the agent-stamped invocation event must still verify (value change, not format break)")
 	}
+}
+
+// AC IS-T6: with the ROOT-OWNED require-mandate floor engaged, a MISSING
+// agentid.json is a hard DENY (agent_mandate_required), NOT the silent opt-out.
+// Against the pre-IS-T6 code (no mandate → Configured=false → allow) this bites:
+// the identical setup previously allowed the skill (see TestGate_NoMandateUnchanged).
+func TestGate_RequireMandateFloor_MissingMandateDenied(t *testing.T) {
+	_ = setupGate(t, "summarize", false) // managed skill + trust-roots, but NO mandate installed
+	orig := gateRequireAgentMandate
+	gateRequireAgentMandate = func() bool { return true }
+	t.Cleanup(func() { gateRequireAgentMandate = orig })
+
+	code, out, _ := feed(t, hookEventFor("summarize"))
+	assertDeny(t, code, out, "not authorized")
+	if !strings.Contains(out, "agent_mandate_required") {
+		t.Fatalf("expected agent_mandate_required reason, got %q", out)
+	}
+}
+
+// Control for IS-T6: with the floor OFF, a missing mandate stays the opt-out
+// default (allow) — the floor is the ONLY thing that turns absence into a deny.
+func TestGate_RequireMandateFloor_OffKeepsOptOut(t *testing.T) {
+	_ = setupGate(t, "summarize", false)
+	orig := gateRequireAgentMandate
+	gateRequireAgentMandate = func() bool { return false }
+	t.Cleanup(func() { gateRequireAgentMandate = orig })
+
+	code, out, _ := feed(t, hookEventFor("summarize"))
+	assertAllow(t, code, out)
+}
+
+// AC IS-T7: the gate enforces the SIGNED manifest SCOPE, not just the skill NAME. A
+// skill NAMED in the grant but whose digest-verified manifest declares fs:write —
+// an intent the network:read-only grant lacks — is DENIED. Against the pre-IS-T7
+// code (which called AuthorizeSkill(skill, nil): no intents/scopes/limits) this
+// bites — the identical in-grant skill was allowed on name membership alone. Drives
+// the REAL gate; only the manifest-resolution seam is injected (so the test needn't
+// mint a real .skb), which is exactly the value the old code discarded.
+func TestGate_ManifestIntentExceedsGrantDenied(t *testing.T) {
+	e := setupGate(t, "pdf", false)
+	e.installMandate(t, "agent:scoped", "pdf", false) // grants pdf + intents network:read
+	orig := skillRequirementsFn
+	skillRequirementsFn = func(home, skill string) agentid.SkillRequirements {
+		return agentid.SkillRequirements{Intents: []string{"fs:write"}}
+	}
+	t.Cleanup(func() { skillRequirementsFn = orig })
+
+	code, out, _ := feed(t, hookEventFor("pdf"))
+	assertDeny(t, code, out, "not authorized")
+	if !strings.Contains(out, "intent_not_in_grant") {
+		t.Fatalf("expected intent_not_in_grant, got %q", out)
+	}
+}
+
+// AC IS-T7 (limits): a manifest declaring a spend over the mandate's spend_eur_max
+// cap of 0 is DENIED at the gate (limit_exceeded). Bites the pre-IS-T7 code that
+// enforced no limits at all.
+func TestGate_ManifestSpendOverCapDenied(t *testing.T) {
+	e := setupGate(t, "pdf", false)
+	e.installMandateWithSpendCap(t, "agent:spender", "pdf", "0")
+	orig := skillRequirementsFn
+	skillRequirementsFn = func(home, skill string) agentid.SkillRequirements {
+		return agentid.SkillRequirements{Limits: map[string]string{"spend_eur_max": "5"}}
+	}
+	t.Cleanup(func() { skillRequirementsFn = orig })
+
+	code, out, _ := feed(t, hookEventFor("pdf"))
+	assertDeny(t, code, out, "not authorized")
+	if !strings.Contains(out, "limit_exceeded") {
+		t.Fatalf("expected limit_exceeded, got %q", out)
+	}
+}
+
+// AC IS-T7 (in-scope still allowed): a manifest fully within the grant (a
+// network:read intent, spend 0 within cap 0) still runs — enforcement denies only
+// what EXCEEDS the grant.
+func TestGate_ManifestWithinGrantAllowed(t *testing.T) {
+	e := setupGate(t, "pdf", false)
+	e.installMandateWithSpendCap(t, "agent:ok", "pdf", "0")
+	orig := skillRequirementsFn
+	skillRequirementsFn = func(home, skill string) agentid.SkillRequirements {
+		return agentid.SkillRequirements{
+			Intents: []string{"network:read"},
+			Limits:  map[string]string{"spend_eur_max": "0"},
+		}
+	}
+	t.Cleanup(func() { skillRequirementsFn = orig })
+
+	code, out, _ := feed(t, hookEventFor("pdf"))
+	assertAllow(t, code, out)
 }
 
 // Direct unit on the authorization predicate via a forged mandate: an unsigned /

--- a/cmd/skillctl/agentid_gate_test.go
+++ b/cmd/skillctl/agentid_gate_test.go
@@ -136,6 +136,49 @@ func (e gateEnv) installMandateWithSpendCap(t *testing.T, agentID, grantSkills, 
 	}
 }
 
+// installMandateSkillsOnly writes a NON-restricting mandate: a skill grant with NO
+// intents / data-scopes / limits, so grantIsRestricting is false (name-only floor).
+func (e gateEnv) installMandateSkillsOnly(t *testing.T, agentID, grantSkills string) {
+	t.Helper()
+	out := filepath.Join(e.home, ".claude", "skillctl", "agentid.json")
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{
+		"--owner", e.f.ownerID, "--owner-key", e.f.ownerKeyPath,
+		"--agent-id", agentID, "--skills", grantSkills,
+		"--trust-root", e.f.regURL, "--expires", "2099-12-31T00:00:00Z", "--out", out,
+	}
+	var so, se strings.Builder
+	if code := runAgentIDIssue(args, &so, &se); code != exitOK {
+		t.Fatalf("install mandate: exit %d %s", code, se.String())
+	}
+}
+
+// writeSidecarAndDeleteSkb records a bundle digest in the skill's provenance sidecar
+// (so installedSkillDigest returns non-empty — the gate KNOWS a bundle exists) and
+// removes every stashed .skb (so the signed manifest is unreadable), modelling a
+// same-uid actor stripping scope enforcement down to name-only.
+func writeSidecarAndDeleteSkb(t *testing.T, home, skill string) {
+	t.Helper()
+	skillDir := filepath.Join(home, ".claude", "skills", skill)
+	side := `{"schema_version":"1","skill":"` + skill + `","version":"1.0.0","bundle_digest":"sha256:` + strings.Repeat("a", 64) + `"}`
+	if err := os.WriteFile(filepath.Join(skillDir, ".m3c-provenance.json"), []byte(side), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, en := range entries {
+		if strings.HasSuffix(en.Name(), ".skb") {
+			if err := os.Remove(filepath.Join(skillDir, en.Name())); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
 func hookEventFor(skill string) string {
 	ev := map[string]any{
 		"hook_event_name": "PreToolUse",
@@ -278,8 +321,8 @@ func TestGate_ManifestIntentExceedsGrantDenied(t *testing.T) {
 	e := setupGate(t, "pdf", false)
 	e.installMandate(t, "agent:scoped", "pdf", false) // grants pdf + intents network:read
 	orig := skillRequirementsFn
-	skillRequirementsFn = func(home, skill string) agentid.SkillRequirements {
-		return agentid.SkillRequirements{Intents: []string{"fs:write"}}
+	skillRequirementsFn = func(home, skill string) (agentid.SkillRequirements, bool) {
+		return agentid.SkillRequirements{Intents: []string{"fs:write"}}, true
 	}
 	t.Cleanup(func() { skillRequirementsFn = orig })
 
@@ -297,8 +340,8 @@ func TestGate_ManifestSpendOverCapDenied(t *testing.T) {
 	e := setupGate(t, "pdf", false)
 	e.installMandateWithSpendCap(t, "agent:spender", "pdf", "0")
 	orig := skillRequirementsFn
-	skillRequirementsFn = func(home, skill string) agentid.SkillRequirements {
-		return agentid.SkillRequirements{Limits: map[string]string{"spend_eur_max": "5"}}
+	skillRequirementsFn = func(home, skill string) (agentid.SkillRequirements, bool) {
+		return agentid.SkillRequirements{Limits: map[string]string{"spend_eur_max": "5"}}, true
 	}
 	t.Cleanup(func() { skillRequirementsFn = orig })
 
@@ -316,13 +359,92 @@ func TestGate_ManifestWithinGrantAllowed(t *testing.T) {
 	e := setupGate(t, "pdf", false)
 	e.installMandateWithSpendCap(t, "agent:ok", "pdf", "0")
 	orig := skillRequirementsFn
-	skillRequirementsFn = func(home, skill string) agentid.SkillRequirements {
+	skillRequirementsFn = func(home, skill string) (agentid.SkillRequirements, bool) {
 		return agentid.SkillRequirements{
 			Intents: []string{"network:read"},
 			Limits:  map[string]string{"spend_eur_max": "0"},
-		}
+		}, true
 	}
 	t.Cleanup(func() { skillRequirementsFn = orig })
+
+	code, out, _ := feed(t, hookEventFor("pdf"))
+	assertAllow(t, code, out)
+}
+
+// Challenge-gate HIGH (IS-T7): requirementsFromManifest must read the SIGNED
+// `intent` block, not just data_dependencies — else a skill declaring egress /
+// subprocess / destructive / arbitrary side-effects with read-shaped data deps
+// passes a grant that never granted those capabilities. Bites the pre-fix code that
+// projected ONLY data_dependencies (req.Intents would have been just {er1:read} and
+// the grant would have ALLOWED it).
+func TestRequirementsFromManifest_IncludesSignedIntentBlock(t *testing.T) {
+	m := map[string]any{
+		"data_dependencies": []any{
+			map[string]any{"id": "ds:x", "kind": "er1_collection", "access": "read"},
+		},
+		"intent": map[string]any{
+			"network":      true,
+			"subprocess":   []any{"curl"},
+			"destructive":  true,
+			"side_effects": []any{"fs:write", "llm:call"},
+		},
+	}
+	req := requirementsFromManifest(m)
+	got := map[string]bool{}
+	for _, i := range req.Intents {
+		got[i] = true
+	}
+	for _, want := range []string{"er1:read", "network:write", "subprocess:exec", "destructive", "fs:write", "llm:call"} {
+		if !got[want] {
+			t.Errorf("required intents %v missing %q (the signed intent block must be read, not just data_dependencies)", req.Intents, want)
+		}
+	}
+	// The exact bite: a grant allowing only er1:read must DENY this skill.
+	g := agentid.Grant{Skills: []string{"pdf"}, Intents: []string{"er1:read"}}
+	if r, ok := g.AuthorizeSkillScoped("pdf", req); ok || r != "intent_not_in_grant" {
+		t.Fatalf("a skill declaring network/subprocess/destructive/fs:write must be denied under an er1:read-only grant, got reason=%q ok=%v", r, ok)
+	}
+}
+
+// An http_endpoint write/egress dependency is the network:write capability (not
+// network:read) — so a network:read-only grant denies an egress skill.
+func TestIntentForKindAccess_HttpEgressIsNetworkWrite(t *testing.T) {
+	for _, acc := range []string{"write", "transform", "egress"} {
+		if got := intentForKindAccess("http_endpoint", acc); got != "network:write" {
+			t.Errorf("http_endpoint %q → %q, want network:write", acc, got)
+		}
+	}
+	for _, acc := range []string{"read", "passthrough", ""} {
+		if got := intentForKindAccess("http_endpoint", acc); got != "network:read" {
+			t.Errorf("http_endpoint %q → %q, want network:read", acc, got)
+		}
+	}
+}
+
+// Challenge-gate MEDIUM (IS-T7): a same-uid actor deleting the stashed .skb must NOT
+// downgrade a RESTRICTING mandate to name-only. When a digest IS on record but the
+// signed manifest is unreadable, the gate fails CLOSED. Uses the REAL resolver (no
+// seam override). Bites the pre-fix code that returned an empty requirement set
+// (name-only) → the in-grant skill was ALLOWED.
+func TestGate_SkbDeletedWithDigestOnRecord_FailsClosed(t *testing.T) {
+	e := setupGate(t, "pdf", false)
+	e.installMandate(t, "agent:x", "pdf", false) // RESTRICTING: grants pdf + intents network:read
+	writeSidecarAndDeleteSkb(t, e.home, "pdf")
+
+	code, out, _ := feed(t, hookEventFor("pdf"))
+	assertDeny(t, code, out, "not authorized")
+	if !strings.Contains(out, "skill_requirements_unresolved") {
+		t.Fatalf("expected skill_requirements_unresolved, got %q", out)
+	}
+}
+
+// Never-brick control for the MEDIUM fix: a NON-restricting grant (skills only) keeps
+// the name-only fallback even when the .skb is gone — a bundle-less-but-named skill
+// under a name-only mandate must still run.
+func TestGate_SkbDeleted_NonRestrictingGrantStillAllows(t *testing.T) {
+	e := setupGate(t, "pdf", false)
+	e.installMandateSkillsOnly(t, "agent:y", "pdf") // NON-restricting
+	writeSidecarAndDeleteSkb(t, e.home, "pdf")
 
 	code, out, _ := feed(t, hookEventFor("pdf"))
 	assertAllow(t, code, out)

--- a/cmd/skillctl/agentid_gate_test.go
+++ b/cmd/skillctl/agentid_gate_test.go
@@ -66,6 +66,18 @@ func setupGate(t *testing.T, skillName string, requireApprover bool) gateEnv {
 	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return exitOK, "", true }
 	t.Cleanup(func() { verifyManagedFn = origOn; verifyManagedOfflineFn = origOff })
 
+	// Default scope-resolution seam: model an installed skill whose digest-verified
+	// manifest declares NO extra capabilities (the common allow case), so the
+	// agent-layer tests (grant / revoke / approver-floor) exercise the mandate layer
+	// without depending on real .skb + provenance-file mechanics. Scope-specific
+	// tests override this seam with a concrete requirement set; tests that exercise
+	// the REAL resolver restore skillRequirementsFn = resolveInstalledSkillRequirements.
+	origReq := skillRequirementsFn
+	skillRequirementsFn = func(string, string) (agentid.SkillRequirements, bool) {
+		return agentid.SkillRequirements{}, true
+	}
+	t.Cleanup(func() { skillRequirementsFn = origReq })
+
 	return gateEnv{home: home, f: f}
 }
 
@@ -428,7 +440,8 @@ func TestIntentForKindAccess_HttpEgressIsNetworkWrite(t *testing.T) {
 // (name-only) → the in-grant skill was ALLOWED.
 func TestGate_SkbDeletedWithDigestOnRecord_FailsClosed(t *testing.T) {
 	e := setupGate(t, "pdf", false)
-	e.installMandate(t, "agent:x", "pdf", false) // RESTRICTING: grants pdf + intents network:read
+	skillRequirementsFn = resolveInstalledSkillRequirements // exercise the REAL resolver
+	e.installMandate(t, "agent:x", "pdf", false)            // RESTRICTING: grants pdf + intents network:read
 	writeSidecarAndDeleteSkb(t, e.home, "pdf")
 
 	code, out, _ := feed(t, hookEventFor("pdf"))
@@ -443,11 +456,119 @@ func TestGate_SkbDeletedWithDigestOnRecord_FailsClosed(t *testing.T) {
 // under a name-only mandate must still run.
 func TestGate_SkbDeleted_NonRestrictingGrantStillAllows(t *testing.T) {
 	e := setupGate(t, "pdf", false)
-	e.installMandateSkillsOnly(t, "agent:y", "pdf") // NON-restricting
+	skillRequirementsFn = resolveInstalledSkillRequirements // exercise the REAL resolver
+	e.installMandateSkillsOnly(t, "agent:y", "pdf")         // NON-restricting
 	writeSidecarAndDeleteSkb(t, e.home, "pdf")
 
 	code, out, _ := feed(t, hookEventFor("pdf"))
 	assertAllow(t, code, out)
+}
+
+// Re-gate root-cause bite (was STILL-ENABLED): installedSkillDigest must resolve
+// the digest from the `.skillctl-offline.json` stash that the PRIMARY `skillctl
+// install` path writes — not only the `.m3c-provenance.json` sidecar that only the
+// `pull` path writes. Pre-fix it read only the sidecar and returned "" here, so
+// IS-T7 resolved no scope and silently degraded EVERY install-path skill to
+// name-only enforcement, with no tampering at all.
+func TestInstalledSkillDigest_FallsBackToOfflineMeta(t *testing.T) {
+	home := t.TempDir()
+	skill := "pdf"
+	dir := filepath.Join(home, ".claude", "skills", skill)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dg := "sha256:" + strings.Repeat("b", 64)
+	// The `skillctl install` layout: an offline stash carrying the bundle digest,
+	// and NO provenance sidecar.
+	om := `{"bundle_meta":{"bundle":{"bundle_digest":"` + dg + `"}},"stashed_at":"2026-01-01T00:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(dir, ".skillctl-offline.json"), []byte(om), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := installedSkillDigest(home, skill); got != dg {
+		t.Fatalf("installedSkillDigest must fall back to the offline-meta digest on the install path; got %q want %q (pre-fix it read only .m3c-provenance.json → \"\")", got, dg)
+	}
+}
+
+// Re-gate core bite (was STILL-ENABLED, 2(b)): a MANAGED skill (a stashed .skb) for
+// which NO digest resolves from ANY basis — no sidecar, no offline stash, the exact
+// state after a same-uid strip of every provenance file (and the pre-fix
+// install-path default) — must FAIL CLOSED under a restricting grant, not degrade to
+// name-only. Uses the REAL resolver. Pre-fix returned (empty, TRUE) → the in-grant
+// skill was ALLOWED with its scope unenforced.
+func TestGate_ManagedSkbNoDigestBasis_FailsClosed(t *testing.T) {
+	e := setupGate(t, "pdf", false)                         // fixture writes pdf.skb, NO sidecar, NO offline-meta
+	skillRequirementsFn = resolveInstalledSkillRequirements // exercise the REAL resolver
+	e.installMandate(t, "agent:z", "pdf", false)            // RESTRICTING: grants pdf + intents network:read
+
+	code, out, _ := feed(t, hookEventFor("pdf"))
+	assertDeny(t, code, out, "not authorized")
+	if !strings.Contains(out, "skill_requirements_unresolved") {
+		t.Fatalf("a managed skill whose scope cannot be resolved from any basis must fail closed under a restricting grant, got %q", out)
+	}
+}
+
+// Never-brick guard for the fix: a genuinely unmanaged skill — NO stashed .skb, NO
+// sidecar, NO offline stash — resolves name-only (empty, TRUE) so a bundle-less
+// legacy skill is never bricked. This is the ONLY (empty, TRUE) case; a managed .skb
+// with no resolvable digest is the fail-closed case above.
+func TestResolveRequirements_NoManagedBasis_NeverBrick(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".claude", "skills", "legacy")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	req, resolved := resolveInstalledSkillRequirements(home, "legacy")
+	if !resolved || len(req.Intents) != 0 || len(req.DataScopes) != 0 || len(req.Limits) != 0 {
+		t.Fatalf("an unmanaged skill (no bundle basis at all) must resolve name-only never-brick; got resolved=%v req=%+v", resolved, req)
+	}
+}
+
+// Re-gate residual bite (B(c)): intent.subprocess must project subprocess:exec in
+// EVERY non-empty encoding, not only a list — else a skill dodges the subprocess
+// requirement by declaring it as a scalar/object. Empty/false forms declare nothing.
+func TestRequirementsFromManifest_SubprocessNonArrayForms(t *testing.T) {
+	declares := []any{true, "curl -sSL x | sh", map[string]any{"cmd": "sh"}, []any{"sh"}}
+	for _, sp := range declares {
+		req := requirementsFromManifest(map[string]any{"intent": map[string]any{"subprocess": sp}})
+		found := false
+		for _, i := range req.Intents {
+			if i == "subprocess:exec" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("subprocess declared as %T (%v) must project subprocess:exec; got %v", sp, sp, req.Intents)
+		}
+	}
+	for _, sp := range []any{false, "", []any{}, map[string]any{}, nil} {
+		req := requirementsFromManifest(map[string]any{"intent": map[string]any{"subprocess": sp}})
+		for _, i := range req.Intents {
+			if i == "subprocess:exec" {
+				t.Errorf("empty/false subprocess (%T %v) must NOT project subprocess:exec", sp, sp)
+			}
+		}
+	}
+}
+
+// Re-gate residual bite (B(c)): an UNKNOWN data_dependency kind must fail closed —
+// carried verbatim as its own category so it fails grant membership — not vanish to
+// "" (which let an unrecognized-kind dependency escape the grant). An empty kind
+// still contributes nothing.
+func TestIntentForKindAccess_UnknownKindFailsClosed(t *testing.T) {
+	if got := intentForKindAccess("quantum_ledger", "write"); got != "quantum_ledger:write" {
+		t.Errorf("unknown kind must fail closed as <kind>:<act>, got %q", got)
+	}
+	if got := intentForKindAccess("", "read"); got != "" {
+		t.Errorf("empty kind → no derived intent, got %q", got)
+	}
+	// And a grant lacking that exact token denies the skill.
+	g := agentid.Grant{Skills: []string{"x"}, Intents: []string{"network:read"}}
+	req := requirementsFromManifest(map[string]any{
+		"data_dependencies": []any{map[string]any{"kind": "quantum_ledger", "access": "write"}},
+	})
+	if r, ok := g.AuthorizeSkillScoped("x", req); ok || r != "intent_not_in_grant" {
+		t.Fatalf("an unknown-kind dependency must be denied unless explicitly granted, got reason=%q ok=%v", r, ok)
+	}
 }
 
 // Direct unit on the authorization predicate via a forged mandate: an unsigned /

--- a/cmd/skillctl/revoked_cache.go
+++ b/cmd/skillctl/revoked_cache.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/kamir/m3c-tools/pkg/er1"
+	"github.com/kamir/m3c-tools/pkg/skillctl/install"
 	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
 )
 
@@ -412,14 +413,30 @@ func fetchRevocationHeadOnline(cfg *er1.Config, ctx string, pub ed25519.PublicKe
 	return head, true
 }
 
-// installedSkillDigest reads the provenance sidecar's bundle_digest for an
-// installed skill, or "" if there is no sidecar / it's unreadable.
+// installedSkillDigest resolves the recorded bundle_digest for an installed
+// skill from whichever managed basis exists, or "" if none does.
+//
+//   - (1) the `.m3c-provenance.json` provenance sidecar — authoritative, but
+//     written ONLY by the trust-mode `skillctl pull` path;
+//   - (2) the `.skillctl-offline.json` offline stash — written by the PRIMARY
+//     `skillctl install` path (SPEC-0188), which writes no provenance sidecar.
+//
+// Reading only the sidecar (the pre-fix behaviour) left the mandate gate (IS-T7)
+// unable to resolve any digest for install-path skills, silently degrading every
+// one of them to name-only scope enforcement, and let a same-uid actor delete the
+// sidecar to strip enforcement even on pull-path skills. Falling back to the
+// offline stash closes both: the gate can resolve the signed scope on either
+// install path, and both provenance files must be removed to reach the
+// unresolvable state (which the resolver then fails closed under a restricting
+// grant, see resolveInstalledSkillRequirements).
 func installedSkillDigest(home, name string) string {
-	side, ok := loadInstalledSidecar(home, name)
-	if !ok {
-		return ""
+	if side, ok := loadInstalledSidecar(home, name); ok && side.BundleDigest != "" {
+		return side.BundleDigest
 	}
-	return side.BundleDigest
+	if d, ok := install.InstalledBundleDigest(home, name); ok {
+		return d
+	}
+	return ""
 }
 
 // installedSkillAuthor reads the provenance sidecar's author identity (the

--- a/pkg/skillctl/agentid/agentid_test.go
+++ b/pkg/skillctl/agentid/agentid_test.go
@@ -344,3 +344,63 @@ func TestEmptyGrantDeniesEverything(t *testing.T) {
 		t.Fatal("empty grant must deny all skills (fail-closed)")
 	}
 }
+
+// SPEC-0277 IS-04 / IS-T7: AuthorizeSkillScoped enforces the SIGNED manifest scope
+// — intents, data-scopes AND declared limits — not just the skill name. The old
+// path enforced neither data-scopes nor limits, so the limit + data-scope cases
+// here bite code that shipped before IS-T7.
+func TestAuthorizeSkillScoped_EnforcesIntentsScopesAndLimits(t *testing.T) {
+	g := Grant{
+		Skills:     []string{"pdf"},
+		Intents:    []string{"network:read"},
+		DataScopes: []string{"ds:er1/plm/allowed"},
+		Limits:     map[string]string{"spend_eur_max": "0"},
+	}
+
+	// Bare in-grant skill (no extra requirements) → allow.
+	if r, ok := g.AuthorizeSkillScoped("pdf", SkillRequirements{}); !ok {
+		t.Fatalf("bare in-grant skill should pass, got reason=%q", r)
+	}
+	// A skill declaring fs:write under a network:read-only grant → DENY.
+	if r, ok := g.AuthorizeSkillScoped("pdf", SkillRequirements{Intents: []string{"fs:write"}}); ok || r != "intent_not_in_grant" {
+		t.Fatalf("fs:write must be denied under a network:read grant, got reason=%q ok=%v", r, ok)
+	}
+	// The granted intent passes.
+	if r, ok := g.AuthorizeSkillScoped("pdf", SkillRequirements{Intents: []string{"network:read"}}); !ok {
+		t.Fatalf("granted intent should pass, got reason=%q", r)
+	}
+	// spend cap 0 DENIES any declared spend > 0.
+	if r, ok := g.AuthorizeSkillScoped("pdf", SkillRequirements{Limits: map[string]string{"spend_eur_max": "5"}}); ok || r != "limit_exceeded" {
+		t.Fatalf("declared spend 5 must be denied under cap 0, got reason=%q ok=%v", r, ok)
+	}
+	// A declared spend AT the cap (0 ≤ 0) is allowed.
+	if r, ok := g.AuthorizeSkillScoped("pdf", SkillRequirements{Limits: map[string]string{"spend_eur_max": "0"}}); !ok {
+		t.Fatalf("declared spend 0 within cap 0 should pass, got reason=%q", r)
+	}
+	// A data-scope outside the (restricting) grant allowlist → DENY.
+	if r, ok := g.AuthorizeSkillScoped("pdf", SkillRequirements{DataScopes: []string{"ds:er1/plm/secret"}}); ok || r != "data_scope_not_in_grant" {
+		t.Fatalf("out-of-grant data scope must be denied, got reason=%q ok=%v", r, ok)
+	}
+	// A granted data-scope passes.
+	if r, ok := g.AuthorizeSkillScoped("pdf", SkillRequirements{DataScopes: []string{"ds:er1/plm/allowed"}}); !ok {
+		t.Fatalf("granted data scope should pass, got reason=%q", r)
+	}
+	// An unparseable declared limit against a cap fails CLOSED.
+	if r, ok := g.AuthorizeSkillScoped("pdf", SkillRequirements{Limits: map[string]string{"spend_eur_max": "lots"}}); ok || r != "limit_exceeded" {
+		t.Fatalf("an unparseable declared limit must fail closed, got reason=%q ok=%v", r, ok)
+	}
+}
+
+// A grant that does NOT restrict data scopes (empty DataScopes) must not deny a
+// scope-declaring skill — data scopes stay bounded by the SPEC-0202 layer. (Intents
+// and limits keep their fail-closed/absent-cap semantics; this guards only scopes.)
+func TestAuthorizeSkillScoped_UnrestrictedDataScopesAllowed(t *testing.T) {
+	g := Grant{Skills: []string{"pdf"}, Intents: []string{"network:read"}}
+	if r, ok := g.AuthorizeSkillScoped("pdf", SkillRequirements{DataScopes: []string{"ds:anything"}}); !ok {
+		t.Fatalf("a scope-silent grant must not deny declared scopes, got reason=%q", r)
+	}
+	// A limit key the grant does not cap is unrestricted.
+	if r, ok := g.AuthorizeSkillScoped("pdf", SkillRequirements{Limits: map[string]string{"calls_max": "999"}}); !ok {
+		t.Fatalf("an uncapped limit key must not deny, got reason=%q", r)
+	}
+}

--- a/pkg/skillctl/agentid/authorize.go
+++ b/pkg/skillctl/agentid/authorize.go
@@ -1,6 +1,9 @@
 package agentid
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // authorize.go — the SPEC-0277 §3 authorization predicate ("skill is verified
 // AND within the agent's grant"). The crypto half (the AgentID verifies) lives
@@ -56,23 +59,111 @@ func (g Grant) AllowsIntent(intent string) bool {
 	return false
 }
 
-// AuthorizeSkill is the single predicate the gate calls: the skill must be in
-// the grant AND every required intent must be in the grant. Returns ("", true)
-// when authorized; otherwise ("<reason>", false) with a stable reason token the
-// gate maps to a refusal_code. Fail-closed by construction — any miss is a deny.
+// AllowsDataScope reports whether the grant permits touching the given SPEC-0196
+// data-scope id (e.g. "ds:er1/plm/skill-creations"). Set-membership,
+// case-sensitive, mirroring AllowsIntent. An empty required scope is permitted (no
+// scope to check). NOTE: unlike intents, an EMPTY grant.data_scopes does NOT deny a
+// declared scope — AuthorizeSkillScoped enforces data-scopes only when the grant
+// RESTRICTS them (see there), so this predicate is only consulted when the grant is
+// non-empty.
+func (g Grant) AllowsDataScope(scope string) bool {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		return true
+	}
+	for _, s := range g.DataScopes {
+		if strings.TrimSpace(s) == scope {
+			return true
+		}
+	}
+	return false
+}
+
+// withinDeclaredLimits reports the first grant ceiling the skill's declared
+// consumption would exceed. For each key the GRANT caps (Grant.Limits), if the
+// skill declares a value for the SAME key, the declared value must be numerically
+// <= the cap. A key the grant does not cap is unrestricted here (the grant only
+// bounds what it names). A cap or a declared value that does not parse as a number
+// fails CLOSED (returns that key, false) — a malformed ceiling can never be shown
+// "satisfied". Returns ("", true) when every capped, declared value is within its
+// ceiling. Example (Estonia's ask): grant {"spend_eur_max":"0"} + a skill declaring
+// {"spend_eur_max":"5"} → ("spend_eur_max", false); a skill declaring nothing → ok.
+func (g Grant) withinDeclaredLimits(declared map[string]string) (string, bool) {
+	for key, capStr := range g.Limits {
+		decStr, ok := declared[key]
+		if !ok {
+			continue // the skill declares no consumption of this capped resource
+		}
+		capVal, cerr := strconv.ParseFloat(strings.TrimSpace(capStr), 64)
+		decVal, derr := strconv.ParseFloat(strings.TrimSpace(decStr), 64)
+		if cerr != nil || derr != nil {
+			return key, false // fail-closed: an unparseable ceiling/declaration is never satisfied
+		}
+		if decVal > capVal {
+			return key, false
+		}
+	}
+	return "", true
+}
+
+// SkillRequirements is the skill's author-signed declared scope, resolved from its
+// DIGEST-VERIFIED bundle.json by the gate. Every field is optional; a zero value
+// reproduces the pre-IS-T7 name-only check.
+type SkillRequirements struct {
+	// Intents are the capability tokens the skill's signed manifest implies (e.g.
+	// "fs:write", "network:read"), checked against Grant.Intents (strict allowlist).
+	Intents []string
+	// DataScopes are the data-scope ids the skill declares (data_dependencies[].id),
+	// checked against Grant.DataScopes — but only when the grant restricts scopes.
+	DataScopes []string
+	// Limits are the skill's declared resource ceilings, keyed like Grant.Limits
+	// (e.g. {"spend_eur_max":"5"}), each checked against the grant's cap.
+	Limits map[string]string
+}
+
+// AuthorizeSkillScoped is the full SPEC-0277 §3 authorization predicate the gate
+// calls: the skill must be NAMED in the grant, and every capability intent, data
+// scope, and declared resource ceiling in its signed manifest must be within the
+// mandate's grant. Returns ("", true) when authorized; otherwise
+// ("<reason>", false) with a stable reason token (skill_not_in_grant |
+// intent_not_in_grant | data_scope_not_in_grant | limit_exceeded). Fail-closed by
+// construction — any miss is a deny.
 //
-// requiredIntents may be nil/empty (the common P1 case: we gate on skill
-// membership and let the skill's own declared intents bound its behaviour at the
-// existing SPEC-0202 layer). When provided (e.g. from the skill's signed
-// data-scope), each must be granted.
-func (g Grant) AuthorizeSkill(skill string, requiredIntents []string) (string, bool) {
+// Data-scope enforcement is GUARDED on a restricting grant (len(DataScopes) > 0):
+// Grant.DataScopes is an optional, fine-grained allowlist, so a grant that names no
+// scopes does not bound them here (they stay bounded by the skill's own SPEC-0202
+// data-scope layer); otherwise every scope-declaring skill under a scope-silent
+// grant would be denied. Intents and limits have no such guard — an empty
+// grant.intents denies any declared intent (fail-closed allowlist), and an absent
+// cap simply does not restrict that resource.
+func (g Grant) AuthorizeSkillScoped(skill string, req SkillRequirements) (string, bool) {
 	if !g.AllowsSkill(skill) {
 		return "skill_not_in_grant", false
 	}
-	for _, intent := range requiredIntents {
+	for _, intent := range req.Intents {
 		if !g.AllowsIntent(intent) {
 			return "intent_not_in_grant", false
 		}
 	}
+	if len(g.DataScopes) > 0 {
+		for _, scope := range req.DataScopes {
+			if !g.AllowsDataScope(scope) {
+				return "data_scope_not_in_grant", false
+			}
+		}
+	}
+	if _, ok := g.withinDeclaredLimits(req.Limits); !ok {
+		return "limit_exceeded", false
+	}
 	return "", true
+}
+
+// AuthorizeSkill is the intent-only convenience predicate (skill NAME + required
+// intents). It delegates to AuthorizeSkillScoped so there is ONE enforcement path.
+//
+// requiredIntents may be nil/empty (gate on skill membership only, letting the
+// skill's own declared behaviour be bounded at the SPEC-0202 layer). When provided,
+// each must be granted.
+func (g Grant) AuthorizeSkill(skill string, requiredIntents []string) (string, bool) {
+	return g.AuthorizeSkillScoped(skill, SkillRequirements{Intents: requiredIntents})
 }

--- a/pkg/skillctl/install/offline_verify.go
+++ b/pkg/skillctl/install/offline_verify.go
@@ -119,6 +119,40 @@ func readOfflineMeta(target string) (*OfflineMeta, error) {
 	return &om, nil
 }
 
+// InstalledBundleDigest returns the canonical bundle digest ("sha256:<hex>")
+// recorded in the stashed offline metadata (.skillctl-offline.json) for an
+// installed skill, or ("", false) when there is no readable offline stash.
+//
+// The primary `skillctl install` path (SPEC-0188) writes this offline stash but
+// NOT a `.m3c-provenance.json` sidecar; only the trust-mode `skillctl pull` path
+// writes the sidecar. The agent-mandate gate (SPEC-0277 IS-T7) therefore uses
+// this as the FALLBACK basis for resolving a skill's digest-verified signed
+// scope — without it, every install-path skill resolves no digest and silently
+// degrades to name-only scope enforcement.
+//
+// The digest is only a lookup key: the caller (verify.ReadDigestVerifiedManifest)
+// recomputes the on-disk .skb digest and constant-time-compares it against this
+// value before trusting any manifest bytes, so a tampered stash cannot forge a
+// smaller scope — it can at most make the digest fail to match (→ fail closed).
+func InstalledBundleDigest(homeDir, name string) (string, bool) {
+	home, err := resolveHomeDir(homeDir)
+	if err != nil {
+		return "", false
+	}
+	canon, err := CanonicalSkillName(name)
+	if err != nil {
+		return "", false
+	}
+	om, err := readOfflineMeta(filepath.Join(home, installRoot, canon))
+	if err != nil || om.BundleMeta == nil || om.BundleMeta.Bundle == nil {
+		return "", false
+	}
+	// The canonical digest lives in the BundleRecord as "bundle_digest"
+	// ("sha256:<hex>"), the same field the verify layer keys on.
+	d, _ := om.BundleMeta.Bundle["bundle_digest"].(string)
+	return d, d != ""
+}
+
 // VerifyInstalledOffline re-runs §7 against an installed skill with NO network,
 // then binds the extracted content to the signed .skb. Returns ErrNoOfflineMeta
 // when there is no stash (caller should fall back to VerifyInstalled).

--- a/pkg/skillctl/pin/pin.go
+++ b/pkg/skillctl/pin/pin.go
@@ -99,6 +99,15 @@ type GenerateOptions struct {
 	// opt-in precisely so a disconnected NON-enterprise host keeps its network
 	// fallback (turning it on by default would fail-close legacy installs offline).
 	StateGateFallback bool
+	// RequireAgentMandate emits `skillctlRequireAgentMandate: true` — the SPEC-0277
+	// IS-06 root-owned floor that turns a MISSING ~/.claude/skillctl/agentid.json from
+	// the silent opt-OUT (skill-chain-only) into a hard DENY at the SPEC-0247 gate.
+	// It lives in the root-owned managed tier precisely so a non-privileged user
+	// cannot delete the mandate to escape agent authorization — deleting agentid.json
+	// then fails CLOSED instead of disabling enforcement. Standalone (NOT
+	// enterprise-gated): it is an authorization policy, orthogonal to the SPEC-0317
+	// offline-locked machinery. Claude Code ignores the unknown key; skillctl reads it.
+	RequireAgentMandate bool
 }
 
 // wire structs — field order here is the emitted JSON key order (encoding/json
@@ -122,6 +131,7 @@ type managedSettings struct {
 	SkillctlEnterprise           bool       `json:"skillctlEnterprise,omitempty"`
 	SkillctlRequireLocalAudit    bool       `json:"skillctlRequireLocalAudit,omitempty"`
 	SkillctlStateGateFallback    bool       `json:"skillctlStateGateFallback,omitempty"`
+	SkillctlRequireAgentMandate  bool       `json:"skillctlRequireAgentMandate,omitempty"`
 	Hooks                        hooksBlock `json:"hooks"`
 }
 
@@ -182,6 +192,10 @@ func Generate(opts GenerateOptions) ([]byte, error) {
 	if opts.StateGateFallback {
 		ms.SkillctlEnterprise = true // state-gating the fallback is enterprise-only
 		ms.SkillctlStateGateFallback = true
+	}
+	if opts.RequireAgentMandate {
+		// Standalone floor — deliberately NOT enterprise-gated (see the field doc).
+		ms.SkillctlRequireAgentMandate = true
 	}
 	if opts.Strict || opts.Harden {
 		ms.AllowManagedHooksOnly = true
@@ -297,6 +311,22 @@ func StateGateFallbackFromBytes(settings []byte) bool {
 		return false
 	}
 	return ms.SkillctlEnterprise && ms.SkillctlStateGateFallback
+}
+
+// RequireAgentMandateFromBytes reports whether managed settings engage the
+// SPEC-0277 IS-06 root-owned require-mandate floor (`skillctlRequireAgentMandate:
+// true`). Standalone — NOT enterprise-gated (it is an authorization policy, not a
+// posture of the SPEC-0317 offline-locked machinery). Same conservative contract as
+// the other readers: a MISSING or MALFORMED managed file yields false, so an
+// unreadable managed file can never itself DENY every skill (never-brick). When it
+// yields true, a missing agentid.json is a hard DENY at the gate instead of the
+// silent opt-out default.
+func RequireAgentMandateFromBytes(settings []byte) bool {
+	var ms managedSettings
+	if json.Unmarshal(settings, &ms) != nil {
+		return false
+	}
+	return ms.SkillctlRequireAgentMandate
 }
 
 // Verify parses managed-settings bytes and reports the pinning level. It matches

--- a/pkg/skillctl/pin/pin_test.go
+++ b/pkg/skillctl/pin/pin_test.go
@@ -440,3 +440,39 @@ func TestStateGateFallbackFromBytes(t *testing.T) {
 		t.Error("require_local_audit alone must NOT enable state_gate_fallback")
 	}
 }
+
+// TestRequireAgentMandateFromBytes locks the SPEC-0277 IS-06 reader: STANDALONE
+// (NOT enterprise-gated) — the bare flag engages it — but conservative: a
+// missing/malformed managed file → false (never-brick).
+func TestRequireAgentMandateFromBytes(t *testing.T) {
+	if !RequireAgentMandateFromBytes([]byte(`{"skillctlRequireAgentMandate":true}`)) {
+		t.Error("the bare flag → require_agent_mandate on (standalone, not enterprise-gated)")
+	}
+	for _, neg := range []string{
+		`{"skillctlRequireAgentMandate":false}`,
+		`{"skillctlEnterprise":true}`,
+		`{}`,
+		`{ not json`,
+		``,
+	} {
+		if RequireAgentMandateFromBytes([]byte(neg)) {
+			t.Errorf("must be off (conservative): %q", neg)
+		}
+	}
+	if RequireAgentMandateFromBytes(nil) {
+		t.Error("a nil managed file must never engage the floor (never-brick)")
+	}
+	// round-trip via Generate; it must NOT drag in the enterprise flag (standalone).
+	b, _ := Generate(GenerateOptions{RequireAgentMandate: true})
+	if !RequireAgentMandateFromBytes(b) {
+		t.Error("Generate(RequireAgentMandate) must round-trip")
+	}
+	if EnterpriseFromBytes(b) {
+		t.Error("--require-agent-mandate must NOT imply enterprise (it is a standalone authorization floor)")
+	}
+	// Independent of the other knobs: a default file does not engage it.
+	def, _ := Generate(GenerateOptions{})
+	if RequireAgentMandateFromBytes(def) {
+		t.Error("a default managed file must not engage require_agent_mandate")
+	}
+}

--- a/pkg/skillctl/registry/er1_backend.go
+++ b/pkg/skillctl/registry/er1_backend.go
@@ -189,55 +189,53 @@ func (b *ER1Backend) Fetch(ctx context.Context, ref artifact.ArtifactRef) ([]byt
 // envelopes for the target skill(s), so the §7 verifier can re-verify them.
 func (b *ER1Backend) Events(ctx context.Context, filter artifact.ListFilter, page artifact.Page) (*artifact.EventPage, error) {
 	out := &artifact.EventPage{}
-	for _, kind := range []string{EventKindAdmitted, EventKindAttested, EventKindRevoked} {
-		tags := []string{"m3c-skill-bundle", "skill-registry:self", "skill-event:" + kind}
-		if filter.Name != "" {
-			tags = append(tags, "skill:"+filter.Name)
-		}
-		items, err := searchByTagsRaw(b.cfg, b.ctxID, tags)
+	// FR-0090 IS-T4b: enumerate by the STABLE bundle tags every skill-event item
+	// carries (registry/context, plus skill:<name> when scoped), NOT the
+	// attacker-controlled skill-event:<kind> tag. Each event's Kind + Digest are then
+	// taken from the SIGNED envelope, so a hostile ER1 tenant retagging a signed
+	// revoke to skill-event:installed (or stripping the tag) can no longer drop it
+	// from discovery — matching git's structural enumeration of every event. This
+	// closes the IS-T4b residual: an intra-set retag AND a cross-kind/strip retag are
+	// both defeated because discovery no longer keys on the tag at all. One search
+	// replaces the three per-kind searches; install envelopes now surface too (a
+	// signed KindInstall), which the §7 verifier / accumulator consumers ignore.
+	tags := []string{"m3c-skill-bundle", "skill-registry:self"}
+	if filter.Name != "" {
+		tags = append(tags, "skill:"+filter.Name)
+	}
+	items, err := searchByTagsRaw(b.cfg, b.ctxID, tags)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		ev, err := extractEvent(itemBody(item))
 		if err != nil {
-			return nil, err
+			continue
 		}
-		for _, item := range items {
-			ev, err := extractEvent(itemBody(item))
-			if err != nil {
-				continue
-			}
-			// FR-0090 IS-T4 (parity with git/oci Events): Kind + Digest come from the
-			// SIGNED envelope, never the skill-event:<kind> TAG (the `kind` loop var is
-			// only the coarse search prefilter). This closes the tag projection for every
-			// item the search FETCHES — an intra-set retag (revoked<->attested) can no
-			// longer flip a verdict. RESIDUAL (tracked, IS-T4b): discovery is still gated
-			// on the skill-event:<kind> tag, so a hostile ER1 tenant retagging a signed
-			// revoke to skill-event:installed (or stripping the tag) can drop it from the
-			// search BEFORE it reaches this classifier. Full parity with git (which
-			// enumerates every event file structurally) needs de-gating the search off
-			// skill-event:<kind>; until then the freshness ceiling (IS-T5) is the
-			// compensating control for managed roots.
-			signedKind := trustcore.KindFromSignedEnvelope(ev)
-			d := trustcore.SignedDigest(ev)
-			if signedKind == "" || !trustcore.ValidDigest(d) {
-				continue // unclassifiable / no well-formed anchor → never a verdict
-			}
-			lvl, _ := ev["governance_level"].(string)
-			rec := artifact.EventRecord{
-				Kind: signedKind, Digest: d, Governance: lvl,
-				Host:      strOrEmpty(ev["packed_on_host"], ev["installed_on_host"]),
-				Rationale: strOrEmpty(ev["rationale"]),
-				Envelope:  ev,
-			}
-			if ts, _ := ev["occurred_at"].(string); ts != "" {
-				if t, perr := time.Parse(time.RFC3339, ts); perr == nil {
-					rec.OccurredAt = t
-				}
-			}
-			// --since (ListFilter.Since): drop events older than the bound; a
-			// zero/unparseable timestamp is kept (best-effort, never a gate).
-			if !filter.Since.IsZero() && !rec.OccurredAt.IsZero() && rec.OccurredAt.Before(filter.Since) {
-				continue
-			}
-			out.Events = append(out.Events, rec)
+		// Kind + Digest come from the SIGNED envelope, never a carrier tag.
+		signedKind := trustcore.KindFromSignedEnvelope(ev)
+		d := trustcore.SignedDigest(ev)
+		if signedKind == "" || !trustcore.ValidDigest(d) {
+			continue // unclassifiable / no well-formed anchor → never a verdict
 		}
+		lvl, _ := ev["governance_level"].(string)
+		rec := artifact.EventRecord{
+			Kind: signedKind, Digest: d, Governance: lvl,
+			Host:      strOrEmpty(ev["packed_on_host"], ev["installed_on_host"]),
+			Rationale: strOrEmpty(ev["rationale"]),
+			Envelope:  ev,
+		}
+		if ts, _ := ev["occurred_at"].(string); ts != "" {
+			if t, perr := time.Parse(time.RFC3339, ts); perr == nil {
+				rec.OccurredAt = t
+			}
+		}
+		// --since (ListFilter.Since): drop events older than the bound; a
+		// zero/unparseable timestamp is kept (best-effort, never a gate).
+		if !filter.Since.IsZero() && !rec.OccurredAt.IsZero() && rec.OccurredAt.Before(filter.Since) {
+			continue
+		}
+		out.Events = append(out.Events, rec)
 	}
 	return out, nil
 }

--- a/pkg/skillctl/registry/er1_pull.go
+++ b/pkg/skillctl/registry/er1_pull.go
@@ -287,7 +287,7 @@ func PullBundles(cfg *er1.Config, ctxID string, tr *SelfTrustRoots, opts PullOpt
 	// attest/revoke event before trusting its governance_level / revoked status
 	// — mirroring Gate 1's admit-envelope verification (~:297). An unsigned or
 	// forged governance verdict is otherwise free to forge.
-	acc, err := loadAttestAccumulator(cfg, ctxID, opts.OnlySkill, tr, opts.now())
+	acc, err := loadAttestAccumulator(cfg, ctxID, tr, opts.now())
 	if err != nil {
 		return nil, err
 	}
@@ -451,8 +451,8 @@ func verifyBundleSignatures(event map[string]any, pub ed25519.PublicKey, recompu
 	return nil
 }
 
-// loadAttestRevoke fetches the attest + revoke items for the registry (optionally
-// scoped to one skill) and returns:
+// loadAttestRevoke fetches the attest + revoke items for the WHOLE registry (never
+// narrowed by skill — see the discovery note below) and returns:
 //   - the latest governance_level per digest (newest occurred_at wins)
 //   - the set of digests that carry any (verified) BundleRevokedEvent
 //
@@ -472,14 +472,14 @@ func verifyBundleSignatures(event map[string]any, pub ed25519.PublicKey, recompu
 // against `pub` (a forged revoke can't be used to suppress, and — more to the
 // point here — a forged revoke can't be used to quarantine a good bundle).
 func FetchRevokedDigests(cfg *er1.Config, ctxID string, pub ed25519.PublicKey) (map[string]struct{}, error) {
-	_, revoked, _, err := loadAttestRevoke(cfg, ctxID, "", pub)
+	_, revoked, _, err := loadAttestRevoke(cfg, ctxID, pub)
 	if err != nil {
 		return nil, err
 	}
 	return revoked, nil
 }
 
-func loadAttestRevoke(cfg *er1.Config, ctxID, onlySkill string, pub ed25519.PublicKey) (map[string]string, map[string]struct{}, map[string]map[string]any, error) {
+func loadAttestRevoke(cfg *er1.Config, ctxID string, pub ed25519.PublicKey) (map[string]string, map[string]struct{}, map[string]map[string]any, error) {
 	attestByDigest := map[string]string{}
 	attestTS := map[string]string{}
 	attestEventByDigest := map[string]map[string]any{} // SPEC-0266 F19: raw signed attestation event (latest) per digest
@@ -491,16 +491,19 @@ func loadAttestRevoke(cfg *er1.Config, ctxID, onlySkill string, pub ed25519.Publ
 	// skill-event:installed (or tag-stripped) was dropped at DISCOVERY, BEFORE the
 	// signed-shape classifier ever saw it — a hostile ER1 tenant could suppress a
 	// revoke by retagging it. We now search only the STABLE bundle tags every
-	// skill-event item carries regardless of kind (the registry/context tags, plus
-	// skill:<name> when scoped) and classify each item by the SIGNED envelope shape
-	// after its signature verifies. Admit/install envelopes fall through to the
-	// default (never a governance verdict), so widening the search adds no false
-	// verdicts; a signed revoke is now discovered whatever its skill-event tag says
-	// (or if it carries none). One search now replaces the two per-kind searches.
+	// skill-event item carries regardless of kind (the registry/context tags) and
+	// classify each item by the SIGNED envelope shape after its signature verifies.
+	//
+	// IS-T4b (scoped-pull residual, challenge-gate LOW): this AUTHORITATIVE revocation
+	// sweep also does NOT narrow on skill:<name> — a skill: tag is equally
+	// writer-controlled, so a revoke with that one tag stripped must not be able to
+	// hide from a scoped pull. Correctness is preserved because every verdict is keyed
+	// on the SIGNED bundle_digest (unique per bundle), so seeing OTHER skills' events
+	// only ever adds their own digests; it never mis-attributes a verdict to the
+	// bundle a caller is checking. The personal registry is tens-to-hundreds of events
+	// (see searchByTagsRaw), so the comprehensive sweep is cheap. One search now
+	// replaces the two per-kind searches.
 	tags := []string{"m3c-skill-bundle", "skill-registry:self"}
-	if onlySkill != "" {
-		tags = append(tags, "skill:"+onlySkill)
-	}
 	items, err := searchByTagsRaw(cfg, ctxID, tags)
 	if err != nil {
 		return nil, nil, nil, err
@@ -544,23 +547,23 @@ func loadAttestRevoke(cfg *er1.Config, ctxID, onlySkill string, pub ed25519.Publ
 	return attestByDigest, revokedDigests, attestEventByDigest, nil
 }
 
-// loadAttestAccumulator fetches the attest + revoke events for the target skill(s)
-// and feeds them into an AttestAccumulator (SPEC-0359 D3/D5) — the shared N-of-M +
+// loadAttestAccumulator fetches the attest + revoke events for the registry and
+// feeds them into an AttestAccumulator (SPEC-0359 D3/D5) — the shared N-of-M +
 // freshness path used by both carriers. Mirrors loadAttestRevoke's fetch; the
 // accumulator performs the SEC-H1 envelope verification against each pinned signer.
-func loadAttestAccumulator(cfg *er1.Config, ctxID, onlySkill string, tr *SelfTrustRoots, now time.Time) (*AttestAccumulator, error) {
+func loadAttestAccumulator(cfg *er1.Config, ctxID string, tr *SelfTrustRoots, now time.Time) (*AttestAccumulator, error) {
 	acc := NewAttestAccumulator(tr, now)
 	// FR-0090 IS-T4b: search the STABLE bundle tags every skill-event item carries
-	// (registry/context, plus skill:<name> when scoped), NOT skill-event:<kind> — so
-	// a signed revoke/attest re-tagged to another kind (or tag-stripped) is still
-	// DISCOVERED. The accumulator's OfferRevoke/OfferAttest re-check the signed
-	// discriminator fields (IS-T3), so a re-tagged event is both routed by what it
-	// actually IS and gated on the signed bytes. Admit/install fall through to the
-	// default (never a governance verdict). One search replaces the two per-kind ones.
+	// (registry/context), NOT skill-event:<kind> and NOT skill:<name> — so a signed
+	// revoke/attest re-tagged to another kind, tag-stripped, OR with its skill tag
+	// stripped is still DISCOVERED, even on a scoped pull (challenge-gate LOW: the
+	// authoritative sweep must not be narrowable by an attacker-strippable skill tag).
+	// The accumulator's OfferRevoke/OfferAttest re-check the signed discriminator
+	// fields (IS-T3) and key every verdict on the SIGNED bundle_digest, so seeing
+	// other skills' events only adds their own digests — never mis-attributing a
+	// verdict to the digest a caller is pulling. Admit/install fall through to the
+	// default (never a governance verdict). One comprehensive search.
 	tags := []string{"m3c-skill-bundle", "skill-registry:self"}
-	if onlySkill != "" {
-		tags = append(tags, "skill:"+onlySkill)
-	}
 	items, err := searchByTagsRaw(cfg, ctxID, tags)
 	if err != nil {
 		return nil, err

--- a/pkg/skillctl/registry/er1_pull.go
+++ b/pkg/skillctl/registry/er1_pull.go
@@ -485,55 +485,60 @@ func loadAttestRevoke(cfg *er1.Config, ctxID, onlySkill string, pub ed25519.Publ
 	attestEventByDigest := map[string]map[string]any{} // SPEC-0266 F19: raw signed attestation event (latest) per digest
 	revokedDigests := map[string]struct{}{}
 
-	for _, kind := range []string{EventKindAttested, EventKindRevoked} {
-		tags := []string{"m3c-skill-bundle", "skill-registry:self", "skill-event:" + kind}
-		if onlySkill != "" {
-			tags = append(tags, "skill:"+onlySkill)
-		}
-		items, err := searchByTagsRaw(cfg, ctxID, tags)
+	// FR-0090 IS-T4b: DISCOVERY must NOT be prefiltered on the attacker-controlled
+	// skill-event:<kind> tag. The old per-kind loop searched
+	// skill-event:{attested,revoked} only, so a signed revoke re-tagged
+	// skill-event:installed (or tag-stripped) was dropped at DISCOVERY, BEFORE the
+	// signed-shape classifier ever saw it — a hostile ER1 tenant could suppress a
+	// revoke by retagging it. We now search only the STABLE bundle tags every
+	// skill-event item carries regardless of kind (the registry/context tags, plus
+	// skill:<name> when scoped) and classify each item by the SIGNED envelope shape
+	// after its signature verifies. Admit/install envelopes fall through to the
+	// default (never a governance verdict), so widening the search adds no false
+	// verdicts; a signed revoke is now discovered whatever its skill-event tag says
+	// (or if it carries none). One search now replaces the two per-kind searches.
+	tags := []string{"m3c-skill-bundle", "skill-registry:self"}
+	if onlySkill != "" {
+		tags = append(tags, "skill:"+onlySkill)
+	}
+	items, err := searchByTagsRaw(cfg, ctxID, tags)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	for _, item := range items {
+		body := itemBody(item)
+		ev, err := extractEvent(body)
 		if err != nil {
-			return nil, nil, nil, err
+			continue
 		}
-		for _, item := range items {
-			body := itemBody(item)
-			ev, err := extractEvent(body)
-			if err != nil {
-				continue
+		digest, _ := ev["bundle_digest"].(string)
+		if digest == "" {
+			continue
+		}
+		// SEC-H1: verify the event envelope signature before trusting its
+		// governance_level / revoked status. Skip (and effectively log via
+		// the dropped event) unsigned or forged verdicts.
+		if err := VerifyEnvelopeSignature(pub, ev); err != nil {
+			continue
+		}
+		// FR-0090 IS-T4/IS-T4b: classify by the SIGNED envelope SHAPE, never a
+		// carrier tag. An ER1 item's tags are metadata a writer controls, so a signed
+		// revoke re-tagged skill-event:attested/installed (to SUPPRESS the revoke) or
+		// an attestation re-tagged skill-event:revoked (to forge a revocation) is
+		// judged by what the SIGNED bytes actually are.
+		switch trustcore.KindFromSignedEnvelope(ev) {
+		case artifact.KindRevoke:
+			revokedDigests[digest] = struct{}{}
+		case artifact.KindAttest:
+			level, _ := ev["governance_level"].(string)
+			ts, _ := ev["occurred_at"].(string)
+			if prev, ok := attestTS[digest]; !ok || ts > prev {
+				attestByDigest[digest] = level
+				attestTS[digest] = ts
+				attestEventByDigest[digest] = ev // keep the SIGNED event for the install-time stash
 			}
-			digest, _ := ev["bundle_digest"].(string)
-			if digest == "" {
-				continue
-			}
-			// SEC-H1: verify the event envelope signature before trusting its
-			// governance_level / revoked status. Skip (and effectively log via
-			// the dropped event) unsigned or forged verdicts.
-			if err := VerifyEnvelopeSignature(pub, ev); err != nil {
-				continue
-			}
-			// FR-0090 IS-T4: classify by the SIGNED envelope SHAPE, not the
-			// skill-event:<kind> TAG. The tag was only a coarse SEARCH prefilter (the
-			// `kind` loop variable above); an ER1 item's tags are carrier metadata a
-			// writer controls, so a signed revoke re-tagged skill-event:attested (to
-			// SUPPRESS the revoke) or an attestation re-tagged skill-event:revoked (to
-			// forge a revocation) must be judged by what the SIGNED bytes actually are.
-			// RESIDUAL (tracked, IS-T4b): the search only returns items still tagged with
-			// one of the searched skill-event:<kind> values, so a revoke retagged to an
-			// UNsearched value (e.g. skill-event:installed) or stripped of the tag is
-			// dropped at DISCOVERY, before this classifier — de-gating the search closes it.
-			switch trustcore.KindFromSignedEnvelope(ev) {
-			case artifact.KindRevoke:
-				revokedDigests[digest] = struct{}{}
-			case artifact.KindAttest:
-				level, _ := ev["governance_level"].(string)
-				ts, _ := ev["occurred_at"].(string)
-				if prev, ok := attestTS[digest]; !ok || ts > prev {
-					attestByDigest[digest] = level
-					attestTS[digest] = ts
-					attestEventByDigest[digest] = ev // keep the SIGNED event for the install-time stash
-				}
-			default:
-				// admit/install/unclassifiable → never a governance verdict here.
-			}
+		default:
+			// admit/install/unclassifiable → never a governance verdict here.
 		}
 	}
 	return attestByDigest, revokedDigests, attestEventByDigest, nil
@@ -545,33 +550,33 @@ func loadAttestRevoke(cfg *er1.Config, ctxID, onlySkill string, pub ed25519.Publ
 // accumulator performs the SEC-H1 envelope verification against each pinned signer.
 func loadAttestAccumulator(cfg *er1.Config, ctxID, onlySkill string, tr *SelfTrustRoots, now time.Time) (*AttestAccumulator, error) {
 	acc := NewAttestAccumulator(tr, now)
-	for _, kind := range []string{EventKindAttested, EventKindRevoked} {
-		tags := []string{"m3c-skill-bundle", "skill-registry:self", "skill-event:" + kind}
-		if onlySkill != "" {
-			tags = append(tags, "skill:"+onlySkill)
-		}
-		items, err := searchByTagsRaw(cfg, ctxID, tags)
+	// FR-0090 IS-T4b: search the STABLE bundle tags every skill-event item carries
+	// (registry/context, plus skill:<name> when scoped), NOT skill-event:<kind> — so
+	// a signed revoke/attest re-tagged to another kind (or tag-stripped) is still
+	// DISCOVERED. The accumulator's OfferRevoke/OfferAttest re-check the signed
+	// discriminator fields (IS-T3), so a re-tagged event is both routed by what it
+	// actually IS and gated on the signed bytes. Admit/install fall through to the
+	// default (never a governance verdict). One search replaces the two per-kind ones.
+	tags := []string{"m3c-skill-bundle", "skill-registry:self"}
+	if onlySkill != "" {
+		tags = append(tags, "skill:"+onlySkill)
+	}
+	items, err := searchByTagsRaw(cfg, ctxID, tags)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		ev, err := extractEvent(itemBody(item))
 		if err != nil {
-			return nil, err
+			continue
 		}
-		for _, item := range items {
-			ev, err := extractEvent(itemBody(item))
-			if err != nil {
-				continue
-			}
-			// FR-0090 IS-T4: route by the SIGNED envelope shape, not the skill-event
-			// TAG (the `kind` loop variable is only the coarse search prefilter). The
-			// accumulator's OfferRevoke/OfferAttest re-check the signed discriminator
-			// fields (IS-T3), so a re-tagged event is both routed and gated by what it
-			// actually IS — a revoke re-tagged attested still reaches OfferRevoke.
-			switch trustcore.KindFromSignedEnvelope(ev) {
-			case artifact.KindRevoke:
-				acc.OfferRevoke(ev)
-			case artifact.KindAttest:
-				acc.OfferAttest(ev)
-			default:
-				// admit/install/unclassifiable → not a governance verdict.
-			}
+		switch trustcore.KindFromSignedEnvelope(ev) {
+		case artifact.KindRevoke:
+			acc.OfferRevoke(ev)
+		case artifact.KindAttest:
+			acc.OfferAttest(ev)
+		default:
+			// admit/install/unclassifiable → not a governance verdict.
 		}
 	}
 	return acc, nil

--- a/pkg/skillctl/registry/er1_pull_signed_identity_test.go
+++ b/pkg/skillctl/registry/er1_pull_signed_identity_test.go
@@ -68,7 +68,7 @@ func TestER1LoadAttestRevokeSignedIdentity(t *testing.T) {
 		"transcript": renderTestEventBody(attEv, "revoked"),
 	})
 
-	attestByDigest, revoked, _, err := loadAttestRevoke(f.cfg(), "skills", "", pub)
+	attestByDigest, revoked, _, err := loadAttestRevoke(f.cfg(), "skills", pub)
 	if err != nil {
 		t.Fatalf("loadAttestRevoke: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestER1LoadAttestRevokeDiscoveryDeGate(t *testing.T) {
 		"transcript": renderTestEventBody(revNoTag, "revoked"),
 	})
 
-	_, revoked, _, err := loadAttestRevoke(f.cfg(), "skills", "", pub)
+	_, revoked, _, err := loadAttestRevoke(f.cfg(), "skills", pub)
 	if err != nil {
 		t.Fatalf("loadAttestRevoke: %v", err)
 	}

--- a/pkg/skillctl/registry/er1_pull_signed_identity_test.go
+++ b/pkg/skillctl/registry/er1_pull_signed_identity_test.go
@@ -89,3 +89,77 @@ func TestER1LoadAttestRevokeSignedIdentity(t *testing.T) {
 		t.Errorf("a signed attestation must be counted (level %q, ok=%v); want green", lvl, ok)
 	}
 }
+
+// TestER1LoadAttestRevokeDiscoveryDeGate is the FR-0090 IS-T4b regression (the
+// IS-03 residual). loadAttestRevoke's DISCOVERY must not be prefiltered on the
+// attacker-controlled skill-event:<kind> tag: a genuinely-signed REVOKE must still
+// be found — and still revoke — when its ER1 item is
+//
+//   - re-tagged to an UNsearched kind (skill-event:installed), or
+//   - stripped of the skill-event tag entirely.
+//
+// Against the OLD code (which searched only skill-event:{attested,revoked}) both
+// items are dropped at DISCOVERY, before the signed-shape classifier, so their
+// digest never enters revokedDigests and a compromised bundle stays installable.
+// After de-gating (search the STABLE bundle tags, classify by the signed envelope)
+// both revokes are discovered and D is revoked.
+func TestER1LoadAttestRevokeDiscoveryDeGate(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	f := newPullFake(t)
+
+	digestInstalledTag := "sha256:" + strings.Repeat("c", 64)
+	digestNoTag := "sha256:" + strings.Repeat("d", 64)
+
+	// (1) A signed REVOKE whose ER1 item is TAGGED skill-event:installed — a kind
+	// the old two-search DISCOVERY never queried.
+	revInstalled, err := BuildBundleRevokedEvent(RevokedEventInput{
+		BundleDigest: digestInstalledTag, ReasonCode: "key-compromise", RevokedBy: "id:test@m3c", OccurredAt: testTime(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SignEnvelopeSignature(priv, revInstalled); err != nil {
+		t.Fatal(err)
+	}
+	f.addItem(map[string]any{
+		"doc_id": "revoke-retagged-installed",
+		"tags": strings.Join([]string{
+			"m3c-skill-bundle", "skill-registry:self",
+			"skill:pdf", "skill-digest:" + digestInstalledTag,
+			"skill-event:" + EventKindInstalled, // dropped by the old search
+		}, ","),
+		"transcript": renderTestEventBody(revInstalled, "installed"),
+	})
+
+	// (2) A signed REVOKE whose ER1 item carries NO skill-event tag at all (stripped).
+	// It still carries the stable bundle tags every item has.
+	revNoTag, err := BuildBundleRevokedEvent(RevokedEventInput{
+		BundleDigest: digestNoTag, ReasonCode: "key-compromise", RevokedBy: "id:test@m3c", OccurredAt: testTime(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SignEnvelopeSignature(priv, revNoTag); err != nil {
+		t.Fatal(err)
+	}
+	f.addItem(map[string]any{
+		"doc_id": "revoke-tag-stripped",
+		"tags": strings.Join([]string{
+			"m3c-skill-bundle", "skill-registry:self",
+			"skill:pdf", "skill-digest:" + digestNoTag,
+			// no skill-event:<kind> tag — the old search would never find this item
+		}, ","),
+		"transcript": renderTestEventBody(revNoTag, "revoked"),
+	})
+
+	_, revoked, _, err := loadAttestRevoke(f.cfg(), "skills", "", pub)
+	if err != nil {
+		t.Fatalf("loadAttestRevoke: %v", err)
+	}
+	if _, ok := revoked[digestInstalledTag]; !ok {
+		t.Error("a signed revoke re-tagged skill-event:installed must STILL be discovered and revoke (de-gated discovery)")
+	}
+	if _, ok := revoked[digestNoTag]; !ok {
+		t.Error("a signed revoke with the skill-event tag stripped must STILL be discovered and revoke (de-gated discovery)")
+	}
+}

--- a/pkg/skillctl/registry/er1_pull_test.go
+++ b/pkg/skillctl/registry/er1_pull_test.go
@@ -376,6 +376,56 @@ func TestPullBundles_Revoked_RejectsAtGate5(t *testing.T) {
 	}
 }
 
+// FR-0090 IS-T4b (scoped-pull residual, challenge-gate LOW): the AUTHORITATIVE
+// revocation sweep must find a signed revoke even on a SCOPED pull (OnlySkill set)
+// when the revoke item's skill:<name> tag has been STRIPPED. Against the pre-fix code
+// (loadAttestAccumulator narrowed the search to skill:<name>) the stripped-tag revoke
+// is invisible to a scoped pull, so the bundle STAGES; after de-scoping the sweep the
+// revoke is found and the bundle is rejected at Gate 5.
+func TestPullBundles_ScopedPull_FindsRevokeWithStrippedSkillTag(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	f := newPullFake(t)
+	admit, digest := mintAdmitItem(t, priv, "pdf", "1.0.0", "skb")
+	attest := mintAttestItem(t, priv, "pdf", "1.0.0", digest, "green", "ok")
+	f.addItem(admit)
+	f.addItem(attest)
+
+	// A signed revoke of `digest`, but the ER1 item carries NO skill:pdf tag.
+	revEv, err := BuildBundleRevokedEvent(RevokedEventInput{
+		BundleDigest: digest, ReasonCode: "key-compromise", RevokedBy: "id:test@m3c", OccurredAt: testTime(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SignEnvelopeSignature(priv, revEv); err != nil {
+		t.Fatal(err)
+	}
+	f.addItem(map[string]any{
+		"doc_id": "revoke-skill-tag-stripped",
+		"tags": strings.Join([]string{
+			"m3c-skill-bundle", "skill-registry:self",
+			"skill-digest:" + digest, "skill-event:" + EventKindRevoked,
+			// deliberately NO skill:pdf tag — the old scoped search would miss this
+		}, ","),
+		"transcript": renderTestEventBody(revEv, "revoked"),
+	})
+
+	trPath := writeTrustRoots(t, pub)
+	tr, _ := LoadSelfTrustRoots(trPath)
+	t.Setenv("M3C_SKILL_CACHE_DIR", t.TempDir())
+
+	res, err := PullBundles(f.cfg(), "skills", tr, PullOpts{OnlySkill: "pdf"})
+	if err != nil {
+		t.Fatalf("PullBundles: %v", err)
+	}
+	if len(res.Staged) != 0 {
+		t.Fatalf("a scoped pull must NOT stage a bundle whose revoke had its skill tag stripped; staged=%+v", res.Staged)
+	}
+	if len(res.Skipped) != 1 || !errors.Is(res.Skipped[0].Gate, ErrGateRevoked) {
+		t.Fatalf("expected ErrGateRevoked (revoke found despite stripped skill tag), got skipped=%+v", res.Skipped)
+	}
+}
+
 func TestPullBundles_WrongKey_RejectsAtGate1(t *testing.T) {
 	_, priv, _ := ed25519.GenerateKey(nil)
 	otherPub, _, _ := ed25519.GenerateKey(nil)


### PR DESCRIPTION
## P1 · Trust / Authorization — signed-mandate scope enforcement (IS-T4b / IS-T6 / IS-T7)

Second P1 wave, trust-core lens. Enforces the **signed** agent mandate at the gate, not just the skill name.

### What it does
- **IS-T7 mandate scope enforcement** — `AuthorizeSkillScoped` now checks the capability **intents / data-scopes / limits** a skill declares in its **digest-verified** `bundle.json`, projecting the signed `intent` block (`side_effects` verbatim, `network`→`network:write`, `subprocess`→`subprocess:exec`, `destructive`), the `data_dependencies` (kind+access), and any `limits`. A skill *named* in the grant but declaring capabilities the mandate never granted is **DENIED**.
- **IS-T7 now effective on BOTH install paths** (challenge-gate + re-gate fix) — `installedSkillDigest` resolves the digest from the `.skillctl-offline.json` stash that `skillctl install` writes, not only the `.m3c-provenance.json` sidecar that only `skillctl pull` writes. A managed `.skb` whose scope cannot be resolved from **any** basis **fails closed** under a restricting grant; name-only never-brick is reserved strictly for a genuinely unmanaged skill (no `.skb`, no provenance).
- **IS-T6 require-mandate floor** — a root-owned floor turns a *missing* mandate from a silent opt-out into a hard DENY (a non-privileged user can't delete `agentid.json` to escape authorization).
- **IS-T4b ER1 discovery de-gate** — event discovery keyed on the signed envelope, not the `skill:<name>` / `skill-event:<kind>` tags (closes IS-03 fully; complements FR-0090).
- **Residuals closed** — `intent.subprocess` in any encoding (bool/string/map/list) → `subprocess:exec`; unknown `data_dependencies[].kind` carried verbatim → fail-closed.

### Assurance
- **Adversarial challenge gate (3 lenses) + a focused re-gate** on the fix delta = **CLEARED** (the gate first caught that the initial fix left IS-T7 inert on the `skillctl install` path — now closed).
- **6 new bite-tests**; 5 empirically **fail against pre-fix** code, 1 is the never-brick guard.
- No signed/canonical bytes touched (no wire-format change). darwin + `GOOS=windows` build + full `pkg/skillctl/...` + `cmd/skillctl` suite green.

Human-merge per the trust-layer flow. `closes IS-03 / IS-04 / IS-06 (partial IS-07 tracked)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
