### PR TITLE
feat(bugtracker): dual-plane bug tracking — private analysis file ↔ public GitHub issue

### DIFF
--- a/.claude/skills/bug-fix/SKILL.md
+++ b/.claude/skills/bug-fix/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: bug-fix
-description: Fix a reported bug and update SPECs with lessons learned. Use after /bug-report has created a structured bug report.
-argument-hint: "BUG-NNNN (e.g. BUG-0001)"
+description: Fix a reported bug, feed the lesson back into the SPECs, and close both planes — the private analysis file and its public GitHub issue. Use after /bug-report has created a structured bug report.
+argument-hint: "BUG-NNNN (e.g. BUG-0213)"
 metadata:
-  version: 1.0.0
+  version: 2.0.0
   category: development
-  tags: [bug-fix, spec, m3c-tools]
+  tags: [bug-fix, spec, dual-plane, m3c-tools]
 ---
 
 # Bug Fix & Learning
@@ -14,66 +14,74 @@ You are a bug-fixing assistant for the **m3c-tools** project.
 
 ## Input
 
-The user provides a **bug report ID** (e.g., `BUG-0001`) or a short slug.
-
 **Bug reference:** $ARGUMENTS
+
+A bug id (`BUG-0213`), a bare number (`213`), or a filename — `scripts/bugtracker.sh`
+normalises all three.
+
+> Set `M3C_MAINTENANCE_DIR` before running this skill. If it is unset, say so and
+> stop.
 
 ## Your Task
 
-Fix the bug and feed lessons back into the project's specification documents.
+Fix the bug, feed the lesson into the specs, and leave **both planes** — the
+private analysis file and, if one exists, its public issue — in agreement.
 
-### Step 1: Load the bug report
+### Step 1: Load the report
 
-> Paths below resolve under `$M3C_MAINTENANCE_DIR` — the private maintenance
-> plane's repo root. Set that environment variable before running this skill.
+```bash
+./scripts/bugtracker.sh path   BUG-NNNN    # the analysis file
+./scripts/bugtracker.sh status BUG-NNNN    # open | in-progress | fixed | wontfix | duplicate
+./scripts/bugtracker.sh issue  BUG-NNNN    # owner/repo#NN, or empty if private-only
+```
 
-- Read the bug report from `${M3C_MAINTENANCE_DIR}/bug-reports/`
-- If only a number is given (e.g. `0001`), search for `BUG-0001-*.md`
-- Parse: severity, component, root cause analysis, suggested fix, affected SPECs
+Read the file. Parse severity, component, root cause, suggested fix, affected SPECs.
+If the bug is already `fixed`, say so and stop unless the user wants it reopened.
+
+Mark that you have started:
+
+```bash
+./scripts/bugtracker.sh status BUG-NNNN in-progress
+```
 
 ### Step 2: Understand the code
 
-- Read the files and functions identified in the bug report's "Root Cause Analysis" section
-- Read surrounding context to understand the broader flow
-- Verify the root cause matches what the code actually does
-- If the report's analysis is wrong or incomplete, note corrections
+- Read the files and functions named in "Root Cause Analysis", plus enough
+  surrounding context to see the flow.
+- Verify the analysis against what the code actually does. **If the report is
+  wrong or incomplete, correct it** — a report that misdiagnoses is worse than
+  none, and the correction is the most valuable thing you will write today.
 
 ### Step 3: Implement the fix
 
-- Make the minimal, targeted code change that resolves the bug
-- Follow existing code patterns and conventions (see CLAUDE.md)
-- Avoid side effects — do not refactor or "improve" nearby code
-- If the fix touches cgo/Objective-C code, ensure thread safety (dispatch_async for UI)
-- If the fix touches ER1 uploads, verify placeholder handling is preserved
+- The minimal, targeted change that resolves the bug.
+- Follow the surrounding conventions (see CLAUDE.md). Do not refactor nearby code.
+- cgo/Objective-C: keep UI work on `dispatch_async`.
+- ER1 uploads: preserve the placeholder audio/image handling.
 
 ### Step 4: Verify
 
