### PR TITLE
P1 · Audit — tamper-evident invocation trail (IS-T8/T11)

### DIFF
--- a/cmd/skillctl/awareness_reset_cmds.go
+++ b/cmd/skillctl/awareness_reset_cmds.go
@@ -32,6 +32,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -45,15 +46,21 @@ import (
 // stale token in shell history isn't a free destructive primitive).
 const awarenessResetMaxTokenAge = 5 * time.Minute
 
+// awarenessResetMaxIssuedDigits bounds the length of the token's issued-at
+// prefix (IS-T11). A Unix-seconds timestamp needs ≤ 19 digits (int64's range);
+// anything longer is definitionally out of range and is rejected before parsing,
+// rather than being fed to a parser that could silently overflow.
+const awarenessResetMaxIssuedDigits = 19
+
 // awarenessResetDryRunResp is the response shape from a `?dry_run=1` GET
 // on the reset endpoint. Stream A's handler returns this.
 type awarenessResetDryRunResp struct {
-	SessionTag    string                   `json:"session_tag"`
-	Affected      []map[string]any         `json:"affected"`
-	AffectedCount int                      `json:"affected_count"`
-	Token         string                   `json:"token"`
-	IssuedAt      string                   `json:"issued_at"`
-	ExpiresAt     string                   `json:"expires_at"`
+	SessionTag    string           `json:"session_tag"`
+	Affected      []map[string]any `json:"affected"`
+	AffectedCount int              `json:"affected_count"`
+	Token         string           `json:"token"`
+	IssuedAt      string           `json:"issued_at"`
+	ExpiresAt     string           `json:"expires_at"`
 }
 
 // awarenessResetConfirmResp is the response shape from a successful DELETE.
@@ -320,14 +327,24 @@ func isAwarenessResetTokenExpired(token string, now time.Time) (bool, error) {
 		return false, fmt.Errorf("token shape: expected <issued>.<sig>, got %q", token)
 	}
 	prefix := token[:dot]
-	var issued int64
-	for _, r := range prefix {
-		if r < '0' || r > '9' {
-			return false, fmt.Errorf("token issued-at prefix %q not numeric", prefix)
-		}
-		issued = issued*10 + int64(r-'0')
+	// IS-T11: parse the issued-at with explicit bounds instead of the old
+	// hand-rolled `issued = issued*10 + (r-'0')` loop, which silently OVERFLOWS
+	// int64 on a long numeric prefix. On overflow the value could wrap to a large
+	// number that lands time.Unix() far in the FUTURE — the `age < 0` branch below
+	// would then treat an absurd token as FRESH, silently skipping the client-side
+	// TTL guard (a non-numeric-or-overflowed prefix must fail closed, not pass).
+	//
+	// strconv.ParseUint rejects a sign and any non-digit (preserving the old
+	// digits-only contract) and returns ErrRange on overflow; bitSize 63 keeps the
+	// result within int64's positive range so the time.Unix conversion is exact.
+	if len(prefix) > awarenessResetMaxIssuedDigits {
+		return false, fmt.Errorf("token issued-at prefix %q too long (max %d digits)", prefix, awarenessResetMaxIssuedDigits)
 	}
-	issuedTime := time.Unix(issued, 0).UTC()
+	issued, err := strconv.ParseUint(prefix, 10, 63)
+	if err != nil {
+		return false, fmt.Errorf("token issued-at prefix %q invalid: %w", prefix, err)
+	}
+	issuedTime := time.Unix(int64(issued), 0).UTC()
 	age := now.UTC().Sub(issuedTime)
 	if age < 0 {
 		// Clock skew: token claims to be from the future. Treat as

--- a/cmd/skillctl/awareness_reset_cmds_test.go
+++ b/cmd/skillctl/awareness_reset_cmds_test.go
@@ -190,3 +190,49 @@ func TestAwarenessReset_CrossIdentityExits19(t *testing.T) {
 		t.Errorf("stderr should mention identity; got: %q", stderr.String())
 	}
 }
+
+// TestIsAwarenessResetTokenExpired_OverflowPrefixRejected is the IS-T11
+// acceptance test. The OLD hand-rolled `issued = issued*10 + (r-'0')` loop
+// silently OVERFLOWED int64 on a long numeric prefix; the wrapped value could
+// land time.Unix() far in the FUTURE, so the `age < 0` branch returned
+// (false, nil) — the token was treated as FRESH and the client-side TTL guard
+// was skipped. The bounded strconv.ParseUint parse must FAIL CLOSED instead.
+func TestIsAwarenessResetTokenExpired_OverflowPrefixRejected(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+
+	// A numeric prefix far longer than int64's range → parse error, NOT a
+	// silently-wrapped future timestamp treated as fresh.
+	longNumeric := strings.Repeat("9", 40) + ".deadbeef"
+	if expired, err := isAwarenessResetTokenExpired(longNumeric, now); err == nil {
+		t.Errorf("long numeric prefix accepted (expired=%v); overflow not rejected", expired)
+	}
+
+	// Over the digit cap (20 digits > 19) → rejected up front.
+	overCap := strings.Repeat("1", 20) + ".sig"
+	if expired, err := isAwarenessResetTokenExpired(overCap, now); err == nil {
+		t.Errorf("over-cap prefix accepted (expired=%v); want error", expired)
+	}
+
+	// Within the digit cap (19 digits) but numerically > MaxInt64 → the range
+	// check (ParseUint bitSize 63) rejects it rather than wrapping negative.
+	overRange := "9999999999999999999.sig" // 19 nines > 9223372036854775807
+	if _, err := isAwarenessResetTokenExpired(overRange, now); err == nil {
+		t.Errorf("out-of-range prefix accepted; want error")
+	}
+
+	// A signed prefix is non-numeric under the digits-only contract → rejected
+	// (ParseUint permits no sign).
+	if _, err := isAwarenessResetTokenExpired("-5.sig", now); err == nil {
+		t.Errorf("signed prefix accepted; want error")
+	}
+
+	// Regression guard: a normal, in-range token still parses and is judged by age.
+	fresh := fmt.Sprintf("%d.sig", now.Unix())
+	if expired, err := isAwarenessResetTokenExpired(fresh, now); err != nil || expired {
+		t.Errorf("fresh in-range token mishandled: expired=%v err=%v", expired, err)
+	}
+	stale := fmt.Sprintf("%d.sig", now.Add(-10*time.Minute).Unix())
+	if expired, err := isAwarenessResetTokenExpired(stale, now); err != nil || !expired {
+		t.Errorf("stale in-range token mishandled: expired=%v err=%v", expired, err)
+	}
+}

--- a/cmd/skillctl/compliance_cmds.go
+++ b/cmd/skillctl/compliance_cmds.go
@@ -77,11 +77,14 @@ func trailEvidenceSentence(tv trailVerification) string {
 	// against an external root (registry attestation of the device key is a
 	// follow-up). Do not let an auditor read self-referential verification as
 	// external attestation.
-	// IS-T8: report the hash-chain contiguity check (seq + prev_hash) that makes a
-	// deleted/truncated middle record tamper-EVIDENT on top of the per-line signature.
-	chain := "hash-chained (seq+prev_hash) contiguous — no middle record deleted or reordered"
+	// IS-T8: report the hash-chain integrity check — keyless seq+prev_hash
+	// contiguity PLUS the second device signature over each link — that makes a
+	// deleted, reordered, or same-uid-rewritten middle record tamper-EVIDENT on top
+	// of the per-line signature. Honest scope: TAIL truncation is NOT covered here
+	// (a valid signed prefix; needs an external SPEC-0358 head anchor).
+	chain := fmt.Sprintf("hash-chained (seq+prev_hash, %d/%d links device-signed) intact — no middle record deleted, reordered, or rewritten (tail-truncation not covered: needs an external SPEC-0358 anchor)", tv.ChainSigned, tv.Total)
 	if !tv.ChainVerified {
-		chain = fmt.Sprintf("hash-chain BROKEN — %d contiguity break(s): the append-only trail was truncated or reordered", tv.ChainBreaks)
+		chain = fmt.Sprintf("hash-chain BROKEN — %d break(s): a record was deleted, reordered, or a link's seq/prev_hash/signature was altered", tv.ChainBreaks)
 	}
 	return fmt.Sprintf("Per-invocation signed events (SPEC-0202): %d/%d invocation records pass local device-key integrity verification (%d unverified, %d replays); %s. Device key %s is locally anchored (integrity-since-signing on this host; not yet registry-attested). Append-only ~/.claude/skillctl/invocation-trail.jsonl.",
 		tv.Verified, tv.Total, tv.Unverified, tv.Replays, chain, key)

--- a/cmd/skillctl/compliance_cmds.go
+++ b/cmd/skillctl/compliance_cmds.go
@@ -77,8 +77,14 @@ func trailEvidenceSentence(tv trailVerification) string {
 	// against an external root (registry attestation of the device key is a
 	// follow-up). Do not let an auditor read self-referential verification as
 	// external attestation.
-	return fmt.Sprintf("Per-invocation signed events (SPEC-0202): %d/%d invocation records pass local device-key integrity verification (%d unverified, %d replays). Device key %s is locally anchored (integrity-since-signing on this host; not yet registry-attested). Append-only ~/.claude/skillctl/invocation-trail.jsonl.",
-		tv.Verified, tv.Total, tv.Unverified, tv.Replays, key)
+	// IS-T8: report the hash-chain contiguity check (seq + prev_hash) that makes a
+	// deleted/truncated middle record tamper-EVIDENT on top of the per-line signature.
+	chain := "hash-chained (seq+prev_hash) contiguous — no middle record deleted or reordered"
+	if !tv.ChainVerified {
+		chain = fmt.Sprintf("hash-chain BROKEN — %d contiguity break(s): the append-only trail was truncated or reordered", tv.ChainBreaks)
+	}
+	return fmt.Sprintf("Per-invocation signed events (SPEC-0202): %d/%d invocation records pass local device-key integrity verification (%d unverified, %d replays); %s. Device key %s is locally anchored (integrity-since-signing on this host; not yet registry-attested). Append-only ~/.claude/skillctl/invocation-trail.jsonl.",
+		tv.Verified, tv.Total, tv.Unverified, tv.Replays, chain, key)
 }
 
 const complianceDisclaimer = "Evidence aid for an auditor — NOT a certification or attestation of compliance. " +

--- a/cmd/skillctl/invocation_trail.go
+++ b/cmd/skillctl/invocation_trail.go
@@ -25,10 +25,12 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -105,6 +107,119 @@ func defaultInvocationTrailSink(home string, line []byte) error {
 	return err
 }
 
+// chainedInvocationRecord is the ON-DISK trail line: a signed
+// skillgate.InvocationRecord PLUS two ADDITIVE, unsigned integrity fields that
+// hash-chain the trail (IS-T8, SPEC-0202 §9 / EU AI Act Art.12 tamper-evidence):
+//
+//   - Seq — a monotonic per-generation sequence number (genesis = 0). A deleted
+//     or truncated middle record leaves a gap the verifier detects.
+//   - PrevHash — the SHA-256 (hex) of the PREVIOUS record's CANONICAL bytes
+//     (skillgate.CanonicalizeInvocationRecord output). Because each record commits
+//     to its predecessor's content, deleting a middle record makes the survivor's
+//     prev_hash no longer match the recomputed hash of its new predecessor.
+//
+// These two fields are deliberately OUTSIDE the signed canonical message: adding
+// them there would change the v1 canonical bytes and invalidate every existing
+// per-line signature (and the golden-bytes pin). So they layer tamper-EVIDENCE
+// (contiguity + content chaining) ON TOP of the unchanged per-line device
+// signature — the signature proves each record's own integrity, the chain proves
+// the trail was not silently truncated in the middle.
+//
+// HONEST SCOPE (no overclaim): the chain fields are not themselves signed, so an
+// adversary holding the device signing key — or one who deletes a record AND
+// rewrites every surviving record's seq/prev_hash — is out of scope here; that is
+// what the device-key custody + the append-only file mode defend. This closes the
+// naive delete/truncate gap (records currently pass clean after a middle deletion).
+// Each rotation generation (.jsonl vs .jsonl.1) is its own self-contained chain.
+type chainedInvocationRecord struct {
+	skillgate.InvocationRecord
+	// Seq is a pointer so a legacy record written BEFORE this feature (no "seq"
+	// key) unmarshals to nil and is excluded from chain verification — avoiding a
+	// false break on pre-existing trails. A non-nil pointer to 0 marks genesis.
+	Seq      *uint64 `json:"seq,omitempty"`
+	PrevHash string  `json:"prev_hash"`
+}
+
+// invocationChainHash returns the hex SHA-256 over a record's canonical bytes —
+// the value the NEXT record stores as its prev_hash. ok is false only if the
+// record refuses to canonicalize (e.g. a newline-smuggled field), in which case
+// the chain intentionally cannot continue across it.
+func invocationChainHash(rec skillgate.InvocationRecord) (hash string, ok bool) {
+	canon, err := skillgate.CanonicalizeInvocationRecord(&rec)
+	if err != nil {
+		return "", false
+	}
+	sum := sha256.Sum256(canon)
+	return hex.EncodeToString(sum[:]), true
+}
+
+// readLastTrailLine returns the last non-empty line of the trail file, reading
+// only a bounded tail so an append stays cheap regardless of trail size. Returns
+// nil when the file is absent, empty, or unreadable.
+func readLastTrailLine(path string) []byte {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil || fi.Size() == 0 {
+		return nil
+	}
+	const tail = 256 << 10 // 256 KiB — far larger than one record line
+	start := int64(0)
+	if fi.Size() > tail {
+		start = fi.Size() - tail
+	}
+	buf := make([]byte, fi.Size()-start)
+	if _, err := f.ReadAt(buf, start); err != nil && err != io.EOF {
+		return nil
+	}
+	// The tail may begin mid-line; iterate from the end and take the last COMPLETE
+	// non-empty line (the trailing record is always fully within the tail).
+	for _, ln := range revLines(buf) {
+		if t := bytes.TrimSpace(ln); len(t) > 0 {
+			return t
+		}
+	}
+	return nil
+}
+
+// revLines splits buf on '\n' and returns the lines in reverse order.
+func revLines(buf []byte) [][]byte {
+	parts := bytes.Split(buf, []byte{'\n'})
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+	return parts
+}
+
+// nextChainLink computes the (seq, prev_hash) to stamp onto the NEXT appended
+// record, from the current live trail. Genesis (0, "") when the trail is fresh,
+// unreadable, about to rotate, or its last record predates the chain feature.
+func nextChainLink(home string) (seq uint64, prevHash string) {
+	path := invocationTrailPath(home)
+	// Mirror the default sink's pre-append rotation: an at/over-cap live file is
+	// renamed to .jsonl.1 and a fresh file started, so the next record opens a new
+	// generation's chain at genesis.
+	if fi, err := os.Stat(path); err == nil && fi.Size() >= invocationTrailMaxBytes {
+		return 0, ""
+	}
+	last := readLastTrailLine(path)
+	if last == nil {
+		return 0, ""
+	}
+	var prev chainedInvocationRecord
+	if err := json.Unmarshal(last, &prev); err != nil || prev.Seq == nil {
+		return 0, "" // unreadable, or a legacy predecessor → start a fresh chain
+	}
+	h, ok := invocationChainHash(prev.InvocationRecord)
+	if !ok {
+		return 0, ""
+	}
+	return *prev.Seq + 1, h
+}
+
 // appendSignedInvocation builds, device-signs, and appends one InvocationRecord
 // to the signed trail. Fire-and-forget: any error or panic is swallowed so it
 // can NEVER reach the caller's decision path.
@@ -151,7 +266,18 @@ func appendSignedInvocation(home string, rec skillgate.InvocationRecord) {
 		return // refused to sign ambiguous bytes (e.g. newline-smuggled field)
 	}
 
-	line, err := json.Marshal(rec)
+	// IS-T8: stamp the hash-chain link (seq + prev_hash over the PRIOR record's
+	// canonical bytes) so a later deletion/truncation of a middle record is
+	// detectable. Additive, unsigned fields — the per-line signature above is
+	// unchanged (rec is signed BEFORE it is wrapped).
+	seq, prevHash := nextChainLink(home)
+	chained := chainedInvocationRecord{
+		InvocationRecord: rec,
+		Seq:              &seq,
+		PrevHash:         prevHash,
+	}
+
+	line, err := json.Marshal(chained)
 	if err != nil {
 		return
 	}
@@ -189,6 +315,18 @@ type trailVerification struct {
 	Replays int
 	// DeviceKeyID is the local device key's id ("" if the key is unavailable).
 	DeviceKeyID string
+	// ChainBreaks counts hash-chain contiguity violations (IS-T8): a chained
+	// record whose seq is not predecessor.seq+1, or whose prev_hash does not equal
+	// the recomputed hash of the preceding chained record's canonical bytes, or a
+	// first chained record that is not genesis (seq 0 / empty prev_hash). A deleted
+	// or truncated middle record yields at least one break. Records predating the
+	// chain feature (no "seq" field) are excluded, so a legacy trail reports 0.
+	ChainBreaks int
+	// ChainVerified is true when the trail's chained records form one contiguous
+	// hash chain with no breaks (vacuously true for a trail with no chained
+	// records). It is the tamper-evidence signal for the Art.12 record-keeping
+	// control: false means the append-only trail was truncated/reordered.
+	ChainVerified bool
 }
 
 // readAndVerifyTrail reads the signed invocation trail at home, verifies each
@@ -225,6 +363,15 @@ func readAndVerifyTrail(home string) trailVerification {
 	tv.Present = true
 
 	seen := make(map[string]struct{})
+	// Hash-chain contiguity state (IS-T8). Tracked across the PHYSICAL order of
+	// chained records (independent of replay dedup / signature validity) so a
+	// deleted or truncated middle record is detected even when every surviving
+	// record still signs cleanly.
+	var (
+		chainStarted  bool
+		expectSeq     uint64 // predecessor.seq + 1
+		prevChainHash string // hash of the predecessor's canonical bytes
+	)
 	sc := bufio.NewScanner(bytes.NewReader(data))
 	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
 	for sc.Scan() {
@@ -233,15 +380,45 @@ func readAndVerifyTrail(home string) trailVerification {
 			continue
 		}
 		tv.Total++
-		var rec skillgate.InvocationRecord
+		var rec chainedInvocationRecord
 		if err := json.Unmarshal(raw, &rec); err != nil {
+			// An unparseable line is counted Unverified; it also breaks the chain
+			// for the following record (whose prev_hash can no longer be recomputed
+			// here), which surfaces as a ChainBreak there — never a silent drop.
 			tv.Unverified++
 			continue
 		}
+
+		// --- hash-chain contiguity (IS-T8) --------------------------------------
+		// Only records carrying the chain fields participate; legacy records
+		// (no "seq") are excluded so pre-feature trails do not report false breaks.
+		if rec.Seq != nil {
+			thisHash, okHash := invocationChainHash(rec.InvocationRecord)
+			if !chainStarted {
+				// The first chained record must be genesis (seq 0, empty prev_hash).
+				// A non-genesis first record means the trail head was truncated.
+				if *rec.Seq != 0 || rec.PrevHash != "" {
+					tv.ChainBreaks++
+				}
+				chainStarted = true
+			} else if *rec.Seq != expectSeq || rec.PrevHash != prevChainHash {
+				// A gap in seq OR a prev_hash that does not match the recomputed hash
+				// of the preceding record → a deleted/truncated/reordered record.
+				tv.ChainBreaks++
+			}
+			expectSeq = *rec.Seq + 1
+			if okHash {
+				prevChainHash = thisHash
+			} else {
+				prevChainHash = "" // cannot recompute → the next record will mismatch
+			}
+		}
+
 		// Replay: a second occurrence of an event_id we've already counted is a
 		// REPLAY, not new evidence — it must NOT inflate the verified-evidence
 		// count (P2 challenge-gate finding). Count it as a replay and move on, so
-		// `Verified` reflects DISTINCT verified events only.
+		// `Verified` reflects DISTINCT verified events only. (Chain state was
+		// already advanced above, so a replayed line does not corrupt contiguity.)
 		if rec.EventID != "" {
 			if _, dup := seen[rec.EventID]; dup {
 				tv.Replays++
@@ -249,11 +426,13 @@ func readAndVerifyTrail(home string) trailVerification {
 			}
 			seen[rec.EventID] = struct{}{}
 		}
-		if havePub && skillgate.VerifyInvocationRecord(&rec, pubKey, base64.StdEncoding.DecodeString) {
+		if havePub && skillgate.VerifyInvocationRecord(&rec.InvocationRecord, pubKey, base64.StdEncoding.DecodeString) {
 			tv.Verified++
 		} else {
 			tv.Unverified++
 		}
 	}
+	// Vacuously true for a legacy/empty trail (no chained records → no breaks).
+	tv.ChainVerified = tv.ChainBreaks == 0
 	return tv
 }

--- a/cmd/skillctl/invocation_trail.go
+++ b/cmd/skillctl/invocation_trail.go
@@ -24,6 +24,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
@@ -108,36 +109,61 @@ func defaultInvocationTrailSink(home string, line []byte) error {
 }
 
 // chainedInvocationRecord is the ON-DISK trail line: a signed
-// skillgate.InvocationRecord PLUS two ADDITIVE, unsigned integrity fields that
-// hash-chain the trail (IS-T8, SPEC-0202 §9 / EU AI Act Art.12 tamper-evidence):
+// skillgate.InvocationRecord PLUS three ADDITIVE integrity fields that hash-chain
+// the trail (IS-T8, SPEC-0202 §9 / EU AI Act Art.12 tamper-evidence):
 //
 //   - Seq — a monotonic per-generation sequence number (genesis = 0). A deleted
-//     or truncated middle record leaves a gap the verifier detects.
+//     record leaves a gap.
 //   - PrevHash — the SHA-256 (hex) of the PREVIOUS record's CANONICAL bytes
 //     (skillgate.CanonicalizeInvocationRecord output). Because each record commits
 //     to its predecessor's content, deleting a middle record makes the survivor's
 //     prev_hash no longer match the recomputed hash of its new predecessor.
+//   - ChainSignatureB64 — a SECOND detached ed25519 signature (same device key,
+//     DISTINCT domain "invocation_chain_v1") over (seq, prev_hash, self_hash),
+//     where self_hash binds the link to THIS record's own canonical bytes so a
+//     signed link cannot be transplanted onto a different record.
 //
-// These two fields are deliberately OUTSIDE the signed canonical message: adding
+// All three sit OUTSIDE the per-line InvocationRecord canonical message: putting
 // them there would change the v1 canonical bytes and invalidate every existing
-// per-line signature (and the golden-bytes pin). So they layer tamper-EVIDENCE
-// (contiguity + content chaining) ON TOP of the unchanged per-line device
-// signature — the signature proves each record's own integrity, the chain proves
-// the trail was not silently truncated in the middle.
+// per-line signature (and the golden-bytes pin). They are additive/separate — the
+// per-line signature proves each record's own integrity; the chain proves the
+// trail was not truncated or reordered in the middle.
 //
-// HONEST SCOPE (no overclaim): the chain fields are not themselves signed, so an
-// adversary holding the device signing key — or one who deletes a record AND
-// rewrites every surviving record's seq/prev_hash — is out of scope here; that is
-// what the device-key custody + the append-only file mode defend. This closes the
-// naive delete/truncate gap (records currently pass clean after a middle deletion).
+// HONEST SCOPE — read carefully, do NOT overclaim:
+//
+//   - seq + prev_hash ALONE are keyless SHA-256 over PUBLIC canonical bytes. On
+//     their own they are a NAIVE delete/reorder DETECTOR (tamper-EVIDENT for a
+//     careless deletion), NOT cryptographic tamper-proofing: a same-uid writer can
+//     recompute a fully valid seq+prev_hash chain with NO key, and O_APPEND does
+//     not stop a same-uid O_TRUNC rewrite of the whole file.
+//   - ChainSignatureB64 is what makes the chain actually tamper-EVIDENT against
+//     that same-uid rewrite: the attacker can edit seq/prev_hash but cannot forge
+//     the device signature over the new values, and cannot transplant an existing
+//     signed link (self_hash pins it to its record). Stripping the signature is
+//     itself a break (a chained record MUST carry a verifiable one when the device
+//     public key is available). This is the "second detached signature" option
+//     from the challenge gate.
+//   - STILL out of scope, even with the signature: (a) anyone holding the device
+//     signing key can forge any record — key custody, not this chain, is the trust
+//     anchor; (b) TAIL truncation — dropping the newest N records leaves a valid,
+//     contiguous, fully-signed prefix, so it is NOT detectable here. Detecting
+//     wholesale/tail truncation needs an EXTERNAL anchor of the head hash (the
+//     SPEC-0358 transparency log), which this local chain does not provide.
+//   - CONCURRENCY (gate N1): two concurrent skillctl processes sharing the trail
+//     can BOTH stamp seq=N+1, so verification may report a benign ChainBreak on a
+//     NON-tampered trail. This is a deliberate FAIL-SAFE over-report — the trail is
+//     advisory (never a gate input) and every per-line signature still verifies; we
+//     accept a false "break" rather than risk a false "clean".
+//
 // Each rotation generation (.jsonl vs .jsonl.1) is its own self-contained chain.
 type chainedInvocationRecord struct {
 	skillgate.InvocationRecord
 	// Seq is a pointer so a legacy record written BEFORE this feature (no "seq"
 	// key) unmarshals to nil and is excluded from chain verification — avoiding a
 	// false break on pre-existing trails. A non-nil pointer to 0 marks genesis.
-	Seq      *uint64 `json:"seq,omitempty"`
-	PrevHash string  `json:"prev_hash"`
+	Seq               *uint64 `json:"seq,omitempty"`
+	PrevHash          string  `json:"prev_hash"`
+	ChainSignatureB64 string  `json:"chain_signature_b64,omitempty"`
 }
 
 // invocationChainHash returns the hex SHA-256 over a record's canonical bytes —
@@ -151,6 +177,36 @@ func invocationChainHash(rec skillgate.InvocationRecord) (hash string, ok bool) 
 	}
 	sum := sha256.Sum256(canon)
 	return hex.EncodeToString(sum[:]), true
+}
+
+// invocationChainDomain domain-separates the SECOND (chain-link) device signature
+// from the per-line InvocationRecord signature (invocation_event_v1) and every
+// other signature family, so a signature captured under one can never replay under
+// another — even with the same key.
+const invocationChainDomain = "invocation_chain_v1"
+
+// invocationChainSigMessage builds the canonical bytes the chain signature covers:
+// the link (seq, prev_hash) BOUND to this record's own canonical hash (self_hash),
+// so a signed link cannot be transplanted onto a different record. LF-delimited,
+// fixed order; every value is a decimal uint or lowercase hex / empty (never
+// contains a newline), so the framing is unambiguous.
+func invocationChainSigMessage(seq uint64, prevHash, selfHash string) []byte {
+	return []byte(fmt.Sprintf("%s\nseq=%d\nprev_hash=%s\nself_hash=%s\n",
+		invocationChainDomain, seq, prevHash, selfHash))
+}
+
+// verifyChainSignature verifies a record's detached chain-link signature over
+// (seq, prev_hash, self_hash) against the local device public key. Fail-closed:
+// a wrong-size key, absent/garbage signature, or any mismatch returns false.
+func verifyChainSignature(pub []byte, seq uint64, prevHash, selfHash, sigB64 string) bool {
+	if len(pub) != ed25519.PublicKeySize || sigB64 == "" {
+		return false
+	}
+	sig, err := base64.StdEncoding.DecodeString(sigB64)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return false
+	}
+	return ed25519.Verify(ed25519.PublicKey(pub), invocationChainSigMessage(seq, prevHash, selfHash), sig)
 }
 
 // readLastTrailLine returns the last non-empty line of the trail file, reading
@@ -268,13 +324,21 @@ func appendSignedInvocation(home string, rec skillgate.InvocationRecord) {
 
 	// IS-T8: stamp the hash-chain link (seq + prev_hash over the PRIOR record's
 	// canonical bytes) so a later deletion/truncation of a middle record is
-	// detectable. Additive, unsigned fields — the per-line signature above is
-	// unchanged (rec is signed BEFORE it is wrapped).
+	// detectable, PLUS a second detached device signature over (seq, prev_hash,
+	// self_hash) so a same-uid keyless rewrite of those fields is tamper-evident.
+	// All additive/separate — the per-line signature above is unchanged (rec is
+	// signed BEFORE it is wrapped).
 	seq, prevHash := nextChainLink(home)
 	chained := chainedInvocationRecord{
 		InvocationRecord: rec,
 		Seq:              &seq,
 		PrevHash:         prevHash,
+	}
+	if selfHash, ok := invocationChainHash(rec); ok {
+		msg := invocationChainSigMessage(seq, prevHash, selfHash)
+		if sig := key.Sign(msg); len(sig) == ed25519.SignatureSize {
+			chained.ChainSignatureB64 = base64.StdEncoding.EncodeToString(sig)
+		}
 	}
 
 	line, err := json.Marshal(chained)
@@ -315,17 +379,30 @@ type trailVerification struct {
 	Replays int
 	// DeviceKeyID is the local device key's id ("" if the key is unavailable).
 	DeviceKeyID string
-	// ChainBreaks counts hash-chain contiguity violations (IS-T8): a chained
-	// record whose seq is not predecessor.seq+1, or whose prev_hash does not equal
-	// the recomputed hash of the preceding chained record's canonical bytes, or a
-	// first chained record that is not genesis (seq 0 / empty prev_hash). A deleted
-	// or truncated middle record yields at least one break. Records predating the
-	// chain feature (no "seq" field) are excluded, so a legacy trail reports 0.
+	// ChainBreaks counts hash-chain integrity violations (IS-T8) — at most one per
+	// record. A chained record breaks the chain when EITHER: its seq is not
+	// predecessor.seq+1 / its prev_hash does not equal the recomputed hash of the
+	// preceding chained record's canonical bytes / it is a first record that is not
+	// genesis (seq 0, empty prev_hash) — the keyless contiguity check; OR (when the
+	// device public key is available) its chain-link device signature over
+	// (seq, prev_hash, self_hash) is missing or does not verify — the check that
+	// catches a same-uid keyless rewrite or a stripped signature. A deleted,
+	// reordered, or rewritten middle record yields at least one break. NOT detected:
+	// tail truncation (a valid signed prefix) — that needs an external SPEC-0358
+	// head anchor. Records predating the chain feature (no "seq") are excluded, so a
+	// legacy trail reports 0. Concurrent writers can cause a benign over-report (a
+	// fail-safe; see chainedInvocationRecord).
 	ChainBreaks int
+	// ChainSigned counts chained records whose chain-link device signature verified
+	// — the number of links backed by cryptographic tamper-evidence (0 when the
+	// device public key is unavailable). ChainSigned == number-of-chained-records
+	// means every link is device-signed.
+	ChainSigned int
 	// ChainVerified is true when the trail's chained records form one contiguous
 	// hash chain with no breaks (vacuously true for a trail with no chained
 	// records). It is the tamper-evidence signal for the Art.12 record-keeping
-	// control: false means the append-only trail was truncated/reordered.
+	// control: false means the append-only trail was truncated (in the middle),
+	// reordered, or a link was altered.
 	ChainVerified bool
 }
 
@@ -389,21 +466,40 @@ func readAndVerifyTrail(home string) trailVerification {
 			continue
 		}
 
-		// --- hash-chain contiguity (IS-T8) --------------------------------------
+		// --- hash-chain integrity (IS-T8) ---------------------------------------
 		// Only records carrying the chain fields participate; legacy records
 		// (no "seq") are excluded so pre-feature trails do not report false breaks.
 		if rec.Seq != nil {
 			thisHash, okHash := invocationChainHash(rec.InvocationRecord)
+			broke := false
+			// (1) Keyless contiguity — detects a naive delete/reorder even with no key.
 			if !chainStarted {
 				// The first chained record must be genesis (seq 0, empty prev_hash).
 				// A non-genesis first record means the trail head was truncated.
 				if *rec.Seq != 0 || rec.PrevHash != "" {
-					tv.ChainBreaks++
+					broke = true
 				}
 				chainStarted = true
 			} else if *rec.Seq != expectSeq || rec.PrevHash != prevChainHash {
 				// A gap in seq OR a prev_hash that does not match the recomputed hash
 				// of the preceding record → a deleted/truncated/reordered record.
+				broke = true
+			}
+			// (2) Chain-link device signature — the cryptographic layer. When the
+			// device public key is available, a chained record MUST carry a chain
+			// signature that verifies over (seq, prev_hash, self_hash); a missing or
+			// invalid one is a break (this is what catches a same-uid KEYLESS rewrite
+			// of seq/prev_hash, and a downgrade that strips the signature). When the
+			// key is unavailable we cannot verify — fall back to contiguity only,
+			// exactly as the per-line signature path reports present-but-unverified.
+			if havePub {
+				if okHash && verifyChainSignature(pubKey, *rec.Seq, rec.PrevHash, thisHash, rec.ChainSignatureB64) {
+					tv.ChainSigned++
+				} else {
+					broke = true
+				}
+			}
+			if broke {
 				tv.ChainBreaks++
 			}
 			expectSeq = *rec.Seq + 1

--- a/cmd/skillctl/invocation_trail.go
+++ b/cmd/skillctl/invocation_trail.go
@@ -528,7 +528,15 @@ func readAndVerifyTrail(home string) trailVerification {
 			tv.Unverified++
 		}
 	}
-	// Vacuously true for a legacy/empty trail (no chained records → no breaks).
-	tv.ChainVerified = tv.ChainBreaks == 0
+	// ChainVerified requires zero breaks AND — for a trail that actually CONTAINS
+	// chained records — that the device public key was available to verify the chain
+	// signatures. Keyless contiguity alone is forgeable: a same-uid actor who deletes
+	// the device key can then recompute a fully contiguous chain (seq/prev_hash/
+	// self_hash) that passes every contiguity check, which is exactly what the chain
+	// signature exists to stop. So a chained trail whose device key is missing is
+	// present-but-UNVERIFIED (reported via ChainSigned == 0), not verified. A
+	// legacy/empty trail (no chained records; chainStarted == false) stays vacuously
+	// verified.
+	tv.ChainVerified = tv.ChainBreaks == 0 && (!chainStarted || havePub)
 	return tv
 }

--- a/cmd/skillctl/invocation_trail_test.go
+++ b/cmd/skillctl/invocation_trail_test.go
@@ -159,6 +159,47 @@ func TestReadAndVerifyTrail_HashChainDetectsMiddleDeletion(t *testing.T) {
 	}
 }
 
+// Re-gate residual bite (audit fail-open): a chained trail whose DEVICE KEY has
+// been removed must NOT report ChainVerified=true. A same-uid actor who deletes the
+// device key can then keyless-recompute a fully contiguous chain (seq/prev_hash/
+// self_hash) that passes every contiguity check; the chain SIGNATURE is what stops
+// that, and it cannot be checked without the key. So a chained-but-keyless trail is
+// present-but-UNVERIFIED (ChainSigned==0), not verified. Pre-fix, ChainVerified was
+// ChainBreaks==0 alone, so removing the key upgraded a forgeable trail to "verified".
+func TestReadAndVerifyTrail_ChainedTrailWithoutDeviceKeyIsUnverified(t *testing.T) {
+	home := t.TempDir()
+	for i, id := range []string{
+		"01HZTRAILEVENT0000000000A",
+		"01HZTRAILEVENT0000000000B",
+		"01HZTRAILEVENT0000000000C",
+	} {
+		rec := sampleInvocation()
+		rec.EventID = id
+		rec.ExitCode = i
+		appendSignedInvocation(home, rec)
+	}
+	// Baseline: with the device key present the intact chain verifies clean.
+	if tv := readAndVerifyTrail(home); !tv.ChainVerified || tv.ChainSigned != 3 {
+		t.Fatalf("baseline intact chain should be signed+verified, got %+v", tv)
+	}
+
+	// Remove the device key material (both priv + pub) — the state after a same-uid
+	// key wipe. readAndVerifyTrail loads the key directly, so this forces havePub=false.
+	_ = os.Remove(device.PrivPath(home))
+	_ = os.Remove(device.PubPath(home))
+
+	tv := readAndVerifyTrail(home)
+	if !tv.Present {
+		t.Fatal("trail should still be present")
+	}
+	if tv.ChainVerified {
+		t.Fatalf("a chained trail with the device key removed must not report ChainVerified=true (keyless contiguity is forgeable); got ChainSigned=%d Total=%d", tv.ChainSigned, tv.Total)
+	}
+	if tv.ChainSigned != 0 {
+		t.Errorf("no chain signatures are verifiable without the device key; ChainSigned=%d, want 0", tv.ChainSigned)
+	}
+}
+
 // TestReadAndVerifyTrail_ChainSignatureDetectsKeylessRewrite is the hardening
 // bite-test for the SECOND (chain-link) device signature. A same-uid attacker
 // with NO key deletes the middle record and rewrites the survivor's seq/prev_hash

--- a/cmd/skillctl/invocation_trail_test.go
+++ b/cmd/skillctl/invocation_trail_test.go
@@ -107,6 +107,57 @@ func TestReadAndVerifyTrail_DetectsReplay(t *testing.T) {
 	}
 }
 
