### PR TITLE
fix(skillctl): sign/verify-sig accept the bundle positional before or after flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/ac04005305ee1637900
 
 skillctl keygen --out ~/.config/m3c/skill-keys/mykey            # ed25519 → mykey.priv + mykey.pub
 skillctl pack --skill ./my-skill -o my-skill.skb --name my-skill --version 1.0.0
-skillctl sign my-skill.skb --key ~/.config/m3c/skill-keys/mykey.priv
-skillctl verify-sig my-skill.skb --pubkey ~/.config/m3c/skill-keys/mykey.pub   # offline, no server
+skillctl sign --key ~/.config/m3c/skill-keys/mykey.priv my-skill.skb
+skillctl verify-sig --pubkey ~/.config/m3c/skill-keys/mykey.pub my-skill.skb   # offline, no server
 ```
 
 → **Full walkthrough:** [Quickstart: skillctl](docs/quickstart-skillctl.md)

--- a/cmd/skillctl/signing_cmds.go
+++ b/cmd/skillctl/signing_cmds.go
@@ -12,9 +12,49 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 
 	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
 )
+
+// extractBundlePositional pulls the single non-flag positional (the BUNDLE.skb
+// path) out of args from ANY position, returning it plus the remaining flag args
+// for fs.Parse. valueFlags names the flags that consume a following value, so
+// that value is not mistaken for the positional (`--key K` → K is not the
+// bundle). Go's stdlib flag package stops at the first positional, so without
+// this the bundle could only come AFTER the flags; this lets users write it
+// before OR after (matching the usage brief, like `attest`). Returns ("", args)
+// when zero or more than one positional is present, so the caller's usage check
+// fires a clean exit-2 instead of guessing.
+func extractBundlePositional(args []string, valueFlags map[string]bool) (bundle string, rest []string) {
+	rest = make([]string, 0, len(args))
+	var positionals []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--" { // POSIX end-of-flags: everything after is positional
+			rest = append(rest, a)
+			positionals = append(positionals, args[i+1:]...)
+			break
+		}
+		if len(a) > 1 && strings.HasPrefix(a, "-") {
+			rest = append(rest, a)
+			name := strings.TrimLeft(a, "-")
+			if strings.ContainsRune(name, '=') {
+				continue // -flag=value is self-contained
+			}
+			if valueFlags[name] && i+1 < len(args) {
+				rest = append(rest, args[i+1]) // -flag value: keep the value with the flag
+				i++
+			}
+			continue
+		}
+		positionals = append(positionals, a)
+	}
+	if len(positionals) == 1 {
+		return positionals[0], rest
+	}
+	return "", args
+}
 
 // Exit codes (from S1 brief). Reserve numbers; do not redefine elsewhere.
 const (
@@ -67,21 +107,23 @@ func runSign(args []string, stdout, stderr io.Writer) int {
 	keyPath := fs.String("key", "", "Path to PEM PKCS#8 ed25519 private key (mode 0600). Required.")
 	identityID := fs.String("identity-id", "", "Author identity id — ADVISORY ONLY, NOT embedded in the signature. The detached signature is over the bundle digest alone; author identity is bound at verify time via the trust-root pin (SPEC-0188 D4), not by this flag.")
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "Usage: skillctl sign BUNDLE.skb --key PATH.priv [--identity-id ID]")
+		fmt.Fprintln(stderr, "Usage: skillctl sign --key PATH.priv [--identity-id ID] BUNDLE.skb")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Computes the bundle's SHA-256 digest, signs the 32 raw bytes")
 		fmt.Fprintln(stderr, "with ed25519, and writes:")
 		fmt.Fprintln(stderr, "  <BUNDLE.skb>.<digest_hex>.author.sig (64 raw bytes, mode 0644)")
+		fmt.Fprintln(stderr, "BUNDLE.skb may appear before or after the flags.")
 		fs.PrintDefaults()
 	}
-	if err := fs.Parse(args); err != nil {
+	// The bundle positional may come before OR after the flags.
+	bundlePath, flagArgs := extractBundlePositional(args, map[string]bool{"key": true, "identity-id": true})
+	if err := fs.Parse(flagArgs); err != nil {
 		return exitUsage
 	}
-	if fs.NArg() != 1 {
+	if bundlePath == "" || fs.NArg() != 0 {
 		fs.Usage()
 		return exitUsage
 	}
-	bundlePath := fs.Arg(0)
 	if *keyPath == "" {
 		fs.Usage()
 		return exitUsage
@@ -107,21 +149,23 @@ func runVerifySig(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	pubPath := fs.String("pubkey", "", "Path to PEM SPKI ed25519 public key. Required.")
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "Usage: skillctl verify-sig BUNDLE.skb --pubkey PATH.pub")
+		fmt.Fprintln(stderr, "Usage: skillctl verify-sig --pubkey PATH.pub BUNDLE.skb")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Recomputes the bundle's SHA-256 digest, locates the matching")
 		fmt.Fprintln(stderr, "<BUNDLE.skb>.<digest_hex>.author.sig file, and verifies it.")
 		fmt.Fprintln(stderr, "Exit codes: 0 ok | 11 signature invalid | 1 other error | 2 usage.")
+		fmt.Fprintln(stderr, "BUNDLE.skb may appear before or after the flags.")
 		fs.PrintDefaults()
 	}
-	if err := fs.Parse(args); err != nil {
+	// The bundle positional may come before OR after the flags.
+	bundlePath, flagArgs := extractBundlePositional(args, map[string]bool{"pubkey": true})
+	if err := fs.Parse(flagArgs); err != nil {
 		return exitUsage
 	}
-	if fs.NArg() != 1 {
+	if bundlePath == "" || fs.NArg() != 0 {
 		fs.Usage()
 		return exitUsage
 	}
-	bundlePath := fs.Arg(0)
 	if *pubPath == "" {
 		fs.Usage()
 		return exitUsage

--- a/cmd/skillctl/signing_cmds_test.go
+++ b/cmd/skillctl/signing_cmds_test.go
@@ -165,3 +165,73 @@ func TestRunVerifySig_UsageErrors(t *testing.T) {
 		t.Errorf("missing --pubkey exit=%d, want %d", code, exitUsage)
 	}
 }
+
+// TestSignVerify_ArgOrder proves the bundle positional works BEFORE the flags
+// (the order the usage brief + README show) as well as after, and in the
+// `--key=value` form — the fix for Go's flag package stopping at the first
+// positional. Before the fix, "sign BUNDLE.skb --key K" failed with a usage error.
+func TestSignVerify_ArgOrder(t *testing.T) {
+	dir := t.TempDir()
+	key := filepath.Join(dir, "k")
+	var out, errb bytes.Buffer
+	if code := runKeygen([]string{"--out", key}, &out, &errb); code != 0 {
+		t.Fatalf("keygen exit=%d stderr=%s", code, errb.String())
+	}
+	priv, pub := key+".priv", key+".pub"
+
+	cases := []struct {
+		name    string
+		signArg func(b string) []string
+		verArg  func(b string) []string
+	}{
+		{"positional-before-flags",
+			func(b string) []string { return []string{b, "--key", priv} },
+			func(b string) []string { return []string{b, "--pubkey", pub} }},
+		{"flags-before-positional",
+			func(b string) []string { return []string{"--key", priv, b} },
+			func(b string) []string { return []string{"--pubkey", pub, b} }},
+		{"key-equals-form",
+			func(b string) []string { return []string{b, "--key=" + priv} },
+			func(b string) []string { return []string{"--pubkey=" + pub, b} }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := makeBundleForCLI(t, dir, tc.name+".skb")
+			var so, se bytes.Buffer
+			if code := runSign(tc.signArg(bundle), &so, &se); code != 0 {
+				t.Fatalf("sign exit=%d stderr=%s", code, se.String())
+			}
+			so.Reset()
+			se.Reset()
+			if code := runVerifySig(tc.verArg(bundle), &so, &se); code != 0 {
+				t.Fatalf("verify-sig exit=%d stderr=%s", code, se.String())
+			}
+		})
+	}
+}
+
+// TestExtractBundlePositional pins the parser: the bundle is found at any slot,
+// a value-taking flag's value is never mistaken for it, and zero/two positionals
+// bail to "" so the caller emits a clean usage error.
+func TestExtractBundlePositional(t *testing.T) {
+	vf := map[string]bool{"key": true, "identity-id": true}
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"after-flags", []string{"--key", "k.priv", "b.skb"}, "b.skb"},
+		{"before-flags", []string{"b.skb", "--key", "k.priv"}, "b.skb"},
+		{"middle", []string{"--key", "k.priv", "b.skb", "--identity-id", "id"}, "b.skb"},
+		{"key-equals", []string{"--key=k.priv", "b.skb"}, "b.skb"},
+		{"value-not-mistaken", []string{"--key", "k.priv"}, ""},
+		{"two-positionals", []string{"a.skb", "b.skb", "--key", "k.priv"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, _ := extractBundlePositional(tc.in, vf); got != tc.want {
+				t.Errorf("bundle=%q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/docs/acceptance-skillctl-lifecycle.md
+++ b/docs/acceptance-skillctl-lifecycle.md
@@ -134,11 +134,11 @@ skillctl pack --skill ~/.claude/skills/<name> -o <name>@<ver>.skb \
 #   Determinism check (acceptance): pack a second time and diff — MUST be byte-identical.
 
 # A3. Sign the bundle (detached ed25519 author signature over the digest).
-skillctl sign <name>@<ver>.skb --key ~/.config/m3c/skill-registry-self.priv --identity-id id:mirko@m3c
+skillctl sign --key ~/.config/m3c/skill-registry-self.priv --identity-id id:mirko@m3c <name>@<ver>.skb
 #   → sidecar <bundle>.<hex>.author.sig ; prints digest sha256:<hex>
 
 # A4. Local self-check BEFORE publishing.
-skillctl verify-sig <name>@<ver>.skb --pubkey ~/.config/m3c/skill-registry-self.pub
+skillctl verify-sig --pubkey ~/.config/m3c/skill-registry-self.pub <name>@<ver>.skb
 #   → EXIT 0 expected.
 
 # --- HUMAN CHECKPOINT: admit (publishing to the registry) ---

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -215,7 +215,7 @@ Exit: `0` ok · `2` usage / validation error.
 ### `sign` — sign a bundle
 
 ```bash
