### PR TITLE
chore(skillctl): AI-slop cleanup — dead abstractions + comment drift

### DIFF
--- a/cmd/skillctl/pin_cmds.go
+++ b/cmd/skillctl/pin_cmds.go
@@ -159,10 +159,8 @@ func runPinStatus(args []string, stdout, stderr io.Writer) int {
 
 	data, readErr := os.ReadFile(path)
 	var res pin.StatusResult
-	absent := false
 	if readErr != nil {
 		if os.IsNotExist(readErr) {
-			absent = true
 			res = pin.StatusResult{Level: pin.LevelAbsent, Findings: []string{
 				"no managed-settings file at " + path + " — the gate is ADVISORY (a user can delete the user-level hook). Run `skillctl pin install`.",
 			}}
@@ -201,7 +199,6 @@ func runPinStatus(args []string, stdout, stderr io.Writer) int {
 	if res.Pinned() {
 		return pinExitOK
 	}
-	_ = absent
 	return pinExitNotPinned
 }
 

--- a/cmd/skillctl/replay_cmds.go
+++ b/cmd/skillctl/replay_cmds.go
@@ -266,11 +266,6 @@ func renderReplayTable(w io.Writer, events []replayEvent, colorize bool) {
 		last = e.Timestamp
 		typeCounts[e.Type]++
 
-		typeStr := e.Type
-		if colorize {
-			typeStr = colorForType(e.Type) + typeStr + ansiReset
-		}
-
 		codeOrExit := ""
 		switch {
 		case e.RefusalCode != "":
@@ -292,7 +287,6 @@ func renderReplayTable(w io.Writer, events []replayEvent, colorize bool) {
 		}
 		fmt.Fprintf(w, "%-22s  %s  %-24s  %-14s  %s\n",
 			truncString(e.Timestamp, 22), typeCol, skillTrunc, tokTrunc, codeOrExit)
-		_ = typeStr // keep variable used for clarity
 	}
 
 	// Footer.

--- a/cmd/skillctl/verify_hook_cmds.go
+++ b/cmd/skillctl/verify_hook_cmds.go
@@ -505,8 +505,11 @@ func runVerifyHook(stdin io.Reader, stdout, stderr io.Writer) (code int) {
 	// SPEC-0279 R3 / FR-0045 D4 — FRESHNESS FAIL-CLOSED. If the revocation snapshot
 	// is too stale to trust (per the trust-root max_staleness), refuse a high-risk
 	// skill invocation rather than run against a revocation list we can no longer
-	// prove is current. This closes the fail-OPEN gap above where a >TTL sweep cache
-	// silently skips the revocation check. Placed BEFORE the verdict-cache fast path
+	// prove is current. This narrows the fail-OPEN gap above where a >TTL sweep cache
+	// silently skips the revocation check — but only when configured: it is a no-op
+	// unless a max_staleness policy is set AND a signed anchor exists (see below), so
+	// on a default host the >TTL stale-cache gap is not closed by this control alone.
+	// Placed BEFORE the verdict-cache fast path
 	// so a cached allow cannot bypass a stale kill-switch. OPT-IN: a no-op unless a
 	// max_staleness policy is set AND a signed HEAD/checkpoint anchor exists.
 	if stale, reason, msg := revocationSnapshotStale(home, skill); stale {

--- a/cmd/skillctl/verify_hook_fallback_gate_test.go
+++ b/cmd/skillctl/verify_hook_fallback_gate_test.go
@@ -6,7 +6,7 @@ package main
 // with no stashed offline metadata (verifyManagedOfflineFn returns ok=false). When
 // the enterprise `state_gate_fallback` opt-in is set, that fallback is SUPPRESSED
 // outside the `online` state so the hot path stays strictly local: such an install
-// fails CLOSED (exit 30 `offline_unverifiable_managed`) instead of blocking on an
+// fails CLOSED (exit 25 `offline_unverifiable_managed`) instead of blocking on an
 // 8s network round-trip. The invariants under test:
 //   - opted in + no offline metadata → deny, and the online seam is NEVER reached
 //     (no network on the hot path);

--- a/pkg/skillctl/artifact/backend.go
+++ b/pkg/skillctl/artifact/backend.go
@@ -71,21 +71,6 @@ type GovernanceLog interface {
 	Events(ctx context.Context, filter ListFilter, page Page) (*EventPage, error)
 }
 
-// Roomer is implemented by backends with SPEC-0096 co-learning rooms: ER1.
-// GitHub/GitLab/OCI/HTTP do not; callers degrade with a clear message.
-type Roomer interface {
-	Share(ctx context.Context, room string, sel RoomSelector) (*RoomResult, error)
-	Unshare(ctx context.Context, room string, sel RoomSelector) (*RoomResult, error)
-	MatchRoom(ctx context.Context, sel RoomSelector, inRooms ...string) (*RoomMatch, error)
-}
-
-// IdentityDirectory is implemented by backends that expose a pubkey directory
-// keyed by identity id: the HTTP admission API. ER1 does not — its trust anchor
-// is the single pinned trust-roots key, not a server lookup.
-type IdentityDirectory interface {
-	Identity(ctx context.Context, id string) (*Identity, error)
-}
-
 // Descriptor is a backend's self-description: its scheme key, a human label,
 // and its declared capabilities.
 type Descriptor struct {

--- a/pkg/skillctl/artifact/capabilities.go
+++ b/pkg/skillctl/artifact/capabilities.go
@@ -2,10 +2,10 @@ package artifact
 
 // Capabilities is a backend's declarative statement of what it can do. Callers
 // branch on these flags BEFORE offering a CLI flag or calling an optional
-// sub-interface — never by probing a method and catching an error. The flags
-// that mirror an optional interface (Rooms ⇔ Roomer, IdentityDir ⇔
-// IdentityDirectory, ServerEventLog ⇔ GovernanceLog) MUST agree with the type
-// assertion; that invariant is what the conformance suite checks.
+// sub-interface — never by probing a method and catching an error. The flag
+// that mirrors an optional interface (ServerEventLog ⇔ GovernanceLog) MUST
+// agree with the type assertion; that invariant is what the conformance suite
+// checks.
 type Capabilities struct {
 	// Lifecycle events this backend can PUBLISH.
 	CanAdmit   bool
@@ -23,10 +23,6 @@ type Capabilities struct {
 
 	// Explicit "latest" semantics — designs out the compareSemver guesswork.
 	LatestPolicy LatestPolicy
-
-	// Optional-interface mirrors (must equal the type assertions).
-	Rooms       bool // ⇔ Roomer
-	IdentityDir bool // ⇔ IdentityDirectory
 
 	// ClaimCheck is true when the bundle blob is stored out-of-line (MinIO
 	// claim-check / OCI blob / git Release asset) rather than inline.

--- a/pkg/skillctl/artifact/types.go
+++ b/pkg/skillctl/artifact/types.go
@@ -128,22 +128,3 @@ type EventRecord struct {
 	Envelope   map[string]any // the raw signed event, for re-verification
 }
 
-// RoomSelector maps 1:1 to registry.RoomShareSelector (SPEC-0096).
-type RoomSelector struct {
-	SkillName string
-	Digest    string
-	All       bool
-}
-
-// RoomResult / RoomMatch are the neutral room-operation results.
-type RoomResult struct{ ItemIDs, Skills []string }
-type RoomMatch struct{ ItemIDs, Skills []string }
-
-// Identity is a neutral mirror of registry.Identity (the pubkey-directory row),
-// defined here so this package stays a leaf. IdentityDirectory backends convert
-// their native identity type into this.
-type Identity struct {
-	ID         string // canonical identity id, e.g. "id:kamir@m3c"
-	PubkeyB64  string // base64 of the raw 32-byte ed25519 public key
-	AuthSource string // "manual" | "github-oidc" | "dsm-sso"
-}

--- a/pkg/skillctl/backend/git/git.go
+++ b/pkg/skillctl/backend/git/git.go
@@ -253,8 +253,6 @@ func (b *gitBackend) Describe() artifact.Descriptor {
 			HonoursSince:   true,  // Events applies ListFilter.Since on occurred_at
 			Governance:     artifact.GovFromEventLog,
 			LatestPolicy:   artifact.LatestSemverMax,
-			Rooms:          false,
-			IdentityDir:    false,
 			ClaimCheck:     false, // the .skb is committed IN-repo, not stored out-of-line (Git-LFS is a follow-up)
 		},
 	}

--- a/pkg/skillctl/backend/oci/oci.go
+++ b/pkg/skillctl/backend/oci/oci.go
@@ -81,7 +81,6 @@ func (b *ociBackend) Describe() artifact.Descriptor {
 			HonoursSince:   true,                     // Events applies ListFilter.Since on occurred_at
 			Governance:     artifact.GovFromEventLog, // newest signed attestation
 			LatestPolicy:   artifact.LatestSemverMax, // highest semver among non-revoked
-			Rooms:          false,                    // no co-learning rooms
 			ClaimCheck:     false,                    // the .skb IS the OCI layer blob (no out-of-line store)
 		},
 	}

--- a/pkg/skillctl/propose/gate.go
+++ b/pkg/skillctl/propose/gate.go
@@ -221,7 +221,7 @@ func Run(opts CheckOptions) Result {
 			checks = append(checks, ok(9, "tests/smoke.sh present"))
 		} else if parsed != nil && parsed.Metadata != nil {
 			if v, ok2 := parsed.Metadata["last_smoke_passed"]; ok2 && v != nil && fmt.Sprintf("%v", v) != "" {
-				checks = append(checks, okFn(9, fmt.Sprintf("metadata.last_smoke_passed = %v", v)))
+				checks = append(checks, ok(9, fmt.Sprintf("metadata.last_smoke_passed = %v", v)))
 			} else {
 				checks = append(checks, fail(9, "smoke-test marker",
 					"no tests/smoke.sh; metadata.last_smoke_passed unset; --skip-smoke not set"))
@@ -360,8 +360,7 @@ func finalize(checks []CheckResult) Result {
 
 var semverPattern = regexp.MustCompile(`^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$`)
 
-func ok(n int, name string) CheckResult   { return CheckResult{Number: n, Name: name, Pass: true} }
-func okFn(n int, name string) CheckResult { return CheckResult{Number: n, Name: name, Pass: true} }
+func ok(n int, name string) CheckResult { return CheckResult{Number: n, Name: name, Pass: true} }
 func fail(n int, name, reason string) CheckResult {
 	return CheckResult{Number: n, Name: name, Pass: false, Reason: reason}
 }

--- a/pkg/skillctl/registry/er1_backend.go
+++ b/pkg/skillctl/registry/er1_backend.go
@@ -47,7 +47,6 @@ func (b *ER1Backend) Describe() artifact.Descriptor {
 			HonoursSince:   true,                      // Events applies ListFilter.Since on occurred_at
 			Governance:     artifact.GovFromEventLog,  // newest signed attestation
 			LatestPolicy:   artifact.LatestMostRecent, // admit-time newest (NOT semver-max — a real ER1↔git difference)
-			Rooms:          false,                     // TODO: expose er1_room.go via Roomer (rooms are an ER1-only feature)
 			ClaimCheck:     false,                     // inline-only today; the MinIO ClaimCheckFn seam is not wired
 		},
 	}

--- a/pkg/skillctl/registry/er1transport.go
+++ b/pkg/skillctl/registry/er1transport.go
@@ -1,98 +1,41 @@
 package registry
 
-// ER1 bundle transport — SPEC-0225 (Personal Skill Registry & Cross-Machine
+// ER1 registry recognizer — SPEC-0225 (Personal Skill Registry & Cross-Machine
 // Trust-Mode Distribution via ER1).
 //
-// This file is the P0 *stub* (PLAN-SPEC-0225 P0.2): it establishes the
-// recognizer and the carrier seam so `skillctl publish` / `pull` / `registry`
-// (P1/P2) can be built against a stable shape, without yet implementing the
-// transport. No behaviour here — every method returns ErrNotImplemented.
+// This file recognizes which `--registry` specs select the ER1 carrier. The
+// carrier itself ships as ER1Backend (er1_backend.go), which implements
+// artifact.Backend (+ GovernanceLog) and is resolved through artifact.Open;
+// the ER1 free functions (er1_publish.go / er1_pull.go) do the publish/pull work.
 //
 // Background. The existing registry.Client in this package is the HTTP client
 // for the aims-core admission API (SPEC-0188 §5) — it talks to a `--registry
-// <url>` endpoint. The ER1 transport is a *different carrier*: it does not call
+// <url>` endpoint. The ER1 carrier is a *different carrier*: it does not call
 // that HTTP API. A published bundle event is one ER1 memory item (created via
 // POST /upload_2, SPEC-0187) whose body is a SPEC-0190 event verbatim and whose
 // payload is either the .skb bytes (base64, inline) or a claim-check pointer
 // into MinIO. So `skillctl --registry self` (or `--registry er1://...`) routes
-// here, not to registry.Client. The full carrier interface is designed in P1
-// against pkg/er1; this stub deliberately keeps the surface tiny.
+// to ER1Backend, not to registry.Client.
 //
 // Wire format (frozen): INFRA/skill-registry/self/WIRE-FORMAT.md in
 // m3c-tools-maintenance. Tenant profile: INFRA/skill-registry/env/self.env.
 
-import (
-	"errors"
-	"strings"
-)
-
-// ErrNotImplemented is returned by every ER1Transport method until the P1/P2
-// implementation lands. Sentinel-comparable so callers (and tests) can branch.
-var ErrNotImplemented = errors.New("registry: ER1 bundle transport not implemented yet (SPEC-0225 P1/P2)")
+import "strings"
 
 // ER1RegistrySelf is the well-known registry spec that means "the author's
 // personal ER1-mediated registry" — the `self` tenant of SPEC-0225 /
 // INFRA/skill-registry/env/self.env. Used as `skillctl ... --registry self`.
 const ER1RegistrySelf = "self"
 
-// ER1RegistryScheme is the URL scheme that also selects the ER1 transport, for
+// ER1RegistryScheme is the URL scheme that also selects the ER1 carrier, for
 // the (rare) case a caller wants to point at a non-default ER1 context
-// explicitly, e.g. `er1://prod/skills`. Parsing of the authority/path is P1.
+// explicitly, e.g. `er1://prod/skills`.
 const ER1RegistryScheme = "er1://"
 
 // IsER1Registry reports whether a `--registry` spec selects the ER1 bundle
-// transport (this file) rather than the HTTP admission client (registry.Client).
+// carrier (ER1Backend) rather than the HTTP admission client (registry.Client).
 // True for the literal "self" and for any "er1://…" spec; false otherwise
 // (including the empty string and http(s) URLs).
 func IsER1Registry(spec string) bool {
 	return spec == ER1RegistrySelf || strings.HasPrefix(spec, ER1RegistryScheme)
 }
-
-// ER1Transport is the (stubbed) carrier for the `self` tenant. Construct via
-// NewER1Transport. In P0 it carries only the resolved registry spec; P1 adds
-// the pkg/er1 client, the signing key, the inline-size cap, and the MinIO
-// overflow handle (all sourced from self.env / trust-roots).
-type ER1Transport struct {
-	// Spec is the `--registry` value this transport was resolved from
-	// ("self" or "er1://…").
-	Spec string
-}
-
-// NewER1Transport builds the stub transport for the given registry spec. It
-// does not validate the spec beyond IsER1Registry (the caller is expected to
-// have routed here on that basis); a non-ER1 spec is accepted but every method
-// will still return ErrNotImplemented in this build.
-func NewER1Transport(spec string) *ER1Transport {
-	return &ER1Transport{Spec: spec}
-}
-
-// String renders the transport for diagnostics, e.g. `er1-transport(self)`.
-func (t *ER1Transport) String() string {
-	if t == nil {
-		return "er1-transport(<nil>)"
-	}
-	return "er1-transport(" + t.Spec + ")"
-}
-
-// Publish will (P1) pack/sign/attest-check a bundle, build a SPEC-0190
-// BundleAdmittedEvent, sign the envelope, place the bytes (inline or MinIO
-// claim-check), and POST the ER1 item. Stub: ErrNotImplemented.
-func (t *ER1Transport) Publish() error { return ErrNotImplemented }
-
-// Pull will (P2) query ER1 for bundle items, run the five-gate verification
-// gauntlet (envelope sig → digest → author+registry sigs → governance floor →
-// not-revoked), and stage verified bundles. Stub: ErrNotImplemented.
-func (t *ER1Transport) Pull() error { return ErrNotImplemented }
-
-// List will (P2) return the registry view — bundle items grouped by skill,
-// deduped by digest, with the event timeline. Stub: ErrNotImplemented.
-func (t *ER1Transport) List() error { return ErrNotImplemented }
-
-// Get will (P2) return full detail for one bundle digest — envelope,
-// signatures, attestations, install events, revocation status. Stub:
-// ErrNotImplemented.
-func (t *ER1Transport) Get() error { return ErrNotImplemented }
-
-// Revoke will (P2) emit a SPEC-0190 BundleRevokedEvent item. Stub:
-// ErrNotImplemented.
-func (t *ER1Transport) Revoke() error { return ErrNotImplemented }

--- a/pkg/skillctl/registry/er1transport_test.go
+++ b/pkg/skillctl/registry/er1transport_test.go
@@ -1,9 +1,6 @@
 package registry
 
-import (
-	"errors"
-	"testing"
-)
+import "testing"
 
 func TestIsER1Registry(t *testing.T) {
 	cases := []struct {
@@ -16,44 +13,13 @@ func TestIsER1Registry(t *testing.T) {
 		{"", false},
 		{"http://localhost:8080/api/skills", false},
 		{"https://kup.onboarding.guide/api/skills", false},
-		{"selfish", false},  // must not prefix-match "self"
-		{"SELF", false},     // case-sensitive
+		{"selfish", false},   // must not prefix-match "self"
+		{"SELF", false},      // case-sensitive
 		{"er1:/prod", false}, // not the scheme
 	}
 	for _, c := range cases {
 		if got := IsER1Registry(c.spec); got != c.want {
 			t.Errorf("IsER1Registry(%q) = %v, want %v", c.spec, got, c.want)
 		}
-	}
-}
-
-func TestER1TransportStubReturnsNotImplemented(t *testing.T) {
-	tr := NewER1Transport(ER1RegistrySelf)
-	if tr == nil {
-		t.Fatal("NewER1Transport returned nil")
-	}
-	if tr.Spec != "self" {
-		t.Errorf("Spec = %q, want %q", tr.Spec, "self")
-	}
-	for name, fn := range map[string]func() error{
-		"Publish": tr.Publish,
-		"Pull":    tr.Pull,
-		"List":    tr.List,
-		"Get":     tr.Get,
-		"Revoke":  tr.Revoke,
-	} {
-		if err := fn(); !errors.Is(err, ErrNotImplemented) {
-			t.Errorf("%s() = %v, want ErrNotImplemented", name, err)
-		}
-	}
-}
-
-func TestER1TransportString(t *testing.T) {
-	if got := NewER1Transport("self").String(); got != "er1-transport(self)" {
-		t.Errorf("String() = %q, want %q", got, "er1-transport(self)")
-	}
-	var nilT *ER1Transport
-	if got := nilT.String(); got != "er1-transport(<nil>)" {
-		t.Errorf("nil String() = %q, want %q", got, "er1-transport(<nil>)")
 	}
 }

--- a/pkg/skillctl/scanner/scanner.go
+++ b/pkg/skillctl/scanner/scanner.go
@@ -110,7 +110,11 @@ func (s *Scanner) Scan() (*model.Inventory, error) {
 	// Run duplicate detection (shared by both modes).
 	// SPEC-0189 §6: cross-reference each skill with sibling-.skb trust state.
 	if s.WithTrust {
-		_ = AnnotateTrust(inv)
+		if err := AnnotateTrust(inv); err != nil {
+			// Best-effort: the scan still returns, but a failure to cross-reference
+			// sibling-.skb trust state must not be silent in a trust tool.
+			fmt.Fprintf(os.Stderr, "skillctl scan: trust annotation incomplete: %v\n", err)
+		}
 	}
 
 	hasher.DetectDuplicates(inv.Skills)

--- a/pkg/skillctl/scanner/tiers.go
+++ b/pkg/skillctl/scanner/tiers.go
@@ -177,7 +177,7 @@ func applyShadowing(inv *model.Inventory, includeShadowed bool) {
 	}
 
 	dropIdx := map[int]bool{}
-	for name, members := range groups {
+	for _, members := range groups {
 		if len(members) <= 1 {
 			continue
 		}
@@ -200,7 +200,6 @@ func applyShadowing(inv *model.Inventory, includeShadowed bool) {
 				dropIdx[m.i] = true
 			}
 		}
-		_ = name
 	}
 
 	if len(dropIdx) == 0 {


### PR DESCRIPTION
Pure-removal cleanup from the anti-bullshit code review — **zero behavior change** (verified: darwin + windows builds, `vet`, 30 packages green; no dangling references).

## What's removed
- **`ER1Transport` dead stub** (type + `NewER1Transport` + `String` + 5 `ErrNotImplemented` methods) + its theater test — superseded by the real `ER1Backend`. The live recognizer (`IsER1Registry` + `ER1RegistrySelf`/`Scheme` + its real test) is kept.
- **Dead `artifact` optional-interface seams `Roomer` + `IdentityDirectory`** — 0 implementations, 0 consumers, 0 type-assertions — plus their support types (`RoomSelector`/`RoomResult`/`RoomMatch`/`Identity`) and the write-only `Rooms`/`IdentityDir` capability fields. **Fixes a false claim:** `capabilities.go` stated all three mirror invariants "is what the conformance suite checks" — only `ServerEventLog⇔GovernanceLog` is; the comment now says so.
- **Dead locals:** `replay_cmds` `typeStr` (+ its "keep variable used for clarity" fiction), `scanner/tiers` unused range key, `propose/gate` `okFn` twin, `pin_cmds` dead `absent`.
- **Swallowed error:** a failed `AnnotateTrust` in the trust scanner is now logged, not silently dropped.
- **Comment drift:** `verify_hook` "closes the fail-OPEN gap" → "narrows … no-op unless configured"; a stale `exit 30` test comment → `exit 25`.

## Explicitly kept (verified NOT slop)
`--since` is live (applied in `er1_pull` + git/oci/er1 backends); `ErrClaimCheckNotImplemented` is an honest fail-loud v1 boundary.

Net **−137 LOC**. The `compareSemver` consolidation (a latent version-ordering bug) ships separately as a gated PR; the `TrustVerified` rename as a third.

🤖 Generated with [Claude Code](https://claude.com/claude-code)