### PR TITLE
fix(plaud): UTC-Zeitstempel der Developer-API als Ortszeit rendern (FR-0095)

### DIFF
--- a/cmd/m3c-tools/commands_shared.go
+++ b/cmd/m3c-tools/commands_shared.go
@@ -19,6 +19,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -723,66 +724,105 @@ func cmdPlaudCheck() {
 }
 
 // cmdPlaudFixTimes backfills the real recording time onto already-synced Plaud
-// items: it PATCHes each synced item's ER1 current_time to its Plaud CreatedAt,
-// so they move from the import moment to their true position in the memory
-// viewer. Dry-run by default; pass apply=true to actually write.
-func cmdPlaudFixTimes(apply bool) {
-	cfg := plaud.LoadConfig()
-	session, err := plaud.LoadToken(cfg.TokenPath)
+// items: it PATCHes each synced item's ER1 current_time to its Plaud start_at,
+// rendered in LOCAL time, so they sit at the moment the button was pressed
+// rather than at the upload moment — or, since FR-0095, two hours before it.
+//
+// It runs on the DEVELOPER API (the same durable token as `plaud dev` and the
+// menubar). The previous version used the retired consumer client and its
+// CreatedAt field: it could not see start_at at all, and on a machine without a
+// consumer token it exited before doing anything — which is why the UTC drift
+// stayed in the corpus unnoticed.
+//
+// Dry-run by default. `since` (YYYY-MM-DD, local) and `limit` narrow the set;
+// an empty/zero value means "all synced recordings".
+func cmdPlaudFixTimes(apply bool, since string, limit int) {
+	var sinceT time.Time
+	if since != "" {
+		var err error
+		sinceT, err = time.ParseInLocation("2006-01-02", since, time.Local)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "--since expects YYYY-MM-DD, got %q\n", since)
+			os.Exit(1)
+		}
+	}
+
+	client, err := plaud.NewDevClientFromFile(plaud.DefaultMCPTokenPath())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading token: %v\nRun: m3c-tools plaud auth --from-er1   (or: m3c-tools plaud auth login)\n", err)
+		fmt.Fprintf(os.Stderr, "Error: no usable developer token: %v\nRun once: node tools/plaud-mcp-login.mjs\n", err)
 		os.Exit(1)
 	}
-	client := plaud.NewClient(cfg, session.Token)
 	recordings, err := client.ListRecordings()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error listing recordings: %v\n", err)
 		os.Exit(1)
 	}
+	sort.SliceStable(recordings, func(i, j int) bool { return recordings[i].StartAt > recordings[j].StartAt })
 
 	ids := make([]string, len(recordings))
 	for i, r := range recordings {
 		ids[i] = r.ID
 	}
-	states := resolvePlaudSyncStates(ids, session.Token)
+	states := resolvePlaudSyncStates(ids, client.AccessToken())
 	er1Cfg := er1.LoadConfig()
 
 	type fixItem struct {
 		title  string
 		docID  string
-		target string
+		wasUTC string // what the buggy path wrote: the UTC wall clock
+		target string // what it should be: the same instant, local
 	}
 	var toFix []fixItem