-- Run relevant tests: `go test -v -count=1 ./e2e/ -run <relevant test>`
-- If no test covers this bug, note it (do NOT write a test unless asked)
-- Check for compilation: `go build ./cmd/m3c-tools/`
-- List any manual verification steps the user should perform
+- Run the relevant tests: `go test -v -count=1 ./e2e/ -run <test>` (or the
+  package's own tests).
+- `go build ./cmd/m3c-tools/` — and `go vet ./...` if the change is non-trivial.
+- If a CLI flag was added, removed or renamed, the manual must move with it:
+  `go run ./cmd/docaudit -cli all` (the release gate; `-scaffold` drafts entries).
+- If no test covers this bug, **say so plainly**. Do not write one unless asked.
+- Report failures with their output. Never describe an unrun check as passing.
 
-### Step 5: Update or create SPEC
+### Step 5: Update or create the SPEC
 
-Check `${M3C_MAINTENANCE_DIR}/SPEC/` for an existing spec that covers the buggy behavior.
+Check `${M3C_MAINTENANCE_DIR}/SPEC/` for a spec covering the buggy behavior.
 
-**If a relevant SPEC exists**, update it:
-- Add or correct the requirement that was violated
-- Reference the bug ID in a changelog/history section
-- Clarify any ambiguity that led to the bug
+**If one exists**, update it: add or correct the violated requirement, reference
+the bug id in its history table, and remove the ambiguity that allowed the bug.
 
-**If no relevant SPEC exists**, create one at:
-```
-${M3C_MAINTENANCE_DIR}/SPEC/SPEC-NNNN-<component>.md
-```
-
-Use this template:
+**If none exists**, create `${M3C_MAINTENANCE_DIR}/SPEC/SPEC-NNNN-<component>.md`:
 
 ```markdown
 # SPEC-NNNN: <Component Name>
 
 **Created:** YYYY-MM-DD
-**Last updated:** YYYY-MM-DD
 **Status:** active
 
 ## Purpose
@@ -82,31 +90,26 @@ Use this template:
 
 ## Requirements
 
-### REQ-1: <Requirement title>
+### REQ-1: <title>
 
-<Clear, testable requirement statement>
+<Clear, testable statement>
 
-**Rationale:** <Why this requirement exists>
-
-### REQ-2: ...
+**Rationale:** <why>
 
 ## Constraints
 
-- <Technical constraints, thread safety rules, platform requirements>
+- <thread safety, platform, protocol constraints>
 
 ## History
 
 | Date | Change | Reference |
 |------|--------|-----------|
-| YYYY-MM-DD | Initial spec created from BUG-NNNN fix | BUG-NNNN |
+| YYYY-MM-DD | Initial spec created from the BUG-NNNN fix | BUG-NNNN |
 ```
 
-### Step 6: Update the bug report
+### Step 6: Record the fix in the analysis file
 
-Edit the original bug report file:
-- Change `**Status:** open` → `**Status:** fixed`
-- Fill in or update the "Lessons Learned" section
-- Add a "Fix Applied" section at the end:
+Append to `BUG-NNNN-<slug>.md`:
 
 ```markdown
 ## Fix Applied
@@ -115,19 +118,47 @@ Edit the original bug report file:
 **Files changed:**
 - `<path>:<line>` — <what changed>
 
-**SPEC updated:** SPEC-NNNN-<component>.md (or "new SPEC created")
+**SPEC updated:** SPEC-NNNN (or "new SPEC created")
 
 **Verification:**
-- [ ] Compiles: `go build ./cmd/m3c-tools/`
-- [ ] Tests pass: `<test command>`
-- [ ] Manual check: <description>
+- Builds: `go build ./cmd/m3c-tools/`
+- Tests: `<command>` — <result>
+- Manual: <what the user should check by hand, if anything>
 ```
 
-### Step 7: Summarize to the user
+Also fill in "Lessons Learned" — the assumption that allowed the bug, not a
+restatement of the fix.
 
-Present:
-1. What was fixed (1-2 sentences)
-2. Files changed (with paths)
+### Step 7: Close both planes
+
+```bash
+./scripts/bugtracker.sh close BUG-NNNN --comment "<public-safe one-liner>"
+```
+
+This sets `Status: fixed` in the analysis file and, if an issue is linked,
+comments and closes it. Use `--status wontfix` or `--status duplicate` when that
+is the honest outcome; those close the issue as *not planned*.
+
+The comment is **public-plane text**: the script runs the SPEC-0358 leak check on
+it and refuses rather than post. Write it for a stranger — what changed and in
+which version, referring to the analysis ID-only.
+
+If the bug is private-only, the command still updates the file and simply reports
+that there is no issue to close.
+
+### Step 8: Confirm they agree
+
+```bash
+./scripts/bugtracker.sh sync BUG-NNNN
+```
+
+Exit 0 means the file and the issue tell the same story.
+
+### Step 9: Summarize to the user
+
+1. What was fixed (1–2 sentences)
+2. Files changed, with paths
 3. SPEC created or updated
-4. Verification status (what passed, what needs manual check)
-5. Any concerns or follow-up items
+4. Verification: what passed, what failed, what still needs a human
+5. Both planes' final state (status + issue URL, or "private-only")
+6. Any follow-up you did **not** do, and why

--- a/.claude/skills/bug-report/SKILL.md
+++ b/.claude/skills/bug-report/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: bug-report
-description: Process field observations into structured bug reports. Use when the user shares logs, error messages, or behavior descriptions from testing m3c-tools.
+description: Turn a field observation into a structured bug report — a private analysis file in the maintenance repo, and (opt-in, redacted) a public GitHub issue linked to it. Use when the user shares logs, error messages, or behavior descriptions from testing.
 argument-hint: "<paste logs, error output, or describe the observed behavior>"
 metadata:
-  version: 1.0.0
+  version: 2.0.0
   category: development
-  tags: [bug-report, triage, m3c-tools]
+  tags: [bug-report, triage, dual-plane, m3c-tools]
 ---
 
 # Bug Report from Field Observation
@@ -14,93 +14,152 @@ You are a bug-tracking assistant for the **m3c-tools** project.
 
 ## Input
 
-The user provides a **field observation** — raw logs, error messages, screenshots, or a description of unexpected behavior observed while using m3c-tools.
+The user provides a **field observation** — raw logs, error messages, screenshots,
+or a description of unexpected behavior.
 
 **Observation:**
 $ARGUMENTS
 
-## Your Task
+## The two planes
 
-Process the observation into a structured bug report by following these steps:
+A bug lives in up to two places, and `scripts/bugtracker.sh` keeps them in step:
+
+| Plane | Where | Holds |
+|-------|-------|-------|
+| **Analysis** (private) | `${M3C_MAINTENANCE_DIR}/bug-reports/BUG-NNNN-<slug>.md` | Everything: root cause, `file:line`, customer context, SPEC references. The source of truth. |
+| **Issue** (public) | a GitHub issue in `$M3C_BUG_REPO` (default: this repo's origin) | A **redacted restatement**: observed, expected, reproduction, version. Refers to the analysis **ID-only** (`BUG-0213`). |
+
+The issue is **never a copy** of the analysis. `bug-reports/` also holds bugs for
+systems this repository does not ship; those stay private. Publishing is per-bug,
+declared in the file, and **cannot be undone** — a GitHub issue on a public repo
+is indexed the moment it is created.
+
+> Set `M3C_MAINTENANCE_DIR` before running this skill. If it is unset, say so and
+> stop — do not guess a path, and never write a private path into a public file.
+
+## Your Task
 
 ### Step 1: Analyze the observation
 
-- Parse log lines, error messages, and stack traces
-- Identify the failing component (which package, which flow)
-- Determine severity: **critical** (data loss, crash), **high** (feature broken), **medium** (degraded UX), **low** (cosmetic)
-- Check if this matches any known pattern in existing bug reports
+- Parse log lines, error messages, and stack traces.
+- Identify the failing component (which package, which flow).
+- Determine severity: **critical** (data loss, crash), **high** (feature broken),
+  **medium** (degraded UX), **low** (cosmetic).
 
 ### Step 2: Locate the code
 
-- Use Grep/Glob to find the relevant source code locations
-- Identify the function(s) involved
-- Read the code to understand the root cause or narrow down candidates
-- Note the file paths and line numbers
+- Use Grep/Glob to find the relevant source locations; read the code to confirm
+  or narrow the root cause. Note file paths and line numbers.
 
-### Step 3: Check existing reports
+### Step 3: Check for duplicates
 
-> Paths below resolve under `$M3C_MAINTENANCE_DIR` — the private maintenance
-> plane's repo root. Set that environment variable before running this skill.
+- Search `${M3C_MAINTENANCE_DIR}/bug-reports/` for an existing report.
+- Search the issue tracker too: `gh issue list --search "<keywords>" --state all`.
+- Read `${M3C_MAINTENANCE_DIR}/SPEC/` for the spec that defines expected behavior.
 
-- Read `${M3C_MAINTENANCE_DIR}/bug-reports/` for duplicates
-- Read `${M3C_MAINTENANCE_DIR}/SPEC/` for relevant specs that define expected behavior
+### Step 4: Write the analysis file
 
-### Step 4: Write the bug report
+Get the next id deterministically — do not count files yourself:
 
-Create a new file at:
-```
-${M3C_MAINTENANCE_DIR}/bug-reports/BUG-NNNN-<short-slug>.md
+```bash
+./scripts/bugtracker.sh next-id      # -> BUG-0213
 ```
 
-Where `NNNN` is the next sequential number (check existing files).
-
-Use this template:
+Write `${M3C_MAINTENANCE_DIR}/bug-reports/BUG-NNNN-<short-slug>.md`:
 
 ```markdown
-# BUG-NNNN: <concise title>
+# BUG-NNNN — <concise title>
 
-**Date:** YYYY-MM-DD
-**Severity:** critical | high | medium | low
-**Status:** open
-**Component:** <package or flow name>
-**Version:** <from Makefile APP_VERSION>
+- **Date:** YYYY-MM-DD
+- **Severity:** critical | high | medium | low
+- **Status:** open
+- **Component:** <package or flow>
+- **Version:** <from Makefile APP_VERSION>
+- **Public:** yes | no
 
 ## Observed Behavior
 
-<What the user saw — include exact log lines, error messages, timestamps>
+<What the user saw — exact log lines, error messages, timestamps>
 
 ## Expected Behavior
 
-<What should have happened — reference SPEC if available>
+<What should have happened — reference the SPEC by id if there is one>
 
 ## Root Cause Analysis
 
-<Your analysis of why this happened>
 - **File:** `<path>:<line>`
-- **Function:** `<function name>`
-- **Mechanism:** <brief explanation of the bug>
+- **Function:** `<name>`
+- **Mechanism:** <why this happens>
 
 ## Reproduction
 
-<Steps to reproduce, or "observed in field — reproduction steps TBD">
+<Steps, or "observed in field — reproduction TBD">
 
 ## Suggested Fix
 
-<Concrete code changes needed, or investigation steps if root cause unclear>
+<Concrete change, or the investigation step if the cause is not yet confirmed>
 
 ## Affected SPECs
 
-<List any SPEC files that define the expected behavior, or "none identified">
+<ID-only references, or "none identified">
 
 ## Lessons Learned
 
-<What pattern or assumption led to this bug? What should we watch for in future?>
+<What assumption led to this? What should we watch for?>
 ```
 
-### Step 5: Summarize to the user
+`Status`, `Public` and `Issue` are the three lines the script owns — keep their
+exact spelling so `status`, `close` and `sync` can parse them.
 
-After writing the file, present:
-1. Bug ID and title
-2. Severity assessment
-3. Root cause (confirmed or candidate)
-4. Suggested next step: `/bug-fix BUG-NNNN` to fix it, or "needs investigation"
+### Step 5: Decide the plane
+
+Set `- **Public:** yes` **only** when all of these hold:
+
+- the bug is in the **shipped artifact** of this repository (m3c-tools / skillctl),
+- it is **not** a security issue (those go through the private plane and a
+  security advisory, never a public issue),
+- it carries **no** customer-specific or tenant-specific detail,
+- a stranger reading it learns nothing about internal infrastructure.
+
+Otherwise set `- **Public:** no`, tell the user why, and stop after Step 4. That
+is a complete outcome, not a failure.
+
+### Step 6: Write the redacted body
+
+For a public bug, write the issue body to a sibling file:
+
+```
+${M3C_MAINTENANCE_DIR}/bug-reports/BUG-NNNN-<slug>.public.md
+```
+
+Line 1 is the issue title (`# <title>`); the rest is the body. Restate the bug
+for someone with no access to the private plane:
+
+- **keep:** observed behavior, expected behavior, reproduction, affected version,
+  the user-visible command and its output, the ID-only reference `BUG-NNNN`
+- **drop:** paths into the maintenance repo, internal endpoints, ER1 context-ids,
+  `X-API-KEY`, internal API paths, customer names, SPEC *paths* (ids are fine),
+  and any root-cause detail that is really internal design discussion
+
+Write it as a restatement, not a summary of the analysis — someone should be able
+to confirm the bug from it without ever seeing the private file.
+
+### Step 7: Open the issue
+
+```bash
+./scripts/bugtracker.sh open BUG-NNNN
+```
+
+The script refuses unless `Public: yes` is declared, the `.public.md` body
+exists, and the body passes the same five leak patterns `tools/boundary-gate.sh`
+enforces in CI (SPEC-0358). If it refuses, **fix the body — never work around
+the refusal.** On success it writes `- **Issue:** owner/repo#NN` back into the
+analysis file.
+
+### Step 8: Summarize to the user
+
+1. Bug id and title
+2. Severity and component
+3. Root cause — confirmed, or the leading candidate
+4. Which planes exist now (private only, or private + issue URL)
+5. Next step: `/bug-fix BUG-NNNN`, or the investigation still needed

--- a/.github/workflows/boundary-gate.yml
+++ b/.github/workflows/boundary-gate.yml
@@ -2,6 +2,12 @@ name: boundary-gate
 
 # SPEC-0358 content-plane leak gate: fail if a public-plane file embeds
 # private-plane content (private-repo paths, internal endpoints/secrets/context).
+#
+# The patterns live in tools/leak-patterns.txt and are shared with
+# scripts/bugtracker.sh, which applies them to GitHub issue bodies — text this
+# gate can never see, because it is posted through the API rather than committed.
+# Both sides' fixtures run here: a leak gate that silently stops flagging still
+# reads green, so it is asserted from the failing side on every push.
 
 on:
   push:
@@ -20,3 +26,9 @@ jobs:
           fetch-depth: 0
       - name: Run boundary-gate
         run: bash tools/boundary-gate.sh
+
+      - name: boundary-gate fixtures (every pattern still blocks)
+        run: bash tools/boundary-gate.test.sh
+
+      - name: bugtracker fixtures (the post-gate refuses to publish a leak)
+        run: bash scripts/bugtracker.test.sh

--- a/scripts/bugtracker.sh
+++ b/scripts/bugtracker.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+#
+# scripts/bugtracker.sh — keep a bug's two planes in step (SPEC-0358,
+# "ship the code, keep the reasoning").
+#
+#   1. the REPORT — ${M3C_MAINTENANCE_DIR}/bug-reports/BUG-NNNN-<slug>.md
+#      The source of truth. PRIVATE plane: root cause, file:line, customer
+#      context, SPEC references, whatever the analysis needs.
+#
+#   2. the ISSUE — a GitHub issue in this (PUBLIC) repository.
+#      The tracker view other people can see. It is a REDACTED restatement,
+#      never a copy: observed behaviour, expected behaviour, reproduction,
+#      version. It refers to the private plane ID-ONLY ("BUG-0213") — never a
+#      path, an internal endpoint, an ER1 context-id or a secret header.
+#
+# The issue is fail-closed on purpose. `open` refuses unless the report declares
+# `- **Public:** yes` and a separate redacted body exists that passes the same
+# leak patterns tools/boundary-gate.sh enforces in CI. bug-reports/ also holds
+# bugs for systems that are NOT this OSS artifact; those get `Public: no` and
+# never leave the private plane. A public issue cannot be un-published.
+#
+# Configuration:
+#   M3C_MAINTENANCE_DIR   required — the private maintenance repo's root
+#   M3C_BUG_REPO          optional — owner/repo for issues (default: origin)
+#
+# Commands:
+#   next-id                       next free BUG id
+#   path   <BUG-NNNN>             resolve the report file
+#   status <BUG-NNNN> [STATUS]    read, or set, the canonical status
+#   issue  <BUG-NNNN>             print the linked issue reference
+#   redact-check [FILE|-]         SPEC-0358 leak patterns over text; 1 = a hit
+#   open   <BUG-NNNN>             create the public issue and link it back
+#   close  <BUG-NNNN> [--status S] [--comment TEXT]
+#   sync   [<BUG-NNNN>]           read-only: report/issue drift
+#
+# Exit: 0 ok · 1 a check failed (drift, leak, refusal) · 2 usage/config error.
+set -euo pipefail
+
+STATUSES="open in-progress fixed wontfix duplicate"
+
+die()  { printf 'bugtracker: %s\n' "$1" >&2; exit "${2:-2}"; }
+note() { printf '%s\n' "$1" >&2; }
+
+# ---------------------------------------------------------------- config ----
+
+bug_dir() {
+  [ -n "${M3C_MAINTENANCE_DIR:-}" ] || die "M3C_MAINTENANCE_DIR is not set.
+  Point it at the private maintenance repo root, e.g.
+      export M3C_MAINTENANCE_DIR=\"\$HOME/path/to/your-maintenance-repo\""
+  [ -d "$M3C_MAINTENANCE_DIR/bug-reports" ] || die "no bug-reports/ under \$M3C_MAINTENANCE_DIR ($M3C_MAINTENANCE_DIR)"
+  printf '%s\n' "$M3C_MAINTENANCE_DIR/bug-reports"
+}
+
+bug_repo() {
+  if [ -n "${M3C_BUG_REPO:-}" ]; then printf '%s\n' "$M3C_BUG_REPO"; return; fi
+  local url
+  url=$(git config --get remote.origin.url 2>/dev/null || true)
+  [ -n "$url" ] || die "M3C_BUG_REPO is not set and this is not a git checkout with an origin"
+  url=${url%.git}
+  url=${url#git@github.com:}
+  url=${url#https://github.com/}
+  printf '%s\n' "$url"
+}
+
+need_gh() { command -v gh >/dev/null 2>&1 || die "the GitHub CLI (gh) is required for issue commands"; }
+
+# ------------------------------------------------------------- resolving ----
+
+# normalise "213" / "bug-0213" / "BUG-0213-slug.md" -> BUG-0213
+bug_id() {
+  local n
+  n=$(printf '%s\n' "$1" | tr '[:lower:]' '[:upper:]' | sed -n 's/^\(BUG-\)\{0,1\}0*\([0-9]\{1,\}\).*$/\2/p')
+  [ -n "$n" ] || die "not a bug id: $1"
+  printf 'BUG-%04d\n' "$n"
+}
+
+report_path() {
+  local id dir hits
+  id=$(bug_id "$1"); dir=$(bug_dir)
+  hits=$(find "$dir" -maxdepth 1 -name "$id-*.md" ! -name '*.public.md' | sort)
+  [ -n "$hits" ] || die "no report file for $id in $dir" 1
+  [ "$(printf '%s\n' "$hits" | wc -l)" -eq 1 ] || die "several files match $id:
+$hits"
+  printf '%s\n' "$hits"
+}
+
+public_body_path() { printf '%s\n' "${1%.md}.public.md"; }
+
+cmd_next_id() {
+  local dir max n
+  dir=$(bug_dir); max=0
+  while IFS= read -r f; do
+    n=$(basename "$f" | sed -n 's/^BUG-0*\([0-9]\{1,\}\)-.*$/\1/p')
+    [ -n "$n" ] && [ "$n" -gt "$max" ] && max=$n
+  done < <(find "$dir" -maxdepth 1 -name 'BUG-*.md')
+  printf 'BUG-%04d\n' "$((max + 1))"
+}
+
+# ---------------------------------------------------------------- fields ----
+#
+# The script owns three canonical lines in the report:
+#     - **Status:** open
+#     - **Public:** yes
+#     - **Issue:**  owner/repo#42
+# Reading tolerates the older loose spellings ("**Status:** Fixed (2026-03-21)");
+# writing always produces the canonical form, so `sync` has something to parse.
+
+# BULLET_* match an optional markdown list marker ("- ", "* ", "+ ") and nothing
+# more — deliberately NOT a [-* ] character class, which would also swallow the
+# "**" that opens the bold field name.
+BULLET_BRE='[[:space:]]*\([-*+][[:space:]]\{1,\}\)\{0,1\}'
+BULLET_ERE='^[ \t]*([-*+][ \t]+)?'
+
+read_field() {
+  sed -n "s/^$BULLET_BRE\*\*$2:\*\*[[:space:]]*//p" "$1" | head -1 | sed 's/[[:space:]]*$//'
+}
+
+canon_status() {
+  local raw
+  raw=$(printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/\*//g; s/[[:space:]]*(.*//; s/[[:space:]]*·.*//; s/^[[:space:]]*//; s/[[:space:]]*$//')
+  case "$raw" in
+    ""|unknown)                 printf 'unknown\n' ;;
+    open|new|reported)          printf 'open\n' ;;
+    in-progress|wip|doing)      printf 'in-progress\n' ;;
+    fixed|resolved|done|closed) printf 'fixed\n' ;;
+    wontfix|declined)           printf 'wontfix\n' ;;
+    duplicate|dup)              printf 'duplicate\n' ;;
+    *)                          printf '%s\n' "$raw" ;;
+  esac
+}
+
+set_field() {
+  local file=$1 name=$2 value=$3 tmp
+  tmp=$(mktemp)
+  if grep -q "^$BULLET_BRE\*\*$name:\*\*" "$file"; then
+    awk -v n="$name" -v v="$value" -v b="$BULLET_ERE" '
+      !seen && $0 ~ b "\\*\\*" n ":\\*\\*" {
+        match($0, b); print substr($0, 1, RLENGTH) "**" n ":** " v; seen=1; next
+      } { print }
+    ' "$file" > "$tmp"
+  else
+    # Insert into the metadata block that follows the H1 title.
+    awk -v n="$name" -v v="$value" '
+      NR==1 { print; next }
+      !seen && /^$/ { print; print "- **" n ":** " v; seen=1; next }
+      { print }
+      END { if (!seen) print "- **" n ":** " v }
+    ' "$file" > "$tmp"
+  fi
+  mv "$tmp" "$file"
+}
+
+cmd_status() {
+  local file; file=$(report_path "$1")
+  if [ $# -lt 2 ]; then canon_status "$(read_field "$file" Status)"; return 0; fi
+  local want; want=$(canon_status "$2")
+  case " $STATUSES " in *" $want "*) ;; *) die "unknown status '$2' (use: $STATUSES)";; esac
+  set_field "$file" Status "$want"
+  printf '%s\n' "$want"
+}
+
+issue_ref()  { read_field "$1" Issue | sed -n 's/.*#\([0-9]\{1,\}\).*/\1/p' | head -1; }
+cmd_issue()  { local f; f=$(report_path "$1"); printf '%s\n' "$(read_field "$f" Issue)"; }
+
+# ----------------------------------------------------------- redact-check ---
+#
+# The leak rules live in tools/leak-patterns.txt and are shared with
+# tools/boundary-gate.sh, the CI commit gate. They are applied here because an
+# issue body is a public-plane artefact that NO CI job ever sees: the commit gate
+# cannot catch what is posted through the API. Every pattern applies, including
+# the ops-exempt ones — those are exempt for the tool's own SOURCE, never for
+# text we publish about it.
+
+leak_patterns_file() {
+  local f
+  f="$(cd "$(dirname "$0")/.." && pwd)/tools/leak-patterns.txt"
+  [ -f "$f" ] || die "missing the shared leak-pattern table: $f"
+  printf '%s\n' "$f"
+}
+
+# redact_scan TEXT -> 0 = clean, 1 = at least one pattern matched (reported on stderr)
+redact_scan() {
+  local text=$1 file scope reason re out clean=0
+  file=$(leak_patterns_file)
+  while IFS=$'\t' read -r scope reason re; do
+    case "$scope" in ''|\#*) continue ;; esac
+    [ -n "$re" ] || continue
+    out=$(grep -nE "$re" <<<"$text" || true)
+    [ -n "$out" ] && { note "  $reason: $out"; clean=1; }
+  done < "$file"
+  return $clean
+}
+
+cmd_redact_check() {
+  local src=${1:--} text
+  if [ "$src" = "-" ]; then text=$(cat); else text=$(cat "$src"); fi
+  if redact_scan "$text"; then
+    echo "redact-check: clean"
+  else
+    note "redact-check: FAIL — this text carries private-plane content (SPEC-0358); it must not be posted publicly"
+    exit 1
+  fi
+}
+
+# ------------------------------------------------------------------ open ----
+
+cmd_open() {
+  local id file pub_file title body num url
+  id=$(bug_id "$1"); file=$(report_path "$1")
+
+  if [ -n "$(issue_ref "$file")" ]; then
+    note "$id already links $(read_field "$file" Issue) — nothing to do"
+    return 0
+  fi
+
+  [ "$(canon_status "$(read_field "$file" Public)")" = "yes" ] && : || \
+    die "refusing to publish $id: the report does not declare '- **Public:** yes'.
+  Publishing is per-bug and deliberate. Declare it only for a bug in THIS
+  shipped artifact — never a security issue, a customer-specific detail, or a
+  bug in a system this repository does not ship." 1
+
+  pub_file=$(public_body_path "$file")
+  [ -f "$pub_file" ] || die "refusing to publish $id: no redacted body at
+  $(basename "$pub_file")
+  Write the public-safe restatement there first — observed behaviour, expected
+  behaviour, reproduction, affected version — referring to the analysis ID-ONLY
+  as '$id'." 1
+
+  title=$(sed -n '1s/^#[[:space:]]*//p' "$pub_file")
+  [ -n "$title" ] || die "the redacted body needs a '# <title>' on line 1" 1
+  body=$(sed '1d' "$pub_file")
+
+  if ! redact_scan "$body$title"; then
+    die "refusing to publish $id: the redacted body still carries private-plane content (SPEC-0358)" 1
+  fi
+
+  need_gh
+  url=$(gh issue create --repo "$(bug_repo)" --title "$title" --label bug \
+        --body "$body"$'\n\n---\n_Analysis is tracked privately as '"$id"'._')
+  num=$(printf '%s\n' "$url" | sed -n 's#.*/issues/\([0-9]\{1,\}\).*#\1#p' | head -1)
+  [ -n "$num" ] || die "could not read the created issue number from: $url" 1
+
+  set_field "$file" Issue "$(bug_repo)#$num"
+  echo "$(bug_repo)#$num  $url"
+}
+
+# ----------------------------------------------------------------- close ----
+
+cmd_close() {
+  local id file status="fixed" comment="" num
+  id=$(bug_id "$1"); file=$(report_path "$1"); shift
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --status)  shift; status=$(canon_status "${1:-}") ;;
+      --comment) shift; comment=${1:-} ;;
+      *) die "close: unknown argument '$1'" ;;
+    esac
+    shift
+  done
+  case " $STATUSES " in *" $status "*) ;; *) die "unknown status '$status' (use: $STATUSES)";; esac
+
+  set_field "$file" Status "$status"
+  echo "$id: status -> $status"
+
+  num=$(issue_ref "$file")
+  [ -n "$num" ] || { note "$id has no linked issue — the private plane is up to date, nothing to close"; return 0; }
+
+  local reason=completed
+  case "$status" in wontfix|duplicate) reason="not planned" ;; esac
+
+  need_gh
+  if [ -n "$comment" ]; then
+    redact_scan "$comment" || die "refusing to comment publicly on $id: the text carries private-plane content (SPEC-0358)" 1
+    gh issue comment "$num" --repo "$(bug_repo)" --body "$comment" >/dev/null
+  fi
+  gh issue close "$num" --repo "$(bug_repo)" --reason "$reason" >/dev/null
+  echo "closed $(bug_repo)#$num ($reason)"
+}
+
+# ------------------------------------------------------------------ sync ----
+
+cmd_sync() {
+  local files drift=0 file id st num state
+  if [ $# -gt 0 ]; then files=$(report_path "$1"); else files=$(find "$(bug_dir)" -maxdepth 1 -name 'BUG-*.md' ! -name '*.public.md' | sort); fi
+  need_gh
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    num=$(issue_ref "$file"); [ -n "$num" ] || continue
+    id=$(basename "$file" | sed -n 's/^\(BUG-[0-9]\{4\}\).*/\1/p')
+    st=$(canon_status "$(read_field "$file" Status)")
+    state=$(gh issue view "$num" --repo "$(bug_repo)" --json state -q .state 2>/dev/null || echo UNKNOWN)
+    case "$st:$state" in
+      fixed:CLOSED|wontfix:CLOSED|duplicate:CLOSED|open:OPEN|in-progress:OPEN) ;;
+      unknown:*) echo "$id: report has no canonical Status line (issue is $state)"; drift=1 ;;
+      *) echo "$id: report says '$st' but issue #$num is $state"; drift=1 ;;
+    esac
+  done <<<"$files"
+  [ "$drift" -eq 0 ] && { echo "sync: reports and issues agree"; return 0; }
+  exit 1
+}
+
+# ------------------------------------------------------------------ main ----
+
+usage() { sed -n '3,37p' "$0" | sed 's/^#\{1,\} \{0,1\}//'; }
+
+case "${1:-}" in
+  next-id)      shift; cmd_next_id "$@" ;;
+  path)         shift; [ $# -ge 1 ] || die "path needs a bug id"; report_path "$1" ;;
+  status)       shift; [ $# -ge 1 ] || die "status needs a bug id"; cmd_status "$@" ;;
+  issue)        shift; [ $# -ge 1 ] || die "issue needs a bug id"; cmd_issue "$1" ;;
+  redact-check) shift; cmd_redact_check "$@" ;;
+  open)         shift; [ $# -ge 1 ] || die "open needs a bug id"; cmd_open "$1" ;;
+  close)        shift; [ $# -ge 1 ] || die "close needs a bug id"; cmd_close "$@" ;;
+  sync)         shift; cmd_sync "$@" ;;
+  -h|--help|help|"") usage ;;
+  *) die "unknown command '$1' (try --help)" ;;
+esac

