### PR TITLE
docs: a manual page for the two-plane bug and feature tracking

### DIFF
--- a/docs/bug-tracking.md
+++ b/docs/bug-tracking.md
@@ -1,0 +1,227 @@
+---
+layout: default
+title: Bug & feature tracking
+---
+
+# Bug & feature tracking — the two planes
+
+A bug or a feature request lives in **two places**, and `scripts/bugtracker.sh` keeps them
+in step.
+
+| Plane | Where | Holds |
+|-------|-------|-------|
+| **Analysis** (private) | `$M3C_MAINTENANCE_DIR/bug-reports/<KIND>-NNNN-<slug>.md` | Everything: root cause or rationale, `file:line`, customer context, SPEC references. The source of truth. |
+| **Issue** (public) | a GitHub issue in the repository the item names | A **redacted restatement**: observed, expected, reproduction, version. Refers to the analysis **ID-only** (`BUG-0213`). |
+
+The issue is **never a copy** of the analysis. `bug-reports/` also holds items for systems
+this repository does not ship; those never leave the private plane.
+
+Two kinds of item, differing on exactly one word:
+
+| Kind | Closes as | Issue label |
+|------|-----------|-------------|
+| `BUG-NNNN` | `fixed` | `bug` |
+| `FR-NNNN` | `implemented` | `enhancement` |
+
+Ids resolve by kind — `BUG-0213`, `FR-0096`, `fr-96`, or a filename. A **bare number means
+a BUG**, so `96` can never silently resolve to the wrong item.
+
+---
+
+## Setup
+
+```bash
+export M3C_MAINTENANCE_DIR="$HOME/path/to/your-maintenance-repo"
+```
+
+That is the only variable you need. The target repository for an issue is **not** taken
+from the environment or from your working directory — see
+[Which repository an issue goes to](#which-repository-an-issue-goes-to).
+
+---
+
+## The item file
+
+Five lines are machine-read. Keep their exact spelling; the rest of the file is prose for
+humans.
+
+| Field | Meaning |
+|-------|---------|
+| `- **Status:**` | `open` · `in-progress` · `fixed` (BUG) / `implemented` (FR) · `wontfix` · `duplicate` |
+| `- **Public:**` | `yes` opts this item into a public issue. Anything else keeps it private. |
+| `- **Repo:**` | `owner/repo` the issue belongs in. Declared here because it is reviewed here. |
+| `- **Spec:**` | Which SPEC this serves. `none — <reason>` is a valid answer; a missing line is not. |
+| `- **Issue:**` | Written back by `open`: `owner/repo#42`. After that it is the authoritative target. |
+
+Reading tolerates the corpus as it stands — `**Status:** Fixed (2026-03-21)` reads as
+`fixed` — while writing is always canonical, so `sync` has something to parse.
+
+---
+
+## Commands
+
+```bash
+scripts/bugtracker.sh <command> [args]
+```
+
+| Command | Purpose |
+|---------|---------|
+| `next-id [BUG\|FR]` | Next free id of that kind (default `BUG`). Use it instead of counting files. |
+| `path <ID>` | Resolve the analysis file. |
+| `status <ID> [STATUS]` | Read, or set, the canonical status. |
+| `issue <ID>` | The linked issue reference, or empty for a private-only item. |
+| `spec <ID>` | The SPEC this item answers to. |
+| `redact-check [FILE\|-]` | Run the leak patterns over text. Exit `1` on a hit. |
+| `open <ID>` | Create the public issue and link it back. |
+| `close <ID> [--status S] [--comment TEXT]` | Set the status and close the issue. |
+| `sync [<ID>]` | Read-only: report the drift between file and issue. |
+
+Exit codes: `0` ok · `1` a check failed (drift, leak, refusal) · `2` usage or configuration
+error.
+
+---
+
+## Filing a bug
+
+```bash
+scripts/bugtracker.sh next-id                    # -> BUG-0213
+```
+
+Write `$M3C_MAINTENANCE_DIR/bug-reports/BUG-0213-<slug>.md` with the five fields above and
+the analysis. If it stays private, you are done.
+
+For a public bug, write the redacted body next to it as
+`BUG-0213-<slug>.public.md` — **line 1 is the issue title**, the rest is the body — then:
+
+```bash
+scripts/bugtracker.sh open BUG-0213
+```
+
+The `/bug-report` skill does all of this from a field observation.
+
+## Raising a feature request
+
+```bash
+scripts/bugtracker.sh next-id FR                 # -> FR-0096
+```
+
+Same shape, with two differences worth knowing:
+
+- A proposal is rarely **one** request. Split it where the asks could be accepted,
+  rejected, scheduled or built independently — and keep the author's own numbering out of
+  this repository's id space; record it in the body instead.
+- Several FRs from one proposal usually share **one** contract. Prefer a single SPEC with a
+  section per area over one SPEC per FR: a contract scattered across seven documents has
+  stopped being a contract.
+
+The `/feature-request` skill runs that flow.
+
+## Closing
+
+```bash
+scripts/bugtracker.sh close BUG-0213 --comment "Fixed in v2.11.1 — see BUG-0213."
+scripts/bugtracker.sh sync  BUG-0213
+```
+
+`close` sets the status and, if an issue is linked, comments and closes it. Use
+`--status wontfix` or `--status duplicate` when that is the honest outcome; those close the
+issue as *not planned*. `sync` exits `0` when the file and the issue tell the same story.
+
+---
+
+## The refusals, and why they exist
+
+A public issue is indexed the moment it is created and cannot be un-published. Every guard
+below therefore fails **closed** — it stops rather than guesses.
+
+| `open` refuses when | Fix it by |
+|---------------------|-----------|
+| the item does not declare `- **Public:** yes` | deciding the plane deliberately, per item |
+| there is no `.public.md` body | writing the redacted restatement |
+| the body carries private-plane content | rewriting the body — **never** by working around the refusal |
+| no repository is named | adding the `- **Repo:**` line |
+
+| `close` refuses when | Fix it by |
+|----------------------|-----------|
+| the item has no `- **Spec:**` line and is being closed as done | answering the question — including `none — <reason>` |
+| a `--comment` carries private-plane content | rewriting the comment |
+
+The Spec rule is the mechanical form of a working rule: **solving an issue means serving
+the contract it belongs to.** It deliberately does not demand a *particular* answer; it
+only prevents the question from being skipped instead of decided, which is how "update the
+SPEC" quietly stops happening.
+
+---
+
+## Redaction
+
+The issue is written for someone who cannot read the private plane. If the body only makes
+sense with the internal document open, it is not finished.
+
+| Keep | Drop |
+|------|------|
+| observed behaviour, expected behaviour | a path into the private repo |
+| reproduction, affected version | internal endpoints and API paths |
+| the user-visible command and its output | ER1 context-ids, secret header names |
+| acceptance criteria | customer or tenant names |
+| ID-only references (`BUG-0213`, `SPEC-0401`) | SPEC *paths* — the id alone is fine |
+
+The patterns are not a second opinion: they live in `tools/leak-patterns.txt` and are read
+by **both** gates —
+
+- `tools/boundary-gate.sh`, the **commit** gate that runs in CI over tracked files, and
+- `scripts/bugtracker.sh`, the **post** gate over issue bodies and comments.
+
+An issue body reaches GitHub through the API, so no CI job ever sees it. That is why the
+second consumer exists, and why the patterns are defined once: a sixth pattern added to
+the commit gate alone would leave the publishing path unchanged, silently.
+
+Check any text yourself:
+
+```bash
+printf 'Observed: the last frame is dropped. See BUG-0213.\n' \
+  | scripts/bugtracker.sh redact-check -
+```
+
+---
+
+## Which repository an issue goes to
+
+The target is a property of the **item**, never of your working directory. Resolution runs
+most-authoritative-first:
+
+1. the recorded `- **Issue:** owner/repo#N` — after creation, this *is* the fact
+2. the declared `- **Repo:** owner/repo` — before creation, reviewed in the file
+3. `$M3C_BUG_REPO` — a stated override for a one-off
+4. otherwise it **refuses**, naming the line to add
+
+The file outranks the environment on purpose: an item that has declared its target must
+not be redirected elsewhere by a stray variable.
+
+> **Why there is no fallback to `git remote origin`.** `bug-reports/` holds items for
+> several systems, so there is no single correct default to infer — and a default that
+> varies with where you happen to stand is exactly how an issue lands in the wrong
+> repository, including someone else's public one.
+
+---
+
+## Testing
+
+Both fixture suites are pure bash, touch no network, and run in the `boundary-gate`
+workflow on every push:
+
+```bash
+tools/boundary-gate.test.sh     # every leak pattern still blocks
+scripts/bugtracker.test.sh      # the tracker, with a stubbed gh
+```
+
+The first exists because a leak gate that stops flagging still reads green, so it is
+asserted from the failing side. The second is mostly refusals, for the same reason the
+guards above are: publishing cannot be undone.
+
+---
+
+## See also
+
+- [Manual: m3c-tools](manual-m3c-tools.md) — the capture toolkit, command by command
+- [Manual: skillctl](manual-skillctl.md) — the agent-skill trust lifecycle

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,7 @@ agent skills that act on it (sign, admit, verify, revoke — offline-verifiable)
 - [Quickstart: skillctl](quickstart-skillctl) — sign, install and verify a skill in 5 minutes
 - [Manual: m3c-tools](manual-m3c-tools) — every command, flag and config variable
 - [Manual: skillctl](manual-skillctl) — the full trust lifecycle, command by command
+- [Bug & feature tracking](bug-tracking) — the private analysis file, the public issue, and the guards between them
 - [Acceptance & Handover: skill lifecycle](acceptance-skillctl-lifecycle) — the two-person (Mirko → Eric) procedure over ER1, with success criteria
 - [Runbook: two-person ER1 exchange](runbook-two-person-er1-exchange) — copy-paste prod runbook (Mirko + Eric lanes) for the live exercise
 - [CISO onboarding deck](skillctl-ciso-deck.html) — sharp, honest arguments to defend skillctl to a security expert + a CTO (infographic)

--- a/docs/manual-m3c-tools.md
+++ b/docs/manual-m3c-tools.md
@@ -727,4 +727,5 @@ m3c-tools cancel vid-001
 - [Menu Bar App](menubar-app.md) — projects, the Gantt time tracker, and reverse tracking in depth
 - [Manual: skillctl](manual-skillctl.md) — the agent-skill trust lifecycle, command by command
 - [Menu Bar App](menubar-app.md) — every menu item and the Observation Window
+- [Bug & feature tracking](bug-tracking.md) — how a defect or a request is tracked across the private and public planes
 - [Platform differences](PLATFORM-DIFFERENCES.md) — macOS vs Linux vs Windows behavior

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -1609,3 +1609,4 @@ ER1 credentials for registry-backed commands resolve via Keychain → Secret Man
 - **[Acceptance & Handover: the skill lifecycle](acceptance-skillctl-lifecycle.md)** — the two-person (Mirko → Eric) acceptance procedure over ER1, with success criteria.
 - **[Quickstart: the offline demo](quickstart-skillctl-demo.md)** — the `skillctl-demo` Kata walkthrough (CISO/booth).
 - **[Manual: m3c-tools](manual-m3c-tools.md)** — the memory-capture toolkit `skillctl` ships alongside.
+- **[Bug & feature tracking](bug-tracking.md)** — how a defect or a request is tracked across the private and public planes.

--- a/tools/id-xref-lint.sh
+++ b/tools/id-xref-lint.sh
@@ -55,8 +55,15 @@ XREF_EXEMPT_EXACT=(
   tools/id-xref-lint.sh          # this lint — its comments carry example bad patterns
   tools/id-xref-lint.test.sh     # its self-test — fixtures embed dangling + glued ids
   tools/boundary-gate.sh         # docstring cites SPEC-1234 / ADR-1234 as placeholders
+  tools/leak-patterns.txt        # defines the rule; its comment cites SPEC-1234 as THE placeholder
+  tools/boundary-gate.test.sh    # fixtures embed dangling ids + a deliberately-bad private path
+  scripts/bugtracker.test.sh     # same: the post-gate fixtures must contain what they reject
   CONTENT-TOPOLOGY.md            # the public topology doc: placeholder ids + rule examples
 )
+
+# NOTE: this list and tools/boundary-gate.sh's BASE_EXACT now name the same set of
+# fixture/definition files, for the same reason — a file whose PURPOSE is the rule has to
+# contain what the rule forbids. Keep them in step; nothing else belongs on either.
 
 # ---- Marker + violation patterns (ERE) -----------------------------------------
 # NOTE: scope is SPEC + ADR per SPEC-0358 §4 (the resolvable design/decision plane).


### PR DESCRIPTION
Dokumentiert, was die letzten drei PRs gebaut haben: die private Analysedatei, das öffentliche Issue und jede Wache dazwischen. Verlinkt aus dem Docs-Index und aus dem „See also" beider Manuals.

## Warum eine eigene Seite

Das ist keine Ablagevorliebe. **docaudit** liest `docs/manual-m3c-tools.md` und `docs/manual-skillctl.md` als die Flag-Oberflächen der beiden CLIs — die Flags des Trackers dort zu dokumentieren hätte sie zu **PHANTOMs** gemacht.

Geprüft statt angenommen:

```
$ printf '| `--comment` | … |\n| `--public` | … |\n' >> docs/manual-m3c-tools.md
$ go run ./cmd/docaudit -cli m3c-tools
  ✗ PHANTOM (documented, not in code — remove, code moved on):
      --comment
      --public
```

Die neue Seite liegt außerhalb der beiden gegateten Manuals; `docaudit -cli all` bleibt grün.

## Was drinsteht

Die Seite führt mit den **Verweigerungen**, weil das ist, was das Werkzeug tatsächlich ist — ein öffentliches Issue ist ab der ersten Sekunde indexiert und nicht zurückzunehmen, also scheitert jede Wache fail-closed:

| `open` verweigert, wenn | |
|---|---|
| kein `- **Public:** yes` deklariert ist | die Ebene wird pro Item bewusst entschieden |
| kein `.public.md`-Körper existiert | die redigierte Neuformulierung fehlt |
| der Körper private Inhalte trägt | Körper umschreiben — **nie** die Verweigerung umgehen |
| kein Repository benannt ist | `- **Repo:**`-Zeile ergänzen |

Dazu die `Spec:`-Regel, die Redaktionstabelle (behalten/weglassen), die geteilte Musterquelle und — ausdrücklich — **warum es keinen Rückfall auf `git remote origin`** gibt, damit niemand die Bequemlichkeit wieder einbaut, die #148 entfernt hat.

## Der repo-eigene Lint hat mitgeredet

`tools/id-xref-lint.sh` (aus #116) über das Ergebnis laufen zu lassen brachte drei Verstöße zutage, die **diese Arbeit eingeführt** hatte, und einen, der keiner war:

- `tools/leak-patterns.txt` nennt `SPEC-1234` als *den* Platzhalter für eine ID-only-Referenz; die beiden Fixture-Suiten tragen dangling Ids und einen absichtlich schlechten Privatpfad. Alle drei gehören in die **bereits vorhandene** Allowlist „Dateien, die die Konvention definieren oder dokumentieren", neben `tools/boundary-gate.sh`. Die Platzhalter sind dort *richtig* — sie durch echte Ids zu ersetzen würde fälschlich nahelegen, das Beispiel zeige auf ein reales Dokument. Diese Liste und `BASE_EXACT` benennen jetzt dieselbe Menge, mit einer Notiz, sie in Gleichschritt zu halten.
- Die vier `SPEC-0401`-Meldungen waren ein **Artefakt einer veralteten Registry**, kein Defekt: der Lint löst gegen einen Nachbar-Checkout auf, der zufällig auf einem anderen Branch stand. Bestätigt, indem ich ihn auf einen Checkout mit der gemergten Spec gezeigt habe — die Meldungen verschwinden.

## Zwei Befunde bleiben bewusst offen

`cmd/thinking-engine/README.md:87` und `pkg/skillctl/registry/types.go:20` betten beide einen privaten Dateinamen ein, wo die Id allein hingehört. Sie sind **älter als diese Arbeit**, und `id-xref-lint` läuft in **keinem** Workflow — ihn einzuhängen setzt voraus, diese zwei zuerst zu beheben. Das ist eine eigene Änderung, kein Anhängsel an einen Docs-PR.

## Verifikation

`docaudit -cli all` PASS · `boundary-gate` clean · `boundary-gate.test.sh` 13/13 · `bugtracker.test.sh` 74/74 · `id-xref-lint.test.sh` 9/9 · `check-docs.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)