### PR TITLE
chore(skillctl): honest scanner trust label — TrustVerified → TrustSignaturePresent

### DIFF
--- a/cmd/skillctl/scan_table.go
+++ b/cmd/skillctl/scan_table.go
@@ -87,7 +87,10 @@ func tabRows(inv *model.Inventory, withTrust bool) []string {
 				}
 				switch sk.Bundle.TrustChain {
 				case "verified":
-					trusted = "yes"
+					// The scanner only checked that a 64-byte detached sig is
+					// present — not that it verifies. Say so; real trust is
+					// established by `skillctl verify`, not this scan.
+					trusted = "sig-only"
 				case "broken":
 					trusted = "BROKEN"
 				case "unverified":

--- a/pkg/skillctl/audit/audit.go
+++ b/pkg/skillctl/audit/audit.go
@@ -179,7 +179,7 @@ func classify(sk *model.SkillDescriptor, minimum MinimumLevel) Verdict {
 			v.State = StateUnverified
 			v.Reason = "no sibling .skb on disk"
 			return v
-		case scanner.TrustVerified:
+		case scanner.TrustSignaturePresent:
 			// Bundle is good; fall through to governance check.
 		}
 	} else {

--- a/pkg/skillctl/audit/audit_test.go
+++ b/pkg/skillctl/audit/audit_test.go
@@ -34,8 +34,8 @@ func mkBundle(chain string, errMsg string, exitCode int) *model.BundleAttestatio
 func TestCompute_AllOK(t *testing.T) {
 	inv := &model.Inventory{
 		Skills: []model.SkillDescriptor{
-			mkSkill("foo", "user", "green", mkBundle(scanner.TrustVerified, "", 0)),
-			mkSkill("bar", "user", "green", mkBundle(scanner.TrustVerified, "", 0)),
+			mkSkill("foo", "user", "green", mkBundle(scanner.TrustSignaturePresent, "", 0)),
+			mkSkill("bar", "user", "green", mkBundle(scanner.TrustSignaturePresent, "", 0)),
 		},
 	}
 	r := Compute(inv, MinGreen)
@@ -50,7 +50,7 @@ func TestCompute_AllOK(t *testing.T) {
 func TestCompute_OneUnverified_Exit2(t *testing.T) {
 	inv := &model.Inventory{
 		Skills: []model.SkillDescriptor{
-			mkSkill("foo", "user", "green", mkBundle(scanner.TrustVerified, "", 0)),
+			mkSkill("foo", "user", "green", mkBundle(scanner.TrustSignaturePresent, "", 0)),
 			mkSkill("bar", "user", "yellow", nil), // no bundle = unverified
 		},
 	}
@@ -66,7 +66,7 @@ func TestCompute_OneUnverified_Exit2(t *testing.T) {
 func TestCompute_OneBroken_Exit3(t *testing.T) {
 	inv := &model.Inventory{
 		Skills: []model.SkillDescriptor{
-			mkSkill("foo", "user", "green", mkBundle(scanner.TrustVerified, "", 0)),
+			mkSkill("foo", "user", "green", mkBundle(scanner.TrustSignaturePresent, "", 0)),
 			mkSkill("hostile", "user", "green", mkBundle(scanner.TrustBroken, "digest mismatch", 0)),
 			mkSkill("bar", "user", "yellow", nil),
 		},
@@ -83,7 +83,7 @@ func TestCompute_OneBroken_Exit3(t *testing.T) {
 func TestCompute_BelowMin(t *testing.T) {
 	inv := &model.Inventory{
 		Skills: []model.SkillDescriptor{
-			mkSkill("yellow-skill", "user", "yellow", mkBundle(scanner.TrustVerified, "", 0)),
+			mkSkill("yellow-skill", "user", "yellow", mkBundle(scanner.TrustSignaturePresent, "", 0)),
 		},
 	}
 	r := Compute(inv, MinGreen)
@@ -101,8 +101,8 @@ func TestCompute_BelowMin(t *testing.T) {
 func TestCompute_NoFloorPassesEverything(t *testing.T) {
 	inv := &model.Inventory{
 		Skills: []model.SkillDescriptor{
-			mkSkill("yellow-skill", "user", "yellow", mkBundle(scanner.TrustVerified, "", 0)),
-			mkSkill("red-skill", "user", "red", mkBundle(scanner.TrustVerified, "", 0)),
+			mkSkill("yellow-skill", "user", "yellow", mkBundle(scanner.TrustSignaturePresent, "", 0)),
+			mkSkill("red-skill", "user", "red", mkBundle(scanner.TrustSignaturePresent, "", 0)),
 		},
 	}
 	r := Compute(inv, MinAny)
@@ -116,7 +116,7 @@ func TestCompute_NonSkillTypesExcluded(t *testing.T) {
 		Skills: []model.SkillDescriptor{
 			{Name: "agent-thing", Type: model.SkillTypeAgent, Tier: "user"},
 			{Name: "mcp-thing", Type: model.SkillTypeMCPServer, Tier: "user"},
-			mkSkill("real-skill", "user", "green", mkBundle(scanner.TrustVerified, "", 0)),
+			mkSkill("real-skill", "user", "green", mkBundle(scanner.TrustSignaturePresent, "", 0)),
 		},
 	}
 	r := Compute(inv, MinGreen)
@@ -135,7 +135,7 @@ func TestCompute_TierlessSkillsExcluded(t *testing.T) {
 				Tier:        "",
 				Frontmatter: &model.Frontmatter{Name: "legacy"},
 			},
-			mkSkill("real", "user", "green", mkBundle(scanner.TrustVerified, "", 0)),
+			mkSkill("real", "user", "green", mkBundle(scanner.TrustSignaturePresent, "", 0)),
 		},
 	}
 	r := Compute(inv, MinGreen)
@@ -147,7 +147,7 @@ func TestCompute_TierlessSkillsExcluded(t *testing.T) {
 func TestCompute_VerdictOrderingBrokenFirst(t *testing.T) {
 	inv := &model.Inventory{
 		Skills: []model.SkillDescriptor{
-			mkSkill("zebra", "user", "green", mkBundle(scanner.TrustVerified, "", 0)),
+			mkSkill("zebra", "user", "green", mkBundle(scanner.TrustSignaturePresent, "", 0)),
 			mkSkill("alpha", "user", "green", mkBundle(scanner.TrustBroken, "digest mismatch", 0)),
 			mkSkill("middle", "user", "yellow", nil),
 		},

--- a/pkg/skillctl/scanner/trust.go
+++ b/pkg/skillctl/scanner/trust.go
@@ -33,11 +33,18 @@ import (
 	"github.com/kamir/m3c-tools/pkg/skillctl/model"
 )
 
-// trust_chain values.
+// trust_chain values recorded by AnnotateTrust (the scan/audit DISPLAY layer).
+//
+// IMPORTANT: TrustSignaturePresent means only that a detached signature file of
+// the correct length (64-byte ed25519) sits next to the .skb — it is NOT a
+// cryptographic verification. The authenticating check (recompute the digest,
+// verify the author/registry/governance signature chain against pinned roots)
+// is pkg/skillctl/verify (`skillctl verify`), not this scanner. The string
+// value stays "verified" for output/JSON compatibility.
 const (
-	TrustVerified   = "verified"
-	TrustUnverified = "unverified"
-	TrustBroken     = "broken"
+	TrustSignaturePresent = "verified" // sig file present + 64-byte length (NOT crypto-verified)
+	TrustUnverified       = "unverified"
+	TrustBroken           = "broken"
 )
 
 // AnnotateTrust walks every claude_code_skill in the inventory and
@@ -123,7 +130,7 @@ func annotateSkillTrust(sk *model.SkillDescriptor) *model.BundleAttestation {
 		BundleDigest:           "sha256:" + digest,
 		Signed:                 true,
 		RegisteredInLocalTrust: false, // populated only when a registry round-trip is run
-		TrustChain:             TrustVerified,
+		TrustChain:             TrustSignaturePresent,
 	}
 }
 

--- a/pkg/skillctl/scanner/trust_test.go
+++ b/pkg/skillctl/scanner/trust_test.go
@@ -49,8 +49,8 @@ func makeBundleDir(t *testing.T, tierRoot, name string, withBundle, validSig boo
 	}
 }
 
-// TestAnnotateTrust_Verified — sibling .skb + correct-size sig → verified.
-func TestAnnotateTrust_Verified(t *testing.T) {
+// TestAnnotateTrust_SignaturePresent — sibling .skb + correct-size sig → verified.
+func TestAnnotateTrust_SignaturePresent(t *testing.T) {
 	tmp := t.TempDir()
 	makeBundleDir(t, tmp, "fetch-contract", true, true)
 
@@ -69,7 +69,7 @@ func TestAnnotateTrust_Verified(t *testing.T) {
 	if sk.Bundle == nil {
 		t.Fatal("Bundle block missing — AnnotateTrust didn't run?")
 	}
-	if sk.Bundle.TrustChain != TrustVerified {
+	if sk.Bundle.TrustChain != TrustSignaturePresent {
 		t.Errorf("trust_chain = %q, want verified; err=%q", sk.Bundle.TrustChain, sk.Bundle.VerifierError)
 	}
 	if !sk.Bundle.Signed {


### PR DESCRIPTION
The trust scanner labels a bundle **"verified"** after checking only that a 64-byte detached sig file exists at the digest-named path — **not** a cryptographic signature verification (that is `pkg/skillctl/verify`). The const identifier `TrustVerified` and the scan table's `TRUSTED="yes"` overstated that.

- Rename the Go const `TrustVerified` → `TrustSignaturePresent` (all refs + the test). **The string value stays `"verified"`**, so the JSON `trust_chain` output is unchanged — no consumer breaks.
- Strengthen the const doc: sig-present + 64-byte length, not crypto-verified.
- `scan_table` TRUSTED column: `"yes"` → `"sig-only"` for this state (there is a separate `SIGNED` column; real trust is `skillctl verify`).

The `trust.go` header comment was already honest (it discloses the signature is not cryptographically verified) — left as-is. Build + 30 packages green; JSON value stable.

Third and final PR from the anti-bullshit review (after #126 cleanup and #127 semver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)