### PR TITLE
feat(tracker): feature requests alongside bugs, and a Spec the close must serve

### DIFF
--- a/.claude/skills/bug-fix/SKILL.md
+++ b/.claude/skills/bug-fix/SKILL.md
@@ -139,6 +139,11 @@ This sets `Status: fixed` in the analysis file and, if an issue is linked,
 comments and closes it. Use `--status wontfix` or `--status duplicate` when that
 is the honest outcome; those close the issue as *not planned*.
 
+`close` **refuses** unless the report carries a `- **Spec:**` line: solving a bug
+means serving the contract it belongs to. `none — <reason>` is a valid answer
+when a bug genuinely changes no contract; a missing line is not, because that is
+how Step 5 gets skipped rather than decided.
+
 The comment is **public-plane text**: the script runs the SPEC-0358 leak check on
 it and refuses rather than post. Write it for a stranger — what changed and in
 which version, referring to the analysis ID-only.

--- a/.claude/skills/feature-request/SKILL.md
+++ b/.claude/skills/feature-request/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: feature-request
+description: Turn a proposal or design critique into tracked feature requests — an FR file per request in the maintenance repo, the SPEC section each one answers to, and a public GitHub issue linked to both. Use when someone proposes a capability, challenges an architecture, or when an audio/meeting note contains several distinct asks.
+argument-hint: "<paste the proposal, critique, or transcript>"
+metadata:
+  version: 1.0.0
+  category: development
+  tags: [feature-request, spec, dual-plane, m3c-tools]
+---
+
+# Feature Request from a Proposal
+
+## Input
+
+**Proposal:**
+$ARGUMENTS
+
+## The three artifacts
+
+| Artifact | Where | Answers |
+|----------|-------|---------|
+| **FR file** (private) | `${M3C_MAINTENANCE_DIR}/bug-reports/FR-NNNN-<slug>.md` | *What is being asked, by whom, and why.* Full reasoning, trade-offs, the arguments against. |
+| **SPEC** (private) | `${M3C_MAINTENANCE_DIR}/SPEC/SPEC-NNNN-<name>.md` | *What contract the result must satisfy.* Requirements, constraints, non-goals. |
+| **Issue** (public) | a GitHub issue in `$M3C_BUG_REPO` | *What will change for a user of this tool.* Redacted; refers to the FR and SPEC **ID-only**. |
+
+The FR is the **ask**; the SPEC is the **contract**; the issue is the **public
+commitment**. Closing an issue means the contract is served — `bugtracker.sh`
+enforces that mechanically by refusing to close an item whose `- **Spec:**`
+line is missing.
+
+> Set `M3C_MAINTENANCE_DIR` before running this skill. If it is unset, say so
+> and stop.
+
+## Your Task
+
+### Step 1: Split the proposal into distinct asks
+
+A proposal is rarely one feature request. Read for the **seams** — a separate FR
+is warranted where the asks could be accepted, rejected, scheduled or built
+*independently*.
+
+Resist two failure modes:
+
+- **Splitting too fine.** Two asks that must ship together are one FR.
+- **Keeping the author's numbering.** A proposal that says "FR-1 … FR-7" is
+  using its own scheme. The repository has its own; `bugtracker.sh next-id FR`
+  is the only source of an id. Record the author's label in the FR body so the
+  conversation stays traceable.
+
+Present the split to the user and get agreement **before** writing files. This
+is the step where a wrong reading is cheapest to correct.
+
+### Step 2: Find the contract underneath
+
+Several FRs from one proposal usually share **one** contract. Prefer a single
+SPEC with a section per area over one SPEC per FR — fragmenting a contract
+across seven documents is how it stops being a contract.
+
+Check `${M3C_MAINTENANCE_DIR}/SPEC/` first: an existing SPEC that already owns
+this area should be **extended**, not duplicated.
+
+Write down the **non-goals** explicitly. A proposal that expands what the tool
+is responsible for is a proposal to change its boundary; if that boundary should
+hold, saying so in the SPEC is the most valuable line in it.
+
+### Step 3: Write the SPEC
+
+```bash
+ls ${M3C_MAINTENANCE_DIR}/SPEC | sed -nE 's/^SPEC-0*([0-9]+).*/\1/p' | sort -n | tail -1
+```
+
+Follow the house format: purpose, numbered requirements with rationale,
+constraints, non-goals, and a history table. Each requirement must be **testable**
+— "the manifest declares data requirements semantically" is a wish; "`validate`
+exits non-zero when a declared requirement has no binding" is a requirement.
+
+Mark anything not yet decided as an open question rather than inventing an
+answer. A SPEC that quietly resolves a real design decision is worse than one
+that names it.
+
+### Step 4: Write the FR files
+
+```bash
+./scripts/bugtracker.sh next-id FR      # -> FR-0096
+```
+
+One file per ask, `${M3C_MAINTENANCE_DIR}/bug-reports/FR-NNNN-<slug>.md`:
+
+```markdown
+# FR-NNNN — <what is being asked, in one line>
+
+- **Date:** YYYY-MM-DD
+- **Status:** open
+- **Raised by:** <who, and in what conversation>
+- **Component:** <package or surface>
+- **Spec:** SPEC-NNNN §N
+- **Public:** yes | no
+
+## The ask
+
+<What is wanted, in the requester's terms>
+
+## Why it matters
+
+<The problem it solves. If the requester gave a rationale, keep theirs.>
+
+## What it changes
+
+<Concretely: manifest fields, CLI surface, verification behaviour>
+
+## Arguments against / open questions
+
+<The strongest case for NOT doing it, and what is still undecided. An FR
+without this section is advocacy, not analysis.>
+
+## Acceptance
+
+<What must be true to close this — pointing at the SPEC requirements it serves>
+```
+
+### Step 5: Decide the plane
+
+Set `- **Public:** yes` only when all hold:
+
+- the request concerns the **shipped artifact** of this repository,
+- it is not a security-sensitive design detail,
+- it carries no customer-specific or tenant-specific context,
+- the requester is content to be named publicly, or the FR is restated without
+  attributing them.
+
+Otherwise `- **Public:** no`, say why, and stop after Step 4.
+
+### Step 6: Write the redacted issue bodies
+
+`${M3C_MAINTENANCE_DIR}/bug-reports/FR-NNNN-<slug>.public.md` — line 1 is the
+title, the rest the body. Write it for a **contributor**, not for the internal
+reader:
+
+- **keep:** what the capability is, why a user wants it, what would change in
+  the manifest/CLI, acceptance criteria, ID-only references (`FR-0096`, `SPEC-0401`)
+- **drop:** paths into the maintenance repo, internal endpoints, ER1 context-ids,
+  `X-API-KEY`, internal API paths, customer names, SPEC *paths*, and internal
+  strategy or competitive reasoning
+
+An issue is a request for work, so it must be **actionable by someone who cannot
+read the SPEC**. If the body only makes sense with the private document open,
+it is not finished.
+
+### Step 7: Show, then open
+
+Show the user every redacted body **before** creating anything. A GitHub issue on
+a public repository is indexed immediately and cannot be un-published — this
+confirmation is the last reversible moment.
+
+```bash
+./scripts/bugtracker.sh open FR-NNNN
+```
+
+The script refuses unless `Public: yes` is declared, the `.public.md` exists, and
+the body passes the SPEC-0358 leak check. **Fix the body; never work around the
+refusal.**
+
+### Step 8: Closing one later
+
+An FR closes as **implemented**, and only once the contract is served:
+
+```bash
+./scripts/bugtracker.sh close FR-NNNN --comment "<public-safe one-liner>"
+./scripts/bugtracker.sh sync FR-NNNN
+```
+
+`close` refuses when the `- **Spec:**` line is missing — solving an issue means
+serving the SPEC it belongs to. Update the SPEC's history table in the same
+change, and record in the FR what was actually built versus what was asked;
+where they differ, that difference is the most useful thing in the file.
+
+### Step 9: Summarize
+
+1. The split you made, and why those seams
+2. SPEC created or extended, with its requirement ids
+3. Each FR: id, one-line ask, plane
+4. Issue URLs, or what is still awaiting confirmation
+5. Open questions the SPEC deliberately left unresolved

