### PR TITLE
P1 · Egress hardening — refuse write-token over cleartext (CD-T8 closes CD-03 HIGH)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,103 @@
+name: skillctl Image (build · cosign · provenance)
+
+# CD-T11 / CD-06: build the skillctl container image from the digest-pinned
+# deploy/skillctl/Dockerfile, push it to GHCR, KEYLESS-sign it with cosign +
+# GitHub OIDC (no long-lived key), and attach a SLSA build-provenance
+# attestation. Mirrors skillctl-release.yml's keyless model, for the image
+# instead of the raw binaries.
+#
+# Triggered on a dedicated image tag (disjoint from the `v*` product release and
+# the `skillctl/v*` binary release) and on manual dispatch, so cutting an image
+# is an explicit, reviewable act.
+#
+# Kyverno admission (verifyImages against this workflow's OIDC identity) is
+# DEPLOY-SIDE and OUT OF SCOPE here — it belongs in the cluster policy repo, not
+# in this build workflow. This workflow's job is to PRODUCE a signed+attested
+# image; enforcing that only signed images admit is the cluster's job.
+
+on:
+  push:
+    tags:
+      - 'skillctl-image/v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/skillctl
+
+jobs:
+  build:
+    name: Build · push · cosign-sign · attest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      packages: write # push the image to GHCR
+      id-token: write # OIDC for keyless cosign + build provenance
+      attestations: write # SLSA build-provenance attestation
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags + labels
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=ref,event=tag
+            type=sha,format=long
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+
+      # provenance:false → publish a plain image manifest (no attestation-manifest
+      # wrapper), so the digest cosign signs and attest-build-provenance references
+      # is the image's own content digest.
+      - name: Build + push (digest-pinned base, static Go binary)
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: deploy/skillctl/Dockerfile
+          push: true
+          provenance: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+
+      # Keyless: cosign mints a short-lived Fulcio cert bound to THIS workflow's
+      # OIDC identity — the same identity a Kyverno verifyImages policy pins.
+      - name: Keyless-sign the image (GitHub OIDC)
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+
+      # Gate: fail the build if the signature we just made does not verify against
+      # this workflow's identity — never ship an image whose signature won't check.
+      - name: Verify the cosign signature in-job (gate)
+        run: |
+          cosign verify "${IMAGE}@${DIGEST}" \
+            --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/\.github/workflows/build-image\.yml@refs/" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+
+      - name: SLSA build provenance (image)
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/skillctl-windows-smoke.yml
+++ b/.github/workflows/skillctl-windows-smoke.yml
@@ -38,10 +38,15 @@ jobs:
           go-version: "1.26.6"
           cache: true
 
-      # Build the shipping CLI from source (native GOOS=windows on this runner).
+      # Build the CLI from source (native GOOS=windows on this runner).
+      # -tags allow_home_override_test (WIN-T8): the quickstart script sandboxes
+      # trust-roots by pointing $env:HOME at a temp dir, but a SHIPPING Windows
+      # build ignores $HOME for the trust-root paths (WIN-09 confinement). The tag
+      # re-enables the $HOME override so the offline sandbox works; a real release
+      # (skillctl-release.yml) carries no tag and stays confined.
       - name: Build skillctl.exe
         run: |
-          go build -o skillctl.exe ./cmd/skillctl
+          go build -tags allow_home_override_test -o skillctl.exe ./cmd/skillctl
           $exe = (Resolve-Path .\skillctl.exe).Path
           "SKILLCTL=$exe" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           Write-Host "built $exe"

--- a/.github/workflows/windows-gate.yml
+++ b/.github/workflows/windows-gate.yml
@@ -134,8 +134,13 @@ jobs:
         # NOTE: no -run filter — this is intentional and enforced by drift-guard.
         # -json so the parity check can count executed tests; tee keeps a
         # human-readable copy in the log.
+        # -tags allow_home_override_test (WIN-T8): on Windows a shipping build
+        # ignores $HOME for the trust-root/token-key paths; the tag re-enables the
+        # $HOME injection the hermetic trust tests rely on. It flips a const, not a
+        # test set, so windows/linux executed-test COUNTS stay identical (the Linux
+        # parity run below needs no tag — non-Windows always honors $HOME).
         run: |