-skillctl sign BUNDLE.skb --key PATH.priv [--identity-id ID]
+skillctl sign --key PATH.priv [--identity-id ID] BUNDLE.skb
 ```
 
 Computes the bundle's SHA-256 digest, signs the 32 raw digest bytes with ed25519, and writes
@@ -227,7 +227,7 @@ a **detached** signature: `<BUNDLE.skb>.<digest_hex>.author.sig` (64 raw bytes, 
 | `-identity-id` | Author identity id — **advisory only, NOT embedded in the signature**. The detached signature is over the bundle digest alone; author identity is bound at verify time via the trust-root pin (SPEC-0188 D4), not by this flag. Recorded for your own bookkeeping. |
 
 ```bash
-skillctl sign my-skill.skb --key ~/.config/m3c/skill-keys/mykey.priv
+skillctl sign --key ~/.config/m3c/skill-keys/mykey.priv my-skill.skb
 ```
 
 Exit: `0` ok · `2` usage.
@@ -237,7 +237,7 @@ Exit: `0` ok · `2` usage.
 ### `verify-sig` — verify a detached signature (offline)
 
 ```bash
-skillctl verify-sig BUNDLE.skb --pubkey PATH.pub
+skillctl verify-sig --pubkey PATH.pub BUNDLE.skb
 ```
 
 Recomputes the bundle's digest, locates the matching `.author.sig`, and verifies it. **No
@@ -248,7 +248,7 @@ network, no CA.**
 | `-pubkey` | Path to PEM SPKI ed25519 public key. **Required.** |
 
 ```bash
