### PR TITLE
fix(next-id): count every claim, not just the ones in your own tree

### DIFF
--- a/docs/bug-tracking.md
+++ b/docs/bug-tracking.md
@@ -66,7 +66,7 @@ scripts/bugtracker.sh <command> [args]
 
 | Command | Purpose |
 |---------|---------|
-| `next-id [BUG\|FR]` | Next free id of that kind (default `BUG`). Use it instead of counting files. |
+| `next-id [BUG\|FR] [--no-fetch]` | Next free id of that kind (default `BUG`). Use it instead of counting files — see [Allocating an id](#allocating-an-id). |
 | `path <ID>` | Resolve the analysis file. |
 | `status <ID> [STATUS]` | Read, or set, the canonical status. |
 | `issue <ID>` | The linked issue reference, or empty for a private-only item. |
@@ -78,6 +78,36 @@ scripts/bugtracker.sh <command> [args]
 
 Exit codes: `0` ok · `1` a check failed (drift, leak, refusal) · `2` usage or configuration
 error.
+
+---
+
+## Allocating an id
+
+`next-id` fetches first, then takes the ceiling from **every** place a number can
+already be claimed:
+
+1. a file in the local `bug-reports/`
+2. a file on **any** local or remote branch — someone else's unmerged work
+3. a **branch name** like `docs/fr-0096-…`
+
+The third matters more than it looks: a branch is usually named before its file
+is written, so it is the earliest visible claim there is. When the ceiling comes
+from outside your working tree, `next-id` says so on stderr rather than silently
+handing you a number someone else is already using.
+
+```
+next-id: highest FR claim is FR-0005 in branch docs/fr-0005-… — not in your working tree
+FR-0006
+```
+
+`--no-fetch` skips the network; the answer is then only as fresh as your last
+pull.
+
+> **This is mitigation, not a fix.** Allocation is still a *read*: two sessions
+> asking in the same moment still get the same number, because nothing records
+> that the first one took it. The durable answer is to make allocation a write —
+> the slot table that already governs SPEC ids does exactly that, and extending
+> it to FR and BUG is tracked separately.
 
 ---
 

--- a/scripts/bugtracker.sh
+++ b/scripts/bugtracker.sh
@@ -148,15 +148,71 @@ $hits"
 
 public_body_path() { printf '%s\n' "${1%.md}.public.md"; }
 
+# claims KIND — every number of that kind anyone has already taken, as
+# "<number><TAB><where>" lines. The point is the SOURCES: reading max+1 out of
+# one working tree is why two sessions can be handed the same id. A claim is
+# real if it exists ANYWHERE another checkout could later push:
+#
+#   1. a file in the local bug-reports/          (what the old code saw)
+#   2. a file on ANY local or remote branch      (someone else's unmerged work)
+#   3. a BRANCH NAME like docs/fr-0096-…         (claimed before the file exists)
+#
+# Source 3 matters more than it looks: a branch is usually named before the file
+# is written, so it is the earliest visible claim there is.
+claims() {
+  local kind=$1 dir lower ref
+  dir=$(bug_dir)
+  lower=$(printf '%s\n' "$kind" | tr '[:upper:]' '[:lower:]')
+
+  find "$dir" -maxdepth 1 -name "$kind-*.md" 2>/dev/null \
+    | sed -E -n "s#.*/$kind-0*([0-9]+)-.*#\\1\\tlocal file#p"
+
+  git -C "$dir" rev-parse --git-dir >/dev/null 2>&1 || return 0
+
+  for ref in $(git -C "$dir" for-each-ref --format='%(refname:short)' refs/heads refs/remotes 2>/dev/null); do
+    git -C "$dir" ls-tree --name-only "$ref" bug-reports/ 2>/dev/null \
+      | sed -E -n "s#.*/$kind-0*([0-9]+)-.*#\\1\\t$ref#p"
+    printf '%s\n' "$ref" \
+      | sed -E -n "s#.*[^a-z]$lower-?0*([0-9]+).*#\\1\\tbranch $ref#p"
+  done
+}
+
 cmd_next_id() {
-  local kind=${1:-BUG} dir max n
+  local kind=${1:-BUG} fetch=1 dir n where max=0 top="" all
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --no-fetch) fetch=0 ;;
+      -*) die "next-id: unknown flag '$1'" ;;
+      *) kind=$1 ;;
+    esac
+    shift
+  done
   kind=$(printf '%s\n' "$kind" | tr '[:lower:]' '[:upper:]')
   statuses_for "$kind" >/dev/null      # rejects an unknown kind