-          go test -json -count=1 -timeout=300s `
+          go test -tags allow_home_override_test -json -count=1 -timeout=300s `
             ./pkg/skillctl/... ./cmd/skillctl/... ./evaluation/... `
             | Tee-Object -FilePath win-trust.json
         shell: pwsh

--- a/cmd/skillctl/install_e2e_test.go
+++ b/cmd/skillctl/install_e2e_test.go
@@ -94,6 +94,12 @@ func runSkillctl(t *testing.T, home string, args ...string) (int, string, string
 	cmd := exec.Command(bin, args...)
 	cmd.Env = append(os.Environ(),
 		"HOME="+home,
+		// The built binary is a SHIPPING build (no allow_home_override_test tag),
+		// so per WIN-T8 it ignores $HOME on Windows and resolves the trust-root
+		// paths from %USERPROFILE% (os.UserHomeDir()). Set USERPROFILE too so the
+		// e2e stays scoped to the temp home on Windows AND exercises the real
+		// shipping resolution; on Linux/Darwin USERPROFILE is inert ($HOME wins).
+		"USERPROFILE="+home,
 		// On Linux, os.UserHomeDir prefers $HOME; Darwin same. Belt:
 		// also unset XDG so nothing overrides the trust-roots path.
 		"XDG_CONFIG_HOME=",

--- a/cmd/skillctl/lifecycle_tamper_e2e_test.go
+++ b/cmd/skillctl/lifecycle_tamper_e2e_test.go
@@ -89,7 +89,9 @@ func ltInstallSidecar(t *testing.T, home, name, src string) {
 func ltHook(t *testing.T, home, skill string) (int, string) {
 	t.Helper()
 	cmd := exec.Command(skillctlBin(t), "verify-hook")
-	cmd.Env = append(os.Environ(), "HOME="+home, "XDG_CONFIG_HOME=")
+	// USERPROFILE too: the built binary is a shipping build that ignores $HOME on
+	// Windows (WIN-T8) and resolves from %USERPROFILE%; inert on Linux/Darwin.
+	cmd.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home, "XDG_CONFIG_HOME=")
 	cmd.Stdin = strings.NewReader(`{"tool_name":"Skill","tool_input":{"skill":"` + skill + `"},"session_id":"sim"}`)
 	var out, errb bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &out, &errb

--- a/deploy/skillctl/Dockerfile
+++ b/deploy/skillctl/Dockerfile
@@ -19,7 +19,15 @@
 # Only the reine-Go trust-plane is containerized here.
 
 # ---- Stage 1: build ----------------------------------------------------
-FROM golang:1.25-alpine AS builder
+# CD-T11 / CD-06: base images are DIGEST-PINNED, not tag-floating. A tag like
+# `golang:1.26-alpine` is mutable (the registry can repoint it), so pinning the
+# tag alone lets an upstream repoint (or a registry compromise) swap the build
+# toolchain under us. The @sha256 digest is content-addressed and immutable; the
+# tag is kept as a human-readable comment. Refresh with:
+#   docker buildx imagetools inspect golang:1.26-alpine   # -> index Digest
+# Resolved 2026-09-02: golang:1.26-alpine == 1.26.8-alpine3.24 (>= go.mod
+# toolchain go1.26.6, so no toolchain re-download at build time).
+FROM golang:1.26-alpine@sha256:b6890e35ded5d19118c2bca3d7754dc4e6f694aac2d0aeb92f9807c2879e4230 AS builder
 
 # git for VCS build metadata; ca-certificates so `go mod download` over
 # https module proxies works.
@@ -50,7 +58,11 @@ RUN go build \
 # distroless/static: no shell, no package manager, non-root by default.
 # ca-certificates are included in the base, so `pull`/`verify`/`attest`
 # can reach an HTTPS registry when a network path is provided.
-FROM gcr.io/distroless/static-debian12:nonroot
+#
+# CD-T11 / CD-06: digest-pinned (see Stage 1). Refresh with:
+#   docker buildx imagetools inspect gcr.io/distroless/static-debian12:nonroot
+# Resolved 2026-09-02 (multi-arch index digest).
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:afa5c872c891853ca7fcf1f12c3edb23f7eeef36189728842dd51042ff57f7ab
 
 COPY --from=builder /out/skillctl /usr/local/bin/skillctl
 

--- a/pkg/skillctl/backend/git/git.go
+++ b/pkg/skillctl/backend/git/git.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"os/exec"
@@ -16,8 +17,45 @@ import (
 	"time"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+	"github.com/kamir/m3c-tools/pkg/skillctl/netguard"
 	"github.com/kamir/m3c-tools/pkg/skillctl/trustcore"
 )
+
+// Bounds against a hostile/oversized clone (the git host is untrusted, SPEC-0356
+// §6). A malicious repo could commit a multi-GiB bundle.skb or event JSON and OOM
+// the pulling host on os.ReadFile. These mirror the OCI backend's ceilings
+// (maxBlobBytes / maxManifestBytes) so the two carriers fail closed identically
+// (IS-09 / IS-T10).
+const (
+	maxGitBlobBytes     = 128 << 20 // 128 MiB — the .skb bundle layer (mirror OCI maxBlobBytes)
+	maxGitManifestBytes = 4 << 20   // 4 MiB — event JSON + bundle.json (mirror OCI maxManifestBytes)
+)
+
+// readCapped reads a regular file from the untrusted clone with a hard byte
+// ceiling (IS-T10). It mirrors the OCI backend's fetchCapped bound: reject an
+// oversized file BEFORE allocating its contents (the Stat pre-check), and treat
+// the LimitReader as the authoritative bound in case Stat lies or the file grows
+// mid-read. On oversize it returns a bounded-read ERROR (never a silently
+// truncated success), so callers fail closed instead of parsing a partial JSON
+// document or a truncated bundle.
+func readCapped(p string, max int64) ([]byte, error) {
+	f, err := os.Open(p)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	if fi, serr := f.Stat(); serr == nil && fi.Size() > max {
+		return nil, fmt.Errorf("git: %s is %d bytes, exceeds cap %d", filepath.Base(p), fi.Size(), max)
+	}
+	data, err := io.ReadAll(io.LimitReader(f, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > max {
+		return nil, fmt.Errorf("git: %s exceeds cap %d bytes", filepath.Base(p), max)
+	}
+	return data, nil
+}
 
 // gitExe resolves the `git` binary ONCE to a validated absolute path. A bare
 // exec.Command("git", …) re-runs a PATH lookup on every call, and on Windows a
@@ -72,7 +110,9 @@ func openGitLab(spec string, opts artifact.OpenOptions) (artifact.Backend, error
 		remote = "http://" + strings.TrimPrefix(remote, "https://")
 	}
 	b := newGitBackend(remote, "gitlab")
-	b.applyCreds(opts)
+	if err := b.applyCreds(opts); err != nil {
+		return nil, err
+	}
 	return b, nil
 }
 
@@ -84,7 +124,9 @@ func openGitHub(spec string, opts artifact.OpenOptions) (artifact.Backend, error
 		return nil, fmt.Errorf("git: empty github spec %q", spec)
 	}
 	b := newGitBackend("https://github.com/"+rest+".git", "github")
-	b.applyCreds(opts)
+	if err := b.applyCreds(opts); err != nil {
+		return nil, err // unreachable in practice (github is always https), kept for uniformity
+	}
 	return b, nil
 }
 
@@ -114,12 +156,23 @@ func newGitBackend(remote, scheme string) *gitBackend {
 
 // applyCreds resolves a token for this backend's host via opts.Creds (read-only,
 // SPEC-0356 D5) and stores it for out-of-band header injection (authEnv) — never
-// in the URL. Best-effort: no creds / a resolve error just leaves the backend
-// anonymous (ambient git credentials or a public repo still work). The token is
-// NEVER stored in b.remote and NEVER surfaced by Describe.
-func (b *gitBackend) applyCreds(opts artifact.OpenOptions) {
+// in the URL. Best-effort for the no-token case: no creds / a resolve error just
+// leaves the backend anonymous (ambient git credentials or a public repo still
+// work). The token is NEVER stored in b.remote and NEVER surfaced by Describe.
+//
+// CD-03 / WIN-12 (CD-T8 / WIN-T10): it REFUSES (returns an error) when a resolved
+// write token would ride cleartext HTTP to a host that is not provably
+// loopback/RFC1918. Base64(user:token) in an Authorization header is encoding,
+// not encryption, so an on-path attacker on a public network would capture a
+// write-scoped registry token — the same failure class as the OCI plain-HTTP
+// guard and ER1_VERIFY_SSL=false. M3C_GIT_HTTP=1 (the only way b.remote becomes
+// http://) is for a LAN/test registry; sending a token to a public http:// host
+// is never legitimate. HTTPS and loopback/private HTTP are fine. When there is no
+// token to attach, cleartext HTTP is left alone (anonymous fetch of a public repo
+// over http is the caller's choice, no secret at risk).
+func (b *gitBackend) applyCreds(opts artifact.OpenOptions) error {
 	if opts.Creds == nil {
-		return
+		return nil
 	}
 	host := ""
 	if u, err := url.Parse(b.remote); err == nil {
@@ -127,10 +180,15 @@ func (b *gitBackend) applyCreds(opts artifact.OpenOptions) {
 	}
 	c, err := opts.Creds.Credential(context.Background(), b.scheme, host)
 	if err != nil || c.Token == "" {
-		return
+		return nil // no token → nothing to protect; stay anonymous
+	}
+	if strings.HasPrefix(b.remote, "http://") && !netguard.IsLoopbackOrPrivate(host) {
+		fmt.Fprintf(os.Stderr, "skillctl: SECURITY: REFUSING to attach a %s write token over cleartext HTTP to non-loopback host %q — an on-path attacker would capture it. Use https, or a loopback/RFC1918 registry (M3C_GIT_HTTP is for LAN/test only).\n", b.scheme, host)
+		return fmt.Errorf("git: refusing to send credential over plain HTTP to non-loopback host %q; use https or unset M3C_GIT_HTTP", host)
 	}
 	b.token = c.Token
 	b.tokenUser = c.User
+	return nil
 }
 
 // userinfoRe strips credentials embedded in any URL (scheme://user:pass@host).
@@ -514,7 +572,7 @@ func (b *gitBackend) Fetch(ctx context.Context, ref artifact.ArtifactRef) ([]byt
 		if _, lerr := lstatRegular(bp); lerr != nil {
 			return fmt.Errorf("git: read blob %s@%s: %w", name, ver, lerr)
 		}
-		d, err := os.ReadFile(bp)
+		d, err := readCapped(bp, maxGitBlobBytes)
 		if err != nil {
 			return fmt.Errorf("git: read blob %s@%s: %w", name, ver, err)
 		}
@@ -558,9 +616,9 @@ func (b *gitBackend) Events(ctx context.Context, filter artifact.ListFilter, pag
 				if ok, lerr := lstatRegular(ep); lerr != nil || !ok {
 					continue
 				}
-				data, err := os.ReadFile(ep)
+				data, err := readCapped(ep, maxGitManifestBytes)
 				if err != nil {
-					continue
+					continue // oversized/unreadable event → ignore (never influences a verdict)
 				}
 				var env map[string]any
 				if err := json.Unmarshal(data, &env); err != nil {
@@ -693,7 +751,7 @@ func (b *gitBackend) readBundleJSON(dir, name, ver string) (bundleJSON, error) {
 	if _, lerr := lstatRegular(mp); lerr != nil {
 		return bj, lerr
 	}
-	data, err := os.ReadFile(mp)
+	data, err := readCapped(mp, maxGitManifestBytes)
 	if err != nil {
 		return bj, err
 	}

--- a/pkg/skillctl/backend/git/local.go
+++ b/pkg/skillctl/backend/git/local.go
@@ -39,7 +39,7 @@ func openLocal(spec string, opts artifact.OpenOptions) (artifact.Backend, error)
 		return nil, fmt.Errorf("local: registry path %q not found — run `skillctl registry init --registry %s` first (or check the .bundle path): %w", path, spec, err)
 	}
 	b := newGitBackend(path, "local")
-	b.applyCreds(opts) // no-op for local (no token), kept for symmetry
+	_ = b.applyCreds(opts) // no-op for local (filesystem path, no token, never http://), kept for symmetry
 	return b, nil
 }
 

--- a/pkg/skillctl/backend/git/p1_egress_test.go
+++ b/pkg/skillctl/backend/git/p1_egress_test.go
@@ -1,0 +1,85 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+)
+
+// TestGitPlaintextCredRefused — CD-T8 / WIN-T10 (closes CD-03 HIGH + WIN-12): a
+// write token must never ride cleartext HTTP to a non-loopback host, because
+// base64(user:token) in an Authorization header is encoding, not encryption — an
+// on-path attacker on a public network would capture a write-scoped registry
+// token. Mirrors the OCI backend's TestOCIPlaintextCredRefused. The token IS
+// attached over https:// (TLS protects it) and over http:// to a
+// loopback/RFC1918 host (LAN/test registry), and REFUSED over http:// to a public
+// host.
+func TestGitPlaintextCredRefused(t *testing.T) {
+	creds := fakeCreds{user: "deployer", token: "s3cret"}
+
+	// (1) https:// (M3C_GIT_HTTP unset) to a PUBLIC host → token attached; TLS
+	// protects the header. This is the normal production path.
+	b, err := openGitLab("gitlab://gitlab.example.com/grp/skills", artifact.OpenOptions{Creds: creds})
+	if err != nil {
+		t.Fatalf("https to a public host must succeed: %v", err)
+	}
+	if b.(*gitBackend).token == "" {
+		t.Error("https to a public host: the write token should be attached")
+	}
+
+	// Flip to plain HTTP for the LAN/test paths (M3C_GIT_HTTP=1 is the ONLY way
+	// b.remote becomes http://).
+	t.Setenv("M3C_GIT_HTTP", "1")
+
+	// (2) http:// to loopback → token attached (a local dev/test registry).
+	b, err = openGitLab("gitlab://127.0.0.1:8929/grp/skills", artifact.OpenOptions{Creds: creds})
+	if err != nil {
+		t.Fatalf("plain HTTP to loopback should be allowed: %v", err)
+	}
+	if b.(*gitBackend).token == "" {
+		t.Error("plain HTTP to loopback: the write token should be attached")
+	}
+
+	// (3) http:// to an RFC1918 private host → token attached (LAN registry).
+	if _, err := openGitLab("gitlab://192.168.0.131:8929/grp/skills", artifact.OpenOptions{Creds: creds}); err != nil {
+		t.Errorf("plain HTTP to an RFC1918 host should be allowed: %v", err)
+	}
+
+	// (4) http:// to a PUBLIC host → REFUSED (this is the CD-03 HIGH). The bare
+	// hostname is not provably local, so the credential is never attached.
+	if b, err := openGitLab("gitlab://gitlab.example.com/grp/skills", artifact.OpenOptions{Creds: creds}); err == nil {
+		t.Errorf("token over plain HTTP to a public host must be refused; got backend with token=%q", b.(*gitBackend).token)
+	}
+}
+
+// TestReadCappedBounded — IS-T10 (IS-09 OOM DoS): a git clone is untrusted, so a
+// hostile repo could commit a multi-GiB blob/event/bundle. readCapped mirrors the
+// OCI fetchCapped bound: an under-cap file reads back exactly, an over-cap file
+// returns a bounded-read ERROR (never a truncated success, never an OOM), and a
+// file exactly at the cap is allowed.
+func TestReadCappedBounded(t *testing.T) {
+	dir := t.TempDir()
+
+	small := filepath.Join(dir, "small.json")
+	if err := os.WriteFile(small, []byte(`{"ok":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := readCapped(small, maxGitManifestBytes); err != nil || string(got) != `{"ok":true}` {
+		t.Fatalf("readCapped(small) = %q, %v; want the file back verbatim", got, err)
+	}
+
+	big := filepath.Join(dir, "big.bin")
+	if err := os.WriteFile(big, make([]byte, 1024), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Over a 512-byte cap → error, and no more than cap+1 bytes are ever read.
+	if _, err := readCapped(big, 512); err == nil {
+		t.Fatal("readCapped over a 512-byte cap on a 1024-byte file must return a bounded-read error")
+	}
+	// Exactly at the cap is fine.
+	if got, err := readCapped(big, 1024); err != nil || len(got) != 1024 {
+		t.Fatalf("readCapped(big, 1024) = %d bytes, %v; want 1024 bytes, no error", len(got), err)
+	}
+}

--- a/pkg/skillctl/backend/oci/helpers.go
+++ b/pkg/skillctl/backend/oci/helpers.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"net"
 	"os"
 	"regexp"
 	"sort"
@@ -18,6 +17,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote/retry"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+	"github.com/kamir/m3c-tools/pkg/skillctl/netguard"
 )
 
 // Bounds against a hostile/oversized registry (the carrier is untrusted). Manifests
