### PR TITLE
ci: wire id-xref-lint into the boundary gate, and clear the two references blocking it

### DIFF
--- a/.github/workflows/boundary-gate.yml
+++ b/.github/workflows/boundary-gate.yml
@@ -8,6 +8,14 @@ name: boundary-gate
 # gate can never see, because it is posted through the API rather than committed.
 # Both sides' fixtures run here: a leak gate that silently stops flagging still
 # reads green, so it is asserted from the failing side on every push.
+#
+# id-xref-lint enforces the other half of SPEC-0358: a public-plane reference into
+# the private plane must be ID-ONLY ("implements SPEC-NNNN"), never a path or a
+# document filename. Its resolution check needs the private registry, which public
+# CI does not have — so here it runs FORMAT-ONLY and says so in its own output.
+# That half is still worth gating: a glued `SPEC-NNNN-some-private-doc.md` leaks a
+# private filename whether or not the id resolves. (Written with NNNN on purpose —
+# a real four-digit id here would be the very violation this step rejects.)
 
 on:
   push:
@@ -32,3 +40,9 @@ jobs:
 
       - name: bugtracker fixtures (the post-gate refuses to publish a leak)
         run: bash scripts/bugtracker.test.sh
+
+      - name: id-xref-lint (public->private references are id-only)
+        run: bash tools/id-xref-lint.sh
+
+      - name: id-xref-lint fixtures (including the registry-absent degrade)
+        run: bash tools/id-xref-lint.test.sh

--- a/cmd/thinking-engine/README.md
+++ b/cmd/thinking-engine/README.md
@@ -84,8 +84,9 @@ users' engines pointed at the same broker still cannot share a group.
 
 ## Dev-Cycle Recipes
 
-See `SPEC-0167-m3c-thinking-engine.md` and `PLAN-0167-week3-kickoff.md`
-(in the sibling `m3c-tools-maintenance` repo) §Stream 3c for detail.
+See **SPEC-0167** and **PLAN-0167** §Stream 3c in the private maintenance plane
+for detail — referenced by id, because a public-plane file must not carry a path
+into the private one (SPEC-0358).
 `NewAdapterFromEnv()` picks an LLM by env:
 `OPENAI_API_KEY` → OpenAI; else `OLLAMA_URL` → Ollama (zero-cost local);
 both + `M3C_LLM_FALLBACK=ollama` → OpenAI primary with Ollama fallback on 5xx.

--- a/pkg/skillctl/registry/types.go
+++ b/pkg/skillctl/registry/types.go
@@ -17,8 +17,8 @@
 //	GET /api/skills/identities/<id>
 //	    → {"id": "...", "pubkey_b64": "...", "auth_source": "...", "revoked_at": ""}
 //
-// Field-naming caveat: the S5 brief in PLAN-SPEC-0188-parallel-execution.md
-// publishes the response shape but not the exact JSON field spelling. This
+// Field-naming caveat: the S5 parallel-execution brief for SPEC-0188 publishes
+// the response shape but not the exact JSON field spelling. This
 // package decodes leniently for both common spellings (`pubkey` vs
 // `pubkey_b64`) so a small drift between the brief and what S5 ships
 // doesn't block S8. Any drift discovered at integration time is documented


### PR DESCRIPTION
`tools/id-xref-lint.sh` setzt die **andere Hälfte** von SPEC-0358 durch — ein Verweis aus der öffentlichen in die private Ebene muss **ID-only** sein, nie ein Pfad oder ein Dokumentname — und lief in **keinem** Workflow. Ein Gate, das niemand ausführt, ist keins; dasselbe Argument hat die boundary-gate-Fixtures hervorgebracht.

## Die zwei Verweise, die zuerst weg mussten

| Datei | vorher | jetzt |
|---|---|---|
| `cmd/thinking-engine/README.md` | `` `SPEC-0167-m3c-thinking-engine.md` `` plus der Name des privaten Repos in Prosa | **SPEC-0167** per Id, mit Begründung |
| `pkg/skillctl/registry/types.go` | „the S5 brief in `PLAN-SPEC-0188-parallel-execution.md`" | „the S5 parallel-execution brief for **SPEC-0188**" |

Beides reine Kommentaränderungen — Build und Paket-Tests unverändert (`go test ./pkg/skillctl/registry/` ok).

## Was CI davon prüft — und was nicht

Die **Auflösungs-Hälfte** des Lints braucht die private Registry, die öffentliche CI nicht hat. Er degradiert dann auf **format-only** und sagt das in seiner eigenen Ausgabe:

```
id-xref-lint: resolution skipped (private registry not present at …); format-only checks running
```

Diese Hälfte ist für sich genommen ein Gate wert: ein zusammengeklebter Dateiname verrät einen privaten Dokumentnamen, **unabhängig davon**, ob die Id auflöst.

Geprüft statt angenommen — ein eingeschleustes `SPEC-0358-content-topology.md` wird **ohne Registry** gefangen:

```
docs/bug-tracking.md:229: id-not-alone (embeds private doc filename): …
id-xref-lint: FAIL
```

Der CI-Schritt beißt also, statt zu dekorieren.

## Der Check hat diesen Commit zweimal erwischt

1. Der Workflow-Kommentar, den ich zur **Erklärung der Regel** geschrieben habe, enthielt ein Beispiel ihres Bruchs — einen zusammengeklebten vierstelligen Dateinamen.
2. Der Platzhalter `"implements SPEC-1234"` **dangelt**, sobald eine Registry *vorhanden* ist — genau das, was ein Entwickler beim lokalen Lauf gesehen hätte.

Beide nutzen jetzt `SPEC-NNNN`, was auf kein Marker-Muster passt — und der Kommentar sagt warum, damit der Nächste es nicht hilfsbereit durch eine echte Id ersetzt.

**Keine neue Exemption.** Die Allowlist bleibt, was sie behauptet zu sein: Dateien, deren Zweck die Regel *ist*.

## Der boundary-gate-Job jetzt

```
Run boundary-gate
boundary-gate fixtures (every pattern still blocks)
bugtracker fixtures (the post-gate refuses to publish a leak)
id-xref-lint (public->private references are id-only)
id-xref-lint fixtures (including the registry-absent degrade)
```

## Verifikation

`id-xref-lint` clean in **beiden** Modi (Registry vorhanden und abwesend) · `id-xref-lint.test.sh` 9/9 · `boundary-gate` clean · `boundary-gate.test.sh` 13/13 · `bugtracker.test.sh` 74/74 · `check-docs.sh` PASS · `docaudit -cli all` PASS · `go test ./pkg/skillctl/registry/` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)