--- a/scripts/bugtracker.sh
+++ b/scripts/bugtracker.sh
@@ -3,9 +3,13 @@
 # scripts/bugtracker.sh — keep a bug's two planes in step (SPEC-0358,
 # "ship the code, keep the reasoning").
 #
-#   1. the REPORT — ${M3C_MAINTENANCE_DIR}/bug-reports/BUG-NNNN-<slug>.md
-#      The source of truth. PRIVATE plane: root cause, file:line, customer
-#      context, SPEC references, whatever the analysis needs.
+# It tracks the two kinds of item that live in bug-reports/:
+#   BUG-NNNN  a defect        — closed as `fixed`
+#   FR-NNNN   a feature request — closed as `implemented`
+#
+#   1. the REPORT — ${M3C_MAINTENANCE_DIR}/bug-reports/<KIND>-NNNN-<slug>.md
+#      The source of truth. PRIVATE plane: root cause or rationale, file:line,
+#      customer context, SPEC references, whatever the analysis needs.
 #
 #   2. the ISSUE — a GitHub issue in this (PUBLIC) repository.
 #      The tracker view other people can see. It is a REDACTED restatement,
@@ -23,20 +27,31 @@
 #   M3C_MAINTENANCE_DIR   required — the private maintenance repo's root
 #   M3C_BUG_REPO          optional — owner/repo for issues (default: origin)
 #