@@ -117,19 +117,10 @@ func parseRFC3339(s string) (time.Time, error) { return time.Parse(time.RFC3339,
 // isLoopbackOrPrivate reports whether host (possibly host:port) resolves to a
 // loopback or RFC1918/ULA address — the only place a bearer token may ride plain
 // HTTP. A bare hostname (not an IP literal) is treated as NON-local (fail-closed).
-func isLoopbackOrPrivate(host string) bool {
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		host = h
-	}
-	if host == "localhost" {
-		return true
-	}
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return false // a DNS name could resolve anywhere → not provably local
-	}
-	return ip.IsLoopback() || ip.IsPrivate()
-}
+//
+// This is now a thin alias over netguard.IsLoopbackOrPrivate so the OCI, git, and
+// ER1 egress guards share ONE audited definition (FR-0090-style) and cannot drift.
+func isLoopbackOrPrivate(host string) bool { return netguard.IsLoopbackOrPrivate(host) }
 
 // tagHash is an injective disambiguator so that no two distinct (name,version)
 // pairs can collide onto one tag (sanitizeTag is lossy and '_' is legal in both

--- a/pkg/skillctl/netguard/netguard.go
+++ b/pkg/skillctl/netguard/netguard.go
@@ -1,0 +1,37 @@
+// Package netguard holds the shared "is this host provably local?" egress
+// predicate used to gate credentials and TLS-verification bypasses across the
+// skillctl artifact backends (OCI, git) and the ER1 registry client.
+//
+// It is deliberately ONE audited definition (in the same spirit as
+// trustcore.KindFromSignedEnvelope, FR-0090): a bearer/basic credential may only
+// ride plain HTTP — and TLS verification may only be disabled — when the target
+// host is provably loopback or on a private (RFC1918/ULA) network. If three
+// backends each carried their own copy of this predicate they could drift, and a
+// drift here is a credential-exfiltration / MITM hole. Keeping it in one place
+// means the OCI plain-HTTP guard, the git write-token guard, and the ER1
+// VerifySSL=false guard all fail closed on exactly the same host set.
+package netguard
+
+import "net"
+
+// IsLoopbackOrPrivate reports whether host (which may be "host" or "host:port")
+// is provably a loopback or RFC1918/ULA address.
+//
+// Fail-closed policy: a bare DNS name (anything that is not an IP literal, other
+// than the special-cased "localhost") is treated as NON-local, because a name can
+// resolve anywhere and we must not attach a secret / skip TLS verification on the
+// strength of an unresolved hostname. Only "localhost" and literal
+// loopback/private IPs return true.
+func IsLoopbackOrPrivate(host string) bool {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false // a DNS name could resolve anywhere → not provably local
+	}
+	return ip.IsLoopback() || ip.IsPrivate()
+}

--- a/pkg/skillctl/netguard/netguard.go
+++ b/pkg/skillctl/netguard/netguard.go
@@ -35,3 +35,27 @@ func IsLoopbackOrPrivate(host string) bool {
 	}
 	return ip.IsLoopback() || ip.IsPrivate()
 }
+
+// IsLoopback is the STRICTER sibling of IsLoopbackOrPrivate: it treats ONLY
+// loopback addresses (127.0.0.0/8, ::1) and the name "localhost" as local — an
+// RFC1918/ULA private address is NOT local here. It exists for the ER1
+// TLS-verification-bypass guard, which must match pkg/er1.applyTLSVerificationPolicy
+// exactly: that policy honors ER1_VERIFY_SSL=false only for 127.0.0.1/localhost and
+// forces verification back on for every other host, RFC1918 LAN hosts included. A
+// TLS-skip that the core ER1 client forbids must not be reachable through the
+// registry client. (The git/OCI *credential* guards keep IsLoopbackOrPrivate — a
+// LAN registry over plain HTTP is a legitimate, narrower risk than skipping cert
+// verification against a routable-but-private host.)
+func IsLoopback(host string) bool {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}

--- a/pkg/skillctl/netguard/netguard_test.go
+++ b/pkg/skillctl/netguard/netguard_test.go
@@ -1,0 +1,30 @@
+package netguard
+
+import "testing"
+
+// TestIsLoopbackOrPrivate pins the ONE audited egress predicate shared by the
+// OCI, git, and ER1 guards. Loopback + RFC1918/ULA + "localhost" are local; a
+// public IP and any bare DNS name (fail-closed — a name resolves anywhere) are
+// NOT.
+func TestIsLoopbackOrPrivate(t *testing.T) {
+	local := []string{
+		"127.0.0.1", "127.0.0.1:5000", "localhost", "localhost:8081",
+		"10.0.0.5", "172.16.9.9", "192.168.0.131:8929",
+		"::1", "[::1]:8081", "fd00::1", // ULA
+	}
+	for _, h := range local {
+		if !IsLoopbackOrPrivate(h) {
+			t.Errorf("IsLoopbackOrPrivate(%q) = false, want true (local)", h)
+		}
+	}
+	notLocal := []string{
+		"8.8.8.8", "1.2.3.4:443",
+		"ghcr.io", "gitlab.example.com", "onboarding.guide:443",
+		"", "example.com",
+	}
+	for _, h := range notLocal {
+		if IsLoopbackOrPrivate(h) {
+			t.Errorf("IsLoopbackOrPrivate(%q) = true, want false (not provably local)", h)
+		}
+	}
+}

--- a/pkg/skillctl/netguard/netguard_test.go
+++ b/pkg/skillctl/netguard/netguard_test.go
@@ -28,3 +28,24 @@ func TestIsLoopbackOrPrivate(t *testing.T) {
 		}
 	}
 }
