### PR TITLE
test(fuzz): native fuzz targets for the trust-layer parsers + nightly gate

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,74 @@
+name: Nightly Fuzz (trust-layer parsers)
+
+# Nightly Go native-fuzzing sweep over the untrusted-input surfaces of the
+# skillctl trust layer (archive readers, semver comparator, event envelope,
+# revocation list, trust-roots + SKILL.md parsers). Each target runs for a bounded
+# time and FAILS the job on any NEW crasher — an input that panics or violates the
+# target's invariant oracle (a path escape, a fail-open verify, an ordering
+# inconsistency).
+#
+# When a target crashes, `go test -fuzz` writes the minimised failing input to
+#   pkg/<...>/testdata/fuzz/<FuzzTarget>/<hash>
+# The fix workflow is: reproduce locally, COMMIT that testdata/fuzz/<FuzzTarget>/
+# seed to the repo, and fix the bug. Once committed the seed is replayed by the
+# ORDINARY `go test` PR gate (no -fuzz needed), so it becomes a permanent
+# regression guard that fails every future PR reintroducing the bug. The nightly
+# job also uploads the crasher as an artifact so it can be retrieved even if the
+# runner is ephemeral.
+#
+# Cheap runner + no PortAudio: every fuzzed package is pure Go stdlib (no cgo), so
+# this runs on ubuntu-latest with just setup-go.
+
+on:
+  schedule:
+    - cron: "27 3 * * *" # nightly at 03:27 UTC
+  workflow_dispatch: {}
+
+# Least privilege: the fuzz job only reads the repo.
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # one target's crasher must not cancel the others
+      matrix:
+        include:
+          - target: FuzzUnpack
+            dir: pkg/skillbundle
+          - target: FuzzExtractTo
+            dir: pkg/skillbundle
+          - target: FuzzCompare
+            dir: pkg/skillctl/semver
+          - target: FuzzEventEnvelope
+            dir: pkg/skillctl/registry
+          - target: FuzzVerifyRevocationList
+            dir: pkg/skillctl/verify
+          - target: FuzzParseTrustRoots
+            dir: pkg/skillctl/verify
+          - target: FuzzParse
+            dir: pkg/skillctl/parser
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.6"
+
+      # -run=^$ skips the ordinary unit tests; -fuzz=^<target>$ selects exactly
+      # one fuzz function; a new crasher makes `go test` exit non-zero → job fails.
+      - name: Fuzz ${{ matrix.target }} (${{ matrix.dir }})
+        run: go test -run=^$ -fuzz=^${{ matrix.target }}$ -fuzztime=3m ./${{ matrix.dir }}/
+
+      # On a crash, surface the minimised failing input(s) so a human can commit
+      # them under testdata/fuzz/<target>/ as a permanent PR-gate regression seed.
+      - name: Upload crasher(s)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: crasher-${{ matrix.target }}
+          path: ${{ matrix.dir }}/testdata/fuzz/${{ matrix.target }}/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/pkg/skillbundle/fuzz_test.go
+++ b/pkg/skillbundle/fuzz_test.go
@@ -1,0 +1,183 @@
+package skillbundle
+
+// Native Go fuzz targets for the skill-bundle archive readers (SPEC-0252). Both
+// surfaces take fully untrusted input — a downloaded/pulled bundle blob and the
+// per-entry relative paths derived from it — so the invariant we care about is
+// containment: nothing a hostile archive says may ever escape the archive root
+// (Unpack) or the destination directory (ExtractTo). The oracle is the escape
+// itself: any returned entry / on-disk write outside the sandbox is a t.Fatal,
+// so the fuzzer treats a containment break as a crash.
+//
+// titem/reg/dir/sym/hard/chardev live in unpack_test.go (same package); the
+// gzip+tar seed blobs here are built with buildFuzzTGZ so no *testing.T is
+// needed at f.Add time.
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildFuzzTGZ assembles a gzip+tar blob from items verbatim (no sanitisation)
+// so seeds can carry hostile headers. It panics on the (impossible for static
+// seeds) writer error — it is only ever called with the constant corpora below.
+func buildFuzzTGZ(items []titem) []byte {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, it := range items {
+		hdr := &tar.Header{Name: it.name, Typeflag: it.typ, Mode: 0o644}
+		switch it.typ {
+		case tar.TypeReg:
+			hdr.Size = int64(len(it.body))
+		case tar.TypeSymlink, tar.TypeLink:
+			hdr.Linkname = it.link
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			panic(err)
+		}
+		if it.typ == tar.TypeReg {
+			if _, err := tw.Write([]byte(it.body)); err != nil {
+				panic(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		panic(err)
+	}
+	if err := gz.Close(); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+// FuzzUnpack drives Unpack with untrusted archive bytes and a fuzzed options
+// byte. Oracles: Unpack never panics, and on success NO returned entry escapes
+// the archive root (never absolute, "", ".", "..", "../…"; SafeJoin under a
+// throwaway dest always stays contained).
+func FuzzUnpack(f *testing.F) {
+	// valid + adversarial archive seeds (reuse the traversal/symlink/hardlink/
+	// device/oversized/too-many-files classes exercised in unpack_test.go).
+	seeds := [][]titem{
+		{reg("SKILL.md", "# s"), reg("scripts/run.sh", "echo hi"), reg("references/doc.md", "ref")},
+		{dir("bundle"), reg("bundle/SKILL.md", "# s"), reg("bundle/scripts/run.sh", "x")}, // wrapped
+		{reg("mybundle/Skill.md", "# s")},                                                 // canonicalize
+		{reg("../evil", "x")},                                                             // traversal
+		{reg("a/../../b", "x")},                                                           // deep escape
+		{reg("/etc/passwd", "x")},                                                         // absolute
+		{reg("..", "x")},                                                                  // bare dotdot
+		{reg(`a\..\..\evil`, "x")},                                                        // backslash
+		{sym("link", "/etc/passwd")},                                                      // symlink refused
+		{hard("hl", "/etc/passwd")},                                                       // hardlink refused
+		{chardev("dev")},                                                                  // device refused
+		{reg("big", strings.Repeat("A", 4096))},                                           // exercises the byte ceiling when opt bit set
+		{reg("a", "1"), reg("b", "2"), reg("c", "3")},                                     // exercises the file-count cap when opt bit set
+	}
+	// optBits: bit0 StripWrapper, bit1 CanonicalizeMD, bit2 tiny MaxBytes, bit3 tiny MaxFiles.
+	optCombos := []uint8{0, 1, 2, 3, 4, 8, 12}
+	for _, s := range seeds {
+		blob := buildFuzzTGZ(s)
+		for _, o := range optCombos {
+			f.Add(blob, o)
+		}
+	}
+	// Non-archive / degenerate byte seeds.
+	f.Add([]byte("not a gzip at all"), uint8(0))
+	f.Add([]byte{}, uint8(0))
+	f.Add([]byte{0x1f, 0x8b}, uint8(0)) // gzip magic, truncated
+
+	f.Fuzz(func(t *testing.T, data []byte, optBits uint8) {
+		opts := UnpackOptions{
+			StripWrapper:   optBits&1 != 0,
+			CanonicalizeMD: optBits&2 != 0,
+		}
+		if optBits&4 != 0 {
+			opts.MaxBytes = 512 // small ceiling → exercise gzip-bomb branch
+		}
+		if optBits&8 != 0 {
+			opts.MaxFiles = 2 // small cap → exercise tar-bomb branch
+		}
+
+		entries, err := Unpack(data, opts) // must never panic
+		if err != nil {
+			return
+		}
+		dest := t.TempDir()
+		absDest, aerr := filepath.Abs(dest)
+		if aerr != nil {
+			t.Fatalf("abs(dest): %v", aerr)
+		}
+		for _, e := range entries {
+			if e.Rel == "" || e.Rel == "." || e.Rel == ".." ||
+				strings.HasPrefix(e.Rel, "../") || strings.HasPrefix(e.Rel, "/") ||
+				filepath.IsAbs(filepath.FromSlash(e.Rel)) {
+				t.Fatalf("Unpack returned an escaping entry rel=%q", e.Rel)
+			}
+			full, jerr := SafeJoin(dest, e.Rel)
+			if jerr != nil {
+				t.Fatalf("Unpack returned rel=%q that SafeJoin rejects: %v", e.Rel, jerr)
+			}
+			if full != absDest && !strings.HasPrefix(full, absDest+string(filepath.Separator)) {
+				t.Fatalf("Unpack entry rel=%q resolves outside dest: full=%q dest=%q", e.Rel, full, absDest)
+			}
+		}
+	})
+}
+
+// FuzzExtractTo drives ExtractTo directly with an Entry whose Rel is fully
+// fuzzed (bypassing Unpack's sanitiser) to exercise the SafeJoin write guard in
+// isolation. Oracle: whatever ExtractTo does, no filesystem entry is ever
+// created OUTSIDE destDir — checked after the fact by walking the sandbox root.
+func FuzzExtractTo(f *testing.F) {
+	seeds := []struct {
+		rel     string
+		content []byte
+		isDir   bool
+	}{
+		{"SKILL.md", []byte("# s"), false},
+		{"scripts/run.sh", []byte("echo"), false},
+		{"nested/deeper/dir", nil, true},
+		{"../escape", []byte("x"), false},
+		{"../../etc/passwd", []byte("x"), false},
+		{"/abs/path", []byte("x"), false},
+		{"a/../../b", []byte("x"), false},
+		{"..", []byte("x"), false},
+		{`a\..\..\evil`, []byte("x"), false},
+		{"name:ads", []byte("x"), false},
+		{"", []byte("x"), false},
+	}
+	for _, s := range seeds {
+		f.Add(s.rel, s.content, s.isDir)
+	}
+
+	f.Fuzz(func(t *testing.T, rel string, content []byte, isDir bool) {
+		root := t.TempDir()
+		dest := filepath.Join(root, "dest")
+		if err := os.MkdirAll(dest, 0o755); err != nil {
+			t.Fatalf("mkdir dest: %v", err)
+		}
+		absRoot, _ := filepath.Abs(root)
+		absDest, _ := filepath.Abs(dest)
+
+		entries := []Entry{{Rel: rel, Content: content, IsDir: isDir, Mode: 0o644}}
+		_ = ExtractTo(entries, dest) // must never panic; an error is a fine outcome
+
+		// Oracle: nothing was written outside dest. The only pre-existing entry
+		// under root is dest itself; anything else is a containment breach.
+		_ = filepath.WalkDir(absRoot, func(p string, _ fs.DirEntry, werr error) error {
+			if werr != nil {
+				return nil
+			}
+			if p == absRoot || p == absDest || strings.HasPrefix(p, absDest+string(filepath.Separator)) {
+				return nil
+			}
+			t.Fatalf("ExtractTo wrote outside destDir: rel=%q created %q (dest=%q)", rel, p, absDest)
+			return nil
+		})
+	})
+}

--- a/pkg/skillctl/parser/fuzz_test.go
+++ b/pkg/skillctl/parser/fuzz_test.go
@@ -1,0 +1,45 @@
+package parser
+
+// Native Go fuzz target for the SKILL.md frontmatter parser. The whole file
+// (delimiters + embedded YAML block) is untrusted author input. Oracle: Parse
+// never panics on any byte sequence — a malformed delimiter run or a hostile
+// YAML block must surface as an error/no-frontmatter, never a crash.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// FuzzParse drives Parse with fuzzed markdown+frontmatter bytes. Seeds reuse the
+// real adversarial + benign SKILL.md corpus under pkg/skillctl/bodyscan/testdata
+// (every file there opens with a --- frontmatter block) plus hand-crafted
+// delimiter edge cases. Oracle: never panics.
+func FuzzParse(f *testing.F) {
+	// Reuse the bodyscan corpus (relative to this package dir) as realistic seeds.
+	for _, sub := range []string{"adversarial", "benign"} {
+		glob := filepath.Join("..", "bodyscan", "testdata", "corpus", sub, "*.md")
+		matches, _ := filepath.Glob(glob)
+		for _, p := range matches {
+			if b, err := os.ReadFile(p); err == nil {
+				f.Add(b)
+			}
+		}
+	}
+
+	// Delimiter / YAML edge cases.
+	f.Add([]byte("---\nname: x\nversion: 1.0.0\n---\nbody text"))
+	f.Add([]byte("---\r\nname: x\r\n---\r\nbody"))       // CRLF
+	f.Add([]byte("---\nname: x\nno closing delimiter"))  // unterminated
+	f.Add([]byte("---\n: : :\n---\n"))                    // broken YAML block
+	f.Add([]byte("---\nmetadata:\n  a: [1,2,3]\n---\n"))  // nested
+	f.Add([]byte("---"))                                  // just the opener
+	f.Add([]byte("------\n---\n"))                        // dashes soup
+	f.Add([]byte("no frontmatter here"))
+	f.Add([]byte(""))
+	f.Add([]byte("---\n\n---\n"))                         // empty YAML block
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _, _ = Parse(data) // must never panic
+	})
+}

--- a/pkg/skillctl/registry/fuzz_test.go
+++ b/pkg/skillctl/registry/fuzz_test.go
@@ -1,0 +1,67 @@
+package registry
+
+// Native Go fuzz target for the SPEC-0190 event envelope canonicalisation +
+// signature verification. Event JSON is the untrusted item body on the ER1/bus
+// transport. The two invariants: neither CanonicalEventBytes nor
+// VerifyEnvelopeSignature ever panics on arbitrary JSON, and verification never
+// fails OPEN — a pubkey the fuzzer cannot have signed for must never accept a
+// forged/non-matching signature.
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// FuzzEventEnvelope feeds raw JSON → map[string]any → CanonicalEventBytes +
+// VerifyEnvelopeSignature against a fixed, deterministic pubkey. Oracles: never
+// panics; if VerifyEnvelopeSignature returns nil, the signature MUST actually
+// verify against that key (re-checked independently) — otherwise it is a
+// fail-open bug.
+func FuzzEventEnvelope(f *testing.F) {
+	// Deterministic, valid ed25519 key. The fuzzer cannot produce a signature
+	// that verifies against it, so a nil verify error is either a genuine (and
+	// astronomically unlikely) forgery or a fail-open bug — both are t.Fatal.
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+
+	validDigest := "sha256:" + strings.Repeat("a", 64)
+	sig64 := base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+	f.Add([]byte(`{"schema_version":"1.0.0","name":"x","version":"1.0.0"}`))
+	f.Add([]byte(`{"envelope_signature":"AAAA","bundle_digest":"` + validDigest + `"}`))
+	f.Add([]byte(`{"envelope_signature":123}`))
+	f.Add([]byte(`{"a":{"b":[1,2,3]},"envelope_signature":"not-base64-!!!"}`))
+	f.Add([]byte(`{"envelope_signature":"` + sig64 + `","x":"y"}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`[]`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`not json`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var ev map[string]any
+		if err := json.Unmarshal(data, &ev); err != nil || ev == nil {
+			return // only well-formed JSON objects reach the functions
+		}
+
+		canon, cerr := CanonicalEventBytes(ev) // must never panic
+		verr := VerifyEnvelopeSignature(pub, ev) // must never panic
+		if verr == nil {
+			// Fail-open guard: an accepted event must carry a signature that
+			// genuinely verifies against pub over the canonical bytes.
+			if cerr != nil {
+				t.Fatalf("VerifyEnvelopeSignature accepted the event but CanonicalEventBytes errored: %v", cerr)
+			}
+			raw, _ := ev[EnvelopeSignatureField].(string)
+			sig, derr := base64.StdEncoding.DecodeString(raw)
+			if derr != nil || !ed25519.Verify(pub, canon, sig) {
+				t.Fatalf("VerifyEnvelopeSignature verified a non-matching/forged signature (fail-open): sig=%q", raw)
+			}
+		}
+	})
+}

--- a/pkg/skillctl/semver/fuzz_test.go
+++ b/pkg/skillctl/semver/fuzz_test.go
@@ -1,0 +1,47 @@
+package semver
+
+// Native Go fuzz target for the loose-semver comparator. Version strings come
+// from manifests and git tags (untrusted), and Compare gates version
+// monotonicity + "highest non-revoked version" selection in a trust path, so a
+// panic or an ordering inconsistency here is a correctness bug. The oracles are
+// the order axioms the callers rely on.
+
+import "testing"
+
+// FuzzCompare checks the comparator's total-preorder axioms under fuzzed input.
+// Oracles: never panics; antisymmetry Compare(a,b) == -Compare(b,a);
+// reflexivity Compare(a,a) == 0.
+func FuzzCompare(f *testing.F) {
+	seeds := [][2]string{
+		{"1.2.0", "1.2.0"},
+		{"1.2.0", "1.2.3"},
+		{"v1.2.0", "1.2.0"},
+		{"1.0.0-rc", "1.0.0"},
+		{"1.0.0+meta", "1.0.0"},
+		{"2.0", "1.9.9"},
+		{"", "0"},
+		{"1.2.0-rc.1", "1.2.0"},
+		{"v0", "v0.0.0"},
+		{"abc", "1.0.0"},
+		{"1.2.3.4.5", "1.2.3"},
+		{"  1.2.0  ", "1.2.0"},
+		{"99999999999999999999", "1"}, // Atoi overflow path, both sides
+	}
+	for _, s := range seeds {
+		f.Add(s[0], s[1])
+	}
+
+	f.Fuzz(func(t *testing.T, a, b string) {
+		ab := Compare(a, b) // must never panic
+		ba := Compare(b, a)
+		if ab != -ba {
+			t.Fatalf("antisymmetry violated: Compare(%q,%q)=%d but -Compare(%q,%q)=%d", a, b, ab, b, a, -ba)
+		}
+		if aa := Compare(a, a); aa != 0 {
+			t.Fatalf("reflexivity violated: Compare(%q,%q)=%d, want 0", a, a, aa)
+		}
+		if ab < -1 || ab > 1 {
+			t.Fatalf("Compare(%q,%q)=%d out of the {-1,0,1} range", a, b, ab)
+		}
+	})
+}

--- a/pkg/skillctl/verify/fuzz_test.go
+++ b/pkg/skillctl/verify/fuzz_test.go
@@ -1,0 +1,100 @@
+package verify
+
+// Native Go fuzz targets for two untrusted-input surfaces in the verify package:
+//   - VerifyRevocationList (+ CanonicalRevocationBytes): a signed, offline
+//     revocation snapshot pulled from a registry. It must never fail OPEN — a
+//     forged/unsigned list can neither block a healthy bundle nor be accepted
+//     without a valid signature over the canonical bytes.
+//   - ParseTrustRoots: the strict YAML trust-roots decoder+validator (the
+//     step-1 refactor). Arbitrary YAML must never panic it.
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// FuzzVerifyRevocationList feeds fuzzed JSON → RevocationList → VerifyRevocationList
+// against a fixed active registry key. Oracles: never panics; a revoked set is
+// returned ONLY together with a signature that genuinely verifies over the
+// canonical bytes (re-checked independently) — anything else is fail-open.
+func FuzzVerifyRevocationList(f *testing.F) {
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i + 7)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+	const regURL = "https://reg.example.com"
+	root := &TrustRoot{
+		RegistryURL:  regURL,
+		RegistryKeys: []RegistryKey{{ID: "k1", Pubkey: pub}}, // active (not retired)
+	}
+
+	// A genuinely-signed list: this seed MUST pass the oracle (its signature
+	// verifies), which is exactly why the oracle re-checks rather than asserting
+	// "err always non-nil".
+	if good, err := NewSignedRevocationList(regURL, "2026-01-01T00:00:00Z", 1,
+		[]string{"sha256:" + strings.Repeat("a", 64)}, priv); err == nil {
+		if goodJSON, jerr := json.Marshal(good); jerr == nil {
+			f.Add(goodJSON)
+		}
+	}
+	f.Add([]byte(`{"registry_url":"` + regURL + `","revoked_digests":["sha256:` + strings.Repeat("b", 64) + `"],"signature_b64":"AAAA"}`))
+	f.Add([]byte(`{"revoked_digests":["not-a-digest"],"signature_b64":"!!!"}`))
+	f.Add([]byte(`{"signature_b64":"` + base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize)) + `","epoch":5}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`garbage`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var list RevocationList
+		if err := json.Unmarshal(data, &list); err != nil {
+			return
+		}
+		set, err := VerifyRevocationList(&list, root, 0) // must never panic
+		if err != nil {
+			return
+		}
+		if set == nil {
+			t.Fatalf("VerifyRevocationList returned a nil error AND a nil set")
+		}
+		// Fail-open guard: re-derive the canonical bytes and re-verify the
+		// signature against the active pinned key.
+		canon, cerr := CanonicalRevocationBytes(list.RegistryURL, list.IssuedAt, list.Epoch, list.RevokedDigests)
+		if cerr != nil {
+			t.Fatalf("returned a revoked set but canonical bytes errored: %v", cerr)
+		}
+		sig, derr := base64.StdEncoding.DecodeString(list.SignatureB64)
+		if derr != nil || !ed25519.Verify(pub, canon, sig) {
+			t.Fatalf("VerifyRevocationList returned a revoked set without a valid signature (fail-open)")
+		}
+	})
+}
+
+// FuzzParseTrustRoots drives the strict trust-roots YAML decoder+validator with
+// arbitrary bytes. Oracle: never panics (an accept/reject decision is fine).
+func FuzzParseTrustRoots(f *testing.F) {
+	pk := base64.StdEncoding.EncodeToString(make([]byte, ed25519.PublicKeySize))
+	validYAML := "trust_roots:\n" +
+		"  - registry_url: https://reg.example.com\n" +
+		"    registry_keys:\n" +
+		"      - id: k1\n" +
+		"        pubkey: " + pk + "\n" +
+		"        issued: 2026-01-01\n" +
+		"    identity_keys_authorized: from-registry\n" +
+		"    governance_minimum: green\n"
+	f.Add([]byte(validYAML))
+	f.Add([]byte("trust_roots: []\n"))
+	f.Add([]byte(""))
+	f.Add([]byte("not: valid: yaml: : :\n"))
+	f.Add([]byte("unknown_key: 1\n")) // strict decode rejects unknown fields
+	f.Add([]byte("trust_roots:\n  - registry_url: https://x\n    registry_keys: []\n"))
+	f.Add([]byte("trust_roots:\n  - registry_url: \"http://8.8.8.8/api\"\n")) // non-private http rejected
+	f.Add([]byte("trust_roots:\n  - registry_url: https://x\n    registry_keys:\n      - id: k\n        pubkey: \"!!!not-base64\"\n"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ParseTrustRoots(data) // must never panic
+	})
+}

--- a/pkg/skillctl/verify/trustroots.go
+++ b/pkg/skillctl/verify/trustroots.go
@@ -605,20 +605,43 @@ func Load(path string) (*TrustRoots, error) {
 		return nil, fmt.Errorf("trust-roots: read %s: %w", abs, err)
 	}
 
+	tr, err := ParseTrustRoots(data)
+	if err != nil {
+		return nil, err
+	}
+	tr.Path = abs
+	return tr, nil
+}
+
+// ParseTrustRoots decodes + validates a trust-roots YAML document from an
+// in-memory byte slice. It is the pure, filesystem-free core that Load wraps:
+// Load resolves + reads the file, then hands the bytes here. Splitting the parse
+// out lets a fuzzer drive the (untrusted-input) decoder/validator directly with
+// no disk I/O, and lets callers validate a document they already hold in memory.
+//
+// Behaviour matches the in-file parse Load used to do inline:
+//   - strict decode (KnownFields(true)) — an unknown YAML key is rejected loudly
+//     rather than silently disabling a key (see Load's doc comment);
+//   - FR-0090 IS-T5 managed (enterprise) fail-closed defaults are stamped BEFORE
+//     validate, so the require_signed_governance⇒reviewers invariant sees the
+//     defaulted value;
+//   - validate() runs the full sanity check and hydrates raw pubkey bytes.
+//
+// Path is NOT set here (there is no file) — Load sets it on the returned value.
+func ParseTrustRoots(data []byte) (*TrustRoots, error) {
 	var tr TrustRoots
 	dec := yaml.NewDecoder(strings.NewReader(string(data)))
 	dec.KnownFields(true) // strict: unknown fields → error
 	if err := dec.Decode(&tr); err != nil {
-		return nil, fmt.Errorf("trust-roots: parse %s: %w", abs, err)
+		return nil, fmt.Errorf("trust-roots: parse: %w", err)
 	}
-	tr.Path = abs
 
 	// FR-0090 IS-T5: stamp managed (enterprise) fail-closed defaults BEFORE validate,
 	// so the require_signed_governance⇒reviewers invariant sees the defaulted value.
 	tr.applyManagedDefaults()
 
 	if err := tr.validate(); err != nil {
-		return nil, fmt.Errorf("trust-roots: validate %s: %w", abs, err)
+		return nil, fmt.Errorf("trust-roots: validate: %w", err)
 	}
 	return &tr, nil
 }


### PR DESCRIPTION
Gate 4 of the WF-001 hardening track — **fuzz/property targets** for the untrusted-input parsers, with the R01–R12 security invariants encoded as differential oracles.

**Refactor (behavior-preserving):** extract `verify.ParseTrustRoots([]byte)` out of `Load` (Load now reads the file → delegates). Only observable change: parse/validate error strings no longer embed the abs path (no test asserts on it). Full `pkg/skillctl/verify` suite passes unchanged.

**7 fuzz targets** (Go native, seed corpora reuse existing adversarial fixtures; invariants as `t.Fatal` oracles so a violation = a crash):
- `skillbundle.FuzzUnpack` / `FuzzExtractTo` — no panic; **no entry/write escapes the archive root** (traversal/symlink/hardlink/device/size/count seeds).
- `semver.FuzzCompare` — no panic; antisymmetry, reflexivity, range {-1,0,1}.
- `registry.FuzzEventEnvelope` — `CanonicalEventBytes`+`VerifyEnvelopeSignature`; a forged/non-matching sig accepted = **fail-open crash**.
- `verify.FuzzVerifyRevocationList` — a returned revoked set must carry a signature that re-verifies (never fail-open); seeds include a genuinely-signed list.
- `verify.FuzzParseTrustRoots`, `parser.FuzzParse` — never panic.

**Nightly gate:** `.github/workflows/fuzz.yml` — cron + dispatch, `permissions: contents: read`, matrix runs each target `-fuzztime=3m` on ubuntu; a crasher fails the job and uploads the minimised input, which then gets committed under `testdata/fuzz/` as a permanent PR-gate regression seed. Actions SHA-pinned; passes pin-guard. `verify.Verify` (whole-dir fixture) noted as a follow-up.

Seed-replay (`go test`, no `-fuzz`) + `go vet` green across all five packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)