--- a/scripts/bugtracker.test.sh
+++ b/scripts/bugtracker.test.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# scripts/bugtracker.test.sh — self-contained fixtures for scripts/bugtracker.sh.
+#
+# Builds a throwaway maintenance tree and stubs `gh` on PATH, so nothing here
+# touches the network or creates a real issue. The point of most assertions is
+# the REFUSALS: a public issue cannot be un-published, so every guard that keeps
+# private-plane content off the public plane is tested from the failing side.
+#
+# No deps beyond bash + coreutils. Exit 0 = all assertions passed.
+#
+set -euo pipefail
+
+BT="$(cd "$(dirname "$0")" && pwd)/bugtracker.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+export M3C_MAINTENANCE_DIR="$TMP/maint"
+export M3C_BUG_REPO="acme/widget"
+mkdir -p "$M3C_MAINTENANCE_DIR/bug-reports"
+BUGS="$M3C_MAINTENANCE_DIR/bug-reports"
+
+# --- gh stub: records the call, answers the few things the script reads --------
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_CALLS"
+case "$1 $2" in
+  "issue create") echo "https://github.com/acme/widget/issues/${GH_NEW_ISSUE:-77}" ;;
+  "issue view")   echo "${GH_ISSUE_STATE:-OPEN}" ;;
+  *) : ;;
+esac
+GHEOF
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+export GH_CALLS="$TMP/gh-calls.log"
+: > "$GH_CALLS"
+
+pass=0; fail=0
+ok()   { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; }
+is()   { [ "$2" = "$3" ] && ok "$1" || bad "$1 (got '$2', want '$3')"; }
+# refuses DESC CMD... -> the command must exit non-zero
+refuses() { local d=$1; shift; if "$@" >/dev/null 2>&1; then bad "$d (it did NOT refuse)"; else ok "$d"; fi; }
+accepts() { local d=$1; shift; if "$@" >/dev/null 2>&1; then ok "$d"; else bad "$d (it refused)"; fi; }
+
+# --- next-id ------------------------------------------------------------------
+is "next-id on an empty tree" "$("$BT" next-id)" "BUG-0001"
+
+: > "$BUGS/BUG-0007-alpha.md"
+: > "$BUGS/BUG-0042-beta.md"
+: > "$BUGS/FR-0099-not-a-bug.md"
+is "next-id takes the max, ignores FR-" "$("$BT" next-id)" "BUG-0043"
+rm "$BUGS/BUG-0007-alpha.md" "$BUGS/BUG-0042-beta.md" "$BUGS/FR-0099-not-a-bug.md"
+
+# --- a realistic report -------------------------------------------------------
+REPORT="$BUGS/BUG-0213-widget-drops-the-last-frame.md"
+cat > "$REPORT" <<'EOF'
+# BUG-0213 — widget drops the last frame
+
+- **Datum:** 2026-09-03
+- **Severity:** S2
+- **Component:** widget/render
+- **Status:** Fixed (2026-03-21)
+
+## Symptom
+
+Internal note: the queue drains via /upload_2 against 127.0.0.1:8081.
+EOF
+
+is "id normalises from a bare number"   "$("$BT" path 213)"        "$REPORT"
+is "id normalises from lowercase"       "$("$BT" path bug-0213)"   "$REPORT"
+is "id normalises from a filename"      "$("$BT" path BUG-0213-widget-drops-the-last-frame.md)" "$REPORT"
+refuses "path refuses an unknown id"    "$BT" path 999
+
+# --- status: read tolerates legacy spellings, write is canonical --------------
+is "legacy 'Fixed (date)' reads as fixed" "$("$BT" status 213)" "fixed"
+is "status write returns the canonical value" "$("$BT" status 213 OPEN)" "open"
+is "status write is canonical in the file" \
+   "$(grep -c '^- \*\*Status:\*\* open$' "$REPORT")" "1"
+is "status write does not duplicate the line" \
+   "$(grep -c '^\s*[-* ]*\*\*Status:\*\*' "$REPORT")" "1"
+refuses "status refuses an unknown value" "$BT" status 213 banana
+
+NOSTATUS="$BUGS/BUG-0214-no-metadata-block.md"
+printf '# BUG-0214 — no metadata block\n\nJust prose.\n' > "$NOSTATUS"
+is "status is inserted when absent" "$("$BT" status 214 open)" "open"
+is "the inserted line sits under the title" "$(sed -n '3p' "$NOSTATUS")" "- **Status:** open"
+
+# --- redact-check: the five SPEC-0358 patterns --------------------------------
+accepts "redact-check passes clean text" \
+  bash -c "printf 'Observed: the last frame is dropped. See BUG-0213.\n' | '$BT' redact-check -"
+refuses "redact-check catches a private-repo path" \
+  bash -c "printf 'see m3c-tools-maintenance/bug-reports/x.md\n' | '$BT' redact-check -"
+refuses "redact-check catches an internal endpoint" \
+  bash -c "printf 'against 127.0.0.1:8081\n' | '$BT' redact-check -"
+refuses "redact-check catches an ER1 context-id" \
+  bash -c "printf 'ctx 123456789012345678901___skills\n' | '$BT' redact-check -"
+refuses "redact-check catches a secret header" \
+  bash -c "printf 'send X-API-KEY: ...\n' | '$BT' redact-check -"
+refuses "redact-check catches an internal API path" \
+  bash -c "printf 'POST /upload_2\n' | '$BT' redact-check -"
+accepts "an ID-only private reference stays clean" \
+  bash -c "printf 'Tracked internally as BUG-0213.\n' | '$BT' redact-check -"
+
+# --- open: fail-closed on every missing guard ---------------------------------
+refuses "open refuses without a Public declaration" "$BT" open 213
+is "no issue was created" "$(grep -c 'issue create' "$GH_CALLS" || true)" "0"
+
+"$BT" status 213 open >/dev/null
+printf '%s\n' "- **Public:** yes" >> "$REPORT"
+refuses "open refuses without a redacted body" "$BT" open 213
+
+PUB="$BUGS/BUG-0213-widget-drops-the-last-frame.public.md"
+cat > "$PUB" <<'EOF'
+# widget drops the last frame when the queue drains
+
+Observed: the internal path /upload_2 is called once too often.
+EOF
+refuses "open refuses a redacted body that still leaks" "$BT" open 213
+is "still no issue was created" "$(grep -c 'issue create' "$GH_CALLS" || true)" "0"
+
+cat > "$PUB" <<'EOF'
+# widget drops the last frame when the queue drains
+
+**Observed:** the last frame of a drain is not written.
+**Expected:** every frame is written.
+**Version:** 2.11.0
+EOF
+accepts "open publishes once the body is clean" "$BT" open 213
+is "the issue is linked back into the report" "$("$BT" issue 213)" "acme/widget#77"
+is "exactly one issue was created" "$(grep -c 'issue create' "$GH_CALLS")" "1"
+accepts "open is idempotent" "$BT" open 213
+is "still exactly one issue was created" "$(grep -c 'issue create' "$GH_CALLS")" "1"
+
+is "the public body is not mistaken for a report" "$("$BT" path 213)" "$REPORT"
+
+# --- close: both planes, and the comment is checked too -----------------------
+refuses "close refuses a leaking public comment" \
+  "$BT" close 213 --comment "fixed in m3c-tools-maintenance/SPEC/SPEC-0001-x.md"
+is "no close was issued" "$(grep -c 'issue close' "$GH_CALLS" || true)" "0"
+
+accepts "close sets the status and closes the issue" \
+  "$BT" close 213 --comment "Fixed in v2.11.1 — see BUG-0213."
+is "the report is fixed"  "$("$BT" status 213)" "fixed"
+is "the issue was closed as completed" \
+   "$(grep -c 'issue close 77 --repo acme/widget --reason completed' "$GH_CALLS")" "1"
+
+: > "$GH_CALLS"
+accepts "close --status wontfix closes as not planned" "$BT" close 213 --status wontfix
+is "wontfix closes with 'not planned'" \
+   "$(grep -c "reason not planned" "$GH_CALLS")" "1"
+
+: > "$GH_CALLS"
+accepts "close on an unlinked report touches no issue" "$BT" close 214
+is "no gh call was made" "$(wc -l < "$GH_CALLS" | tr -d ' ')" "0"
+
+# --- sync ---------------------------------------------------------------------
+"$BT" status 213 fixed >/dev/null
+GH_ISSUE_STATE=CLOSED accepts "sync is quiet when both agree" "$BT" sync 213
+GH_ISSUE_STATE=OPEN   refuses "sync reports a fixed report with an open issue" "$BT" sync 213
+"$BT" status 213 open >/dev/null
+GH_ISSUE_STATE=OPEN   accepts "sync agrees again once the report reopens" "$BT" sync 213
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tools/boundary-gate.sh
+++ b/tools/boundary-gate.sh
@@ -17,12 +17,13 @@
 #
 # Leak patterns
 # -------------