+# An item is named BUG-0213 / FR-0096, or fr-96, or a filename. A BARE NUMBER
+# means a BUG — the FR kind must be spelled out, so "96" can never silently
+# resolve to the wrong item.
+#
 # Commands:
-#   next-id                       next free BUG id
-#   path   <BUG-NNNN>             resolve the report file
-#   status <BUG-NNNN> [STATUS]    read, or set, the canonical status
-#   issue  <BUG-NNNN>             print the linked issue reference
+#   next-id [BUG|FR]              next free id of that kind (default BUG)
+#   path   <ID>                   resolve the report file
+#   status <ID> [STATUS]          read, or set, the canonical status
+#   issue  <ID>                   print the linked issue reference
+#   spec   <ID>                   print the SPEC the item answers to
 #   redact-check [FILE|-]         SPEC-0358 leak patterns over text; 1 = a hit
-#   open   <BUG-NNNN>             create the public issue and link it back
-#   close  <BUG-NNNN> [--status S] [--comment TEXT]
-#   sync   [<BUG-NNNN>]           read-only: report/issue drift
+#   open   <ID>                   create the public issue and link it back
+#   close  <ID> [--status S] [--comment TEXT]
+#   sync   [<ID>]                 read-only: report/issue drift
+#
+# Closing an item as done requires a `- **Spec:**` line. Solving an issue means
+# serving the contract it belongs to, so the value may be `none — <reason>`, but
+# the question has to have been ANSWERED rather than skipped.
 #
 # Exit: 0 ok · 1 a check failed (drift, leak, refusal) · 2 usage/config error.
 set -euo pipefail
 
-STATUSES="open in-progress fixed wontfix duplicate"
+# The states that mean "done" — closing an issue as completed, and the states
+# that require a Spec answer.
+DONE_STATES="fixed implemented"
 
 die()  { printf 'bugtracker: %s\n' "$1" >&2; exit "${2:-2}"; }
 note() { printf '%s\n' "$1" >&2; }
