### PR TITLE
docs: Release-Runbook + top-notch README (Security/Contributing, Pin-Bump)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing
+
+Thanks for helping improve **m3c-tools** and **skillctl**. This guide covers the local setup,
+the checks CI enforces, and the conventions that keep the two tools releasable at all times.
+
+## Prerequisites
+
+- **Go 1.25+**.
+- For the macOS menu-bar GUI only: `portaudio` + `ffmpeg` (cgo). The CLIs and `skillctl` need
+  neither.
+
+```bash
+git clone https://github.com/kamir/m3c-tools.git && cd m3c-tools
+make build                                  # → ./build/m3c-tools
+go build -o build/skillctl ./cmd/skillctl   # skillctl
+```
+
+## Before you open a PR — run the gates CI runs
+
+```bash
+make ci            # vet · golangci-lint · unit tests · build (the gate CI enforces)
+make code-review   # build, vet, tests, secret scan, dead code, deps
+make check-docs    # documentation ↔ implementation consistency
+```
+
+- **Formatting is not negotiable.** Run `gofumpt -w .` and keep imports grouped with `gci`
+  (std / external / `github.com/kamir/m3c-tools`). `.golangci.yml` is the enforced config.
+- **Tests bite.** Add tests with your change; the suite runs with `-race`. Offline tests live
+  under `make test-unit`; networked / ER1 / whisper suites are opt-in (`make test-*`).
+- **Document CLI flags.** Every CLI flag must be described in its manual
+  (`docs/manual-m3c-tools.md` / `docs/manual-skillctl.md`) — and only real flags may be
+  documented. Undocumented or phantom flags are treated as a defect.
+
+## Commit messages — Conventional Commits
+
+The release version bump is **derived from your commits**, so the prefix matters
+([`scripts/derive-bump.sh`](scripts/derive-bump.sh)):
+
+| Prefix | Meaning | Release effect |
+|--------|---------|----------------|
+| `feat:` | a new capability | **minor** |
+| `fix:` | a bug fix | **patch** |
+| `feat!:` / `fix!:` / `BREAKING CHANGE:` trailer | a breaking change to callers | **major** (never automatic) |
+| `chore:` / `docs:` / `refactor:` / `test:` | no user-facing behaviour change | **patch** |
+
+Line count is not a signal: a one-line feature is a `feat:`; a large behaviour-preserving
+refactor is not.
+
+## Branching & PRs
+
+- Branch off `master`; open a PR against `master`.
+- Keep PRs focused; a green `make ci` is the baseline for review.
+- Pushing changes under `.github/workflows/**` requires an **SSH** remote (the HTTPS OAuth token
+  lacks the `workflow` scope).
+
+## Where things live
+
+- **Code** lives in this repository.
+- **Plans, SPECs and design docs** live in the sibling private maintenance repository, not in
+  this tree — the boundary is enforced by [`tools/boundary-gate.sh`](tools/boundary-gate.sh).
+  Contributor/release tooling resolves it via `M3C_MAINTENANCE_DIR` (see the README).
+
+## Releasing
+
+Releases are tag-driven and signed in CI. The full runbook is in
+**[docs/releasing.md](docs/releasing.md)**.
+
+## Security
+
+Please report vulnerabilities privately — see [SECURITY.md](SECURITY.md).
+
+## License
+
+By contributing you agree that your contributions are licensed under the project's
+**Apache-2.0** license (see [LICENSE](LICENSE)).

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@
 see, hear and decide into durable, structured memory — and for governing the agent skills
 that act on it. Two command-line tools, one repository, zero mandatory cloud middleman.
 