-#   1. private-repo path reference  m3c-tools-maintenance/   (a PATH into the private
-#      repo; public->private references must be ID-ONLY, e.g. "implements SPEC-1234")
-#   2. internal endpoint            127.0.0.1:8081
-#   3. ER1 context-id               [0-9]{18,25}___[a-z0-9]+
-#   4. secret header                X-API-KEY
-#   5. internal API path            /upload_2  or  /api/plm/
+# Defined ONCE in tools/leak-patterns.txt (scope TAB reason TAB regex) and read by
+# this gate AND by scripts/bugtracker.sh, which applies the same rules to GitHub
+# issue bodies — text no CI job would ever see. Adding a pattern there tightens
+# both; that is the whole point of not writing them out twice.
+#
+#   scope "always"      checked everywhere, no exceptions (the private-repo path).
+#   scope "ops-exempt"  skipped on the public tool's own operational surface.
 #
 # ID-only markers are fine on purpose: a bare "SPEC-1234" / "ADR-1234" matches no
 # pattern here, so referencing the private reasoning plane by identifier never trips
@@ -44,13 +45,34 @@ cd "$(git rev-parse --show-toplevel)"
 fail=0
 emit() { printf '%s\n' "$1"; fail=1; }
 
+# ---- Load the shared pattern table --------------------------------------------
+PATTERNS_FILE="tools/leak-patterns.txt"
+[ -f "$PATTERNS_FILE" ] || { echo "boundary-gate: missing $PATTERNS_FILE" >&2; exit 2; }
+P_SCOPE=(); P_REASON=(); P_RE=()
+while IFS=$'\t' read -r scope reason re; do
+  case "$scope" in ''|\#*) continue ;; esac
+  [ -n "$re" ] || continue
+  P_SCOPE+=("$scope"); P_REASON+=("$reason"); P_RE+=("$re")
+done < "$PATTERNS_FILE"
+[ "${#P_RE[@]}" -gt 0 ] || { echo "boundary-gate: no patterns loaded from $PATTERNS_FILE" >&2; exit 2; }
+
 # match_prefix PATH PREFIX...  -> 0 if PATH starts with any PREFIX
 match_prefix() { local p=$1; shift; local x; for x in "$@"; do [ "${p#"$x"}" != "$p" ] && return 0; done; return 1; }
 # match_exact  PATH ITEM...    -> 0 if PATH equals any ITEM
 match_exact()  { local p=$1; shift; local x; for x in "$@"; do [ "$p" = "$x" ] && return 0; done; return 1; }
 
 # ---- Base allowlist: skipped by every rule -------------------------------------