-  dir=$(bug_dir); max=0
-  while IFS= read -r f; do
-    n=$(basename "$f" | sed -E -n "s/^$kind-0*([0-9]+)-.*\$/\1/p")
-    [ -n "$n" ] && [ "$n" -gt "$max" ] && max=$n
-  done < <(find "$dir" -maxdepth 1 -name "$kind-*.md")
+  dir=$(bug_dir)
+
+  # Without a fetch the answer is only as fresh as your last pull — which is
+  # exactly how a number that someone else already pushed still looks free.
+  if [ "$fetch" -eq 1 ] && git -C "$dir" rev-parse --git-dir >/dev/null 2>&1; then
+    git -C "$dir" fetch --quiet origin 2>/dev/null \
+      || note "next-id: could not fetch — the answer may be stale (use --no-fetch to silence)"
+  fi
+
+  all=$(claims "$kind" | sort -u)
+  while IFS=$'\t' read -r n where; do
+    [ -n "$n" ] || continue
+    if [ "$n" -gt "$max" ]; then max=$n; top=$where; fi
+  done <<EOF
+$all
+EOF
+
+  # Say where the ceiling came from when it is NOT something in your own tree:
+  # that is the claim you would otherwise have walked straight into.
+  case "$top" in
+    ""|"local file") ;;
+    *) note "next-id: highest $kind claim is $(printf '%s-%04d' "$kind" "$max") in $top — not in your working tree" ;;
+  esac
+
   printf '%s-%04d\n' "$kind" "$((max + 1))"
 }
 

--- a/scripts/bugtracker.test.sh
+++ b/scripts/bugtracker.test.sh
@@ -56,6 +56,42 @@ is "next-id fr is case-insensitive"                 "$("$BT" next-id fr)" "FR-01
 rm "$BUGS/BUG-0007-alpha.md" "$BUGS/BUG-0042-beta.md" "$BUGS/FR-0099-not-a-bug.md"
 is "next-id FR on an empty tree" "$("$BT" next-id FR)" "FR-0001"
 
+# --- next-id sees claims outside the working tree ------------------------------
+#
+# Reading max+1 out of one tree is how two sessions get handed the same id. This
+# rebuilds the real case: a number taken on master, another on someone else's
+# unmerged branch, and a third claimed by a BRANCH NAME before any file exists.
+
+GITBUGS="$TMP/gitmaint"
+mkdir -p "$GITBUGS/bug-reports"
+( cd "$GITBUGS"
+  git init -q -b master; git config user.email t@t; git config user.name t
+  printf '# FR-0001\n' > bug-reports/FR-0001-on-master.md
+  git add -A >/dev/null; git commit -qm one
+  # someone else's unmerged work: a file that exists on no other checkout
+  git checkout -q -b feat/other
+  printf '# FR-0003\n' > bug-reports/FR-0003-on-a-branch.md
+  git add -A >/dev/null; git commit -qm three
+  # the earliest claim there is: a branch named before its file is written
+  git checkout -q -b docs/fr-0005-not-written-yet
+  git checkout -q master ) >/dev/null 2>&1
+
+is "the working tree alone sees only FR-0001" \
+   "$(ls "$GITBUGS/bug-reports" | sed -nE 's/^FR-0*([0-9]+)-.*/\1/p' | sort -n | tail -1)" "1"
+is "next-id skips a file on another branch AND a branch-name claim" \
+   "$(M3C_MAINTENANCE_DIR=$GITBUGS "$BT" next-id FR --no-fetch)" "FR-0006"
+is "the reason is reported, naming where the ceiling came from" \
+   "$(M3C_MAINTENANCE_DIR=$GITBUGS "$BT" next-id FR --no-fetch 2>&1 >/dev/null | grep -c 'docs/fr-0005-not-written-yet')" "1"
+
+# a BUG id must not be raised by an FR claim, and vice versa
+is "kinds do not bleed into each other" \
+   "$(M3C_MAINTENANCE_DIR=$GITBUGS "$BT" next-id BUG --no-fetch)" "BUG-0001"
+
+# a non-git bug dir must keep working exactly as before
+is "a bug-reports dir outside git still resolves" "$("$BT" next-id FR)" "FR-0001"
+
+refuses "next-id rejects an unknown flag" "$BT" next-id FR --nope
+
 # --- a realistic report -------------------------------------------------------
 REPORT="$BUGS/BUG-0213-widget-drops-the-last-frame.md"
 cat > "$REPORT" <<'EOF'