@@ -66,17 +81,39 @@ need_gh() { command -v gh >/dev/null 2>&1 || die "the GitHub CLI (gh) is require
 
 # ------------------------------------------------------------- resolving ----
 
-# normalise "213" / "bug-0213" / "BUG-0213-slug.md" -> BUG-0213
-bug_id() {
-  local n
-  n=$(printf '%s\n' "$1" | tr '[:lower:]' '[:upper:]' | sed -n 's/^\(BUG-\)\{0,1\}0*\([0-9]\{1,\}\).*$/\2/p')
-  [ -n "$n" ] || die "not a bug id: $1"
-  printf 'BUG-%04d\n' "$n"
+# normalise "213" / "bug-0213" / "FR-96" / "BUG-0213-slug.md" -> BUG-0213 / FR-0096
+item_id() {
+  local up kind n
+  up=$(printf '%s\n' "$1" | tr '[:lower:]' '[:upper:]')
+  kind=$(printf '%s\n' "$up" | sed -E -n 's/^(BUG|FR)[-_]?[0-9].*$/\1/p')
+  [ -n "$kind" ] || kind=BUG
+  n=$(printf '%s\n' "$up" | sed -E -n 's/^(BUG|FR)?[-_]?0*([0-9]+).*$/\2/p')
+  [ -n "$n" ] || die "not an item id: $1 (expected BUG-NNNN, FR-NNNN or a bare number)"
+  printf '%s-%04d\n' "$kind" "$n"
+}
+
+kind_of() { printf '%s\n' "${1%%-*}"; }
+
+# The vocabulary differs by kind on one word only: a defect is FIXED, a feature
+# request is IMPLEMENTED. Sharing the rest keeps sync and close uniform.
+statuses_for() {
+  case "$1" in
+    BUG) printf 'open in-progress fixed wontfix duplicate\n' ;;
+    FR)  printf 'open in-progress implemented wontfix duplicate\n' ;;
+    *)   die "unknown item kind: $1" ;;
+  esac
+}
+
+label_for() {
+  case "$1" in
+    BUG) printf 'bug\n' ;;
+    FR)  printf 'enhancement\n' ;;
+  esac
 }
 
 report_path() {
   local id dir hits
-  id=$(bug_id "$1"); dir=$(bug_dir)
+  id=$(item_id "$1"); dir=$(bug_dir)
   hits=$(find "$dir" -maxdepth 1 -name "$id-*.md" ! -name '*.public.md' | sort)
   [ -n "$hits" ] || die "no report file for $id in $dir" 1
   [ "$(printf '%s\n' "$hits" | wc -l)" -eq 1 ] || die "several files match $id:
@@ -87,13 +124,15 @@ $hits"
 public_body_path() { printf '%s\n' "${1%.md}.public.md"; }
 
 cmd_next_id() {
-  local dir max n
+  local kind=${1:-BUG} dir max n
+  kind=$(printf '%s\n' "$kind" | tr '[:lower:]' '[:upper:]')
+  statuses_for "$kind" >/dev/null      # rejects an unknown kind
   dir=$(bug_dir); max=0
   while IFS= read -r f; do
-    n=$(basename "$f" | sed -n 's/^BUG-0*\([0-9]\{1,\}\)-.*$/\1/p')
+    n=$(basename "$f" | sed -E -n "s/^$kind-0*([0-9]+)-.*\$/\1/p")
     [ -n "$n" ] && [ "$n" -gt "$max" ] && max=$n
-  done < <(find "$dir" -maxdepth 1 -name 'BUG-*.md')
-  printf 'BUG-%04d\n' "$((max + 1))"
+  done < <(find "$dir" -maxdepth 1 -name "$kind-*.md")
+  printf '%s-%04d\n' "$kind" "$((max + 1))"
 }
 
 # ---------------------------------------------------------------- fields ----
@@ -122,7 +161,8 @@ canon_status() {
     ""|unknown)                 printf 'unknown\n' ;;
     open|new|reported)          printf 'open\n' ;;
     in-progress|wip|doing)      printf 'in-progress\n' ;;
-    fixed|resolved|done|closed) printf 'fixed\n' ;;
+    fixed|resolved|closed)      printf 'fixed\n' ;;
+    implemented|shipped|delivered|done) printf 'implemented\n' ;;
     wontfix|declined)           printf 'wontfix\n' ;;
     duplicate|dup)              printf 'duplicate\n' ;;
     *)                          printf '%s\n' "$raw" ;;