-skillctl verify-sig my-skill.skb --pubkey ~/.config/m3c/skill-keys/mykey.pub
+skillctl verify-sig --pubkey ~/.config/m3c/skill-keys/mykey.pub my-skill.skb
 ```
 
 Exit: `0` ok · `11` signature invalid · `1` other error · `2` usage.
@@ -1402,8 +1402,8 @@ skillctl keygen --out ~/.config/m3c/skill-keys/author            # -> author.pri
 skillctl pack --skill ~/.claude/skills/my-skill -o my-skill.skb \
   --name my-skill --version 1.0.0 --summary "…" \
   --data-scopes '{"id":"ds:fs/cwd","kind":"local_fs","access":"write","scope":"<cwd>/out/**","reason":"…"}'
-skillctl sign my-skill.skb --key ~/.config/m3c/skill-keys/author.priv
-skillctl verify-sig my-skill.skb --pubkey ~/.config/m3c/skill-keys/author.pub   # offline self-check
+skillctl sign --key ~/.config/m3c/skill-keys/author.priv my-skill.skb
+skillctl verify-sig --pubkey ~/.config/m3c/skill-keys/author.pub my-skill.skb   # offline self-check
 ```
 
 You may **not** attest your own skill (reviewer≠author is enforced — SPEC-0246) and `--author-intent`