+[![CI](https://github.com/kamir/m3c-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/kamir/m3c-tools/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/v/release/kamir/m3c-tools?sort=semver)](https://github.com/kamir/m3c-tools/releases/latest)
 [![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-blue)](#install)
 [![Made with Go](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go)](https://go.dev)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kamir/m3c-tools)](https://goreportcard.com/report/github.com/kamir/m3c-tools)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
 [Quickstart: m3c-tools](docs/quickstart-m3c-tools.md) ·
 [Quickstart: skillctl](docs/quickstart-skillctl.md) ·
@@ -71,7 +75,7 @@ m3c-tools doctor                        # verify connectivity & config
 ```bash
 # macOS / Linux / Windows — signed installer: fetches the right binary from the
 # signed skillctl/v* release and verifies cosign/OIDC provenance + SHA-256 first.
-curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/tools/skillctl-install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.sh | bash
 
 skillctl keygen --out ~/.config/m3c/skill-keys/mykey            # ed25519 → mykey.priv + mykey.pub
 skillctl pack --skill ./my-skill -o my-skill.skb --name my-skill --version 1.0.0
@@ -167,7 +171,7 @@ The **scripted one-liners** fetch the right binary for your host, **verify cosig
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/tools/skillctl-install.ps1 | iex
+irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.ps1 | iex
 ```
 
 Installs `skillctl` to `%LOCALAPPDATA%\Programs\skillctl` after verifying cosign provenance +
@@ -177,16 +181,16 @@ use **one or the other**, not both, so you don't end up with two `skillctl.exe` 
 
 **macOS / Linux:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/tools/skillctl-install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.sh | bash
 ```
 
 Override the target dir or release with `INSTALL_DIR=…` / `RELEASE_BASE=…` (default `~/.local/bin`).
-These verify a **signed** `skillctl/v0.3.x` release; until it is published they report a missing
-download — see the [skillctl quickstart](docs/quickstart-skillctl.md#1-install) for an interim
-(unsigned) Windows install.
+These verify the **signed** `skillctl/v*` release — cosign provenance (GitHub OIDC) + the SHA-256
+digest, with an **ed25519 fallback** for hosts without cosign — see the
+[skillctl quickstart](docs/quickstart-skillctl.md#1-install).
 
 **Bootstrap integrity.** The one-liner URLs are pinned to the **immutable commit
-`ac04005`** — not the mutable `master` branch, where a single rewrite could swap the
+`82c8328`** — not the mutable `master` branch, where a single rewrite could swap the
 bootstrap script *and* every pin inside it (a TOFU trap). Verify the fetched bytes
 out-of-band before trusting them. Expected SHA-256:
 
@@ -199,7 +203,7 @@ Verify-then-run instead of piping straight to `iex` / `bash`:
 
 ```powershell
 # Windows
-$u = 'https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/tools/skillctl-install.ps1'
+$u = 'https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.ps1'
 $f = "$env:TEMP\skillctl-install.ps1"; irm $u -OutFile $f
 if ((Get-FileHash $f -Algorithm SHA256).Hash -ne '9E8CEEC9D2C87B4F5A7136653E8CA69224FA6579A55DA221D9E2FE875F9924C8') { throw 'SHA-256 mismatch' }
 & $f
@@ -207,7 +211,7 @@ if ((Get-FileHash $f -Algorithm SHA256).Hash -ne '9E8CEEC9D2C87B4F5A7136653E8CA6
 
 ```bash
 # macOS / Linux
-u='https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/tools/skillctl-install.sh'
+u='https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.sh'
 f=$(mktemp); curl -fsSL "$u" -o "$f"
 echo 'adf9d768a376ee921f9df728546de072a2b3f14e9616e10bf3419fef520034a9  '"$f" | shasum -a 256 -c - && bash "$f"
 ```
@@ -252,6 +256,31 @@ PowerShell setup.
 
 ---
 
+## Security & supply chain
+
+Because `skillctl` is a *trust* tool, its own supply chain is held to the standard it asks of
+others — **evidence you can verify yourself, with no mandatory hosted authority in the path.**
+
+- **Signed releases, keyless.** Every release is signed with **cosign** via GitHub OIDC — no
+  long-lived key in the repo. The signing job **verifies its own signature in-job**, so a broken
+  signature yields a failed/draft release, never an unsigned one. The signed `skillctl/v*` line
+  additionally carries an **ed25519 fallback signature**, so hosts without cosign still verify.
+- **Build provenance (SLSA).** Releases ship **SLSA provenance** (`multiple.intoto.jsonl`), gated
+  by `slsa-verifier`; the signed `skillctl/v*` line targets **SLSA Level 3**.
+- **SBOM.** The skillctl release includes a **CycloneDX SBOM** (`skillctl.sbom.cdx.json`).
+- **Offline verification.** `skillctl verify-sig` checks a skill's ed25519 trust chain with **no
+  server and no hosted CA** in the verification path; revocation lists are signed, offline and
+  fail-closed.
+- **CI hygiene on every push.** `go vet`, **golangci-lint**, **govulncheck** (reachability-aware
+  CVE scan) and **gitleaks** (secret scan) all run in [CI](.github/workflows/ci.yml).
+- **Pinned bootstrap.** The install one-liners pin an **immutable commit** + each script's
+  SHA-256 (not the mutable `master`) — verify-then-run is documented under [Install](#install).
+
+The full release, signing and provenance flow is in **[docs/releasing.md](docs/releasing.md)**;
+**report a vulnerability** privately via **[SECURITY.md](SECURITY.md)**.
+
+---
+
 ## Build from source
 
 Requires **Go 1.25+**. The macOS menu-bar GUI additionally needs `portaudio` + `ffmpeg` (cgo).
@@ -280,6 +309,27 @@ export M3C_MAINTENANCE_DIR=/absolute/path/to/your/maintenance/checkout
 ```
 
 If it is unset, those scripts fail loudly rather than silently pointing at a missing path. **End users of the CLI do not need this** — it only matters when running the maintenance/release tooling.
+
+### Quality gates
+
+New contributors: start with **[CONTRIBUTING.md](CONTRIBUTING.md)**. Run the same checks CI runs,
+locally:
+
+```bash
+make ci            # vet · golangci-lint · unit tests · build — the gate CI enforces
+make code-review   # pre-release review: build, vet, tests, secret scan, dead code, deps
+make check-docs    # documentation ↔ implementation consistency
+make vet           # go vet ./...
+```
+
+Formatting is **`gofumpt` + `gci`** on top of golangci-lint (formatting is not negotiable in Go —
+it is built into the toolchain), and `.golangci.yml` is the enforced linter config.
+
+### Releasing
+
+Releases are **tag-driven** — pushing a `vX.Y.Z` or `skillctl/vX.Y.Z` tag builds, signs and
+publishes via GitHub Actions. The full runbook — bump derivation, the two release lines, cosign +
+SLSA signing, post-release steps and gotchas — is in **[docs/releasing.md](docs/releasing.md)**.
 
 ---
 
@@ -315,4 +365,4 @@ built and battle-tested in the open.
 
 ## License
 
-See [LICENSE](LICENSE).
+**Apache-2.0** — see [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,68 @@
+# Security policy
+
+`skillctl` is a trust tool, so we hold its own supply chain to the standard it asks of others.
+This document says how to report a vulnerability and how to verify what you install.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.** Report it privately through
+GitHub's **[Security Advisories](https://github.com/kamir/m3c-tools/security/advisories/new)**
+("Report a vulnerability" on the repository's *Security* tab). Include:
+
+- affected component (`m3c-tools`, `skillctl`, an install script, a workflow) and version/commit;
+- a minimal reproduction and the impact you observed;
+- any suggested remediation.
+
+We aim to acknowledge a report within a few working days and to coordinate a fix and disclosure
+timeline with you. Please give us a reasonable window to remediate before any public disclosure.
+
+## Supported versions
+
+Security fixes target the **latest** release of each line — `vX.Y.Z` (product) and
+`skillctl/vX.Y.Z` (the signed trust CLI). Older tags are not maintained; upgrade to the latest
+release.
+
+## Supply-chain guarantees
+
+Every release is built and signed in GitHub Actions — there is **no long-lived signing key** in
+the repository:
+
+- **Keyless cosign signatures** over the release checksums, via GitHub OIDC. The signing job
+  verifies its own signature in-job, so a broken signature fails the release rather than shipping
+  unsigned.
+- **SLSA build provenance** (`multiple.intoto.jsonl`), gated by `slsa-verifier`; the signed
+  `skillctl/v*` line targets **SLSA Level 3**.
+- **ed25519 fallback signature** on the skillctl `SHA256SUMS`, verified against the pinned
+  `skillctl-release.pub`, so hosts without cosign still get an integrity guarantee.
+- **CycloneDX SBOM** shipped with the skillctl release.
+- **Pinned bootstrap.** The install one-liners pin an immutable commit and each script's SHA-256,
+  not the mutable `master` branch.
+
+## Verifying a release
+
+**cosign (product line):**
+
+```bash
+cosign verify-blob checksums.txt \
+  --bundle checksums.txt.cosign.bundle \
+  --certificate-identity-regexp '^https://github.com/kamir/m3c-tools/\.github/workflows/release\.yml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+**SLSA provenance:**
+
+```bash
+slsa-verifier verify-artifact <asset> \
+  --provenance-path multiple.intoto.jsonl \
+  --source-uri github.com/kamir/m3c-tools
+```
+
+**Skills you install with `skillctl`** are verified **offline** — the ed25519 trust chain is
+checked with no server and no hosted CA in the verification path, and revocation is signed,
+offline and fail-closed:
+
+```bash
+skillctl verify-sig my-skill.skb --pubkey trusted.pub   # no network
+```
+
+See [docs/releasing.md](docs/releasing.md) for the full signing and provenance flow.

--- a/docs/acceptance-skillctl-lifecycle.md
+++ b/docs/acceptance-skillctl-lifecycle.md
@@ -58,16 +58,16 @@ Prerequisites on **both** machines (see [manual §Installation](manual-skillctl.
 ```bash
 # Install skillctl (signed one-liner; verifies cosign provenance + SHA-256):
 #   macOS/Linux:
-curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/tools/skillctl-install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.sh | bash
 #   Windows (PowerShell):
-#   irm https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/tools/skillctl-install.ps1 | iex
+#   irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.ps1 | iex
 
 skillctl version          # MUST print a real skillctl/vX.Y.Z — NOT "dev" (see Troubleshooting)
 skillctl login --base-url https://onboarding.guide   # ER1 device pairing (FR-0043)
 skillctl login --status
 ```
 
-> **Bootstrap integrity.** The installer URLs are pinned to the **immutable commit `ac04005`**
+> **Bootstrap integrity.** The installer URLs are pinned to the **immutable commit `82c8328`**
 > (not the mutable `master` branch — one rewrite there could swap the bootstrap script *and* every
 > pin inside it). Verify the fetched bytes out-of-band — expected SHA-256:
 > `tools/skillctl-install.ps1` → `9e8ceec9d2c87b4f5a7136653e8ca69224fa6579a55da221d9e2fe875f9924c8`,
@@ -94,15 +94,15 @@ straight from here):
 
 ```powershell
 # 1) Install skillctl (verifies cosign provenance + SHA-256, no admin):
-irm https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/tools/skillctl-install.ps1 | iex
+irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.ps1 | iex
 
 # 2) Download + run the lifecycle smoke (keygen -> pack -> sign -> verify -> trust -> tamper):
 $q = "$env:TEMP\skillctl-quickstart.ps1"
-irm https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/scripts/skillctl-quickstart-windows.ps1 -OutFile $q
+irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/scripts/skillctl-quickstart-windows.ps1 -OutFile $q
 powershell -ExecutionPolicy Bypass -File $q
 ```
 
-> **Pinned + verifiable.** Both URLs above are pinned to the **immutable commit `ac04005`**.
+> **Pinned + verifiable.** Both URLs above are pinned to the **immutable commit `82c8328`**.
 > Expected SHA-256: `tools/skillctl-install.ps1` → `9e8ceec9d2c87b4f5a7136653e8ca69224fa6579a55da221d9e2fe875f9924c8`;
 > `scripts/skillctl-quickstart-windows.ps1` → `74b8ca8dbc7b6cae932bb9c1e016628aaac9c678db3ac7cb9159204dc5d7e27c`.
 > Verify the fetched bytes (`Get-FileHash <file> -Algorithm SHA256`) before running.

--- a/docs/quickstart-skillctl.md
+++ b/docs/quickstart-skillctl.md
@@ -28,7 +28,7 @@ no admin rights required.
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/tools/skillctl-install.ps1 | iex
+irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.ps1 | iex
 ```
 
 Installs to `%LOCALAPPDATA%\Programs\skillctl` after verifying cosign provenance + SHA-256.
@@ -39,12 +39,12 @@ two `skillctl.exe` on your `PATH`.
 
 **macOS / Linux:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/tools/skillctl-install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.sh | bash
 ```
 
 Override the target dir or the release with `INSTALL_DIR=…` / `RELEASE_BASE=…`.
 
-**Bootstrap integrity.** The one-liner URLs are pinned to the **immutable commit `ac04005`**
+**Bootstrap integrity.** The one-liner URLs are pinned to the **immutable commit `82c8328`**
 (not the mutable `master` branch, where one rewrite could swap the bootstrap script *and* every
 pin inside it). Verify the fetched bytes out-of-band before trusting them — expected SHA-256:
 `tools/skillctl-install.ps1` → `9e8ceec9d2c87b4f5a7136653e8ca69224fa6579a55da221d9e2fe875f9924c8`;

--- a/docs/releasing-skillctl-windows.md
+++ b/docs/releasing-skillctl-windows.md
@@ -75,18 +75,18 @@ gh run watch $(gh run list --workflow=skillctl-windows-smoke.yml --limit 1 --jso
 **(b) Real Windows PowerShell — the true acceptance (after Step 2 publishes):**
 ```powershell
 # 1) one-click install — verifies cosign provenance + SHA-256, installs to %LOCALAPPDATA%\Programs\skillctl:
-irm https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/tools/skillctl-install.ps1 | iex
+irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.ps1 | iex
 
 # 2) open a NEW terminal (PATH was updated), then:
 skillctl version        # -> skillctl/v0.3.1
 
 # 3) walk the packaged lifecycle smoke (keygen -> pack -> sign -> verify -> trust -> tamper):
 $q = "$env:TEMP\skillctl-qs.ps1"
-irm https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee163790024520cda2d7aee1c2eed9/scripts/skillctl-quickstart-windows.ps1 -OutFile $q
+irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/scripts/skillctl-quickstart-windows.ps1 -OutFile $q
 powershell -ExecutionPolicy Bypass -File $q
 ```
 
-> **Bootstrap integrity.** These URLs are pinned to the **immutable commit `ac04005`**, not the
+> **Bootstrap integrity.** These URLs are pinned to the **immutable commit `82c8328`**, not the
 > mutable `master` branch (where one rewrite could swap the bootstrap script *and* every pin
 > inside it). Expected SHA-256: `tools/skillctl-install.ps1` →
 > `9e8ceec9d2c87b4f5a7136653e8ca69224fa6579a55da221d9e2fe875f9924c8`;

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,197 @@
+# Release flow
+
+How a new version of **m3c-tools** and **skillctl** is cut, built, signed and
+published. This is the operational runbook; for the Windows‑signing specifics see
+[releasing-skillctl-windows.md](releasing-skillctl-windows.md).
+
+> **TL;DR** — a release is **tag‑driven**. Pushing a version tag to GitHub is the
+> trigger; CI does the multi‑platform build, signing and publishing. There is no
+> `VERSION` file — the tag *is* the version (GoReleaser reads `{{.Version}}`).
+
+---
+
+## Two independent release lines
+
+The repo ships two products from one tree; each has its **own** version series and
+its **own** workflow. Never assume they move together.
+
+| Line | Tag pattern | Workflow | Produces |
+|------|-------------|----------|----------|
+| **Product** (`m3c-tools` + bundled binaries) | `vX.Y.Z` | [`.github/workflows/release.yml`](../.github/workflows/release.yml) | macOS universal (arm64+amd64), Linux amd64/arm64, Windows amd64, the NSIS `M3C-Tools-Setup.exe`, `checksums.txt` + **cosign bundle** + **SLSA provenance** |
+| **skillctl** (the signed trust CLI) | `skillctl/vX.Y.Z` | [`.github/workflows/skillctl-release.yml`](../.github/workflows/skillctl-release.yml) | the 4 platform `skillctl` binaries + `.exe`, `install.sh`/`install.ps1`, `SHA256SUMS` + **cosign bundle** + **ed25519 fallback sig**, **CycloneDX SBOM**, SLSA provenance — published as a **draft** |
+
+Example from the last cut: product `v2.11.0` and `skillctl/v0.4.0` were released
+from the **same** commit but as two separate tags.
+
+---
+
+## Choosing the version bump
+
+Semver level is **derived from the commits**, not guessed, by
+[`scripts/derive-bump.sh`](../scripts/derive-bump.sh) (Conventional Commits):
+
+| Commit signal (highest wins) | Bump |
+|------|------|
+| `feat!:` / `fix!:` / a `BREAKING CHANGE:` trailer | **major** |
+| any `feat:` | **minor** |
+| everything else | **patch** |
+
+Line count is **not** a signal — a one‑line feature is still a `minor`; a
+thousand‑line behaviour‑preserving refactor is still a `patch`. **major is never
+issued automatically** ("breaking" is a statement about callers, which no diff can
+see); `make release` aborts and demands the explicit `make release-major`.
+
+> This rule exists because the Fleet kill‑switch (a feature) once shipped as a
+> patch (`v2.8.1`) under a hard‑wired `release-patch`. The commits already carried
+> `feat:` — the information was there; now it is used.
+
+---
+
+## The canonical path — tag `origin/master` by hash
+
+**Recommended, and what the maintainers actually use.** Because working copies
+drift onto feature branches and worktrees, do **not** let a script tag "the
+current branch". Tag the exact reviewed commit on `master`, by hash:
+
+```bash
+git fetch origin
+HASH=$(git rev-parse origin/master)          # the reviewed, green commit
+
+# Product line:
+git tag  v2.12.0 "$HASH"
+git push origin v2.12.0
+
+# skillctl line (independent version):
+git tag  skillctl/v0.5.0 "$HASH"
+git push origin skillctl/v0.5.0
+```
+
+The tag push starts the matching workflow. Watch it:
+
+```bash
+gh run watch "$(gh run list --workflow=release.yml --limit 1 --json databaseId -q '.[0].databaseId')"
+```
+
+### Pre‑flight (before you tag)
+
+The gates below run inside `make release`, but the **tag‑push path bypasses them**
+— which is how `v2.11.0` skipped the docs check. Run them yourself on the commit
+you are about to tag, and rely on the in‑CI gates (below) as the backstop:
+
+```bash
+make ci                 # vet · lint · test-unit · build
+make code-review        # build · vet · tests · secrets · TODO · dead-code · sizes · err-handling · version · deps
+make check-docs         # documentation ↔ implementation consistency
+./tools/boundary-gate.sh
+goreleaser check        # validate .goreleaser.yml before relying on it
+```
+
+---
+
+## The scripted path — `make release` (local, convenience)
+
+```bash
+make release            # derive-bump → code-review → check-docs → release-auto
+make release-minor      # force a level (also: release-patch / release-major)
+```
+
+`make release` runs `code-review` + `check-docs` first, then
+[`scripts/release.sh`](../scripts/release.sh) bumps, tags and creates the release.
+
+> ⚠️ **`scripts/release.sh` operates on your WORKING COPY.** It will
+> `git add -A && git commit` any dirty files, `git push` the **current** branch,
+> and create the release with **local macOS‑only** assets. Run it **only** from a
+> clean checkout of `master` — **never** from a feature branch or a worktree, or
+> you will publish the wrong branch. When in doubt, use the tag‑by‑hash path
+> above and let CI build every platform. The CI workflow then enriches the same
+> release with the full signed multi‑platform artifacts.
+
+---
+
+## What CI signs (the trust story)
+
+Both workflows sign **keyless** with cosign via GitHub OIDC — **no long‑lived key
+in the repo** — and each **verifies its own signature in‑job** (a broken signing
+step yields a draft/failure, never an unsigned release):
+
+- **Product `v*`** → `cosign sign-blob checksums.txt` → `checksums.txt.cosign.bundle`;
+  SLSA subjects → `multiple.intoto.jsonl`, gated by `slsa-verifier`.
+- **skillctl `skillctl/v*`** → `cosign sign-blob SHA256SUMS` →
+  `SHA256SUMS.cosign.bundle` (identity `…/skillctl-release.yml@refs/tags/skillctl/v…`);
+  **plus** an ed25519 `SHA256SUMS.sig` against the pinned `skillctl-release.pub`,
+  so users without cosign still verify via the fallback baked into `install.sh`;
+  **plus** a CycloneDX SBOM.
+
+Consumers verify with (product example):
+
+```bash
+cosign verify-blob checksums.txt \
+  --bundle checksums.txt.cosign.bundle \
+  --certificate-identity-regexp '^https://github.com/kamir/m3c-tools/\.github/workflows/release\.yml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+slsa-verifier verify-artifact <asset> --provenance-path multiple.intoto.jsonl \
+  --source-uri github.com/kamir/m3c-tools
+```
+
+---
+
+## After the workflow goes green — manual steps
+
+1. **Publish the skillctl draft.** `skillctl-release.yml` publishes as a *draft* for
+   a sanity check. Promote it:
+   ```bash
+   gh release edit skillctl/v0.5.0 --draft=false
+   ```
+2. **Decide the "Latest" badge.** GitHub's *Latest* flag is **global**, not
+   per‑line — publishing the skillctl draft flips it onto skillctl. Pin it to the
+   product release if that is what users should land on:
+   ```bash
+   gh release edit v2.12.0 --latest
+   ```
+3. **Bump the install‑script pins** (a security step — see below).
+4. **Verify the download surface**: `gh release view v2.12.0 --json assets -q '.assets[].name'`.
+
+### Bumping the pinned install one‑liners
+
+The `README.md` and `docs/quickstart-skillctl*.md` one‑liners pin the bootstrap
+scripts to an **immutable commit hash** (not `master`), plus the expected SHA‑256
+of each script — a TOFU defence, since `master` could be rewritten to swap the
+script *and* its inner pins at once. On **each** signed release, bump the commit
+**and** both hashes together:
+
+```bash
+NEWPIN=$(git rev-parse origin/master)
+shasum -a 256 tools/skillctl-install.sh tools/skillctl-install.ps1
+# → update the pinned commit + both SHAs in README.md and docs/quickstart-skillctl.md
+```
+
+---
+
+## Gotchas (learned the hard way)
+
+- **Tag by hash, from `master`.** Working copies drift; a script that tags "the
+  current branch" is a foot‑gun. See the canonical path above.
+- **`.github/workflows/**` needs SSH to push** — the HTTPS OAuth token lacks the
+  `workflow` scope. Push workflow edits over an SSH remote.
+- **The macOS universal build depends on the owned‑infra PortAudio mirror**
+  (`portaudio-vendor` release asset). If the upstream host is down, the mirror +
+  pinned SHA‑256 keep the build green; do not point it back at a third party.
+- **GitHub Actions storage is tight (~0.5 GB).** CI artifacts have a 7‑day
+  retention and the policy is to keep only the **latest** release's
+  goreleaser‑binaries — clean older ones so the account budget is not exhausted.
+- **Artifacts must be wired in BOTH** `.goreleaser.yml` **and** the release
+  workflow — a binary added to one but not the other silently goes missing.
+
+---
+
+## Rollback
+
+Tags are the source of truth, so a bad release is undone by removing the tag and
+release and re‑cutting:
+
+```bash
+gh release delete v2.12.0 --yes
+git push origin :refs/tags/v2.12.0    # delete the remote tag
+git tag -d v2.12.0                     # and the local tag
+# fix, then re-tag the corrected commit
+```


### PR DESCRIPTION
## Was & warum

Zwei Doku-Aufgaben: den **Release-Flow** dokumentieren und die **README auf „top notch"** heben.

### Neu
- **`docs/releasing.md`** — vollständiges tag-getriebenes Release-Runbook: die zwei unabhängigen Linien (`v*` Produkt / `skillctl/v*`), Bump-Ableitung aus Commits (`derive-bump.sh`), der kanonische *tag-origin/master-by-hash*-Pfad + die Gefahren von `scripts/release.sh` (arbeitet auf der Working Copy), cosign/SLSA/SBOM-Signierung mit Consumer-Verify-Kommandos, Post-Release-Schritte (Draft publishen, „Latest"-Badge, Pins bumpen), Gotchas und Rollback.
- **`SECURITY.md`** — private Vuln-Disclosure via GitHub Security Advisories + Supply-Chain-Garantien + Verify-Kommandos.
- **`CONTRIBUTING.md`** — Setup, die CI-Gates lokal, **Conventional Commits** (weil der Release-Bump daraus abgeleitet wird), Branching, wo Planungs-Docs leben.

### README (top notch)
- Badges: **CI**, **Go Report Card**, **SLSA 3**, **License Apache-2.0**.
- Neue **„Security & supply chain"**-Sektion (evidenz-basiert, kein Overclaim: cosign-keyless, SLSA, SBOM, Offline-Verify, CI-Hygiene, gepinnter Bootstrap).
- **„Quality gates"** + **„Releasing"** unter Build-from-source (verlinkt das Runbook).
- Stale `skillctl/v0.3.x`-Referenz gefixt (die signierte Linie ist live), License = Apache-2.0, Verweise auf SECURITY/CONTRIBUTING.

### Security: Bootstrap-Pin gebumpt
Der Install-Einzeiler-Pin `ac04005` → **`82c8328`** (der signierte Release **skillctl/v0.4.0**). Die Skript-SHA-256 wurden gegen den neuen Pin **verifiziert und sind byte-identisch** — daher unverändert (nichts fabriziert). Betrifft README + quickstart-skillctl + releasing-skillctl-windows + acceptance-skillctl-lifecycle.

> `CODESTYLE.md` und die `docaudit`-Gate-Behauptungen wurden bewusst **ausgelassen**, solange der code↔manual-Gate-Branch nicht gemerged ist — keine toten Links, kein Overclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)