@@ -151,16 +191,18 @@ set_field() {
 }
 
 cmd_status() {
-  local file; file=$(report_path "$1")
+  local id file kind allowed want
+  id=$(item_id "$1"); file=$(report_path "$1"); kind=$(kind_of "$id")
   if [ $# -lt 2 ]; then canon_status "$(read_field "$file" Status)"; return 0; fi
-  local want; want=$(canon_status "$2")
-  case " $STATUSES " in *" $want "*) ;; *) die "unknown status '$2' (use: $STATUSES)";; esac
+  allowed=$(statuses_for "$kind"); want=$(canon_status "$2")
+  case " $allowed " in *" $want "*) ;; *) die "status '$2' is not valid for a $kind (use: $allowed)";; esac
   set_field "$file" Status "$want"
   printf '%s\n' "$want"
 }
 
 issue_ref()  { read_field "$1" Issue | sed -n 's/.*#\([0-9]\{1,\}\).*/\1/p' | head -1; }
 cmd_issue()  { local f; f=$(report_path "$1"); printf '%s\n' "$(read_field "$f" Issue)"; }
+cmd_spec()   { local f; f=$(report_path "$1"); printf '%s\n' "$(read_field "$f" Spec)"; }
 
 # ----------------------------------------------------------- redact-check ---
 #
@@ -206,7 +248,7 @@ cmd_redact_check() {
 
 cmd_open() {
   local id file pub_file title body num url
-  id=$(bug_id "$1"); file=$(report_path "$1")
+  id=$(item_id "$1"); file=$(report_path "$1")
 
   if [ -n "$(issue_ref "$file")" ]; then
     note "$id already links $(read_field "$file" Issue) — nothing to do"
@@ -235,8 +277,8 @@ cmd_open() {
   fi
 
   need_gh
-  url=$(gh issue create --repo "$(bug_repo)" --title "$title" --label bug \
-        --body "$body"$'\n\n---\n_Analysis is tracked privately as '"$id"'._')
+  url=$(gh issue create --repo "$(bug_repo)" --title "$title" --label "$(label_for "$(kind_of "$id")")" \
+        --body "$body"$'\n\n---\n_Tracked privately as '"$id"'._')
   num=$(printf '%s\n' "$url" | sed -n 's#.*/issues/\([0-9]\{1,\}\).*#\1#p' | head -1)
   [ -n "$num" ] || die "could not read the created issue number from: $url" 1
 
@@ -247,8 +289,11 @@ cmd_open() {
 # ----------------------------------------------------------------- close ----
 
 cmd_close() {
-  local id file status="fixed" comment="" num
-  id=$(bug_id "$1"); file=$(report_path "$1"); shift
+  local id file kind allowed status comment="" num
+  id=$(item_id "$1"); file=$(report_path "$1"); kind=$(kind_of "$id")
+  allowed=$(statuses_for "$kind")
+  case "$kind" in BUG) status=fixed ;; FR) status=implemented ;; esac
+  shift
   while [ $# -gt 0 ]; do
     case "$1" in
       --status)  shift; status=$(canon_status "${1:-}") ;;
@@ -257,7 +302,18 @@ cmd_close() {
     esac
     shift
   done
-  case " $STATUSES " in *" $status "*) ;; *) die "unknown status '$status' (use: $STATUSES)";; esac
+  case " $allowed " in *" $status "*) ;; *) die "status '$status' is not valid for a $kind (use: $allowed)";; esac
+
+  # Solving an issue means serving the contract it belongs to. The Spec line may
+  # legitimately say "none — <reason>"; what it may not do is be missing, which
+  # is how the question gets skipped rather than answered.
+  case " $DONE_STATES " in
+    *" $status "*)
+      [ -n "$(read_field "$file" Spec)" ] || die "refusing to close $id as '$status': the report has no '- **Spec:**' line.
+  Record which SPEC this serves — or state 'none — <reason>' if it genuinely
+  serves none. Either is an answer; a missing line is not." 1
+      ;;
+  esac
 
   set_field "$file" Status "$status"
   echo "$id: status -> $status"
