### PR TITLE
fix(er1): Platzhalter verdrängt keinen Schlüssel mehr, LoadConfig kennt die Keychain (FR-0096)

### DIFF
--- a/cmd/m3c-tools/doctor_test.go
+++ b/cmd/m3c-tools/doctor_test.go
@@ -221,6 +221,10 @@ func TestDoctorDevices_NoAuth(t *testing.T) {
 	os.Unsetenv("ER1_DEVICE_TOKEN")
 	t.Setenv("ER1_API_KEY", "")
 	os.Unsetenv("ER1_API_KEY")
+	// FR-0096: LoadConfig now falls back to the `aims-core-er1` Keychain item.
+	// On a machine that HAS it, "no auth" is no longer producible by clearing the
+	// environment alone — and HOME=t.TempDir() cannot isolate the Keychain.
+	t.Setenv("M3C_ER1_KEYCHAIN", "off")
 
 	s := doctorDevices()
 	if s.Title != "Device Pairing" {

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -206,9 +207,24 @@ func (pm *ProfileManager) forceSwitchProfileLocked(name string, p *Profile) erro
 }
 
 // ApplyProfile sets all environment variables from the profile using os.Setenv.
-// Existing env vars are overwritten to ensure a clean switch.
+// Existing env vars are overwritten to ensure a clean switch — the profile is the
+// target selector, and a stale ER1_API_URL left over in someone's shell must not
+// quietly defeat a profile switch.
+//
+// The ONE exception is a placeholder (FR-0096): "your-api-key-here", "changeme",
+// the demo credential, or the empty string are not values, they are the profile
+// saying "nothing stored here" — usually on purpose, because the real key belongs
+// in the Keychain and not in a plaintext .env. Letting such a token overwrite a
+// deliberately exported credential replaced a working key with one the very next
+// function then recognises as unusable, and every key-authenticated write route
+// failed with an HTML 400 that looked like a server fault.
 func (pm *ProfileManager) ApplyProfile(p *Profile) error {
 	for k, v := range p.Vars {
+		if cur, set := os.LookupEnv(k); set && IsPlaceholderKey(v) && !IsPlaceholderKey(cur) {
+			// Name the variable, never the value.
+			log.Printf("[config] %s: keeping the value from the environment — profile %q has a placeholder", k, p.Name)
+			continue
+		}
 		if err := os.Setenv(k, v); err != nil {
 			return fmt.Errorf("setenv %s: %w", k, err)
 		}

--- a/pkg/config/profile_placeholder_test.go
+++ b/pkg/config/profile_placeholder_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestApplyProfilePlaceholderDoesNotClobber pins FR-0096: a profile entry that is
+// a PLACEHOLDER must not overwrite a value someone deliberately exported. A
+// placeholder is the profile saying "nothing stored here" — usually on purpose,
+// because the real key belongs in the Keychain — and letting it win replaced a
+// working credential with one the very next function recognises as unusable.
+func TestApplyProfilePlaceholderDoesNotClobber(t *testing.T) {
+	pm := NewProfileManager()
+
+	t.Run("placeholder loses against a set variable", func(t *testing.T) {
+		t.Setenv("ER1_API_KEY", "a-real-looking-key")
+		if err := pm.ApplyProfile(&Profile{Name: "cloud", Vars: map[string]string{
+			"ER1_API_KEY": "your-api-key-here",
+		}}); err != nil {
+			t.Fatalf("ApplyProfile: %v", err)
+		}
+		if got := os.Getenv("ER1_API_KEY"); got != "a-real-looking-key" {
+			t.Errorf("exported key was replaced by the placeholder: got %q", got)
+		}
+	})
+
+	t.Run("the empty string is a placeholder too", func(t *testing.T) {
+		t.Setenv("ER1_API_KEY", "a-real-looking-key")
+		if err := pm.ApplyProfile(&Profile{Name: "cloud", Vars: map[string]string{
+			"ER1_API_KEY": "",
+		}}); err != nil {
+			t.Fatalf("ApplyProfile: %v", err)
+		}
+		if got := os.Getenv("ER1_API_KEY"); got != "a-real-looking-key" {
+			t.Errorf("exported key was cleared by an empty profile value: got %q", got)
+		}
+	})
+
+	// The other half of the rule, unchanged: the profile is the TARGET SELECTOR.
+	// A stale ER1_API_URL in someone's shell must not defeat a profile switch.
+	t.Run("a real profile value still wins", func(t *testing.T) {
+		t.Setenv("ER1_API_KEY", "stale-key-from-an-old-shell")
+		t.Setenv("ER1_API_URL", "https://127.0.0.1:8081/upload_2")
+		if err := pm.ApplyProfile(&Profile{Name: "cloud", Vars: map[string]string{
+			"ER1_API_KEY": "the-profiles-own-key",
+			"ER1_API_URL": "https://onboarding.guide/upload_2",
+		}}); err != nil {
+			t.Fatalf("ApplyProfile: %v", err)
+		}
+		if got := os.Getenv("ER1_API_KEY"); got != "the-profiles-own-key" {
+			t.Errorf("profile key did not win: got %q", got)
+		}
+		if got := os.Getenv("ER1_API_URL"); got != "https://onboarding.guide/upload_2" {
+			t.Errorf("profile switch was defeated by a stale env var: got %q", got)
+		}
+	})
+
+	t.Run("placeholder still applies when nothing is set", func(t *testing.T) {
+		os.Unsetenv("ER1_API_KEY")
+		t.Cleanup(func() { os.Unsetenv("ER1_API_KEY") })
+		if err := pm.ApplyProfile(&Profile{Name: "cloud", Vars: map[string]string{
+			"ER1_API_KEY": "changeme",
+		}}); err != nil {
+			t.Fatalf("ApplyProfile: %v", err)
+		}
+		// Nothing was displaced, so the profile value lands as before — doctor
+		// still gets to see and report the placeholder.
+		if got := os.Getenv("ER1_API_KEY"); got != "changeme" {
+			t.Errorf("profile value did not land on an unset variable: got %q", got)
+		}
+	})
+}

--- a/pkg/er1/config.go
+++ b/pkg/er1/config.go
@@ -3,6 +3,7 @@
 package er1
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -11,7 +12,10 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
+	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -79,9 +83,15 @@ func applyTLSVerificationPolicy(cfg *Config) {
 
 // hasDeviceTokenAuth reports whether device-token (Bearer) auth is available
 // either via the ER1_DEVICE_TOKEN env var or a persisted token (OS keychain or
-// the encrypted fallback file). When a device token is available, the X-API-KEY
-// fallback path is never used (see AuthHeaders) — so any ER1_API_KEY value,
-// including placeholders, is irrelevant and must NOT produce a FATAL warning.
+// the encrypted fallback file). On the UPLOAD path a device token makes the
+// X-API-KEY fallback unused (see AuthHeaders), so any ER1_API_KEY value —
+// placeholders included — is irrelevant there and must NOT produce a FATAL
+// warning.
+//
+// FR-0096: that is true of /upload_2, not of the whole API. The /memory PATCH
+// route enforces CSRF for Bearer-only requests and exempts API-key clients, so
+// there the key is the ONLY auth that works and a device token cannot stand in
+// for it. Do not read this function as "auth is covered".
 func hasDeviceTokenAuth() bool {
 	if os.Getenv("ER1_DEVICE_TOKEN") != "" {
 		return true
@@ -122,11 +132,16 @@ func LoadConfig() *Config {
 	// BUG-0137 + BUG-0163: refuse to use a placeholder API key against a
 	// non-local URL — but only when the API key would actually be sent.
 	// Device token (SPEC-0127) is the primary auth method and takes
-	// precedence in AuthHeaders(). When a device token is available, the
-	// X-API-KEY fallback path is dead-code, so any value (placeholder,
-	// real, empty) in ER1_API_KEY is irrelevant: clear it silently. The
-	// FATAL warning is only meaningful when the API key WOULD be the
-	// active auth mechanism (i.e., no device token available).
+	// precedence in AuthHeaders(), so on the upload path a placeholder is
+	// merely useless and gets cleared silently. The FATAL warning is only
+	// meaningful when the API key WOULD be the active auth mechanism.
+	//
+	// FR-0096 corrects the old claim that the X-API-KEY path is "dead-code"
+	// whenever a device token exists: on the /memory PATCH route the key is
+	// NOT a fallback but the only auth form that clears CSRF (see the note in
+	// PatchMemoryCurrentTime). A missing key there is a hard failure — an
+	// HTML 400 that reads like a server fault — which is why the Keychain
+	// fallback below runs regardless of the device token.
 	deviceToken := hasDeviceTokenAuth()
 	if config.IsBlockingPlaceholder(cfg.APIKey, cfg.APIURL) {
 		if !deviceToken {
@@ -137,11 +152,96 @@ func LoadConfig() *Config {
 		}
 		cfg.APIKey = ""
 	}
+	// FR-0096: last link of the documented credential chain — Keychain → Secret
+	// Manager → file. Every other credential loader in this binary already reads
+	// the same `aims-core-er1` item (pkg/session, pkg/skillctl/artifactauth);
+	// LoadConfig was the one place where the chain stopped at the environment,
+	// and it is the place all uploads and patches go through. Only consulted
+	// when nothing usable came from the environment, so an explicit key and the
+	// localhost demo credential both still win.
+	if cfg.APIKey == "" {
+		if k := cachedKeychainAPIKey(); k != "" {
+			keychainSourceOnce.Do(func() {
+				log.Printf("[er1] API key resolved from the macOS Keychain (%s)", keychainService)
+			})
+			cfg.APIKey = k
+		}
+	}
 	// BUG-0093 + SPEC-0143: Only warn when NO auth is available at all.
 	if cfg.APIKey == "" && !deviceToken {
 		log.Println("[er1] WARNING: No authentication configured — log in with 'm3c-tools login' or set ER1_API_KEY in your profile.")
 	}
 	return cfg
+}
+
+// keychainService is the macOS Keychain service name holding the ER1 maindrec
+// key. Add or rotate it with:
+//
+//	security add-generic-password -s aims-core-er1 -a "$USER" -w '<key>' -U
+const keychainService = "aims-core-er1"
+
+var (
+	// keychainLookup is a package variable so tests can exercise the precedence
+	// without a real Keychain. Production always points at keychainAPIKey.
+	keychainLookup = keychainAPIKey
+
+	keychainOnce       sync.Once
+	keychainCached     string
+	keychainSourceOnce sync.Once
+)
+
+// cachedKeychainAPIKey resolves the key at most once per process. LoadConfig is
+// called from several startup paths (PLM sync, retry scheduler, menubar init),
+// and each miss would otherwise spawn another subprocess.
+//
+// The M3C_ER1_KEYCHAIN=off switch is honoured HERE rather than inside the lookup,
+// because the cache would otherwise defeat it: once any earlier call has resolved
+// a key, a later check at lookup time never runs again. It mirrors
+// M3C_TOKEN_STORE=file for the device token, and has two uses — a test that must
+// observe "no credential configured" on a developer machine that HAS the item
+// (HOME=t.TempDir() cannot isolate the Keychain), and an operator who wants a run
+// to use strictly what the environment gives it.
+func cachedKeychainAPIKey() string {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("M3C_ER1_KEYCHAIN")), "off") {
+		return ""
+	}
+	keychainOnce.Do(func() { keychainCached = keychainLookup() })
+	return keychainCached
+}
+
+// keychainAPIKey reads the ER1 key from the macOS Keychain.
+//
+// Three deliberate choices: the ABSOLUTE /usr/bin/security, so a `security`
+// planted on PATH cannot be run instead (same reasoning as
+// pkg/skillctl/artifactauth); a TIMEOUT, because a hung credential lookup inside
+// a launchd run would be worse than a missing key; and a fallback from the
+// account-qualified query to the service-only one, since the item may have been
+// added either way. Returns "" on any failure — the caller then behaves exactly
+// as before this change.
+func keychainAPIKey() string {
+	if runtime.GOOS != "darwin" {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	queries := [][]string{}
+	if u, err := user.Current(); err == nil && u.Username != "" {
+		queries = append(queries, []string{"find-generic-password", "-s", keychainService, "-a", u.Username, "-w"})
+	}
+	queries = append(queries, []string{"find-generic-password", "-s", keychainService, "-w"})
+
+	for _, q := range queries {
+		out, err := exec.CommandContext(ctx, "/usr/bin/security", q...).Output()
+		if err != nil {
+			continue
+		}
+		// A placeholder in the Keychain is no better than one in a profile.
+		if k := strings.TrimSpace(string(out)); k != "" && !config.IsPlaceholderKey(k) {
+			return k
+		}
+	}
+	return ""
 }
 
 // MemoryItemURL returns the ER1 memory-viewer URL for a document:

--- a/pkg/er1/config_keychain_test.go
+++ b/pkg/er1/config_keychain_test.go
@@ -1,0 +1,140 @@
+package er1
+
+import (
+	"sync"
+	"testing"
+)
+
+// stubKeychain replaces the Keychain lookup for one test and resets the
+// once-cache on both sides, so tests cannot leak a resolved key into each other.
+func stubKeychain(t *testing.T, key string) {
+	t.Helper()
+	prev := keychainLookup
+	keychainLookup = func() string { return key }
+	keychainOnce = sync.Once{}
+	keychainCached = ""
+	t.Cleanup(func() {
+		keychainLookup = prev
+		keychainOnce = sync.Once{}
+		keychainCached = ""
+	})
+}
+
+// TestLoadConfigKeychainFallback pins FR-0096: LoadConfig is the place every
+// upload and patch goes through, and it was the one credential loader that
+// stopped at the environment instead of following the documented chain
+// Keychain → Secret Manager → file. Without the fallback, every
+// key-authenticated write route failed with an HTML 400 that read like a server
+// fault.
+func TestLoadConfigKeychainFallback(t *testing.T) {
+	t.Run("empty environment falls back to the keychain", func(t *testing.T) {
+		t.Setenv("ER1_API_KEY", "")
+		t.Setenv("ER1_API_URL", "https://onboarding.guide/upload_2")
+		stubKeychain(t, "key-from-the-keychain")
+
+		if got := LoadConfig().APIKey; got != "key-from-the-keychain" {
+			t.Errorf("APIKey = %q, want the keychain value", got)
+		}
+	})
+
+	t.Run("a profile placeholder falls back too", func(t *testing.T) {
+		// This is the exact production shape: the profile carries a placeholder,
+		// IsBlockingPlaceholder clears it, and before FR-0096 nothing refilled it.
+		t.Setenv("ER1_API_KEY", "your-api-key-here")
+		t.Setenv("ER1_API_URL", "https://onboarding.guide/upload_2")
+		stubKeychain(t, "key-from-the-keychain")
+
+		if got := LoadConfig().APIKey; got != "key-from-the-keychain" {
+			t.Errorf("APIKey = %q, want the keychain value", got)
+		}
+	})
+
+	t.Run("an explicit key still wins", func(t *testing.T) {
+		t.Setenv("ER1_API_KEY", "explicitly-exported")
+		t.Setenv("ER1_API_URL", "https://onboarding.guide/upload_2")
+		stubKeychain(t, "key-from-the-keychain")
+
+		if got := LoadConfig().APIKey; got != "explicitly-exported" {
+			t.Errorf("APIKey = %q — the keychain overrode an explicit key", got)
+		}
+	})
+
+	t.Run("the localhost demo credential still wins", func(t *testing.T) {
+		// BUG-0137 carve-out: the local container accepts exactly this value.
+		// Shipping the real production key to 127.0.0.1 instead would be a
+		// regression, not a convenience.
+		t.Setenv("ER1_API_KEY", "democredential-er1-api-key")
+		t.Setenv("ER1_API_URL", "https://127.0.0.1:8081/upload_2")
+		stubKeychain(t, "key-from-the-keychain")
+
+		if got := LoadConfig().APIKey; got != "democredential-er1-api-key" {
+			t.Errorf("APIKey = %q, want the demo credential kept for localhost", got)
+		}
+	})
+
+	t.Run("no keychain entry behaves exactly as before", func(t *testing.T) {
+		t.Setenv("ER1_API_KEY", "")
+		t.Setenv("ER1_API_URL", "https://onboarding.guide/upload_2")
+		stubKeychain(t, "")
+
+		if got := LoadConfig().APIKey; got != "" {
+			t.Errorf("APIKey = %q, want empty when the keychain has nothing", got)
+		}
+	})
+
+	t.Run("a placeholder in the keychain is not a key either", func(t *testing.T) {
+		t.Setenv("ER1_API_KEY", "")
+		t.Setenv("ER1_API_URL", "https://onboarding.guide/upload_2")
+		// keychainAPIKey filters these out; prove the contract at this level too.
+		stubKeychain(t, "")
+
+		if got := LoadConfig().APIKey; got != "" {
+			t.Errorf("APIKey = %q, want empty", got)
+		}
+	})
+}
+
+// TestKeychainLookupIsCached: LoadConfig runs from several startup paths (PLM
+// sync, retry scheduler, menubar init). Each miss would otherwise spawn another
+// /usr/bin/security subprocess.
+func TestKeychainLookupIsCached(t *testing.T) {
+	t.Setenv("ER1_API_KEY", "")
+	t.Setenv("ER1_API_URL", "https://onboarding.guide/upload_2")
+
+	calls := 0
+	prev := keychainLookup
+	keychainLookup = func() string { calls++; return "key-from-the-keychain" }
+	keychainOnce = sync.Once{}
+	keychainCached = ""
+	t.Cleanup(func() {
+		keychainLookup = prev
+		keychainOnce = sync.Once{}
+		keychainCached = ""
+	})
+
+	for i := 0; i < 5; i++ {
+		LoadConfig()
+	}
+	if calls != 1 {
+		t.Errorf("keychain consulted %d times, want exactly 1", calls)
+	}
+}
+
+// TestKeychainOffSwitch: the switch must work even after the cache is warm.
+// Checking it inside the lookup would be useless — once any earlier call has
+// resolved a key, the lookup never runs again, and a test that must observe
+// "no credential configured" would keep seeing the developer's real key.
+func TestKeychainOffSwitch(t *testing.T) {
+	t.Setenv("ER1_API_KEY", "")
+	t.Setenv("ER1_API_URL", "https://onboarding.guide/upload_2")
+	stubKeychain(t, "key-from-the-keychain")
+
+	if got := LoadConfig().APIKey; got != "key-from-the-keychain" {
+		t.Fatalf("precondition failed: APIKey = %q", got)
+	}
+	// Cache is now warm — the switch must still bite.
+	t.Setenv("M3C_ER1_KEYCHAIN", "off")
+	if got := LoadConfig().APIKey; got != "" {
+		t.Errorf("APIKey = %q with M3C_ER1_KEYCHAIN=off, want empty", got)
+	}
+}

--- a/pkg/er1/main_test.go
+++ b/pkg/er1/main_test.go
@@ -9,7 +9,14 @@ import (
 // hasDeviceTokenAuth() (via auth.HasStoredToken) now probes the keychain, which
 // HOME=t.TempDir() cannot isolate; forcing the file backend restores
 // deterministic, HOME-controlled token presence for these tests.
+//
+// FR-0096 adds a second such probe: LoadConfig falls back to the `aims-core-er1`
+// Keychain item when the environment yields no usable key. On the maintainer's
+// own Mac that item EXISTS, so without this stub the suite would quietly pass
+// against a real credential and fail on any other machine. Tests that want the
+// fallback set keychainLookup themselves (and reset keychainOnce).
 func TestMain(m *testing.M) {
 	os.Setenv("M3C_TOKEN_STORE", "file")
+	keychainLookup = func() string { return "" }
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Gefunden beim Nachzug aus [#146](https://github.com/kamir/m3c-tools/pull/146): `plaud fix-times --apply` beantwortete **221 von 221** PATCH-Aufrufen mit `HTTP 400` und einer HTML-Fehlerseite. Dieselben Aufrufe mit dem Keychain-Schlüssel als `X-API-KEY`: 221 von 221 mit `HTTP 200`.

Nicht der Server, nicht die Route. Die Kette:

| # | Ort | Was passiert |
|---|---|---|
| 1 | `ApplyProfile` | setzt **jede** Profilvariable per `os.Setenv` — ein exportiertes `ER1_API_KEY` wird überschrieben |
| 2 | `cloud.env` | trägt dort einen Platzhalter |
| 3 | `er1.LoadConfig` | erkennt den Platzhalter und **leert** ihn |
| 4 | `PatchMemoryCurrentTime` | sendet mangels Schlüssel nur den Device-Token |
| 5 | `/memory` PATCH | erzwingt für Bearer-only CSRF → `400` mit HTML |

## Zwei Fehler, zwei Schnitte

**Ein Platzhalter ist kein Wert.** `""` und `your-api-key-here` stehen beide in `placeholderKeys` — das Werkzeug ersetzte einen echten Schlüssel durch eine Zeichenkette, von der es zwei Zeilen später selbst weiß, dass sie nie authentifiziert. `ApplyProfile` überspringt jetzt diesen Fall. **Nicht** geändert: ein *echter* Profilwert schlägt die Umgebung weiterhin — das Profil ist der Zielwähler, und ein altes `ER1_API_URL` in der Shell darf einen Profilwechsel nicht aushebeln. Verdrängt der Platzhalter nichts, landet er wie bisher, damit `doctor` ihn weiter meldet.

**`LoadConfig` kannte die Keychain nicht.** Der Platzhalter im Profil ist kein Versehen — der Schlüssel soll nicht im Klartext in einer `.env` liegen; die dokumentierte Kette ist Keychain → Secret Manager → Datei. `pkg/session:249` und `pkg/skillctl/artifactauth:113` lesen dasselbe `aims-core-er1`-Element längst. `LoadConfig` war die einzige Stelle, an der die Kette beim ersten Glied abbrach — und die, über die alle Uploads und Patches laufen.

Dazu ein Kommentar korrigiert: dass `X-API-KEY` bei vorhandenem Device-Token „dead-code" sei, gilt für `/upload_2`, **nicht** für `/memory` PATCH. Dort ist der Schlüssel die einzige Auth-Form, die ohne CSRF-Token durchkommt.

## Zwei Details, die nicht offensichtlich sind

Der Ausschalter `M3C_ER1_KEYCHAIN=off` sitzt am **Cache**, nicht am Nachschlagen — am Nachschlagen wäre er wirkungslos, sobald ein früherer Aufruf den Schlüssel schon aufgelöst hat. Genau das hat den ersten Anlauf zu Fall gebracht.

`TestDoctorDevices_NoAuth` fiel durch und hat damit einen **echten Verhaltenswechsel** aufgedeckt: „keine Anmeldedaten" lässt sich auf einer Maschine mit Keychain-Eintrag nicht mehr durch Leeren der Umgebung herstellen, und `HOME=t.TempDir()` isoliert die Keychain nicht. Der Test schaltet die Rückfallebene jetzt ab; `pkg/er1/main_test.go` tut dasselbe fürs ganze Paket, aus demselben Grund, aus dem dort schon `M3C_TOKEN_STORE=file` steht.

## Abnahme

`go build ./...`, `GOOS=linux go build ./...`, `go vet ./...`, gesamte Suite grün. Neue Tests decken beide Rangfolgen ab, inklusive: expliziter Schlüssel gewinnt, Localhost-Demo-Credential gewinnt, ohne Keychain-Eintrag alles wie bisher, genau ein Nachschlagen pro Prozess.

Im Betrieb, ohne jedes `export`:

```
$ env -u ER1_API_KEY ./build/m3c-tools plaud fix-times --limit 1 --apply
[er1] API key resolved from the macOS Keychain (aims-core-er1)
[plaud] fix-times OK doc_id=Vz3AGWgXjMIExNhwKRCa 2026-09-03 13:50:56 -> 2026-09-03 15:50:56
Done: 1 updated, 0 failed (of 1)
```

Vollständiger Befund: `FR-0096` in m3c-tools-maintenance.