-BASE_EXACT=(tools/boundary-gate.sh CONTENT-TOPOLOGY.md)
+# Files that DEFINE or EXERCISE the leak rules necessarily contain the literals
+# themselves — the pattern table and the two fixture suites, exactly like this
+# gate's own source. Nothing else belongs on this list: an exemption here is a
+# blind spot, so it is granted only to files whose whole purpose is the rule.
+BASE_EXACT=(
+  tools/boundary-gate.sh
+  tools/boundary-gate.test.sh
+  tools/leak-patterns.txt
+  scripts/bugtracker.test.sh
+  CONTENT-TOPOLOGY.md
+)
 BASE_PREFIX=(CHANGELOG .git)          # CHANGELOG*, .gitignore/.gitattributes/.github/...
 
 # ---- Operational-surface exemption: patterns 2-5 only --------------------------
@@ -82,18 +104,19 @@ check() {
   match_prefix "$f" "${BASE_PREFIX[@]}" && return 0
   grep -Iq . "$f" 2>/dev/null || return 0        # skip binary / empty files
 
-  # Rule 1 — reference into the PRIVATE repo (always checked, minus the baseline)
-  if [ "${#PRIV_BASELINE[@]}" -eq 0 ] || ! match_exact "$f" "${PRIV_BASELINE[@]}"; then
-    scan_pattern "$f" 'private-repo path reference' 'm3c-tools-maintenance/'
-  fi
+  local ops_exempt=0 baselined=0 i
+  match_prefix "$f" "${OPS_EXEMPT_PREFIX[@]}" && ops_exempt=1
+  match_exact  "$f" "${OPS_EXEMPT_EXACT[@]}"  && ops_exempt=1
+  if [ "${#PRIV_BASELINE[@]}" -gt 0 ] && match_exact "$f" "${PRIV_BASELINE[@]}"; then baselined=1; fi
 
-  # Rules 2-5 — internal endpoint / ER1 context-id / secret header / internal API path
-  if ! match_prefix "$f" "${OPS_EXEMPT_PREFIX[@]}" && ! match_exact "$f" "${OPS_EXEMPT_EXACT[@]}"; then
-    scan_pattern "$f" 'internal endpoint' '127\.0\.0\.1:8081'
-    scan_pattern "$f" 'ER1 context-id'    '[0-9]{18,25}___[a-z0-9]+'
-    scan_pattern "$f" 'secret header'     'X-API-KEY'
-    scan_pattern "$f" 'internal API path' '/upload_2|/api/plm/'
-  fi
+  for i in "${!P_RE[@]}"; do
+    case "${P_SCOPE[$i]}" in
+      always)     [ "$baselined"  -eq 1 ] && continue ;;
+      ops-exempt) [ "$ops_exempt" -eq 1 ] && continue ;;
+      *) emit "$PATTERNS_FILE: unknown scope '${P_SCOPE[$i]}'"; continue ;;
+    esac
+    scan_pattern "$f" "${P_REASON[$i]}" "${P_RE[$i]}"
+  done
 }
 
 while IFS= read -r f; do