@@ -281,16 +337,16 @@ cmd_close() {
 
 cmd_sync() {
   local files drift=0 file id st num state
-  if [ $# -gt 0 ]; then files=$(report_path "$1"); else files=$(find "$(bug_dir)" -maxdepth 1 -name 'BUG-*.md' ! -name '*.public.md' | sort); fi
+  if [ $# -gt 0 ]; then files=$(report_path "$1"); else files=$(find "$(bug_dir)" -maxdepth 1 \( -name 'BUG-*.md' -o -name 'FR-*.md' \) ! -name '*.public.md' | sort); fi
   need_gh
   while IFS= read -r file; do
     [ -n "$file" ] || continue
     num=$(issue_ref "$file"); [ -n "$num" ] || continue
-    id=$(basename "$file" | sed -n 's/^\(BUG-[0-9]\{4\}\).*/\1/p')
+    id=$(basename "$file" | sed -E -n 's/^((BUG|FR)-[0-9]{4}).*/\1/p')
     st=$(canon_status "$(read_field "$file" Status)")
     state=$(gh issue view "$num" --repo "$(bug_repo)" --json state -q .state 2>/dev/null || echo UNKNOWN)
     case "$st:$state" in
-      fixed:CLOSED|wontfix:CLOSED|duplicate:CLOSED|open:OPEN|in-progress:OPEN) ;;
+      fixed:CLOSED|implemented:CLOSED|wontfix:CLOSED|duplicate:CLOSED|open:OPEN|in-progress:OPEN) ;;
       unknown:*) echo "$id: report has no canonical Status line (issue is $state)"; drift=1 ;;
       *) echo "$id: report says '$st' but issue #$num is $state"; drift=1 ;;
     esac
@@ -301,16 +357,17 @@ cmd_sync() {
 
 # ------------------------------------------------------------------ main ----
 
-usage() { sed -n '3,37p' "$0" | sed 's/^#\{1,\} \{0,1\}//'; }
+usage() { sed -n '3,50p' "$0" | sed 's/^#\{1,\} \{0,1\}//'; }
 
 case "${1:-}" in
   next-id)      shift; cmd_next_id "$@" ;;
-  path)         shift; [ $# -ge 1 ] || die "path needs a bug id"; report_path "$1" ;;
-  status)       shift; [ $# -ge 1 ] || die "status needs a bug id"; cmd_status "$@" ;;
-  issue)        shift; [ $# -ge 1 ] || die "issue needs a bug id"; cmd_issue "$1" ;;
+  path)         shift; [ $# -ge 1 ] || die "path needs an item id"; report_path "$1" ;;
+  status)       shift; [ $# -ge 1 ] || die "status needs an item id"; cmd_status "$@" ;;
+  issue)        shift; [ $# -ge 1 ] || die "issue needs an item id"; cmd_issue "$1" ;;
+  spec)         shift; [ $# -ge 1 ] || die "spec needs an item id"; cmd_spec "$1" ;;
   redact-check) shift; cmd_redact_check "$@" ;;
-  open)         shift; [ $# -ge 1 ] || die "open needs a bug id"; cmd_open "$1" ;;
-  close)        shift; [ $# -ge 1 ] || die "close needs a bug id"; cmd_close "$@" ;;
+  open)         shift; [ $# -ge 1 ] || die "open needs an item id"; cmd_open "$1" ;;
+  close)        shift; [ $# -ge 1 ] || die "close needs an item id"; cmd_close "$@" ;;
   sync)         shift; cmd_sync "$@" ;;
   -h|--help|help|"") usage ;;
   *) die "unknown command '$1' (try --help)" ;;