-	var skippedNoDoc, skippedNoTime int
+	var skippedNoDoc, skippedNoTime, skippedOlder int
 	for _, r := range recordings {
 		st := states[r.ID]
-		if st.Status != "synced" {
+		// plaudStateSynced, not `st.Status == "synced"`: the server-side check
+		// (SPEC-0117) returns the doc_id without necessarily setting a status
+		// string, and it is the only source on a machine whose local tracking DB
+		// is empty. The old fix-times compared the status directly and therefore
+		// found zero items on exactly the machines that needed it. FR-0095.
+		if !plaudStateSynced(st) {
 			continue
 		}
 		if st.DocID == "" {
 			skippedNoDoc++ // synced on another device; doc_id unknown here
 			continue
 		}
-		target := er1.FormatCaptureTime(r.CreatedAt)
-		if target == "" {
-			skippedNoTime++ // no recording time from Plaud
+		local, ok := r.StartedAtLocal()
+		if !ok {
+			skippedNoTime++ // no parsable recording time from Plaud
 			continue
 		}
-		toFix = append(toFix, fixItem{title: r.Title, docID: st.DocID, target: target})
+		if !sinceT.IsZero() && local.Before(sinceT) {
+			skippedOlder++
+			continue
+		}
+		toFix = append(toFix, fixItem{
+			title:  r.Name,
+			docID:  st.DocID,
+			wasUTC: er1.FormatCaptureTime(local.UTC()),
+			target: er1.FormatCaptureTime(local),
+		})
+		if limit > 0 && len(toFix) >= limit {
+			break
+		}
 	}
 
-	fmt.Printf("Plaud fix-times — %d synced items to correct to their real recording time\n", len(toFix))
+	fmt.Printf("Plaud fix-times — %d synced item(s) to set to their real recording time (local)\n", len(toFix))
 	if skippedNoDoc > 0 {
 		fmt.Printf("  (%d synced items skipped: doc_id not known locally — run on the device that synced them)\n", skippedNoDoc)
 	}
 	if skippedNoTime > 0 {
-		fmt.Printf("  (%d skipped: no recording time from Plaud)\n", skippedNoTime)
+		fmt.Printf("  (%d skipped: no parsable recording time from Plaud)\n", skippedNoTime)
+	}
+	if skippedOlder > 0 {
+		fmt.Printf("  (%d skipped: recorded before %s)\n", skippedOlder, since)
 	}
 
 	if !apply {
-		fmt.Println("\nDRY-RUN — pass --apply to write. recording -> doc_id -> new current_time:")
+		fmt.Println("\nDRY-RUN — pass --apply to write. recording -> doc_id -> current_time (was UTC -> now local):")
 		for _, f := range toFix {
-			fmt.Printf("  %-40s  doc_id=%s  ->  %s\n", truncateStr(f.title, 40), f.docID, f.target)
+			fmt.Printf("  %-38s  doc_id=%s  %s  ->  %s\n", truncateStr(f.title, 38), f.docID, f.wasUTC, f.target)
 		}
 		fmt.Printf("\n%d item(s) would be updated. Re-run with: m3c-tools plaud fix-times --apply\n", len(toFix))
 		return
@@ -795,7 +835,7 @@ func cmdPlaudFixTimes(apply bool) {
 			log.Printf("[plaud] fix-times FAIL doc_id=%s: %v", f.docID, err)
 		} else {
 			ok++
-			log.Printf("[plaud] fix-times OK doc_id=%s -> %s", f.docID, f.target)
+			log.Printf("[plaud] fix-times OK doc_id=%s %s -> %s", f.docID, f.wasUTC, f.target)
 		}
 	}
 	fmt.Printf("Done: %d updated, %d failed (of %d)\n", ok, failed, len(toFix))

--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -253,7 +253,8 @@ Commands:
 
   plaud list             List Plaud recordings with sync status + ER1 doc_id
   plaud check            Sync-coverage report: how many synced/unsynced + doc_id links
-  plaud fix-times        Backfill real recording time onto synced items (--apply to write)
+  plaud fix-times        Set synced items' ER1 time to the real (local) recording time
+                         [--since YYYY-MM-DD] [--limit N] [--apply]   dry-run by default
   plaud sync <id>        Sync a Plaud recording to ER1
   plaud sync --all       Sync all new Plaud recordings to ER1
   plaud auth mcp         Import the official OAuth token (npx @plaud-ai/mcp login) — durable, no DevTools
@@ -4394,13 +4395,28 @@ func cmdPlaud(args []string) {
 	case "check":
 		cmdPlaudCheck()
 	case "fix-times":
-		apply := false
-		for _, a := range args[1:] {
-			if a == "--apply" {
+		apply, since, limit := false, "", 0
+		for i := 1; i < len(args); i++ {
+			switch a := args[i]; {
+			case a == "--apply":
 				apply = true
+			case a == "--since" && i+1 < len(args):
+				since = args[i+1]
+				i++
+			case strings.HasPrefix(a, "--since="):
+				since = strings.TrimPrefix(a, "--since=")
+			case a == "--limit" && i+1 < len(args):
+				if v, err := strconv.Atoi(args[i+1]); err == nil {
+					limit = v
+				}
+				i++
+			case strings.HasPrefix(a, "--limit="):
+				if v, err := strconv.Atoi(strings.TrimPrefix(a, "--limit=")); err == nil {
+					limit = v
+				}
 			}
 		}
-		cmdPlaudFixTimes(apply)
+		cmdPlaudFixTimes(apply, since, limit)
 	case "sync":
 		if len(args) < 2 {
 			fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud sync <#|ID|--all> [flags]")
@@ -5068,10 +5084,16 @@ func sortDevNewestFirst(recs []plaud.DevRecording) {
 	sort.SliceStable(recs, func(i, j int) bool { return recs[i].StartAt > recs[j].StartAt })
 }
 
-// devWhen renders the developer API's ISO StartAt as "YYYY-MM-DD HH:MM".
+// devWhen renders the developer API's ISO StartAt as LOCAL "YYYY-MM-DD HH:MM".
+//
+// FR-0095: the API emits a zone-less ISO string that is UTC ("2026-09-03T13:44:14"
+// for a recording made at 15:44 CEST). Slicing those 16 characters printed the UTC
+// wall clock as if it were local time — every row an hour (CET) or two (CEST) too
+// early. Parse, then convert; an unparsable value is shown RAW rather than guessed,
+// so a format change from Plaud is visible instead of silently plausible.
 func devWhen(iso string) string {
-	if len(iso) >= 16 {
-		return strings.Replace(iso[:16], "T", " ", 1)
+	if t, ok := plaud.ParseDevTime(iso); ok {
+		return t.Local().Format("2006-01-02 15:04")
 	}
 	return iso
 }
@@ -5316,7 +5338,13 @@ func syncOneDevRecording(client *plaud.DevClient, er1Cfg *er1.Config, contentTyp
 			audio = nil
 		}
 	}
-	captureTime := parseDevTime(r.StartAt)
+	// LOCAL, not UTC: both consumers of this instant — ER1's `current_time` and the
+	// composite doc's "Date:" line — format with a ZONE-LESS layout, so whatever
+	// zone the time.Time carries becomes the stored wall clock. The other producer
+	// of the same ER1 field (the file import, ~line 1261) uses os.FileInfo.ModTime,
+	// which is local; without this the two producers disagree by 1-2 h and the
+	// braindump corpus mixes both. FR-0095.
+	captureTime := parseDevTime(r.StartAt).Local()
 	transcript := detail.TranscriptText()
 	notes := detail.NotesText()
 
@@ -5575,11 +5603,10 @@ func cmdPlaudDevSync(selectors []string, all bool, limit int, dryRun, force, whi
 }
 
 // parseDevTime parses the developer API's timestamps (falls back to now).
+// The zone handling lives in plaud.ParseDevTime — see FR-0095.
 func parseDevTime(s string) time.Time {
-	for _, layout := range []string{"2006-01-02T15:04:05", time.RFC3339, "2006-01-02T15:04:05.000Z"} {
-		if t, err := time.Parse(layout, s); err == nil {
-			return t
-		}
+	if t, ok := plaud.ParseDevTime(s); ok {
+		return t
 	}
 	return time.Now()
 }

--- a/cmd/m3c-tools/main_other.go
+++ b/cmd/m3c-tools/main_other.go
@@ -396,13 +396,28 @@ func cmdPlaud(args []string) {
 	case "check":
 		cmdPlaudCheck()
 	case "fix-times":
-		apply := false
-		for _, a := range args[1:] {
-			if a == "--apply" {
+		apply, since, limit := false, "", 0
+		for i := 1; i < len(args); i++ {
+			switch a := args[i]; {
+			case a == "--apply":
 				apply = true
+			case a == "--since" && i+1 < len(args):
+				since = args[i+1]
+				i++
+			case strings.HasPrefix(a, "--since="):
+				since = strings.TrimPrefix(a, "--since=")
+			case a == "--limit" && i+1 < len(args):
+				if v, err := strconv.Atoi(args[i+1]); err == nil {
+					limit = v
+				}
+				i++
+			case strings.HasPrefix(a, "--limit="):
+				if v, err := strconv.Atoi(strings.TrimPrefix(a, "--limit=")); err == nil {
+					limit = v
+				}
 			}
 		}
-		cmdPlaudFixTimes(apply)
+		cmdPlaudFixTimes(apply, since, limit)
 	case "sync":
 		if len(args) < 2 {
 			fmt.Fprintln(os.Stderr, "Usage: m3c-tools plaud sync <#|ID|--all> [-f]")

--- a/cmd/m3c-tools/plaud_devwhen_test.go
+++ b/cmd/m3c-tools/plaud_devwhen_test.go
@@ -1,0 +1,43 @@
+//go:build darwin
+
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDevWhenRendersLocal is the display half of FR-0095: the Plaud Sync window
+// and `plaud dev list` must show the LOCAL recording time, not the UTC wall
+// clock the API happens to send. The screenshot that started the report showed
+// "13:50" for a recording made at 15:50 CEST.
+func TestDevWhenRendersLocal(t *testing.T) {
+	prev := time.Local
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Skipf("no tzdata for Europe/Berlin: %v", err)
+	}
+	time.Local = berlin
+	defer func() { time.Local = prev }()
+
+	cases := []struct{ in, want string }{
+		{"2026-09-03T13:50:56", "2026-09-03 15:50"}, // CEST: +2
+		{"2026-01-15T13:50:56", "2026-01-15 14:50"}, // CET:  +1
+		{"2026-09-03T23:30:00", "2026-09-04 01:30"}, // rolls into the next local day
+	}
+	for _, tc := range cases {
+		if got := devWhen(tc.in); got != tc.want {
+			t.Errorf("devWhen(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestDevWhenShowsUnparsableRaw: never guess. A format we cannot read is shown
+// as-is, so it is obviously wrong rather than convincingly wrong.
+func TestDevWhenShowsUnparsableRaw(t *testing.T) {
+	for _, in := range []string{"", "tomorrow", "2026-09-03"} {
+		if got := devWhen(in); got != in {
+			t.Errorf("devWhen(%q) = %q, want the raw input back", in, got)
+		}
+	}
+}

--- a/pkg/menubar/plaud_sync_darwin.go
+++ b/pkg/menubar/plaud_sync_darwin.go
@@ -490,7 +490,7 @@ static void showPlaudSyncWindow(const char *accountInfo) {
 
 		NSTableColumn *colDate = [[NSTableColumn alloc] initWithIdentifier:@"date"];
 		[colDate setWidth:140]; [colDate setMinWidth:80];
-		[[colDate headerCell] setStringValue:@"Date"];
+		[[colDate headerCell] setStringValue:@"Recorded"];
 		[g_plaudTable addTableColumn:colDate];
 
 		NSTableColumn *colStatus = [[NSTableColumn alloc] initWithIdentifier:@"status"];

--- a/pkg/plaud/devapi.go
+++ b/pkg/plaud/devapi.go
@@ -208,6 +208,35 @@ type DevRecording struct {
 	SerialNumber string `json:"serial_number"`
 }
 
+// ParseDevTime parses a developer-API timestamp (start_at, created_at) and
+// reports whether it could.
+//
+// The zone-less layout is deliberate and correct: Plaud emits UTC WITHOUT a
+// suffix — "2026-09-03T13:44:14" is a recording made at 15:44 Berlin time during
+// CEST — and time.Parse assigns UTC to a layout that carries no zone, so the
+// returned INSTANT is right. Only its rendering zone is still open: every caller
+// that shows the value to a human, or writes it into a zone-less field such as
+// ER1's current_time, must call .Local() first. RFC3339 stays in the list so a
+// future Plaud release that does add an offset keeps working. FR-0095.
+func ParseDevTime(s string) (time.Time, bool) {
+	for _, layout := range []string{"2006-01-02T15:04:05", time.RFC3339, "2006-01-02T15:04:05.000Z"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// StartedAtLocal returns the recording's true start time in the machine's local
+// zone — the moment the button was pressed, not the upload or the transcription.
+func (r DevRecording) StartedAtLocal() (time.Time, bool) {
+	t, ok := ParseDevTime(r.StartAt)
+	if !ok {
+		return time.Time{}, false
+	}
+	return t.Local(), true
+}
+
 // ListRecordings returns ALL of the user's recordings from the developer API,
 // paginating (the endpoint returns a default page of ~20).
 func (c *DevClient) ListRecordings() ([]DevRecording, error) {

--- a/pkg/plaud/devtime_test.go
+++ b/pkg/plaud/devtime_test.go
@@ -1,0 +1,82 @@
+package plaud
+
+import (
+	"testing"
+	"time"
+)
+
+// TestParseDevTimeIsUTC pins the fact FR-0095 turned on: the developer API's
+// zone-less timestamps are UTC, so the parsed instant rendered in Europe/Berlin
+// must move forward — two hours in CEST, ONE in CET. The winter case is in here
+// deliberately: the bug was half as large in winter and correspondingly easier
+// to dismiss as "close enough".
+func TestParseDevTimeIsUTC(t *testing.T) {
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Skipf("no tzdata for Europe/Berlin: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		in        string
+		wantLocal string
+	}{
+		// The recording from the FR: shown as 13:50 in the importer, actually 15:50.
+		{"summer CEST is +2", "2026-09-03T13:50:56", "2026-09-03 15:50:56"},
+		{"winter CET is +1", "2026-01-15T13:50:56", "2026-01-15 14:50:56"},
+		// A date crossing midnight in UTC belongs to the NEXT local day.
+		{"late evening rolls the date", "2026-09-03T23:30:00", "2026-09-04 01:30:00"},
+		// If Plaud ever starts sending an offset, honour it instead of assuming UTC.
+		{"explicit offset is honoured", "2026-09-03T15:50:56+02:00", "2026-09-03 15:50:56"},
+		{"explicit Z is honoured", "2026-09-03T13:50:56Z", "2026-09-03 15:50:56"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseDevTime(tc.in)
+			if !ok {
+				t.Fatalf("ParseDevTime(%q) failed to parse", tc.in)
+			}
+			if s := got.In(berlin).Format("2006-01-02 15:04:05"); s != tc.wantLocal {
+				t.Errorf("ParseDevTime(%q) in Berlin = %s, want %s", tc.in, s, tc.wantLocal)
+			}
+		})
+	}
+}
+
+// TestParseDevTimeRejectsGarbage: an unparsable value must be REPORTED, never
+// silently replaced by a plausible-looking one. The display path shows the raw
+// string and the backfill skips the item, so a Plaud format change becomes
+// visible instead of quietly writing today's date into the corpus.
+func TestParseDevTimeRejectsGarbage(t *testing.T) {
+	for _, in := range []string{"", "not-a-time", "2026-09-03", "03.09.2026 13:50"} {
+		if got, ok := ParseDevTime(in); ok {
+			t.Errorf("ParseDevTime(%q) = %v, true; want failure", in, got)
+		}
+	}
+}
+
+// TestStartedAtLocal proves the helper the backfill relies on returns the local
+// rendering of start_at — the value that must end up in ER1's zone-less
+// current_time field.
+func TestStartedAtLocal(t *testing.T) {
+	prev := time.Local
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Skipf("no tzdata for Europe/Berlin: %v", err)
+	}
+	time.Local = berlin
+	defer func() { time.Local = prev }()
+
+	r := DevRecording{ID: "x", StartAt: "2026-09-03T13:44:14"}
+	got, ok := r.StartedAtLocal()
+	if !ok {
+		t.Fatal("StartedAtLocal failed on a well-formed start_at")
+	}
+	if s := got.Format("2006-01-02 15:04:05"); s != "2026-09-03 15:44:14" {
+		t.Errorf("StartedAtLocal = %s, want 2026-09-03 15:44:14", s)
+	}
+
+	if _, ok := (DevRecording{StartAt: ""}).StartedAtLocal(); ok {
+		t.Error("StartedAtLocal accepted an empty start_at")
+	}
+}


### PR DESCRIPTION
Die Plaud-Developer-API liefert `start_at`/`created_at` **zonenlos**, und die Werte sind UTC. `devWhen()` schnitt 16 Zeichen aus dem String — damit stand die UTC-Wanduhr als Ortszeit in der Liste: im Sommer zwei Stunden, im Winter eine zu früh.

Dieselbe Verwechslung stand im **Schreibpfad**: `captureTime` floss ungewandelt in ER1s zonenloses `current_time` und in die `Date:`-Zeile des Composite-Docs, während der Datei-Import (`os.FileInfo.ModTime`) dort Ortszeit schreibt. Zwei Produzenten, ein Feld, zwei Bedeutungen — im Denkkorpus unsichtbar, weil die Reihenfolge stimmt.

Beleg für die UTC-These aus dem stündlichen Sync-Log, nicht aus einer Vermutung: die Läufe um 14:20 und 15:20 Ortszeit fanden nichts, erst der um 16:20 — passend zu `created_at` 13:59 UTC.

## Änderungen

- `pkg/plaud`: `ParseDevTime` + `DevRecording.StartedAtLocal()` — die Zonenregel liegt jetzt **einmal** beim API-Client statt verstreut bei den Aufrufern
- `devWhen` parst und rendert `.Local()`; Unparsbares wird **roh** gezeigt, nie geraten
- Sync-Pfad: `parseDevTime(...).Local()`
- `plaud fix-times` auf die Developer-API umgebaut (`--since` / `--limit` / `--apply`, Dry-Run mit vorher→nachher). Dabei ein **zweiter, verdeckter Fehler**: es prüfte `st.Status == "synced"` statt `plaudStateSynced()` und fand deshalb auf Maschinen, deren Sync-Wahrheit nur vom Serverabgleich kommt, **null** Items — ausgerechnet dort, wo es gebraucht wurde
- Spaltenkopf `Date` → `Recorded`: die Web-App-Spalte zeigt den Zeitpunkt der KI-Notiz, diese hier den der Aufnahme. Sie werden nie gleich sein.
- Tests für Sommer (+2) **und** Winter (+1), Mitternachtswechsel, explizites Offset/`Z`, Ablehnung unparsbarer Werte

## Verifikation

`go build ./...`, `GOOS=linux go build ./...`, `go vet`, alle Tests grün. Installiert und im Betrieb: die Liste zeigt `15:50`/`15:44` statt `13:50`/`13:44`.

**Noch nicht im Betrieb beobachtet:** dass ein *neu* synchronisiertes Item die Ortszeit trägt. Die Zonenlogik ist durch Unit-Tests gedeckt; die Prüfstellen für die nächste echte Aufnahme stehen in FR-0095.

## Folgen

221 bereits synchronisierte ER1-Items wurden nachgezogen (221/221 OK), die Rohschicht des Denkkorpus neu gebaselined.

Vollständiger Befund: `FR-0095` in m3c-tools-maintenance.