--- a/docs/quickstart-skillctl.md
+++ b/docs/quickstart-skillctl.md
@@ -119,7 +119,7 @@ Useful optional manifest fields:
 ## 4. Sign it
 
 ```bash
-skillctl sign my-skill.skb --key ~/.config/m3c/skill-keys/mykey.priv
+skillctl sign --key ~/.config/m3c/skill-keys/mykey.priv my-skill.skb
 ```
 
 This computes the bundle's SHA-256 digest, signs it with ed25519, and writes a **detached**
@@ -130,7 +130,7 @@ signature next to the bundle: `my-skill.skb.<digest>.author.sig`.
 ## 5. Verify it — offline
 
 ```bash
-skillctl verify-sig my-skill.skb --pubkey ~/.config/m3c/skill-keys/mykey.pub
+skillctl verify-sig --pubkey ~/.config/m3c/skill-keys/mykey.pub my-skill.skb
 ```
 
 It recomputes the digest, finds the matching signature, and checks it. **No network, no CA.**


### PR DESCRIPTION
The release smoke test surfaced this: Go's stdlib `flag` package stops at the first positional, so `skillctl sign BUNDLE.skb --key K` — **the order the usage brief, README and manual all show** — failed with a usage error. Only flags-first worked, so the quickstart commands were broken on the shipped v0.4.0.

## (2) Code — accept the positional anywhere
- **`extractBundlePositional()`** pulls the single `.skb` positional from any slot; it is **value-flag-aware** (`--key K` → `K` is never mistaken for the bundle), mirroring how `attest` handles its digest positional. Both `sign` and `verify-sig` use it. Usage strings updated; **both orders now work** (`--key=value` too).
- **Tests**: `TestSignVerify_ArgOrder` (positional before/after/`=`-form, sign→verify round-trip) + `TestExtractBundlePositional` (any slot · value-not-mistaken · zero/two positionals → clean usage error).

## (1) Docs — normalize to the flags-first form
README + quickstart + manual + acceptance `sign`/`verify-sig` examples all reordered to `--flag value BUNDLE.skb`. Flags-first is the **universally safe** order: it works on the already-shipped **v0.4.0** (where positional-first fails) *and* after this fix ships.

## Gates
`check-docs` (docaudit) **PASS** · `go vet` clean · `./cmd/skillctl` tests ok · gofmt-clean. Verified manually against a fresh build: `sign B.skb --key K`, `sign --key K B.skb`, `--key=K`, and the no-bundle negative (exit 2) all behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)