--- a/scripts/bugtracker.test.sh
+++ b/scripts/bugtracker.test.sh
@@ -50,8 +50,11 @@ is "next-id on an empty tree" "$("$BT" next-id)" "BUG-0001"
 : > "$BUGS/BUG-0007-alpha.md"
 : > "$BUGS/BUG-0042-beta.md"
 : > "$BUGS/FR-0099-not-a-bug.md"
-is "next-id takes the max, ignores FR-" "$("$BT" next-id)" "BUG-0043"
+is "next-id takes the max, ignores the other kind" "$("$BT" next-id)" "BUG-0043"
+is "next-id FR counts FR files"                     "$("$BT" next-id FR)" "FR-0100"
+is "next-id fr is case-insensitive"                 "$("$BT" next-id fr)" "FR-0100"
 rm "$BUGS/BUG-0007-alpha.md" "$BUGS/BUG-0042-beta.md" "$BUGS/FR-0099-not-a-bug.md"
+is "next-id FR on an empty tree" "$("$BT" next-id FR)" "FR-0001"
 
 # --- a realistic report -------------------------------------------------------
 REPORT="$BUGS/BUG-0213-widget-drops-the-last-frame.md"
@@ -135,10 +138,23 @@ is "still exactly one issue was created" "$(grep -c 'issue create' "$GH_CALLS")"
 
 is "the public body is not mistaken for a report" "$("$BT" path 213)" "$REPORT"
 
+# --- close: the Spec question must be ANSWERED, not skipped -------------------
+refuses "close as done refuses a report with no Spec line" "$BT" close 213
+is "the status was not changed by the refusal" "$("$BT" status 213)" "open"
+accepts "close as wontfix does not need a Spec line" "$BT" close 213 --status wontfix
+"$BT" status 213 open >/dev/null
+
+printf '%s\n' "- **Spec:** none — a rendering slip, no contract to change" >> "$REPORT"
+accepts "a 'none — reason' Spec answer satisfies the rule" "$BT" close 213
+is "spec reads back the recorded answer" \
+   "$("$BT" spec 213)" "none — a rendering slip, no contract to change"
+"$BT" status 213 open >/dev/null
+
 # --- close: both planes, and the comment is checked too -----------------------
+: > "$GH_CALLS"          # count only the calls the assertions below are about
 refuses "close refuses a leaking public comment" \
   "$BT" close 213 --comment "fixed in m3c-tools-maintenance/SPEC/SPEC-0001-x.md"
-is "no close was issued" "$(grep -c 'issue close' "$GH_CALLS" || true)" "0"
+is "no close was issued by the leaking comment" "$(grep -c 'issue close 77' "$GH_CALLS" || true)" "0"
 
 accepts "close sets the status and closes the issue" \
   "$BT" close 213 --comment "Fixed in v2.11.1 — see BUG-0213."
@@ -152,8 +168,43 @@ is "wontfix closes with 'not planned'" \
    "$(grep -c "reason not planned" "$GH_CALLS")" "1"
 
 : > "$GH_CALLS"
+printf '%s\n' "- **Spec:** SPEC-0401" >> "$NOSTATUS"
 accepts "close on an unlinked report touches no issue" "$BT" close 214
 is "no gh call was made" "$(wc -l < "$GH_CALLS" | tr -d ' ')" "0"