### PR DESCRIPTION
Zwei Sessions bekamen am selben Abend `FR-0096`. `next-id` rechnete max+1 über **einen** Arbeitsbaum in **einem** Moment — eine anderswo belegte Nummer sah damit frei aus, und der Verlierer ist, wer als zweiter mergt.

## Jetzt zählt es alles, wo ein Anspruch existieren kann

| | Quelle | |
|---|---|---|
| 1 | Datei im lokalen `bug-reports/` | was es vorher sah |
| 2 | Datei auf **irgendeinem** lokalen oder Remote-Branch | fremde, ungemergte Arbeit |
| 3 | **Branchname** wie `docs/fr-0096-…` | belegt, bevor die Datei existiert |

Quelle 3 hätte genau diesen Fall gefangen. Ein Branch wird meist benannt, **bevor** seine Datei geschrieben ist — der früheste sichtbare Anspruch, den es gibt. Die Kollision stand über eine Stunde lang in einem Branchnamen, bevor die beiden Dateien einander begegneten.

Kommt die Obergrenze von außerhalb deines Arbeitsbaums, sagt `next-id` woher:

```
next-id: highest FR claim is FR-0005 in branch docs/fr-0005-… — not in your working tree
FR-0006
```

`--no-fetch` überspringt das Netz und sagt, dass die Antwort veraltet sein kann.

## Das echte Repo konnte es nicht zeigen

Der geteilte Checkout wanderte während der Arbeit zwischen Branches; aus manchen antworten alter und neuer Code beide `FR-0103`. Ein Beweis, der von der Tageslaune eines fremden Checkouts abhängt, ist keiner — also ist der Fall **deterministisch nachgebaut**: eine Nummer auf master, eine zweite auf einem ungemergten Branch, eine dritte nur als Branchname ohne Datei, geprüft aus dem Baum, der lediglich die erste sieht.

**80 Assertions**, weiterhin ohne Netz. Ein `bug-reports/`-Verzeichnis außerhalb von git funktioniert unverändert, und BUG- und FR-Nummern heben einander nicht.

## Umfang, deutlich gesagt

Das ist **Mitigation, keine Lösung.** Vergabe bleibt ein *Lesevorgang* — zwei Sessions, die in derselben Sekunde fragen, kollidieren weiter, weil nichts festhält, dass die erste die Nummer genommen hat. Die dauerhafte Antwort ist, Vergabe zum *Schreibvorgang* zu machen, wie es die Slot-Tabelle für SPEC-Ids längst tut. Das Manual sagt das ebenfalls, statt die Verbesserung wie eine Lösung aussehen zu lassen.

Laufzeit gegen das echte Repo: **0,26 s**.

## Verifikation

`bugtracker.test.sh` 80/80 · `boundary-gate` clean · `boundary-gate.test.sh` 13/13 · `id-xref-lint` clean · `docaudit -cli all` PASS · `check-docs.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)