--- a/tools/boundary-gate.test.sh
+++ b/tools/boundary-gate.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# tools/boundary-gate.test.sh — fixtures for tools/boundary-gate.sh (SPEC-0358).
+#
+# A leak gate that stops flagging is worse than no gate, because it still reads
+# green. These fixtures assert the gate from the FAILING side: each pattern in
+# tools/leak-patterns.txt must actually block, the scope split must hold, and a
+# clean tree must pass. Written when the patterns moved into a shared table read
+# by both this gate and scripts/bugtracker.sh.
+#
+# Builds a throwaway git repo; no network. Exit 0 = all assertions passed.
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+GATE="$HERE/boundary-gate.sh"
+PATTERNS="$HERE/leak-patterns.txt"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+REPO="$TMP/repo"
+mkdir -p "$REPO/tools" "$REPO/cmd" "$REPO/docs"
+cp "$GATE" "$REPO/tools/boundary-gate.sh"
+cp "$PATTERNS" "$REPO/tools/leak-patterns.txt"
+cd "$REPO"
+git init -q; git config user.email t@t; git config user.name t
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; }
+
+# run_gate -> prints output, returns the gate's exit code
+run_gate() { git add -A >/dev/null 2>&1; bash tools/boundary-gate.sh >"$TMP/out" 2>&1; }
+
+# blocks DESC FILE CONTENT   — the gate must FAIL and name the file
+blocks() {
+  local d=$1 f=$2 c=$3
+  printf '%s\n' "$c" > "$f"
+  if run_gate; then bad "$d (the gate passed)"; else
+    grep -q "^$f:" "$TMP/out" && ok "$d" || bad "$d (failed, but did not name $f)"
+  fi
+  rm -f "$f"
+}
+
+# allows DESC FILE CONTENT   — the gate must PASS
+allows() {
+  local d=$1 f=$2 c=$3
+  printf '%s\n' "$c" > "$f"
+  if run_gate; then ok "$d"; else bad "$d (the gate blocked: $(head -1 "$TMP/out"))"; fi
+  rm -f "$f"
+}
+
+# --- a clean tree passes -------------------------------------------------------
+printf '# widget\n\nImplements SPEC-1234 and follows ADR-0007.\n' > README.md
+if run_gate; then ok "a clean tree passes"; else bad "a clean tree passes ($(head -1 "$TMP/out"))"; fi
+
+# --- every pattern in the table actually blocks --------------------------------
+# Each fixture is written into a NON-exempt path (README-like), where both scopes apply.
+blocks "always-scope: a private-repo path is blocked" \
+  "docs.md" 'see m3c-tools-maintenance/bug-reports/BUG-0001-x.md for the analysis'
+blocks "ops-exempt scope: an internal endpoint is blocked outside the tool surface" \
+  "NOTES.md" 'the server runs on 127.0.0.1:8081 locally'
+blocks "ops-exempt scope: an ER1 context-id is blocked" \
+  "NOTES.md" 'context 123456789012345678901___skills holds it'
+blocks "ops-exempt scope: a secret header is blocked" \
+  "NOTES.md" 'authenticate with X-API-KEY: <token>'
+blocks "ops-exempt scope: an internal API path is blocked" \
+  "NOTES.md" 'POST /upload_2 with the payload'
+blocks "ops-exempt scope: the PLM API path is blocked" \
+  "NOTES.md" 'GET /api/plm/projects/1'
+
+# --- the scope split holds -----------------------------------------------------
+allows "ops-exempt scope is skipped on the tool's own surface" \
+  "cmd/client.go" 'const defaultURL = "http://127.0.0.1:8081" // the ER1 client ships this'
+blocks "always scope is NOT skipped there — a private path is blocked everywhere" \
+  "cmd/notes.go" '// see m3c-tools-maintenance/SPEC/SPEC-0001-x.md'
+
+# --- ID-only references stay legal (the point of the rule) ---------------------
+allows "an ID-only private reference is allowed" \
+  "docs/design.md" 'This implements SPEC-0358 and closes BUG-0213.'
+
+# --- the table is the source of truth ------------------------------------------
+n_patterns=$(grep -cvE '^[[:space:]]*(#|$)' tools/leak-patterns.txt)
+[ "$n_patterns" -ge 5 ] && ok "the pattern table is loaded ($n_patterns patterns)" \
+                        || bad "the pattern table looks empty ($n_patterns patterns)"
+
+: > tools/leak-patterns.txt
+if run_gate; then bad "an empty pattern table must not pass silently"; else
+  grep -q 'no patterns loaded' "$TMP/out" && ok "an empty pattern table fails loudly" \
+    || bad "an empty pattern table failed, but not with the expected message"
+fi
+cp "$PATTERNS" tools/leak-patterns.txt
+
+rm -f tools/leak-patterns.txt
+if run_gate; then bad "a missing pattern table must not pass silently"; else
+  grep -q 'missing tools/leak-patterns.txt' "$TMP/out" && ok "a missing pattern table fails loudly" \
+    || bad "a missing pattern table failed, but not with the expected message"
+fi
+cp "$PATTERNS" tools/leak-patterns.txt
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tools/leak-patterns.txt
+++ b/tools/leak-patterns.txt
@@ -1,0 +1,26 @@
+# tools/leak-patterns.txt — the SPEC-0358 content-plane leak patterns, in ONE place.
+#
+# Read by BOTH gates, so a pattern added here tightens both at once:
+#   * tools/boundary-gate.sh   — the COMMIT gate (tracked files, in CI)
+#   * scripts/bugtracker.sh    — the POST gate (issue bodies and comments, which
+#                                no CI job ever sees)
+#
+# Format:  <scope>TAB<reason>TAB<extended regex>
+#
+#   always      checked in every public-plane file, no exceptions. A reference
+#               from the public plane into the private one must be ID-ONLY
+#               ("implements SPEC-1234"), never a concrete path.
+#   ops-exempt  skipped for the public tool's OWN operational surface (cmd/,
+#               pkg/, docs/, scripts/, tools/, .claude/, …): per SPEC-0358
+#               "ship the code", the ER1 client legitimately carries its own
+#               endpoint, header name and API paths there. Everywhere else —
+#               and in every issue body — these are leaks.
+#
+# This file necessarily contains the literals it defines, so it is exempt from
+# the commit gate (tools/boundary-gate.sh BASE_EXACT), exactly as that gate's
+# own source is.
+always	private-repo path reference	m3c-tools-maintenance/
+ops-exempt	internal endpoint	127\.0\.0\.1:8081
+ops-exempt	ER1 context-id	[0-9]{18,25}___[a-z0-9]+
+ops-exempt	secret header	X-API-KEY
+ops-exempt	internal API path	/upload_2|/api/plm/