+
+# --- the FR kind: same machinery, one different word --------------------------
+FR="$BUGS/FR-0096-declarative-data-requirements.md"
+cat > "$FR" <<'EOF'
+# FR-0096 — declarative data requirements
+
+- **Status:** open
+- **Spec:** SPEC-0401 §1
+- **Public:** yes
+EOF
+is "an FR id is resolved by kind"      "$("$BT" path FR-0096)" "$FR"
+is "a lowercase short FR id resolves"  "$("$BT" path fr-96)"   "$FR"
+refuses "a bare number never resolves to an FR" "$BT" path 96
+
+is "an FR closes as implemented, not fixed" "$("$BT" status FR-0096 implemented)" "implemented"
+refuses "'fixed' is not a valid FR status"  "$BT" status FR-0096 fixed
+"$BT" status FR-0096 open >/dev/null
+refuses "'implemented' is not a valid BUG status" "$BT" status 213 implemented
+
+cat > "${FR%.md}.public.md" <<'EOF'
+# Declare a skill's data requirements semantically
+
+A skill should say what KIND of data it needs, not which server holds it today.
+EOF
+: > "$GH_CALLS"
+GH_NEW_ISSUE=88 accepts "an FR opens an issue too" "$BT" open FR-0096
+is "an FR is labelled enhancement, not bug" \
+   "$(grep -c 'label enhancement' "$GH_CALLS")" "1"
+is "the FR issue is linked back" "$("$BT" issue FR-0096)" "acme/widget#88"
+
+: > "$GH_CALLS"
+accepts "closing an FR defaults to implemented" "$BT" close FR-0096
+is "the FR is implemented" "$("$BT" status FR-0096)" "implemented"
+is "the FR issue closed as completed" "$(grep -c 'issue close 88 .* --reason completed' "$GH_CALLS")" "1"
 
 # --- sync ---------------------------------------------------------------------
 "$BT" status 213 fixed >/dev/null


### PR DESCRIPTION
Baut auf #137 auf. Macht den Tracker zu dem, was `bug-reports/` tatsächlich enthält — **206 BUG- und 88 FR-Dateien** — und ergänzt die Regel, die der eigentliche Punkt ist.

## Zwei Arten, ein Unterschied

| | schließt als | Issue-Label |
|---|---|---|
| `BUG-NNNN` | `fixed` | `bug` |
| `FR-NNNN` | `implemented` | `enhancement` |

Ids lösen nach Art auf: `BUG-0213`, `FR-0096`, `fr-96`, ein Dateiname. Eine **nackte Zahl bedeutet BUG** — so kann `96` nie stillschweigend zur falschen Sache auflösen. `next-id FR` zählt FR-Dateien.

## Die eigentliche Ergänzung: `- **Spec:**`

`close` **verweigert**, solange die Zeile fehlt. Ein Issue zu lösen heißt, den Vertrag zu bedienen, zu dem es gehört.

Die Regel verlangt bewusst **keine bestimmte Antwort** — `none — a rendering slip, no contract to change` erfüllt sie. Sie verhindert nur, dass die Frage *übersprungen* statt *entschieden* wird. Genau so hört „SPEC aktualisieren" sonst leise auf zu passieren.

## Vier Tests fielen um — und das war richtig

Als die Regel landete, scheiterten vier bestehende Assertions: die Fixtures hatten keine `Spec:`-Zeile. Das ist die Regel bei der Arbeit, also wurden die Fixtures **erweitert statt gelockert**, und die Verweigerung wird jetzt direkt getestet:

- `close` als erledigt verweigert ohne `Spec:`-Zeile, und lässt den Status unverändert
- `close --status wontfix` braucht keine
- `none — <Grund>` erfüllt die Regel
- Id-Auflösung pro Art · `fixed` ist für ein FR ungültig, `implemented` für einen BUG · `enhancement`-Label · implemented-Close

**63 Assertions**, weiterhin ohne Netz.

## Neuer Skill `/feature-request`

Zerlegt ein Proposal in unabhängige Anfragen, sucht den **einen** Vertrag darunter statt eine SPEC pro FR zu fragmentieren, hält die **Nicht-Ziele** fest (ein Proposal, das die Verantwortung des Werkzeugs ausweitet, ist ein Antrag auf Grenzverschiebung), und zeigt jeden öffentlichen Körper, bevor etwas Irreversibles passiert. Er hält außerdem die Nummerierung des Autors aus dem Id-Raum des Repos heraus.

## Erster echter Durchlauf

Sieben Feature Requests aus einer Architekturkritik: FR-0096 … FR-0102, ein gemeinsamer Vertrag, Issues #138–#144. Alle sieben `redact-check` clean, `sync` sagt beide Ebenen stimmen überein.

## Verifikation

`boundary-gate` clean · `boundary-gate.test.sh` 13/13 · `bugtracker.test.sh` 63/63 · `check-docs.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)