### PR TITLE
fix(tracker): the target repository belongs to the item, never to the cwd

### DIFF
--- a/.claude/skills/bug-report/SKILL.md
+++ b/.claude/skills/bug-report/SKILL.md
@@ -27,7 +27,7 @@ A bug lives in up to two places, and `scripts/bugtracker.sh` keeps them in step:
 | Plane | Where | Holds |
 |-------|-------|-------|
 | **Analysis** (private) | `${M3C_MAINTENANCE_DIR}/bug-reports/BUG-NNNN-<slug>.md` | Everything: root cause, `file:line`, customer context, SPEC references. The source of truth. |
-| **Issue** (public) | a GitHub issue in `$M3C_BUG_REPO` (default: this repo's origin) | A **redacted restatement**: observed, expected, reproduction, version. Refers to the analysis **ID-only** (`BUG-0213`). |
+| **Issue** (public) | a GitHub issue in the repo the report's `Repo:` line names | A **redacted restatement**: observed, expected, reproduction, version. Refers to the analysis **ID-only** (`BUG-0213`). |
 
 The issue is **never a copy** of the analysis. `bug-reports/` also holds bugs for
 systems this repository does not ship; those stay private. Publishing is per-bug,
@@ -76,6 +76,7 @@ Write `${M3C_MAINTENANCE_DIR}/bug-reports/BUG-NNNN-<short-slug>.md`:
 - **Component:** <package or flow>
 - **Version:** <from Makefile APP_VERSION>
 - **Public:** yes | no
+- **Repo:** <owner/repo the issue belongs in>
 
 ## Observed Behavior
 
@@ -108,8 +109,12 @@ Write `${M3C_MAINTENANCE_DIR}/bug-reports/BUG-NNNN-<short-slug>.md`:
 <What assumption led to this? What should we watch for?>
 ```
 
-`Status`, `Public` and `Issue` are the three lines the script owns — keep their
-exact spelling so `status`, `close` and `sync` can parse them.
+`Status`, `Public`, `Repo` and `Issue` are the lines the script owns — keep their
+exact spelling so `status`, `open`, `close` and `sync` can parse them.
+
+`Repo` names the repository the issue belongs in. It is **not** inferred from the
+working directory: `bug-reports/` holds items for several systems, and guessing
+from wherever you happen to stand is how an issue lands in the wrong repository.
 
 ### Step 5: Decide the plane
 

--- a/.claude/skills/feature-request/SKILL.md
+++ b/.claude/skills/feature-request/SKILL.md
@@ -21,7 +21,7 @@ $ARGUMENTS
 |----------|-------|---------|
 | **FR file** (private) | `${M3C_MAINTENANCE_DIR}/bug-reports/FR-NNNN-<slug>.md` | *What is being asked, by whom, and why.* Full reasoning, trade-offs, the arguments against. |
 | **SPEC** (private) | `${M3C_MAINTENANCE_DIR}/SPEC/SPEC-NNNN-<name>.md` | *What contract the result must satisfy.* Requirements, constraints, non-goals. |
-| **Issue** (public) | a GitHub issue in `$M3C_BUG_REPO` | *What will change for a user of this tool.* Redacted; refers to the FR and SPEC **ID-only**. |
+| **Issue** (public) | a GitHub issue in the repo the FR's `Repo:` line names | *What will change for a user of this tool.* Redacted; refers to the FR and SPEC **ID-only**. |
 
 The FR is the **ask**; the SPEC is the **contract**; the issue is the **public
 commitment**. Closing an issue means the contract is served — `bugtracker.sh`
@@ -95,6 +95,7 @@ One file per ask, `${M3C_MAINTENANCE_DIR}/bug-reports/FR-NNNN-<slug>.md`:
 - **Component:** <package or surface>
 - **Spec:** SPEC-NNNN §N
 - **Public:** yes | no
+- **Repo:** <owner/repo the issue belongs in>
 
 ## The ask
 

--- a/scripts/bugtracker.sh
+++ b/scripts/bugtracker.sh
@@ -25,7 +25,9 @@
 #
 # Configuration:
 #   M3C_MAINTENANCE_DIR   required — the private maintenance repo's root
-#   M3C_BUG_REPO          optional — owner/repo for issues (default: origin)
+#   M3C_BUG_REPO          optional — owner/repo fallback for an item that does
+#                         not declare `- **Repo:**` and has no issue yet. The
+#                         target is NEVER inferred from the working directory.
 #
 # An item is named BUG-0213 / FR-0096, or fr-96, or a filename. A BARE NUMBER
 # means a BUG — the FR kind must be spelled out, so "96" can never silently
@@ -66,15 +68,38 @@ bug_dir() {
   printf '%s\n' "$M3C_MAINTENANCE_DIR/bug-reports"
 }
 
-bug_repo() {
-  if [ -n "${M3C_BUG_REPO:-}" ]; then printf '%s\n' "$M3C_BUG_REPO"; return; fi
-  local url
-  url=$(git config --get remote.origin.url 2>/dev/null || true)
-  [ -n "$url" ] || die "M3C_BUG_REPO is not set and this is not a git checkout with an origin"
-  url=${url%.git}
-  url=${url#git@github.com:}
-  url=${url#https://github.com/}
-  printf '%s\n' "$url"
+# repo_for FILE — which GitHub repository this item's issue lives in.
+#
+# The target is a property of the ITEM, never of the working directory. Deriving
+# it from `git remote origin` was wrong in both directions: run from the private
+# maintenance checkout it resolved to the private repo (so `close` would address
+# a DIFFERENT issue of the same number), and run from some other public checkout
+# it would have published into that repo instead. bug-reports/ holds items for
+# several systems, so there is no single correct default to infer.
+#
+# Resolution order, most authoritative first:
+#   1. the recorded `- **Issue:** owner/repo#N` — after creation this IS the fact
+#   2. the declared `- **Repo:** owner/repo`    — before creation, reviewed in-file
+#   3. $M3C_BUG_REPO                            — a stated override for one-offs
+#   4. refuse
+#
+# The file outranks the environment on purpose: an item that has declared its
+# target must not be redirected somewhere else by a stray variable.
+repo_for() {
+  local file=$1 r
+  # NB: `s///p` prints the whole line, so the pattern must consume the "#N" too.
+  r=$(read_field "$file" Issue | sed -n 's|^\([A-Za-z0-9_.-]\{1,\}/[A-Za-z0-9_.-]\{1,\}\)#.*$|\1|p' | head -1)
+  [ -n "$r" ] || r=$(read_field "$file" Repo)
+  [ -n "$r" ] || r=${M3C_BUG_REPO:-}
+  [ -n "$r" ] || die "$(basename "$file"): no target repository.
+  Declare it in the report as
+      - **Repo:** owner/repo
+  or set M3C_BUG_REPO for a one-off. It is NOT inferred from the working
+  directory: bug-reports/ holds items for several systems, and guessing from
+  wherever you happen to stand is how an issue lands in the wrong repository." 1
+  printf '%s\n' "$r" | grep -qE '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$' \
+    || die "$(basename "$file"): '$r' is not a valid owner/repo" 1
+  printf '%s\n' "$r"
 }
 
 need_gh() { command -v gh >/dev/null 2>&1 || die "the GitHub CLI (gh) is required for issue commands"; }
@@ -276,14 +301,16 @@ cmd_open() {
     die "refusing to publish $id: the redacted body still carries private-plane content (SPEC-0358)" 1
   fi
 
+  local repo; repo=$(repo_for "$file")
+
   need_gh
-  url=$(gh issue create --repo "$(bug_repo)" --title "$title" --label "$(label_for "$(kind_of "$id")")" \
+  url=$(gh issue create --repo "$repo" --title "$title" --label "$(label_for "$(kind_of "$id")")" \
         --body "$body"$'\n\n---\n_Tracked privately as '"$id"'._')
   num=$(printf '%s\n' "$url" | sed -n 's#.*/issues/\([0-9]\{1,\}\).*#\1#p' | head -1)
   [ -n "$num" ] || die "could not read the created issue number from: $url" 1
 
-  set_field "$file" Issue "$(bug_repo)#$num"
-  echo "$(bug_repo)#$num  $url"
+  set_field "$file" Issue "$repo#$num"
+  echo "$repo#$num  $url"
 }
 
 # ----------------------------------------------------------------- close ----
@@ -324,13 +351,15 @@ cmd_close() {
   local reason=completed
   case "$status" in wontfix|duplicate) reason="not planned" ;; esac
 
+  local repo; repo=$(repo_for "$file")   # from the recorded Issue line, not the cwd
+
   need_gh
   if [ -n "$comment" ]; then
     redact_scan "$comment" || die "refusing to comment publicly on $id: the text carries private-plane content (SPEC-0358)" 1
-    gh issue comment "$num" --repo "$(bug_repo)" --body "$comment" >/dev/null
+    gh issue comment "$num" --repo "$repo" --body "$comment" >/dev/null
   fi
-  gh issue close "$num" --repo "$(bug_repo)" --reason "$reason" >/dev/null
-  echo "closed $(bug_repo)#$num ($reason)"
+  gh issue close "$num" --repo "$repo" --reason "$reason" >/dev/null
+  echo "closed $repo#$num ($reason)"
 }
 
 # ------------------------------------------------------------------ sync ----
@@ -344,7 +373,7 @@ cmd_sync() {
     num=$(issue_ref "$file"); [ -n "$num" ] || continue
     id=$(basename "$file" | sed -E -n 's/^((BUG|FR)-[0-9]{4}).*/\1/p')
     st=$(canon_status "$(read_field "$file" Status)")
-    state=$(gh issue view "$num" --repo "$(bug_repo)" --json state -q .state 2>/dev/null || echo UNKNOWN)
+    state=$(gh issue view "$num" --repo "$(repo_for "$file")" --json state -q .state 2>/dev/null || echo UNKNOWN)
     case "$st:$state" in
       fixed:CLOSED|implemented:CLOSED|wontfix:CLOSED|duplicate:CLOSED|open:OPEN|in-progress:OPEN) ;;
       unknown:*) echo "$id: report has no canonical Status line (issue is $state)"; drift=1 ;;