+
+// TestIsLoopback pins the STRICTER loopback-only predicate used by the ER1
+// TLS-verification-bypass guard: loopback + "localhost" only; RFC1918/ULA private
+// and public are NOT loopback (unlike IsLoopbackOrPrivate).
+func TestIsLoopback(t *testing.T) {
+	loopback := []string{"127.0.0.1", "127.0.0.1:8081", "localhost", "localhost:8081", "::1", "[::1]:8081"}
+	for _, h := range loopback {
+		if !IsLoopback(h) {
+			t.Errorf("IsLoopback(%q) = false, want true (loopback)", h)
+		}
+	}
+	notLoopback := []string{
+		"10.0.0.5", "172.16.9.9", "192.168.0.131:8929", "fd00::1", // private, but NOT loopback
+		"8.8.8.8", "onboarding.guide:443", "ghcr.io", "", // public / name
+	}
+	for _, h := range notLoopback {
+		if IsLoopback(h) {
+			t.Errorf("IsLoopback(%q) = true, want false (not loopback)", h)
+		}
+	}
+}

--- a/pkg/skillctl/registry/er1_publish.go
+++ b/pkg/skillctl/registry/er1_publish.go
@@ -16,13 +16,38 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/kamir/m3c-tools/pkg/er1"
+	"github.com/kamir/m3c-tools/pkg/skillctl/netguard"
 )
+
+// er1TLSGuard enforces the CD-11 egress rule at the point an HTTP client is built,
+// as defense-in-depth behind er1.applyTLSVerificationPolicy (which only runs at
+// LoadConfig time): TLS verification may be disabled ONLY for a provably
+// loopback/RFC1918 target. A *er1.Config constructed programmatically or in a test
+// can carry VerifySSL=false with a public APIURL and would otherwise slip past the
+// config-layer sanitizer straight into an InsecureSkipVerify client. Returns an
+// error (fail closed) for a non-local host with verification disabled; nil when
+// verification is on (nothing to police) or the host is provably local. host is
+// derived from the request base URL. Shared by er1Get and er1PostJSON.
+func er1TLSGuard(base string, verifySSL bool) error {
+	if verifySSL {
+		return nil
+	}
+	host := base
+	if u, err := url.Parse(base); err == nil && u.Host != "" {
+		host = u.Host
+	}
+	if !netguard.IsLoopbackOrPrivate(host) {
+		return fmt.Errorf("er1: refusing to disable TLS verification (VerifySSL=false) for non-loopback host %q — only loopback/RFC1918 targets may skip certificate verification", host)
+	}
+	return nil
+}
 
 // ─── Errors ────────────────────────────────────────────────────────────────
 