### PR DESCRIPTION
## Was das ist

Ein Bug lebt ab jetzt an zwei Orten, und `scripts/bugtracker.sh` hält sie in Übereinstimmung:

| Ebene | Wo | Inhalt |
|-------|----|--------|
| **Analyse** (privat) | `${M3C_MAINTENANCE_DIR}/bug-reports/BUG-NNNN-<slug>.md` | Alles: Root Cause, `file:line`, Kundenkontext, SPEC-Bezüge. Source of truth. |
| **Issue** (öffentlich) | GitHub-Issue in diesem Repo | Eine **redigierte Neuformulierung** — observed/expected/reproduction/version. Verweist auf die Analyse **ID-only** (`BUG-0213`). |

Das Issue ist **nie eine Kopie** der Analyse. `bug-reports/` enthält auch Bugs für Systeme, die dieses Repo nicht ausliefert; die verlassen die private Ebene nie.

## Fail-closed, weil ein Issue nicht zurückzunehmen ist

`open` verweigert, solange nicht **alle drei** Bedingungen erfüllt sind:

1. die Analyse deklariert `- **Public:** yes`
2. eine separate `.public.md` mit dem redigierten Körper existiert
3. dieser Körper besteht den Leak-Check

`close` setzt den kanonischen Status **und** schließt das Issue — der Kommentar wird vor dem Posten geprüft. `sync` meldet Drift zwischen beiden Ebenen.