--- a/scripts/bugtracker.test.sh
+++ b/scripts/bugtracker.test.sh
@@ -206,6 +206,79 @@ accepts "closing an FR defaults to implemented" "$BT" close FR-0096
 is "the FR is implemented" "$("$BT" status FR-0096)" "implemented"
 is "the FR issue closed as completed" "$(grep -c 'issue close 88 .* --reason completed' "$GH_CALLS")" "1"
 
+# --- the target repository belongs to the ITEM, not to the cwd ----------------
+#
+# The regression this guards: repo_for used to read `git remote origin`, so the
+# same command addressed a different repository depending on where you stood —
+# and `close` ignored the repo the item had already recorded.
+
+# a throwaway checkout whose origin is a DIFFERENT repository
+OTHER="$TMP/other-checkout"
+mkdir -p "$OTHER"; ( cd "$OTHER"; git init -q; git remote add origin https://github.com/someone/unrelated.git )
+
+: > "$GH_CALLS"
+( cd "$OTHER" && M3C_BUG_REPO= "$BT" close 213 --status wontfix >/dev/null 2>&1 )
+is "close from a foreign checkout still targets the recorded repo" \
+   "$(grep -c 'issue close 77 --repo acme/widget' "$GH_CALLS")" "1"
+
+: > "$GH_CALLS"
+( cd "$OTHER" && M3C_BUG_REPO=wrong/repo "$BT" close 213 --status wontfix >/dev/null 2>&1 )
+is "a stray M3C_BUG_REPO cannot redirect an item that has an issue" \
+   "$(grep -c 'issue close 77 --repo acme/widget' "$GH_CALLS")" "1"
+"$BT" status 213 open >/dev/null
+
+: > "$GH_CALLS"
+( cd "$OTHER" && GH_ISSUE_STATE=OPEN M3C_BUG_REPO=wrong/repo "$BT" sync 213 >/dev/null 2>&1 )
+is "sync reads the state from the recorded repo" \
+   "$(grep -c 'issue view 77 --repo acme/widget' "$GH_CALLS")" "1"
+
+# --- open, before an issue exists ---------------------------------------------
+DECL="$BUGS/BUG-0215-declares-its-own-repo.md"
+cat > "$DECL" <<'EOF'
+# BUG-0215 — declares its own repo
+
+- **Status:** open
+- **Public:** yes
+- **Repo:** declared/target
+EOF
+cat > "${DECL%.md}.public.md" <<'EOF'
+# a title
+
+a clean body
+EOF
+: > "$GH_CALLS"
+GH_NEW_ISSUE=91 accepts "open uses the declared Repo line" \
+  bash -c "M3C_BUG_REPO=env/override '$BT' open 215"
+is "the file outranks the environment" "$(grep -c 'issue create --repo declared/target' "$GH_CALLS")" "1"
+is "the backlink records the repo it published to" "$("$BT" issue 215)" "declared/target#91"
+
+NOREPO="$BUGS/BUG-0216-declares-nothing.md"
+cat > "$NOREPO" <<'EOF'
+# BUG-0216 — declares nothing
+
+- **Status:** open
+- **Public:** yes
+EOF
+cp "${DECL%.md}.public.md" "${NOREPO%.md}.public.md"
+: > "$GH_CALLS"
+refuses "open refuses when nothing declares a target" \
+  bash -c "cd '$OTHER' && M3C_BUG_REPO= '$BT' open 216"
+is "nothing was created without a target" "$(grep -c 'issue create' "$GH_CALLS" || true)" "0"
+accepts "M3C_BUG_REPO fills the gap when the file is silent" \
+  bash -c "cd '$OTHER' && M3C_BUG_REPO=env/fallback GH_NEW_ISSUE=92 '$BT' open 216"
+is "the env fallback was used" "$(grep -c 'issue create --repo env/fallback' "$GH_CALLS")" "1"
+
+BADREPO="$BUGS/BUG-0217-malformed-repo.md"
+cat > "$BADREPO" <<'EOF'
+# BUG-0217 — malformed repo
+
+- **Status:** open
+- **Public:** yes
+- **Repo:** https://github.com/owner/repo
+EOF
+cp "${DECL%.md}.public.md" "${BADREPO%.md}.public.md"
+refuses "a malformed Repo value is rejected, not passed to gh" "$BT" open 217
+
 # --- sync ---------------------------------------------------------------------
 "$BT" status 213 fixed >/dev/null
 GH_ISSUE_STATE=CLOSED accepts "sync is quiet when both agree" "$BT" sync 213


### PR DESCRIPTION
## Der Fehler

`repo_for` las `git remote origin` — dasselbe Kommando adressierte also je nach Standort ein anderes Repository. Das war in **beide** Richtungen falsch, und die schlimmere war bereits scharf:

`FR-0096` trägt `- **Issue:** kamir/m3c-tools#138`. Aus dem privaten Maintenance-Checkout heraus hätte `close FR-0096` aufgerufen:

```
gh issue close 138 --repo <maintenance>     # ein ANDERES Issue mit derselben Nummer
```

**Das Item kannte sein Repository — und das Skript fragte stattdessen das Dateisystem.**

Die andere Richtung ist die gefährlichere: aus einem beliebigen anderen *öffentlichen* Checkout heraus hätte `open` in **dessen** Repo publiziert.

## Die Lösung: nicht raten, sondern deklarieren

Die Inferenz ist **entfernt**, nicht repariert. `bug-reports/` enthält Items für mehrere Systeme — es gibt keinen einen richtigen Default, und ein Default, der mit dem Arbeitsverzeichnis variiert, ist genau der Mechanismus, durch den ein Issue im falschen Repo landet.

Auflösung jetzt **item-bezogen**, autoritativstes zuerst:

| | Quelle | wann |
|---|---|---|
| 1 | `- **Issue:** owner/repo#N` | nach dem Anlegen — das *ist* die Tatsache |
| 2 | `- **Repo:** owner/repo` | davor — im File deklariert, also mitreviewt |
| 3 | `$M3C_BUG_REPO` | ausgesprochener Einzelfall-Override |
| 4 | **Verweigerung** mit Nennung der fehlenden Zeile | sonst |

Das File schlägt die Umgebung **absichtlich**: ein Item, das sein Ziel deklariert hat, darf nicht durch eine verirrte Variable umgeleitet werden.

## Die Fixtures haben sich hier zweimal bezahlt gemacht

Zuerst fanden sie einen **echten Defekt in genau diesem Patch**: `sed s///p` gibt die ganze Zeile aus, der Extraktor lieferte also `acme/widget#77` statt `acme/widget`, und jedes `close` verweigerte. Acht Assertions fielen um, bevor der Fehler jemand anderen erreichte.

Dann haben sie das Verhalten festgenagelt. Ein Wegwerf-Checkout, dessen `origin` auf ein unbeteiligtes Repository zeigt, beweist jetzt:

- `close` und `sync` adressieren weiterhin das **aufgezeichnete** Repo
- ein verirrtes `M3C_BUG_REPO` kann ein Item mit Issue **nicht** umleiten
- die deklarierte `Repo:`-Zeile schlägt die Umgebung
- ein fehlendes Ziel **verweigert**, statt zu raten — und es wird nichts angelegt
- ein malformter Wert (`https://github.com/owner/repo`) wird abgewiesen, bevor er `gh` erreicht

**74 Assertions**, weiterhin ohne Netz.

## Verifiziert an den echten Daten

`sync FR-0096` läuft jetzt aus dem Maintenance-Checkout heraus **ohne jede Umgebungsvariable** korrekt durch — vorher hätte derselbe Aufruf das private Repo befragt.

Die `bug-report`- und `feature-request`-Skills schreiben die `Repo:`-Zeile in den Metadatenblock, damit das Ziel dort deklariert wird, wo es gereviewt wird.

## Verifikation

`boundary-gate` clean · `boundary-gate.test.sh` 13/13 · `bugtracker.test.sh` 74/74 · `check-docs.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)