+// TestReadAndVerifyTrail_HashChainDetectsMiddleDeletion is the IS-T8 acceptance
+// test: append three signed records, delete the MIDDLE line, and assert the
+// hash-chain contiguity check reports a break. Before IS-T8 this excision passed
+// clean — each surviving line still carries a valid per-line device signature, so
+// nothing flagged the removed record. The seq + prev_hash chain now bites.
+func TestReadAndVerifyTrail_HashChainDetectsMiddleDeletion(t *testing.T) {
+	home := t.TempDir()
+	for i, id := range []string{
+		"01HZTRAILEVENT0000000000A",
+		"01HZTRAILEVENT0000000000B",
+		"01HZTRAILEVENT0000000000C",
+	} {
+		rec := sampleInvocation()
+		rec.EventID = id
+		rec.ExitCode = i // distinct content per record
+		appendSignedInvocation(home, rec)
+	}
+
+	// Intact chain: three verified records, zero breaks.
+	if tv := readAndVerifyTrail(home); tv.Total != 3 || tv.Verified != 3 || tv.ChainBreaks != 0 || !tv.ChainVerified {
+		t.Fatalf("intact 3-record chain should verify clean, got %+v", tv)
+	}
+
+	// Excise the MIDDLE line (the seq=1 record).
+	path := invocationTrailPath(home)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read trail: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 trail lines, got %d", len(lines))
+	}
+	kept := lines[0] + "\n" + lines[2] + "\n" // drop the middle record
+	if err := os.WriteFile(path, []byte(kept), 0o600); err != nil {
+		t.Fatalf("rewrite trail: %v", err)
+	}
+
+	tv := readAndVerifyTrail(home)
+	// Both survivors STILL pass their per-line signature (that is exactly why the
+	// deletion was previously invisible)...
+	if tv.Total != 2 || tv.Verified != 2 || tv.Unverified != 0 {
+		t.Fatalf("surviving lines should still individually sign: %+v", tv)
+	}
+	// ...but the hash chain now reports the gap the deletion opened: the seq=2
+	// survivor's seq is not 0+1 and its prev_hash points at the deleted record.
+	if tv.ChainBreaks == 0 || tv.ChainVerified {
+		t.Errorf("middle-record deletion not detected as a chain/sequence gap: %+v", tv)
+	}
+}
+
 func TestAppendSignedInvocation_SinkFailureIsSwallowed(t *testing.T) {
 	home := t.TempDir()
 	orig := invocationTrailSink

--- a/cmd/skillctl/invocation_trail_test.go
+++ b/cmd/skillctl/invocation_trail_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -155,6 +156,90 @@ func TestReadAndVerifyTrail_HashChainDetectsMiddleDeletion(t *testing.T) {
 	// survivor's seq is not 0+1 and its prev_hash points at the deleted record.
 	if tv.ChainBreaks == 0 || tv.ChainVerified {
 		t.Errorf("middle-record deletion not detected as a chain/sequence gap: %+v", tv)
+	}
+}
+
+// TestReadAndVerifyTrail_ChainSignatureDetectsKeylessRewrite is the hardening
+// bite-test for the SECOND (chain-link) device signature. A same-uid attacker
+// with NO key deletes the middle record and rewrites the survivor's seq/prev_hash
+// so the KEYLESS contiguity check passes again — but cannot re-sign the link, so
+// the chain-signature layer must still report a break. Case B covers the downgrade
+// where the attacker strips the signature entirely to fall back to keyless-only.
+func TestReadAndVerifyTrail_ChainSignatureDetectsKeylessRewrite(t *testing.T) {
+	buildTrail := func(t *testing.T) (home string, rec0, rec2 chainedInvocationRecord) {
+		t.Helper()
+		home = t.TempDir()
+		for i, id := range []string{
+			"01HZREWRITE000000000000A",
+			"01HZREWRITE000000000000B",
+			"01HZREWRITE000000000000C",
+		} {
+			r := sampleInvocation()
+			r.EventID = id
+			r.ExitCode = i
+			appendSignedInvocation(home, r)
+		}
+		data, err := os.ReadFile(invocationTrailPath(home))
+		if err != nil {
+			t.Fatalf("read trail: %v", err)
+		}
+		lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+		if len(lines) != 3 {
+			t.Fatalf("want 3 trail lines, got %d", len(lines))
+		}
+		if err := json.Unmarshal([]byte(lines[0]), &rec0); err != nil {
+			t.Fatalf("parse rec0: %v", err)
+		}
+		if err := json.Unmarshal([]byte(lines[2]), &rec2); err != nil {
+			t.Fatalf("parse rec2: %v", err)
+		}
+		return home, rec0, rec2
+	}
+	writeTwo := func(t *testing.T, home string, a, b chainedInvocationRecord) {
+		t.Helper()
+		la, _ := json.Marshal(a)
+		lb, _ := json.Marshal(b)
+		var buf []byte
+		buf = append(buf, la...)
+		buf = append(buf, '\n')
+		buf = append(buf, lb...)
+		buf = append(buf, '\n')
+		if err := os.WriteFile(invocationTrailPath(home), buf, 0o600); err != nil {
+			t.Fatalf("rewrite trail: %v", err)
+		}
+	}
+
+	// Case A — rewrite seq/prev_hash to look contiguous, keep the OLD signature
+	// (which signed seq=2). The device-signature check must catch it.
+	home, rec0, rec2 := buildTrail(t)
+	h0, ok := invocationChainHash(rec0.InvocationRecord)
+	if !ok {
+		t.Fatal("canonicalize rec0")
+	}
+	one := uint64(1)
+	rec2.Seq = &one    // was 2 → now 1, so keyless contiguity now PASSES
+	rec2.PrevHash = h0 // points at rec0 instead of the deleted rec1
+	writeTwo(t, home, rec0, rec2)
+
+	tv := readAndVerifyTrail(home)
+	if tv.Total != 2 || tv.Verified != 2 {
+		t.Fatalf("per-line signatures should still verify (attack does not touch them): %+v", tv)
+	}
+	if tv.ChainBreaks == 0 || tv.ChainVerified {
+		t.Errorf("keyless seq/prev_hash rewrite not caught by the chain signature: %+v", tv)
+	}
+
+	// Case B — same rewrite but STRIP the signature (downgrade to keyless-only).
+	home2, rec0b, rec2b := buildTrail(t)
+	h0b, _ := invocationChainHash(rec0b.InvocationRecord)
+	one2 := uint64(1)
+	rec2b.Seq = &one2
+	rec2b.PrevHash = h0b
+	rec2b.ChainSignatureB64 = "" // a chained record with no verifiable sig is a break
+	writeTwo(t, home2, rec0b, rec2b)
+
+	if tv2 := readAndVerifyTrail(home2); tv2.ChainBreaks == 0 || tv2.ChainVerified {
+		t.Errorf("stripped chain signature (downgrade) not caught: %+v", tv2)
 	}
 }
 


### PR DESCRIPTION
## P1 · Audit robustness — tamper-evident AI-Act invocation trail (IS-T8 / IS-T11)

Second P1 wave, trust-core lens. Makes the SPEC invocation trail (EU AI Act Art. 12 record-keeping) tamper-evident.

### What it does
- **IS-T8 hash-chain** — each record carries `seq` + `prev_hash` over the predecessor's canonical bytes; a deleted/reordered/truncated middle record surfaces as a contiguity break even when every surviving line still individually signs.
- **Second (chain-link) device signature** — a detached ed25519 signature over `(seq, prev_hash, self_hash)` under a distinct domain, so a same-uid **keyless** rewrite of the chain fields is caught, not just a naive delete.
- **ChainVerified fail-open closed** (re-gate fix) — a chained trail whose **device key is missing** is now reported **present-but-unverified** (`ChainSigned==0`), not `ChainVerified=true`. Keyless contiguity alone is forgeable by a same-uid full recompute; the chain signature is what stops it, and it can't be checked without the key. Legacy/empty trails stay vacuously verified.
- **IS-T11** — bounded scan buffers (no unbounded line growth).

### Assurance
- Challenge gate + focused re-gate = **CLEARED** (the re-gate caught the device-key-wipe fail-open — now closed).
- Bite-tests: middle-deletion, keyless-rewrite, signature-strip, **and** the new device-key-wipe case; the new one empirically **fails against pre-fix**. skillgate canonicalization untouched → per-line golden bytes byte-identical.
- **Honest scope (no overclaim):** a device-key *holder* re-signing the trail remains a documented accepted LOW (needs the external SPEC-0358 anchor); the compliance summary reports `ChainSigned/Total` + the tail-truncation caveat.

Human-merge per the trust-layer flow. `closes IS-05`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