Beim **Lesen** toleriert das Tool den Bestand wie er ist (`**Status:** Fixed (2026-03-21)` liest als `fixed`), beim **Schreiben** ist es immer kanonisch — sonst hätte `sync` nichts zu parsen. `next-id` ersetzt „zähl die Dateien selbst".

## Die Muster stünden sonst doppelt da

Beim Bau fiel auf: die Leak-Muster hätten ab jetzt an zwei Stellen existiert — im Commit-Gate (`tools/boundary-gate.sh`) und im Post-Gate (`scripts/bugtracker.sh`). Das Versagen wäre **lautlos**: jemand ergänzt ein sechstes Muster im Commit-Gate, und der Issue-Pfad publiziert es weiter.

Deshalb **`tools/leak-patterns.txt`** — eine Tabelle, zwei Konsumenten, eine Stelle zum Nachschärfen:

```
<scope>	<reason>	<extended regex>
always      → überall geprüft, ohne Ausnahme (der Privatpfad)
ops-exempt  → übersprungen auf der eigenen Werkzeugoberfläche (cmd/, pkg/, docs/, …)
```

Ein Issue-Body ist der Grund, warum es den zweiten Konsumenten braucht: er wird über die API gepostet, nicht committet — **kein CI-Job sieht ihn jemals**.

## Ein Leak-Gate umbauen heißt beweisen, dass er weiter blockt

Ein Gate, das aufhört zu melden, liest sich genauso grün wie einer, der funktioniert. `tools/boundary-gate.test.sh` prüft ihn deshalb **von der Fehlerseite** (13 Assertions):

- jedes Muster der Tabelle blockt tatsächlich
- der Scope-Split hält: ein interner Endpunkt ist in `cmd/` erlaubt, ein Privatpfad **nirgends**
- ID-only-Verweise (`implements SPEC-0358`) bleiben legal — das ist der Sinn der Regel
- eine **leere oder fehlende** Tabelle scheitert laut, statt still grün zu sein

`scripts/bugtracker.test.sh` (43 Assertions) stubbt `gh`, berührt kein Netz und prüft überwiegend **Verweigerungen** — jede Wache, die private Inhalte von der öffentlichen Ebene fernhält, wird von der scheiternden Seite getestet.

Beide Suiten laufen jetzt im `boundary-gate`-Workflow.

## BASE_EXACT

Bekommt nur Dateien, deren *Zweck* die Regel ist — die Tabelle und die zwei Fixture-Suiten, genau wie die Gate-Quelle selbst. Eine Exemption dort ist ein blinder Fleck; das steht jetzt auch so im Code.

## Skills

`bug-report` und `bug-fix` sind darum herum neu geschrieben:

- **bug-report** entscheidet die Ebene explizit (vier Bedingungen, die *alle* gelten müssen), schreibt den redigierten Körper und ruft `open`
- **bug-fix** ruft `close` und `sync`, statt eine Statuszeile von Hand zu editieren — und lässt bei einer Flag-Änderung zusätzlich den docaudit-Gate laufen

## Setup

Die Skills brauchen (wie schon vorher) `M3C_MAINTENANCE_DIR`:

```bash
export M3C_MAINTENANCE_DIR="$HOME/path/to/your-maintenance-repo"
```

## Verifikation

`tools/boundary-gate.sh` clean · `boundary-gate.test.sh` 13/13 · `bugtracker.test.sh` 43/43 · `check-docs.sh` PASS · `docaudit -cli all` PASS · `go test ./cmd/docaudit/` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)