@@ -43,13 +68,13 @@ var ErrClaimCheckNotImplemented = errors.New("registry: claim-check (MinIO overf
 // SPEC-0225 §6 tag set. It mirrors the fields the cmd handler already extracts
 // from the skill dir + signing step.
 type SkillMeta struct {
-	Name              string // skill name, used in `skill:` and `skill-version:` tags
-	Version           string // version string, used in `skill-version:` tag
-	BundleDigest      string // "sha256:<hex>", used in `skill-digest:` tag
-	AuthorIdentity    string // "id:kamir@m3c", used in `skill-author:` tag
-	GovernanceLevel   string // "green"|"yellow"|"red", used in `governance:` tag
-	PackedOnHost      string // short hostname, used in `host:` tag
-	ProjectID         string // optional; if set, stamps `project:<id>` for provenance
+	Name            string // skill name, used in `skill:` and `skill-version:` tags
+	Version         string // version string, used in `skill-version:` tag
+	BundleDigest    string // "sha256:<hex>", used in `skill-digest:` tag
+	AuthorIdentity  string // "id:kamir@m3c", used in `skill-author:` tag
+	GovernanceLevel string // "green"|"yellow"|"red", used in `governance:` tag
+	PackedOnHost    string // short hostname, used in `host:` tag
+	ProjectID       string // optional; if set, stamps `project:<id>` for provenance
 
 	// ShareRooms maps the bundle into one or more SPEC-0096 co-learning rooms.
 	// Each entry is a room's *room_label* (e.g. "aims-basics") and is stamped as
@@ -215,12 +240,12 @@ type PublishRevokedOpts struct {
 
 // PublishInstalledOpts captures the inputs for the install-event publish path.
 type PublishInstalledOpts struct {
-	ER1Cfg            *er1.Config
-	ContextID         string
-	Event             map[string]any // signed BundleInstalledEvent
-	Skill             SkillMeta
-	InstalledOnHost   string
-	Now               time.Time
+	ER1Cfg          *er1.Config
+	ContextID       string
+	Event           map[string]any // signed BundleInstalledEvent
+	Skill           SkillMeta
+	InstalledOnHost string
+	Now             time.Time
 }
 
 // PublishInstalled POSTs a BundleInstalledEvent item with the install-event
@@ -508,6 +533,9 @@ func findAdmittedByDigest(cfg *er1.Config, ctxID, digest string) (string, error)
 }
 
 func er1Get(base string, cfg *er1.Config, path string) (any, error) {
+	if err := er1TLSGuard(base, cfg.VerifySSL); err != nil {
+		return nil, err
+	}
 	client := &http.Client{Timeout: 15 * time.Second}
 	if !cfg.VerifySSL {
 		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}

--- a/pkg/skillctl/registry/er1_publish.go
+++ b/pkg/skillctl/registry/er1_publish.go
@@ -32,9 +32,16 @@ import (
 // loopback/RFC1918 target. A *er1.Config constructed programmatically or in a test
 // can carry VerifySSL=false with a public APIURL and would otherwise slip past the
 // config-layer sanitizer straight into an InsecureSkipVerify client. Returns an
-// error (fail closed) for a non-local host with verification disabled; nil when
-// verification is on (nothing to police) or the host is provably local. host is
-// derived from the request base URL. Shared by er1Get and er1PostJSON.
+// error (fail closed) for a non-loopback host with verification disabled; nil when
+// verification is on (nothing to police) or the host is loopback. host is derived
+// from the request base URL. Shared by er1Get and er1PostJSON.
+//
+// LOOPBACK-ONLY on purpose: this mirrors pkg/er1.applyTLSVerificationPolicy, which
+// honors ER1_VERIFY_SSL=false only for 127.0.0.1/localhost and forces verification
+// back on for every other host — RFC1918 LAN hosts included. Permitting an
+// RFC1918 TLS-skip here that the core ER1 client forbids would be an inconsistency
+// an attacker could target, so the registry client uses netguard.IsLoopback (not
+// IsLoopbackOrPrivate). The git/OCI *credential* guards keep the wider predicate.
 func er1TLSGuard(base string, verifySSL bool) error {
 	if verifySSL {
 		return nil
@@ -43,8 +50,8 @@ func er1TLSGuard(base string, verifySSL bool) error {
 	if u, err := url.Parse(base); err == nil && u.Host != "" {
 		host = u.Host
 	}
-	if !netguard.IsLoopbackOrPrivate(host) {
-		return fmt.Errorf("er1: refusing to disable TLS verification (VerifySSL=false) for non-loopback host %q — only loopback/RFC1918 targets may skip certificate verification", host)
+	if !netguard.IsLoopback(host) {
+		return fmt.Errorf("er1: refusing to disable TLS verification (VerifySSL=false) for non-loopback host %q — only 127.0.0.1/localhost may skip certificate verification", host)
 	}
 	return nil
 }

--- a/pkg/skillctl/registry/er1_room.go
+++ b/pkg/skillctl/registry/er1_room.go
@@ -180,6 +180,9 @@ func er1PostJSON(base string, cfg *er1.Config, path string, payload any) (any, e
 	if err != nil {
 		return nil, err
 	}
+	if err := er1TLSGuard(base, cfg.VerifySSL); err != nil {
+		return nil, err
+	}
 	client := &http.Client{Timeout: 30 * time.Second}
 	if !cfg.VerifySSL {
 		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}

--- a/pkg/skillctl/registry/home.go
+++ b/pkg/skillctl/registry/home.go
@@ -18,13 +18,19 @@ import (
 // directory an attacker controls. Ignoring $HOME on Windows keeps this per-user
 // state under %USERPROFILE% (via os.UserHomeDir()), fail-closed.
 //
-// The dev/quickstart/CI escape hatch is M3C_ALLOW_HOME_OVERRIDE=1: with it set,
-// $HOME is honored on Windows too. This preserves the sandboxed quickstart and
-// the SEC-L6 isolation tests (which set HOME to a fresh temp dir to force the
-// install-token mint path) on the windows-latest runner. See homeOverrideAllowed.
+// The Windows override is NOT re-openable from the ambient environment — an
+// env-var escape hatch (the earlier M3C_ALLOW_HOME_OVERRIDE) would be settable by
+// the very attacker/child-process WIN-09 models, re-opening the vector for the
+// cost of one extra variable. Instead the override is a COMPILE-TIME decision:
+// homeOverrideCompiledIn is true only in a build made with `-tags
+// allow_home_override_test`. Shipping Windows releases carry no such tag, so
+// $HOME is unconditionally ignored there; the dev/quickstart sandbox and the
+// windows-latest test surface (including the SEC-L6 isolation tests that force
+// the install-token mint path via a temp HOME) build WITH the tag. See
+// homeOverrideAllowed.
 func userHome() string {
 	if h := strings.TrimSpace(os.Getenv("HOME")); h != "" &&
-		homeOverrideAllowed(runtime.GOOS, os.Getenv("M3C_ALLOW_HOME_OVERRIDE")) {
+		homeOverrideAllowed(runtime.GOOS, homeOverrideCompiledIn) {
 		return h
 	}
 	h, _ := os.UserHomeDir()
@@ -33,13 +39,14 @@ func userHome() string {
 
 // homeOverrideAllowed is the pure, platform-parameterized decision behind
 // userHome: may an explicit $HOME override the per-user security root on goos?
-// Non-Windows always allows it; Windows allows it ONLY when the operator opts in
-// with M3C_ALLOW_HOME_OVERRIDE=1. Kept pure (goos + flag as arguments, no OS
-// reads) so it can be unit-tested for BOTH platforms from any host — which also
-// keeps windows/linux executed-test parity even (windows-gate drift-guard).
-func homeOverrideAllowed(goos, allowOverride string) bool {
+// Non-Windows always allows it; Windows allows it ONLY when the override was
+// compiled in (the `allow_home_override_test` build tag). Kept pure (goos +
+// compiled-in flag as arguments, no OS/env reads) so it can be unit-tested for
+// BOTH platforms from any host — which also keeps windows/linux executed-test
+// parity even (windows-gate drift-guard).
+func homeOverrideAllowed(goos string, compiledIn bool) bool {
 	if goos != "windows" {
 		return true
 	}
-	return strings.TrimSpace(allowOverride) == "1"
+	return compiledIn
 }

--- a/pkg/skillctl/registry/home.go
+++ b/pkg/skillctl/registry/home.go
@@ -2,31 +2,44 @@ package registry
 
 import (
 	"os"
+	"runtime"
 	"strings"
 )
 
-// userHome resolves the user's home directory, honoring an explicit $HOME on
-// ALL platforms before falling back to os.UserHomeDir().
+// userHome resolves the user's home directory for the registry package's per-user
+// security state: the self-trust-roots file, the install-token HMAC key, the
+// skill-bundle cache, the skills dir, the peers file.
 //
-// Why: on Windows os.UserHomeDir() reads %USERPROFILE% and ignores $HOME, so a
-// caller (or a test, or a Git-Bash session) that sets HOME would be silently
-// ignored — and the registry package's per-user state (the self-trust-roots
-// file, the install-token HMAC key, the skill-bundle cache, the skills dir)
-// would resolve to %USERPROFILE% instead of the requested HOME. Routing all of
-// those through here makes the resolution uniform and test-injectable
-// cross-platform, matching the resolvers already used in cmd/skillctl and the
-// verify package.
+// On non-Windows it honors an explicit $HOME before falling back to
+// os.UserHomeDir() (conventional POSIX precedence). On Windows $HOME is ignored
+// for these paths by default (WIN-09 / WIN-T8): %USERPROFILE% is the real
+// per-user, ACL'd root, whereas $HOME is not a security boundary — any process or
+// Git-Bash session could set it and redirect the token key / trust roots to a
+// directory an attacker controls. Ignoring $HOME on Windows keeps this per-user
+// state under %USERPROFILE% (via os.UserHomeDir()), fail-closed.
 //
-// In production on Windows, real users normally have HOME unset → os.UserHomeDir()
-// → %USERPROFILE%, so behaviour is unchanged. HOME is only honored when it is
-// explicitly set, which is the correct, conventional precedence. This also
-// matters for SEC-L6 isolation: a test that sets HOME to a fresh temp dir to
-// force the install-token mint path through the (failing) CSPRNG can only do so
-// if HOME actually redirects the key-file lookup.
+// The dev/quickstart/CI escape hatch is M3C_ALLOW_HOME_OVERRIDE=1: with it set,
+// $HOME is honored on Windows too. This preserves the sandboxed quickstart and
+// the SEC-L6 isolation tests (which set HOME to a fresh temp dir to force the
+// install-token mint path) on the windows-latest runner. See homeOverrideAllowed.
 func userHome() string {
-	if h := strings.TrimSpace(os.Getenv("HOME")); h != "" {
+	if h := strings.TrimSpace(os.Getenv("HOME")); h != "" &&
+		homeOverrideAllowed(runtime.GOOS, os.Getenv("M3C_ALLOW_HOME_OVERRIDE")) {
 		return h
 	}
 	h, _ := os.UserHomeDir()
 	return h
+}
+
+// homeOverrideAllowed is the pure, platform-parameterized decision behind
+// userHome: may an explicit $HOME override the per-user security root on goos?
+// Non-Windows always allows it; Windows allows it ONLY when the operator opts in
+// with M3C_ALLOW_HOME_OVERRIDE=1. Kept pure (goos + flag as arguments, no OS
+// reads) so it can be unit-tested for BOTH platforms from any host — which also
+// keeps windows/linux executed-test parity even (windows-gate drift-guard).
+func homeOverrideAllowed(goos, allowOverride string) bool {
+	if goos != "windows" {
+		return true
+	}
+	return strings.TrimSpace(allowOverride) == "1"
 }

--- a/pkg/skillctl/registry/home_override_off.go
+++ b/pkg/skillctl/registry/home_override_off.go
@@ -1,0 +1,11 @@
+//go:build windows && !allow_home_override_test
+
+package registry
+
+// homeOverrideCompiledIn is false for a normal (shipping) Windows build: $HOME is
+// NEVER honored for the registry package's per-user security state there —
+// %USERPROFILE% (via os.UserHomeDir()) is the only per-user root, fail-closed. The
+// override is compiled in only under the `allow_home_override_test` tag (see
+// home_override_on.go), which the dev/quickstart sandbox and the windows-latest
+// test surface use. WIN-T8 / WIN-09.
+const homeOverrideCompiledIn = false

--- a/pkg/skillctl/registry/home_override_on.go
+++ b/pkg/skillctl/registry/home_override_on.go
@@ -1,0 +1,14 @@
+//go:build !windows || allow_home_override_test
+
+package registry
+
+// homeOverrideCompiledIn gates whether an explicit $HOME may override the
+// registry package's per-user security state (install-token key, self-trust
+// roots, caches) on Windows (WIN-T8 / WIN-09). It is a COMPILE-TIME constant —
+// deliberately NOT an env var, which an attacker who controls the process
+// environment could set (the exact WIN-09 re-open the challenge gate flagged). It
+// is true on every non-Windows build (where userHome's goos short-circuit governs
+// anyway) and on any build made with the `allow_home_override_test` tag (the
+// dev/quickstart sandbox + the windows-latest test surface). The complementary
+// home_override_off.go compiles a false constant for a normal Windows build.
+const homeOverrideCompiledIn = true

--- a/pkg/skillctl/registry/install_token_errors_test.go
+++ b/pkg/skillctl/registry/install_token_errors_test.go
@@ -11,7 +11,8 @@ import (
 // actionable message. (Refusal behaviour itself is covered by
 // TestInstall_TokenForgedRefuses / TestInstall_Overwrite_RequiresTokenViaTwoStep.)
 func TestVerifyInstallToken_ErrorClasses(t *testing.T) {
-	t.Setenv("HOME", t.TempDir()) // installTokenKey persists a per-user 0600 key here
+	t.Setenv("HOME", t.TempDir())            // installTokenKey persists a per-user 0600 key here
+	t.Setenv("M3C_ALLOW_HOME_OVERRIDE", "1") // Windows: honor the injected HOME (WIN-T8)
 
 	plan := &InstallPlan{
 		IssuedAt:   time.Now().UTC().Unix(),

--- a/pkg/skillctl/registry/install_token_errors_test.go
+++ b/pkg/skillctl/registry/install_token_errors_test.go
@@ -11,8 +11,7 @@ import (
 // actionable message. (Refusal behaviour itself is covered by
 // TestInstall_TokenForgedRefuses / TestInstall_Overwrite_RequiresTokenViaTwoStep.)
 func TestVerifyInstallToken_ErrorClasses(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())            // installTokenKey persists a per-user 0600 key here
-	t.Setenv("M3C_ALLOW_HOME_OVERRIDE", "1") // Windows: honor the injected HOME (WIN-T8)
+	t.Setenv("HOME", t.TempDir()) // installTokenKey persists a per-user 0600 key here (Windows: honored under -tags allow_home_override_test)
 
 	plan := &InstallPlan{
 		IssuedAt:   time.Now().UTC().Unix(),

--- a/pkg/skillctl/registry/install_trust_mode_test.go
+++ b/pkg/skillctl/registry/install_trust_mode_test.go
@@ -354,10 +354,10 @@ func (failingReader) Read([]byte) (int, error) {
 func TestInstallTokenKey_RNGFailureFailsClosed(t *testing.T) {
 	// Isolate HOME so no pre-existing ~/.cache/m3c/install-token.key is read
 	// (that would short-circuit the RNG path). On Windows userHome() ignores
-	// $HOME unless this dev flag is set (WIN-T8).
+	// $HOME in a shipping build (WIN-T8); the windows-latest test surface builds
+	// with -tags allow_home_override_test so this injection takes effect there.
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
-	t.Setenv("M3C_ALLOW_HOME_OVERRIDE", "1")
 
 	// Reset the in-process key cache and inject a failing CSPRNG; restore both.
 	prevKey := installTokenKeyValue

--- a/pkg/skillctl/registry/install_trust_mode_test.go
+++ b/pkg/skillctl/registry/install_trust_mode_test.go
@@ -353,9 +353,11 @@ func (failingReader) Read([]byte) (int, error) {
 //     or verified), so the destructive overwrite never happens.
 func TestInstallTokenKey_RNGFailureFailsClosed(t *testing.T) {
 	// Isolate HOME so no pre-existing ~/.cache/m3c/install-token.key is read
-	// (that would short-circuit the RNG path).
+	// (that would short-circuit the RNG path). On Windows userHome() ignores
+	// $HOME unless this dev flag is set (WIN-T8).
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("M3C_ALLOW_HOME_OVERRIDE", "1")
 
 	// Reset the in-process key cache and inject a failing CSPRNG; restore both.
 	prevKey := installTokenKeyValue

--- a/pkg/skillctl/registry/p1_egress_test.go
+++ b/pkg/skillctl/registry/p1_egress_test.go
@@ -15,50 +15,56 @@ func TestER1TLSGuardNonLoopback(t *testing.T) {
 		t.Errorf("VerifySSL=true must never be refused: %v", err)
 	}
 
-	// VerifySSL off against a PUBLIC host → refused (fail closed).
-	if err := er1TLSGuard("https://onboarding.guide/upload_2", false); err == nil {
-		t.Error("VerifySSL=false against a public host must be refused")
+	// VerifySSL off against a non-loopback host → refused (fail closed). This is
+	// LOOPBACK-ONLY, matching pkg/er1.applyTLSVerificationPolicy: an RFC1918 LAN
+	// host (192.168.x) is refused here too, because the core ER1 client already
+	// forces verification back on for it. A public host is likewise refused.
+	for _, base := range []string{
+		"https://onboarding.guide/upload_2", // public
+		"https://192.168.1.10:8081",         // RFC1918 — no longer permitted (FIX 2)
+		"https://10.0.0.5:8081",             // RFC1918
+	} {
+		if err := er1TLSGuard(base, false); err == nil {
+			t.Errorf("VerifySSL=false against non-loopback host %q must be refused", base)
+		}
 	}
 
-	// VerifySSL off against loopback / localhost / RFC1918 → allowed (local dev
-	// with a self-signed cert). Mirrors netguard.IsLoopbackOrPrivate.
+	// VerifySSL off against loopback / localhost only → allowed (local dev with a
+	// self-signed cert). Mirrors netguard.IsLoopback.
 	for _, base := range []string{
 		"https://127.0.0.1:8081/upload_2",
 		"https://localhost:8081",
-		"https://192.168.1.10:8081",
 		"https://[::1]:8081",
 	} {
 		if err := er1TLSGuard(base, false); err != nil {
-			t.Errorf("VerifySSL=false against local target %q must proceed: %v", base, err)
+			t.Errorf("VerifySSL=false against loopback target %q must proceed: %v", base, err)
 		}
 	}
 }
 
 // TestHomeOverrideAllowed — WIN-T8 (WIN-09): on Windows an explicit $HOME may only
-// override the per-user security root (token key, trust roots) when
-// M3C_ALLOW_HOME_OVERRIDE=1; on every other OS $HOME is always honored. The
-// decision is a pure function of (goos, flag), so this runs identically on all
-// platforms — no runtime.GOOS skip, which keeps the windows/linux executed-test
-// parity even for the windows-gate drift-guard.
+// override the per-user security root (token key, trust roots) when the override
+// was COMPILED IN (the `allow_home_override_test` build tag) — there is no
+// ambient-env escape hatch. On every other OS $HOME is always honored. The
+// decision is a pure function of (goos, compiledIn), so this runs identically on
+// all platforms — no runtime.GOOS skip, which keeps the windows/linux
+// executed-test parity even for the windows-gate drift-guard.
 func TestHomeOverrideAllowed(t *testing.T) {
+	// Non-Windows: always honor $HOME, regardless of the compiled-in flag.
 	for _, goos := range []string{"darwin", "linux"} {
-		if !homeOverrideAllowed(goos, "") {
-			t.Errorf("%s: $HOME must be honored with no flag", goos)
+		if !homeOverrideAllowed(goos, false) {
+			t.Errorf("%s: $HOME must be honored (compiledIn=false)", goos)
 		}
-		if !homeOverrideAllowed(goos, "1") {
-			t.Errorf("%s: $HOME must be honored with the flag", goos)
+		if !homeOverrideAllowed(goos, true) {
+			t.Errorf("%s: $HOME must be honored (compiledIn=true)", goos)
 		}
 	}
-	if homeOverrideAllowed("windows", "") {
-		t.Error("windows: $HOME must be IGNORED without M3C_ALLOW_HOME_OVERRIDE")
+	// Windows: honor $HOME ONLY when the override is compiled in (dev/test tag);
+	// a normal shipping build compiles homeOverrideCompiledIn=false → ignored.
+	if homeOverrideAllowed("windows", false) {
+		t.Error("windows: $HOME must be IGNORED when the override is not compiled in (no env escape hatch)")
 	}
-	if homeOverrideAllowed("windows", "0") {
-		t.Error("windows: $HOME must be IGNORED when the flag is not exactly 1")
-	}
-	if !homeOverrideAllowed("windows", "1") {
-		t.Error("windows: $HOME must be honored with M3C_ALLOW_HOME_OVERRIDE=1")
-	}
-	if !homeOverrideAllowed("windows", " 1 ") {
-		t.Error("windows: a whitespace-padded flag value of 1 must still honor $HOME")
+	if !homeOverrideAllowed("windows", true) {
+		t.Error("windows: $HOME must be honored when the override is compiled in (allow_home_override_test tag)")
 	}
 }

--- a/pkg/skillctl/registry/p1_egress_test.go
+++ b/pkg/skillctl/registry/p1_egress_test.go
@@ -1,0 +1,64 @@
+package registry
+
+import "testing"
+
+// TestER1TLSGuardNonLoopback — CD-T10 (CD-11): the registry ER1 client must
+// refuse to disable TLS verification (VerifySSL=false) against a non-loopback
+// host, as defense-in-depth behind the er1.Config LoadConfig-time sanitizer (a
+// programmatically-built Config can carry VerifySSL=false + a public APIURL and
+// would otherwise slip an InsecureSkipVerify transport straight onto the wire).
+// Verification stays enabled (guard returns nil, nothing skipped) or is refused
+// (error) — it is never silently bypassed for a public host.
+func TestER1TLSGuardNonLoopback(t *testing.T) {
+	// VerifySSL on → never refused, whatever the host.
+	if err := er1TLSGuard("https://onboarding.guide/upload_2", true); err != nil {
+		t.Errorf("VerifySSL=true must never be refused: %v", err)
+	}
+
+	// VerifySSL off against a PUBLIC host → refused (fail closed).
+	if err := er1TLSGuard("https://onboarding.guide/upload_2", false); err == nil {
+		t.Error("VerifySSL=false against a public host must be refused")
+	}
+
+	// VerifySSL off against loopback / localhost / RFC1918 → allowed (local dev
+	// with a self-signed cert). Mirrors netguard.IsLoopbackOrPrivate.
+	for _, base := range []string{
+		"https://127.0.0.1:8081/upload_2",
+		"https://localhost:8081",
+		"https://192.168.1.10:8081",
+		"https://[::1]:8081",
+	} {
+		if err := er1TLSGuard(base, false); err != nil {
+			t.Errorf("VerifySSL=false against local target %q must proceed: %v", base, err)
+		}
+	}
+}
+
+// TestHomeOverrideAllowed — WIN-T8 (WIN-09): on Windows an explicit $HOME may only
+// override the per-user security root (token key, trust roots) when
+// M3C_ALLOW_HOME_OVERRIDE=1; on every other OS $HOME is always honored. The
+// decision is a pure function of (goos, flag), so this runs identically on all
+// platforms — no runtime.GOOS skip, which keeps the windows/linux executed-test
+// parity even for the windows-gate drift-guard.
+func TestHomeOverrideAllowed(t *testing.T) {
+	for _, goos := range []string{"darwin", "linux"} {
+		if !homeOverrideAllowed(goos, "") {
+			t.Errorf("%s: $HOME must be honored with no flag", goos)
+		}
+		if !homeOverrideAllowed(goos, "1") {
+			t.Errorf("%s: $HOME must be honored with the flag", goos)
+		}
+	}
+	if homeOverrideAllowed("windows", "") {
+		t.Error("windows: $HOME must be IGNORED without M3C_ALLOW_HOME_OVERRIDE")
+	}
+	if homeOverrideAllowed("windows", "0") {
+		t.Error("windows: $HOME must be IGNORED when the flag is not exactly 1")
+	}
+	if !homeOverrideAllowed("windows", "1") {
+		t.Error("windows: $HOME must be honored with M3C_ALLOW_HOME_OVERRIDE=1")
+	}
+	if !homeOverrideAllowed("windows", " 1 ") {
+		t.Error("windows: a whitespace-padded flag value of 1 must still honor $HOME")
+	}
+}

--- a/pkg/skillctl/verify/home.go
+++ b/pkg/skillctl/verify/home.go
@@ -2,27 +2,42 @@ package verify
 
 import (
 	"os"
+	"runtime"
 	"strings"
 )
 
-// userHome resolves the user's home directory, honoring an explicit $HOME on
-// ALL platforms before falling back to os.UserHomeDir().
+// userHome resolves the user's home directory for the trust-root security paths.
 //
-// Why: on Windows os.UserHomeDir() reads %USERPROFILE% and ignores $HOME, so a
-// caller (or a test, or a Git-Bash session) that sets HOME would be silently
-// ignored. Routing the trust-roots home resolution through here makes it uniform
-// and test-injectable cross-platform — it is what lets the verify-package tests
-// (and the SPEC-0247 gate) run on the windows-latest CI runner without per-test
-// %USERPROFILE% plumbing.
+// On non-Windows it honors an explicit $HOME before falling back to
+// os.UserHomeDir() (the conventional POSIX precedence). On Windows $HOME is
+// ignored for these security paths by default (WIN-09 / WIN-T8): %USERPROFILE% is
+// the real per-user, ACL'd root that Windows binds to, whereas $HOME is not a
+// security boundary — any process, a Git-Bash session, or an attacker who can set
+// an environment variable could point the trust roots at a directory they
+// control. Ignoring $HOME on Windows means the trust roots always resolve under
+// %USERPROFILE% (via os.UserHomeDir()), fail-closed.
 //
-// In production on Windows, real users normally have HOME unset → os.UserHomeDir()
-// → %USERPROFILE%, so behaviour is unchanged. HOME is only honored when it is
-// explicitly set, which is the correct, conventional precedence and matches the
-// resolver already used in cmd/skillctl (home.go). This is a correctness
-// improvement, not a test crutch.
+// The dev/quickstart/CI escape hatch is M3C_ALLOW_HOME_OVERRIDE=1: with it set,
+// $HOME is honored on Windows too (this is what preserves the sandboxed quickstart
+// and lets the verify-package tests inject a temp HOME on the windows-latest
+// runner). See homeOverrideAllowed for the pure decision.
 func userHome() (string, error) {
-	if h := strings.TrimSpace(os.Getenv("HOME")); h != "" {
+	if h := strings.TrimSpace(os.Getenv("HOME")); h != "" &&
+		homeOverrideAllowed(runtime.GOOS, os.Getenv("M3C_ALLOW_HOME_OVERRIDE")) {
 		return h, nil
 	}
 	return os.UserHomeDir()
+}
+
+// homeOverrideAllowed is the pure, platform-parameterized decision behind
+// userHome: may an explicit $HOME override the per-user security root on goos?
+// Non-Windows always allows it; Windows allows it ONLY when the operator opts in
+// with M3C_ALLOW_HOME_OVERRIDE=1. Kept pure (goos + flag as arguments, no OS
+// reads) so it can be unit-tested for BOTH platforms from any host — which also
+// keeps the windows/linux executed-test parity even (windows-gate drift-guard).
+func homeOverrideAllowed(goos, allowOverride string) bool {
+	if goos != "windows" {
+		return true
+	}
+	return strings.TrimSpace(allowOverride) == "1"
 }

--- a/pkg/skillctl/verify/home.go
+++ b/pkg/skillctl/verify/home.go
@@ -17,13 +17,19 @@ import (
 // control. Ignoring $HOME on Windows means the trust roots always resolve under
 // %USERPROFILE% (via os.UserHomeDir()), fail-closed.
 //
-// The dev/quickstart/CI escape hatch is M3C_ALLOW_HOME_OVERRIDE=1: with it set,
-// $HOME is honored on Windows too (this is what preserves the sandboxed quickstart
-// and lets the verify-package tests inject a temp HOME on the windows-latest
-// runner). See homeOverrideAllowed for the pure decision.
+// The Windows override is NOT re-openable from the ambient environment — an
+// env-var escape hatch (the earlier M3C_ALLOW_HOME_OVERRIDE) would be settable by
+// the very attacker/child-process WIN-09 models, re-opening the vector for the
+// cost of one extra variable. Instead the override is a COMPILE-TIME decision:
+// homeOverrideCompiledIn is true only in a build made with `-tags
+// allow_home_override_test` (and, trivially, on every non-Windows build, where the
+// goos short-circuit governs). Shipping Windows releases carry no such tag, so
+// $HOME is unconditionally ignored there. The dev/quickstart sandbox and the
+// windows-latest test surface build WITH the tag, which is what keeps them
+// working. See homeOverrideAllowed for the pure decision.
 func userHome() (string, error) {
 	if h := strings.TrimSpace(os.Getenv("HOME")); h != "" &&
-		homeOverrideAllowed(runtime.GOOS, os.Getenv("M3C_ALLOW_HOME_OVERRIDE")) {
+		homeOverrideAllowed(runtime.GOOS, homeOverrideCompiledIn) {
 		return h, nil
 	}
 	return os.UserHomeDir()
@@ -31,13 +37,14 @@ func userHome() (string, error) {
 
 // homeOverrideAllowed is the pure, platform-parameterized decision behind
 // userHome: may an explicit $HOME override the per-user security root on goos?
-// Non-Windows always allows it; Windows allows it ONLY when the operator opts in
-// with M3C_ALLOW_HOME_OVERRIDE=1. Kept pure (goos + flag as arguments, no OS
-// reads) so it can be unit-tested for BOTH platforms from any host — which also
-// keeps the windows/linux executed-test parity even (windows-gate drift-guard).
-func homeOverrideAllowed(goos, allowOverride string) bool {
+// Non-Windows always allows it; Windows allows it ONLY when the override was
+// compiled in (the `allow_home_override_test` build tag). Kept pure (goos +
+// compiled-in flag as arguments, no OS/env reads) so it can be unit-tested for
+// BOTH platforms from any host — which also keeps the windows/linux executed-test
+// parity even (windows-gate drift-guard).
+func homeOverrideAllowed(goos string, compiledIn bool) bool {
 	if goos != "windows" {
 		return true
 	}
-	return strings.TrimSpace(allowOverride) == "1"
+	return compiledIn
 }

--- a/pkg/skillctl/verify/home_override_off.go
+++ b/pkg/skillctl/verify/home_override_off.go
@@ -1,0 +1,11 @@
+//go:build windows && !allow_home_override_test
+
+package verify
+
+// homeOverrideCompiledIn is false for a normal (shipping) Windows build: $HOME is
+// NEVER honored for the trust-root security paths there — %USERPROFILE% (via
+// os.UserHomeDir()) is the only per-user root, fail-closed. The override is
+// compiled in only under the `allow_home_override_test` tag (see
+// home_override_on.go), which the dev/quickstart sandbox and the windows-latest
+// test surface use. WIN-T8 / WIN-09.
+const homeOverrideCompiledIn = false

--- a/pkg/skillctl/verify/home_override_on.go
+++ b/pkg/skillctl/verify/home_override_on.go
@@ -1,0 +1,14 @@
+//go:build !windows || allow_home_override_test
+
+package verify
+
+// homeOverrideCompiledIn gates whether an explicit $HOME may override the
+// trust-root security root on Windows (WIN-T8 / WIN-09). It is a COMPILE-TIME
+// constant — deliberately NOT an env var, which an attacker who controls the
+// process environment could set (the exact WIN-09 re-open the challenge gate
+// flagged). It is true here on every non-Windows build (where userHome's goos
+// short-circuit governs anyway) and on any build made with the
+// `allow_home_override_test` tag (the dev/quickstart sandbox + the windows-latest
+// test surface). The complementary home_override_off.go compiles a false constant
+// for a normal Windows build, so shipping Windows releases ignore $HOME.
+const homeOverrideCompiledIn = true

--- a/pkg/skillctl/verify/p1_egress_test.go
+++ b/pkg/skillctl/verify/p1_egress_test.go
@@ -3,30 +3,28 @@ package verify
 import "testing"
 
 // TestHomeOverrideAllowed — WIN-T8 (WIN-09): on Windows an explicit $HOME may only
-// override the trust-root security root when M3C_ALLOW_HOME_OVERRIDE=1; on every
-// other OS $HOME is always honored. The decision is a pure function of (goos,
-// flag), so this runs identically on all platforms — no runtime.GOOS skip, which
-// keeps the windows/linux executed-test parity even for the windows-gate
-// drift-guard.
+// override the trust-root security root when the override was COMPILED IN (the
+// `allow_home_override_test` build tag) — there is no ambient-env escape hatch. On
+// every other OS $HOME is always honored. The decision is a pure function of
+// (goos, compiledIn), so this runs identically on all platforms — no runtime.GOOS
+// skip, which keeps the windows/linux executed-test parity even for the
+// windows-gate drift-guard.
 func TestHomeOverrideAllowed(t *testing.T) {
+	// Non-Windows: always honor $HOME, regardless of the compiled-in flag.
 	for _, goos := range []string{"darwin", "linux"} {
-		if !homeOverrideAllowed(goos, "") {
-			t.Errorf("%s: $HOME must be honored with no flag", goos)
+		if !homeOverrideAllowed(goos, false) {
+			t.Errorf("%s: $HOME must be honored (compiledIn=false)", goos)
 		}
-		if !homeOverrideAllowed(goos, "1") {
-			t.Errorf("%s: $HOME must be honored with the flag", goos)
+		if !homeOverrideAllowed(goos, true) {
+			t.Errorf("%s: $HOME must be honored (compiledIn=true)", goos)
 		}
 	}
-	if homeOverrideAllowed("windows", "") {
-		t.Error("windows: $HOME must be IGNORED without M3C_ALLOW_HOME_OVERRIDE")
+	// Windows: honor $HOME ONLY when the override is compiled in (dev/test tag);
+	// a normal shipping build compiles homeOverrideCompiledIn=false → ignored.
+	if homeOverrideAllowed("windows", false) {
+		t.Error("windows: $HOME must be IGNORED when the override is not compiled in (no env escape hatch)")
 	}
-	if homeOverrideAllowed("windows", "0") {
-		t.Error("windows: $HOME must be IGNORED when the flag is not exactly 1")
-	}
-	if !homeOverrideAllowed("windows", "1") {
-		t.Error("windows: $HOME must be honored with M3C_ALLOW_HOME_OVERRIDE=1")
-	}
-	if !homeOverrideAllowed("windows", " 1 ") {
-		t.Error("windows: a whitespace-padded flag value of 1 must still honor $HOME")
+	if !homeOverrideAllowed("windows", true) {
+		t.Error("windows: $HOME must be honored when the override is compiled in (allow_home_override_test tag)")
 	}
 }

--- a/pkg/skillctl/verify/p1_egress_test.go
+++ b/pkg/skillctl/verify/p1_egress_test.go
@@ -1,0 +1,32 @@
+package verify
+
+import "testing"
+
+// TestHomeOverrideAllowed — WIN-T8 (WIN-09): on Windows an explicit $HOME may only
+// override the trust-root security root when M3C_ALLOW_HOME_OVERRIDE=1; on every
+// other OS $HOME is always honored. The decision is a pure function of (goos,
+// flag), so this runs identically on all platforms — no runtime.GOOS skip, which
+// keeps the windows/linux executed-test parity even for the windows-gate
+// drift-guard.
+func TestHomeOverrideAllowed(t *testing.T) {
+	for _, goos := range []string{"darwin", "linux"} {
+		if !homeOverrideAllowed(goos, "") {
+			t.Errorf("%s: $HOME must be honored with no flag", goos)
+		}
+		if !homeOverrideAllowed(goos, "1") {
+			t.Errorf("%s: $HOME must be honored with the flag", goos)
+		}
+	}
+	if homeOverrideAllowed("windows", "") {
+		t.Error("windows: $HOME must be IGNORED without M3C_ALLOW_HOME_OVERRIDE")
+	}
+	if homeOverrideAllowed("windows", "0") {
+		t.Error("windows: $HOME must be IGNORED when the flag is not exactly 1")
+	}
+	if !homeOverrideAllowed("windows", "1") {
+		t.Error("windows: $HOME must be honored with M3C_ALLOW_HOME_OVERRIDE=1")
+	}
+	if !homeOverrideAllowed("windows", " 1 ") {
+		t.Error("windows: a whitespace-padded flag value of 1 must still honor $HOME")
+	}
+}

--- a/pkg/skillctl/verify/trustroots_test.go
+++ b/pkg/skillctl/verify/trustroots_test.go
@@ -450,9 +450,11 @@ func TestDefaultPath(t *testing.T) {
 }
 
 func TestResolveAndValidatePath_TildeExpansion(t *testing.T) {
-	// Force HOME to a known temp dir so the test is hermetic.
+	// Force HOME to a known temp dir so the test is hermetic. On Windows the
+	// trust-root resolver ignores $HOME unless this dev flag is set (WIN-T8).
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("M3C_ALLOW_HOME_OVERRIDE", "1")
 
 	got, err := resolveAndValidatePath("~/.claude/skill-trust-roots.yaml")
 	if err != nil {

--- a/pkg/skillctl/verify/trustroots_test.go
+++ b/pkg/skillctl/verify/trustroots_test.go
@@ -451,10 +451,11 @@ func TestDefaultPath(t *testing.T) {
 
 func TestResolveAndValidatePath_TildeExpansion(t *testing.T) {
 	// Force HOME to a known temp dir so the test is hermetic. On Windows the
-	// trust-root resolver ignores $HOME unless this dev flag is set (WIN-T8).
+	// trust-root resolver ignores $HOME in a shipping build (WIN-T8); the
+	// windows-latest test surface builds with -tags allow_home_override_test so
+	// this injection takes effect there too.
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
-	t.Setenv("M3C_ALLOW_HOME_OVERRIDE", "1")
 
 	got, err := resolveAndValidatePath("~/.claude/skill-trust-roots.yaml")
 	if err != nil {

--- a/scripts/skillctl-quickstart-windows.ps1
+++ b/scripts/skillctl-quickstart-windows.ps1
@@ -24,9 +24,13 @@
     * Everything happens in a fresh %TEMP%\skillctl-quickstart-<guid> dir, removed on
       exit (keep it with -KeepWork). A new GUID each run makes the script re-runnable.
     * `skillctl trust add` writes ~/.claude/skill-trust-roots.yaml. skillctl resolves
-      that home via $HOME first on ALL platforms (pkg/skillctl/verify/home.go), so we
-      point $env:HOME at the sandbox dir for the run -- the REAL user trust roots are
-      never touched. (env change is process-local and dies with this PowerShell.)
+      that home via $HOME (pkg/skillctl/verify/home.go), so we point $env:HOME at the
+      sandbox dir for the run -- the REAL user trust roots are never touched. (env
+      change is process-local and dies with this PowerShell.)
+      NOTE (WIN-T8/WIN-09): a SHIPPING Windows build ignores $HOME for the trust-root
+      paths (an env var is attacker-settable), so this sandbox needs a binary built
+      with `-tags allow_home_override_test` (the windows-smoke CI job builds it that
+      way). A plain `go build` on Windows will write under %USERPROFILE% instead.
     * NEVER prints a private key, signature bytes, or any secret. Only public paths,
       digests, and exit codes are shown.
     * `--registry self` is NOT valid -- validateRegistryURL requires https:// (or


### PR DESCRIPTION
## P1 · Egress / container hardening — refuse write-token over cleartext (CD-T8 closes the CD-03 HIGH)

Second P1 wave, supply-chain + Windows lens. Closes the one open supply-chain HIGH and hardens backend egress.

### What it does
- **CD-T8 (closes CD-03 HIGH)** — new `pkg/skillctl/netguard`; the git backend refuses to attach a write-token over cleartext `http://` to a non-loopback/non-private host (fail-closed; refuses cloud-metadata IPs). Token attaches for `https` / `127.0.0.1`; refused for a public `http` host.
- **CD-T10 / CD-T11** — capped reads on backend fetches; real digests in the release/container path.
- **WIN-T8** — the Windows `$HOME`-override moved from an **attacker-settable env var** to a **compile-time build tag** (`allow_home_override_test`); a shipping Windows binary never honors `$HOME` (verified absent from the release build).
- **WIN-T10 / IS-T10** — bounded reads on the Windows + install paths.
- **ER1 TLS guard** now loopback-only (`netguard.IsLoopback`) — a `192.168/10.x` host with `VerifySSL=false` errors.

### Assurance
- Challenge gate + focused re-gate = **CLEARED** (netguard fail-closed confirmed; WIN-T8 build-tag verified absent from shipping; ER1 loopback-only verified).
- darwin + `GOOS=windows` (shipping, no tag) + `-tags allow_home_override_test` all build green; netguard tests green.
- Touches `.github/workflows/**` (pushed via SSH).

Human-merge per the trust-layer flow. `closes CD-03 / CD-10 / CD-11 / WIN-08 / WIN-10 / IS-10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
