### PR TITLE
security(skillctl): real gosec/errcheck trust-path findings + challenge-gate hardening

### DIFF
--- a/cmd/m3c-tools/commands_shared.go
+++ b/cmd/m3c-tools/commands_shared.go
@@ -501,7 +501,11 @@ func cmdUpload(args []string) {
 		fmt.Fprintf(os.Stderr, "Upload error: %v\n", err)
 		// ER1 failure detection: queue failed upload for retry
 		entry := er1.EnqueueFailure(queuePath, videoID, payload, tags, err)
-		fmt.Fprintf(os.Stderr, "Queued for retry: %s → %s\n", entry.ID, queuePath)
+		if entry != nil {
+			fmt.Fprintf(os.Stderr, "Queued for retry: %s → %s\n", entry.ID, queuePath)
+		} else {
+			fmt.Fprintf(os.Stderr, "WARNING: retry-queue write failed; upload NOT queued (%s)\n", queuePath)
+		}
 		os.Exit(1)
 	}
 

--- a/cmd/m3c-tools/commands_shared.go
+++ b/cmd/m3c-tools/commands_shared.go
@@ -153,7 +153,9 @@ func cmdRetry(args []string) {
 func defaultExportsDBPath() string {
 	home, _ := os.UserHomeDir()
 	dir := filepath.Join(home, ".m3c-tools")
-	os.MkdirAll(dir, 0700)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not create %s: %v\n", dir, err)
+	}
 	return filepath.Join(dir, "exports.db")
 }
 
@@ -575,7 +577,10 @@ func cmdThumbnail(args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	os.WriteFile(output, data, 0600)
+	if err := os.WriteFile(output, data, 0600); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: could not write %s: %v\n", output, err)
+		os.Exit(1)
+	}
 	fmt.Printf("Saved %s (%d bytes)\n", output, len(data))
 }
 

--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -3672,6 +3672,13 @@ func menubarUploadER1(videoID string) (*menubar.ER1UploadResult, error) {
 		// Queue for retry on failure
 		queuePath := er1.DefaultQueuePath()
 		entry := er1.EnqueueFailure(queuePath, videoID, payload, tags, err)
+		if entry == nil {
+			return &menubar.ER1UploadResult{
+				VideoID: videoID,
+				Message: "Upload failed AND retry-queue write failed",
+				Queued:  false,
+			}, nil
+		}
 		return &menubar.ER1UploadResult{
 			VideoID: videoID,
 			Message: fmt.Sprintf("Upload failed, queued for retry: %s", entry.ID),

--- a/cmd/skillctl/replay_cmds.go
+++ b/cmd/skillctl/replay_cmds.go
@@ -403,8 +403,13 @@ func readDeployEnvStageURL() string {
 
 func newReplayHTTPClient(target string) *http.Client {
 	if target == "local" {
+		// #nosec G402 -- gated: TLS verification is skipped ONLY for target=="local",
+		// whose base URL is the hardcoded loopback https://127.0.0.1:8081
+		// (defaultReplayBaseURL). prod/stage targets fall through to the verifying
+		// client below. The base URL is not caller-overridable — only the --target
+		// selector is — so a public host can never inherit this transport.
 		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 -- loopback-only (target=="local" ⇒ 127.0.0.1)
 		}
 		return &http.Client{Transport: tr, Timeout: 10 * time.Second}
 	}

--- a/cmd/skillctl/replay_cmds_test.go
+++ b/cmd/skillctl/replay_cmds_test.go
@@ -313,6 +313,28 @@ func TestTruncString(t *testing.T) {
 	}
 }
 
+// TestReplayHTTPClient_TLSPolicy pins the secure-by-default contract behind the
+// gated G402 site in newReplayHTTPClient: only target=="local" (which maps to the
+// hardcoded loopback base URL) skips TLS verification; prod/stage must verify.
+func TestReplayHTTPClient_TLSPolicy(t *testing.T) {
+	// prod / stage must NOT skip verification.
+	for _, target := range []string{"prod", "stage"} {
+		c := newReplayHTTPClient(target)
+		if tr, ok := c.Transport.(*http.Transport); ok && tr.TLSClientConfig != nil && tr.TLSClientConfig.InsecureSkipVerify {
+			t.Fatalf("target %q must verify TLS (InsecureSkipVerify must be false)", target)
+		}
+	}
+	// local skips verification — but only because its base URL is loopback.
+	local := newReplayHTTPClient("local")
+	tr, ok := local.Transport.(*http.Transport)
+	if !ok || tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("target=local should use the loopback dev transport (InsecureSkipVerify=true)")
+	}
+	if base := defaultReplayBaseURL("local"); !strings.HasPrefix(base, "https://127.0.0.1") {
+		t.Fatalf("target=local base URL must be loopback, got %q", base)
+	}
+}
+
 func TestColorForType(t *testing.T) {
 	cases := map[string]string{
 		"gate.allowed":    ansiGreen,

--- a/cmd/skillctl/revoke_cmds.go
+++ b/cmd/skillctl/revoke_cmds.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kamir/m3c-tools/pkg/httpsafe"
 	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
 )
 
@@ -205,7 +206,11 @@ func runRevoke(args []string, stdout, stderr io.Writer) int {
 	}
 
 	// POST to <registry>/bundles/<digest>/revoke.
-	client := &http.Client{Timeout: *timeout}
+	// The registry origin was already scheme/host-validated by validateRegistryURL
+	// above (https anywhere; plain http only for loopback/RFC1918). NoCrossHostRedirect
+	// fails closed on any 30x that would bounce this trust-path request off the
+	// validated origin onto an attacker-chosen host.
+	client := &http.Client{Timeout: *timeout, CheckRedirect: httpsafe.NoCrossHostRedirect}
 	endpoint := strings.TrimRight(*registryURL, "/") + "/bundles/" + digest + "/revoke"
 
 	body, err := json.Marshal(&req)
@@ -214,6 +219,9 @@ func runRevoke(args []string, stdout, stderr io.Writer) int {
 		return exitGeneric
 	}
 
+	// #nosec G107 -- endpoint host+scheme validated by validateRegistryURL above and
+	// the client refuses cross-host redirects (httpsafe.NoCrossHostRedirect); not
+	// an attacker-controlled taint source.
 	httpReq, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		fmt.Fprintf(stderr, "skillctl revoke: build request: %v\n", err)

--- a/cmd/skillctl/sync_cmds.go
+++ b/cmd/skillctl/sync_cmds.go
@@ -174,7 +174,7 @@ func buildIngestClient(endpoint, pubkeyPath, logID string, insecure bool, stderr
 		if !isLoopbackHost(u.Hostname()) {
 			return nil, fmt.Errorf("--insecure is only permitted for a loopback endpoint (got host %q)", u.Hostname())
 		}
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // loopback-only, gated above
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // loopback-only, gated above // #nosec G402 -- gated: default (no --insecure) verifies; skip permitted only for a loopback endpoint (isLoopbackHost check above fails closed for any other host) and endpoint is already required to be https
 	}
 
 	var pub ed25519.PublicKey

--- a/cmd/skillctl/sync_cmds.go
+++ b/cmd/skillctl/sync_cmds.go
@@ -174,7 +174,8 @@ func buildIngestClient(endpoint, pubkeyPath, logID string, insecure bool, stderr
 		if !isLoopbackHost(u.Hostname()) {
 			return nil, fmt.Errorf("--insecure is only permitted for a loopback endpoint (got host %q)", u.Hostname())
 		}
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // loopback-only, gated above // #nosec G402 -- gated: default (no --insecure) verifies; skip permitted only for a loopback endpoint (isLoopbackHost check above fails closed for any other host) and endpoint is already required to be https
+		// #nosec G402 -- gated: default (no --insecure) verifies; skip permitted only for a loopback endpoint (isLoopbackHost check above fails closed for any other host) and endpoint is already required to be https //nolint:gosec // loopback-only, gated above
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
 	var pub ed25519.PublicKey

--- a/cmd/skillctl/sync_cmds_test.go
+++ b/cmd/skillctl/sync_cmds_test.go
@@ -356,6 +356,23 @@ func TestSync_RejectsNonHTTPSEndpoint(t *testing.T) {
 	}
 }
 
+// TestSync_DefaultVerifiesTLS pins the secure-by-default contract behind the
+// gated G402 site: with insecure=false (the default) the built client must NOT
+// skip certificate verification.
+func TestSync_DefaultVerifiesTLS(t *testing.T) {
+	c, err := buildIngestClient("https://ingest.example.com", "", "L", false, io.Discard)
+	if err != nil {
+		t.Fatalf("buildIngestClient (default, secure): unexpected error: %v", err)
+	}
+	tr, ok := c.Client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport = %T, want *http.Transport", c.Client.Transport)
+	}
+	if tr.TLSClientConfig != nil && tr.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("default client must verify TLS (InsecureSkipVerify must be false)")
+	}
+}
+
 func TestSync_TamperedRowNotShipped(t *testing.T) {
 	dev := syncTestDeviceKey(t)
 	ingest := syncTestIngestKey(t)

--- a/docs/security/gosec-baseline.md
+++ b/docs/security/gosec-baseline.md
@@ -34,7 +34,7 @@ Active findings by rule (highest first):
 | G703  |  52 | Errors unhandled (audit variant) | Bulk-defer with G104. |
 | G115  |  45 | Integer overflow on conversion | Bulk-defer. Concentrated in WAV/audio byte packing (`byte(v>>8)` — intended truncation). |
 | G204  |  42 | Subprocess launched with variable | Bulk-defer. whisper / ffmpeg / tool wrappers; args are program-controlled, review for injection. |
-| G301/G302/G306 | 79 | Poor file/dir permissions | Bulk-defer; the trust-seal 0644→0600 was fixed in this PR. Re-audit any 0644/0777 on secret-bearing paths. |
+| G301/G302/G306 | 79 | Poor file/dir permissions | Bulk-defer; BOTH trust-seal write paths (review-server `handleSeal` + scanner `delta.SealStore.Seal`) were tightened 0644→0600 (dir 0755→0700) in this PR. Re-audit any 0644/0777 on secret-bearing paths. |
 | G706  |  22 | (audit) | Bulk-defer. |
 | **G402** | **14** | **TLS InsecureSkipVerify** | **Partly triaged (see below).** The 4 named trust-path sites are annotated + suppressed. The remaining 14 are other clients (er1/upload, plaud, pocket, health-check) that share the same loopback-gated `VerifySSL`/`ER1_VERIFY_SSL` pattern — should be verified + annotated in a follow-up. |
 | G704  |   6 | Variable used as HTTP request URL (SSRF surface) | Partly triaged. The revoke path is validated (`validateRegistryURL`) + cross-host-redirect-locked in this PR; the rest are operator-configured registry/ER1 URLs — review each for origin constraints. |

--- a/docs/security/gosec-baseline.md
+++ b/docs/security/gosec-baseline.md
@@ -1,0 +1,64 @@
+# gosec baseline
+
+`gosec-baseline.sarif` is a point-in-time snapshot of the static-analysis
+findings from [gosec](https://github.com/securego/gosec) over the whole module.
+It exists so a **future** CI gate can start green (fail only on *new* findings)
+rather than drowning in the pre-existing backlog. **No CI job is wired yet** —
+that decision is pending; this is only the artifact + triage note.
+
+## How it was generated
+
+```bash
+gosec -track-suppressions -fmt sarif -out docs/security/gosec-baseline.sarif ./...
+```
+
+- `gosec dev` (installed via `go install github.com/securego/gosec/v2/cmd/gosec@latest`)
+- Go 1.26.x, generated 2026-09-03, against branch `fix/skillctl-gosec-real-findings`.
+- `-track-suppressions` keeps `#nosec`-annotated sites **in** the SARIF as
+  `suppressions` entries (rather than dropping them), so the gate can tell an
+  intentional, justified suppression apart from an un-triaged finding.
+
+Regenerate the same way after intentional changes; gosec exits non-zero whenever
+it reports any finding, so a non-zero exit here is expected.
+
+## What's in it
+
+**505 findings total: 501 active + 4 tracked-suppressed.**
+
+Active findings by rule (highest first):
+
+| Rule  | Count | What it flags | Triage |
+|-------|------:|---------------|--------|
+| G304  | 148 | File path from a variable (potential path traversal) | Bulk-defer. Mostly CLI/config reading operator-supplied paths; not attacker-tainted. Review case-by-case; not a blocker. |
+| G104  |  73 | Unhandled error | Bulk-defer. Backlog after this PR fixed the security-relevant ones (retry-queue persistence, trust-seal write, config apply). |
+| G703  |  52 | Errors unhandled (audit variant) | Bulk-defer with G104. |
+| G115  |  45 | Integer overflow on conversion | Bulk-defer. Concentrated in WAV/audio byte packing (`byte(v>>8)` — intended truncation). |
+| G204  |  42 | Subprocess launched with variable | Bulk-defer. whisper / ffmpeg / tool wrappers; args are program-controlled, review for injection. |
+| G301/G302/G306 | 79 | Poor file/dir permissions | Bulk-defer; the trust-seal 0644→0600 was fixed in this PR. Re-audit any 0644/0777 on secret-bearing paths. |
+| G706  |  22 | (audit) | Bulk-defer. |
+| **G402** | **14** | **TLS InsecureSkipVerify** | **Partly triaged (see below).** The 4 named trust-path sites are annotated + suppressed. The remaining 14 are other clients (er1/upload, plaud, pocket, health-check) that share the same loopback-gated `VerifySSL`/`ER1_VERIFY_SSL` pattern — should be verified + annotated in a follow-up. |
+| G704  |   6 | Variable used as HTTP request URL (SSRF surface) | Partly triaged. The revoke path is validated (`validateRegistryURL`) + cross-host-redirect-locked in this PR; the rest are operator-configured registry/ER1 URLs — review each for origin constraints. |
+| others |  ~15 | G112/G705/G202/G404/G101/G122/G702/G124/G203/G117 | Bulk-defer; low volume, review individually. |
+
+## Suppressed (intentional, justified) — `#nosec G402`
+
+These four TLS-skip sites are gated dev/self-signed support, **secure by
+default** (verification on unless an explicit opt-out AND a loopback target).
+Each carries a `#nosec G402 -- <reason>` directive; the reasoning and the
+default-verifies regression tests landed alongside this note.
+
+| File | Line | Gate |
+|------|-----:|------|
+| `pkg/skillctl/registry/er1_room.go`    | ~192 | `er1TLSGuard` fails closed for non-loopback; `applyTLSVerificationPolicy` forces verify on at load |
+| `pkg/skillctl/registry/er1_publish.go` | ~552 | same as above |
+| `cmd/skillctl/sync_cmds.go`            | ~178 | `--insecure` + `isLoopbackHost` only; endpoint must be https |
+| `cmd/skillctl/replay_cmds.go`          | ~412 | `target==local` only → hardcoded loopback base URL |
+
+## Not done here (deliberately)
+
+- No CI wiring. When a gate is added, run gosec against this baseline
+  (`gosec -baseline docs/security/gosec-baseline.sarif ...` once regenerated
+  under the same gosec version) so only regressions fail the build.
+- The G402/G704/G304/G104 backlog above is triaged-for-severity, not fixed. The
+  trust-path items in each category were fixed in this PR; the rest are the
+  next security-hygiene sweep.

--- a/docs/security/gosec-baseline.sarif
+++ b/docs/security/gosec-baseline.sarif
@@ -1,0 +1,18339 @@
+{
+	"runs": [
+		{
+			"results": [
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/audio.go"
+								},
+								"region": {
+									"endColumn": 20,
+									"endLine": 140,
+									"snippet": {
+										"text": "buf.WriteByte(byte(v \u003e\u003e 16))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 20,
+									"startLine": 140
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion uint32 -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/audio.go"
+								},
+								"region": {
+									"endColumn": 20,
+									"endLine": 139,
+									"snippet": {
+										"text": "buf.WriteByte(byte(v \u003e\u003e 8))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 20,
+									"startLine": 139
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion uint32 -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/audio.go"
+								},
+								"region": {
+									"endColumn": 20,
+									"endLine": 138,
+									"snippet": {
+										"text": "buf.WriteByte(byte(v))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 20,
+									"startLine": 138
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion uint32 -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/recorder/wav.go"
+								},
+								"region": {
+									"endColumn": 21,
+									"endLine": 147,
+									"snippet": {
+										"text": "samples[i] = int16(binary.LittleEndian.Uint16(data[i*2 : i*2+2]))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 21,
+									"startLine": 147
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion uint16 -\u003e int16"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/audio.go"
+								},
+								"region": {
+									"endColumn": 20,
+									"endLine": 133,
+									"snippet": {
+										"text": "buf.WriteByte(byte(v))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 20,
+									"startLine": 133
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion uint16 -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "internal/thinking/er1/client.go"
+								},
+								"region": {
+									"endColumn": 17,
+									"endLine": 468,
+									"snippet": {
+										"text": "buf[i] = byte(ts \u003e\u003e (i % 8))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 17,
+									"startLine": 468
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int64 -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/propose_cmds.go"
+								},
+								"region": {
+									"endColumn": 7,
+									"endLine": 305,
+									"snippet": {
+										"text": "byte(now \u003e\u003e 16), byte(now \u003e\u003e 8), byte(now),"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 7,
+									"startLine": 305
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int64 -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/propose_cmds.go"
+								},
+								"region": {
+									"endColumn": 40,
+									"endLine": 305,
+									"snippet": {
+										"text": "byte(now \u003e\u003e 16), byte(now \u003e\u003e 8), byte(now),"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 40,
+									"startLine": 305
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int64 -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/propose_cmds.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 305,
+									"snippet": {
+										"text": "byte(now \u003e\u003e 16), byte(now \u003e\u003e 8), byte(now),"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 305
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int64 -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/propose_cmds.go"
+								},
+								"region": {
+									"endColumn": 41,
+									"endLine": 304,
+									"snippet": {
+										"text": "byte(now \u003e\u003e 40), byte(now \u003e\u003e 32), byte(now \u003e\u003e 24),"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 41,
+									"startLine": 304
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int64 -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/propose_cmds.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 304,
+									"snippet": {
+										"text": "byte(now \u003e\u003e 40), byte(now \u003e\u003e 32), byte(now \u003e\u003e 24),"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 304
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int64 -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/propose_cmds.go"
+								},
+								"region": {
+									"endColumn": 7,
+									"endLine": 304,
+									"snippet": {
+										"text": "byte(now \u003e\u003e 40), byte(now \u003e\u003e 32), byte(now \u003e\u003e 24),"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 7,
+									"startLine": 304
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int64 -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/recorder/wav.go"
+								},
+								"region": {
+									"endColumn": 31,
+									"endLine": 71,
+									"snippet": {
+										"text": "buf = appendLE16(buf, uint16(s))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 31,
+									"startLine": 71
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int16 -\u003e uint16"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/timetracking/gantt.go"
+								},
+								"region": {
+									"endColumn": 31,
+									"endLine": 99,
+									"snippet": {
+										"text": "c := palette[h.Sum32()%uint32(len(palette))]"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 31,
+									"startLine": 99
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e uint32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/recorder/wav.go"
+								},
+								"region": {
+									"endColumn": 20,
+									"endLine": 47,
+									"snippet": {
+										"text": "dataSize := uint32(len(samples) * 2)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 20,
+									"startLine": 47
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e uint32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/audio.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 29,
+									"snippet": {
+										"text": "writeLE32(\u0026buf, uint32(dataSize))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 29
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e uint32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/audio.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 18,
+									"snippet": {
+										"text": "writeLE32(\u0026buf, uint32(36+dataSize))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 18
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e uint32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/poc-recorder/main.go"
+								},
+								"region": {
+									"endColumn": 20,
+									"endLine": 190,
+									"snippet": {
+										"text": "dataSize := uint32(len(samples) * 2) // 2 bytes per int16"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 20,
+									"startLine": 190
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e uint32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/bodyscan/normalize.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 249,
+									"snippet": {
+										"text": "return rune(v), 4, true"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 249
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e rune"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/bodyscan/normalize.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 244,
+									"snippet": {
+										"text": "return rune(v), 6, true"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 244
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e rune"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 86,
+									"endLine": 643,
+									"snippet": {
+										"text": "}"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 86,
+									"startLine": 643
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 26,
+									"endLine": 639,
+									"snippet": {
+										"text": "if s.IsInferred {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 26,
+									"startLine": 639
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 23,
+									"endLine": 815,
+									"snippet": {},
+									"sourceLanguage": "go",
+									"startColumn": 23,
+									"startLine": 815
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 35,
+									"endLine": 815,
+									"snippet": {},
+									"sourceLanguage": "go",
+									"startColumn": 35,
+									"startLine": 815
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 65,
+									"endLine": 804,
+									"snippet": {
+										"text": "cSize := ( /*line :801:11*/_Cfunc_CString /*line :801:19*/)(size)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 65,
+									"startLine": 804
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 45,
+									"endLine": 769,
+									"snippet": {
+										"text": "if index \u003c 0 || index \u003e= int(( /*line :766:31*/_Cfunc_pocketSyncRowCount /*line :766:50*/)()) {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 45,
+									"startLine": 769
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 30,
+									"endLine": 729,
+									"snippet": {
+										"text": "active = 1"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 30,
+									"startLine": 729
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 8,
+									"endLine": 729,
+									"snippet": {
+										"text": "active = 1"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 8,
+									"startLine": 729
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 67,
+									"endLine": 728,
+									"snippet": {
+										"text": "if state.Active {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 67,
+									"startLine": 728
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 47,
+									"endLine": 728,
+									"snippet": {
+										"text": "if state.Active {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 47,
+									"startLine": 728
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 30,
+									"endLine": 624,
+									"snippet": {
+										"text": "active = 1"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 30,
+									"startLine": 624
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 8,
+									"endLine": 624,
+									"snippet": {
+										"text": "active = 1"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 8,
+									"startLine": 624
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 46,
+									"endLine": 623,
+									"snippet": {
+										"text": "if state.Active {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 46,
+									"startLine": 623
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 66,
+									"endLine": 623,
+									"snippet": {
+										"text": "if state.Active {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 66,
+									"startLine": 623
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 72,
+									"endLine": 101,
+									"snippet": {
+										"text": "if template {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 72,
+									"startLine": 101
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 47,
+									"endLine": 874,
+									"snippet": {
+										"text": "cDetail := ( /*line :871:13*/_Cfunc_CString /*line :871:21*/)(detail)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 47,
+									"startLine": 874
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 8,
+									"endLine": 874,
+									"snippet": {
+										"text": "cDetail := ( /*line :871:13*/_Cfunc_CString /*line :871:21*/)(detail)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 8,
+									"startLine": 874
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 69,
+									"endLine": 874,
+									"snippet": {
+										"text": "cDetail := ( /*line :871:13*/_Cfunc_CString /*line :871:21*/)(detail)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 69,
+									"startLine": 874
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 28,
+									"endLine": 874,
+									"snippet": {
+										"text": "cDetail := ( /*line :871:13*/_Cfunc_CString /*line :871:21*/)(detail)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 28,
+									"startLine": 874
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 21,
+									"endLine": 2109,
+									"snippet": {
+										"text": "// Safe to call from any goroutine — dispatches to the main thread internally."
+									},
+									"sourceLanguage": "go",
+									"startColumn": 21,
+									"startLine": 2109
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 63,
+									"endLine": 1931,
+									"snippet": {
+										"text": "}()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 63,
+									"startLine": 1931
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 26,
+									"endLine": 1917,
+									"snippet": {
+										"text": "cMeta.source = allocStr(meta.Source)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 26,
+									"startLine": 1917
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {},
+								"region": {
+									"endColumn": 29,
+									"endLine": 1916,
+									"snippet": {},
+									"sourceLanguage": "go",
+									"startColumn": 29,
+									"startLine": 1916
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e int32"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 51,
+									"endLine": 668,
+									"snippet": {
+										"text": "frame = append(frame, 126|0x80, byte(l\u003e\u003e8), byte(l))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 51,
+									"startLine": 668
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 39,
+									"endLine": 668,
+									"snippet": {
+										"text": "frame = append(frame, 126|0x80, byte(l\u003e\u003e8), byte(l))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 39,
+									"startLine": 668
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "integer overflow conversion int -\u003e byte"
+					},
+					"ruleId": "G115"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/transcript/proxy.go"
+								},
+								"region": {
+									"endColumn": 22,
+									"endLine": 73,
+									"snippet": {
+										"text": "chosen := c.Proxies[rand.Intn(len(c.Proxies))]"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 22,
+									"startLine": 73
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand)"
+					},
+					"ruleId": "G404"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/er1_room.go"
+								},
+								"region": {
+									"endColumn": 87,
+									"endLine": 192,
+									"snippet": {
+										"text": "client.Transport = \u0026http.Transport{TLSClientConfig: \u0026tls.Config{InsecureSkipVerify: true}} // #nosec G402 -- loopback-only, gated by er1TLSGuard"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 87,
+									"startLine": 192
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402",
+					"suppressions": [
+						{
+							"justification": "gated: default is ER1_VERIFY_SSL=true (verifies). VerifySSL=false\nis honored only for loopback — er1TLSGuard above fails closed for any non-loopback\nhost, and pkg/er1.applyTLSVerificationPolicy forces verification back on at load\ntime for non-loopback. Reaching here implies a loopback dev target.",
+							"kind": "inSource"
+						}
+					]
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/er1_publish.go"
+								},
+								"region": {
+									"endColumn": 87,
+									"endLine": 552,
+									"snippet": {
+										"text": "client.Transport = \u0026http.Transport{TLSClientConfig: \u0026tls.Config{InsecureSkipVerify: true}} // #nosec G402 -- loopback-only, gated by er1TLSGuard"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 87,
+									"startLine": 552
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402",
+					"suppressions": [
+						{
+							"justification": "gated: default is ER1_VERIFY_SSL=true (verifies). VerifySSL=false\nis honored only for loopback — er1TLSGuard above fails closed for any non-loopback\nhost, and pkg/er1.applyTLSVerificationPolicy forces verification back on at load\ntime for non-loopback. Reaching here implies a loopback dev target.",
+							"kind": "inSource"
+						}
+					]
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/session/session.go"
+								},
+								"region": {
+									"endColumn": 87,
+									"endLine": 292,
+									"snippet": {
+										"text": "client.Transport = \u0026http.Transport{TLSClientConfig: \u0026tls.Config{InsecureSkipVerify: true}}"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 87,
+									"startLine": 292
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/pocket/syncapi.go"
+								},
+								"region": {
+									"endColumn": 63,
+									"endLine": 64,
+									"snippet": {
+										"text": "transport.TLSClientConfig = \u0026tls.Config{InsecureSkipVerify: true}"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 63,
+									"startLine": 64
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/syncapi.go"
+								},
+								"region": {
+									"endColumn": 63,
+									"endLine": 64,
+									"snippet": {
+										"text": "transport.TLSClientConfig = \u0026tls.Config{InsecureSkipVerify: true}"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 63,
+									"startLine": 64
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/er1source.go"
+								},
+								"region": {
+									"endColumn": 87,
+									"endLine": 60,
+									"snippet": {
+										"text": "client.Transport = \u0026http.Transport{TLSClientConfig: \u0026tls.Config{InsecureSkipVerify: true}}"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 87,
+									"startLine": 60
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/upload.go"
+								},
+								"region": {
+									"endColumn": 87,
+									"endLine": 248,
+									"snippet": {
+										"text": "client.Transport = \u0026http.Transport{TLSClientConfig: \u0026tls.Config{InsecureSkipVerify: true}}"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 87,
+									"startLine": 248
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/upload.go"
+								},
+								"region": {
+									"endColumn": 53,
+									"endLine": 178,
+									"snippet": {
+										"text": "TLSClientConfig: \u0026tls.Config{InsecureSkipVerify: true},"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 53,
+									"startLine": 178
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/upload.go"
+								},
+								"region": {
+									"endColumn": 53,
+									"endLine": 143,
+									"snippet": {
+										"text": "TLSClientConfig: \u0026tls.Config{InsecureSkipVerify: true},"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 53,
+									"startLine": 143
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/config.go"
+								},
+								"region": {
+									"endColumn": 53,
+									"endLine": 295,
+									"snippet": {
+										"text": "TLSClientConfig: \u0026tls.Config{InsecureSkipVerify: true},"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 53,
+									"startLine": 295
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/healthcheck.go"
+								},
+								"region": {
+									"endColumn": 53,
+									"endLine": 87,
+									"snippet": {
+										"text": "TLSClientConfig: \u0026tls.Config{InsecureSkipVerify: true},"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 53,
+									"startLine": 87
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/sync_cmds.go"
+								},
+								"region": {
+									"endColumn": 63,
+									"endLine": 178,
+									"snippet": {
+										"text": "transport.TLSClientConfig = \u0026tls.Config{InsecureSkipVerify: true}"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 63,
+									"startLine": 178
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402",
+					"suppressions": [
+						{
+							"justification": "gated: default (no --insecure) verifies; skip permitted only for a loopback endpoint (isLoopbackHost check above fails closed for any other host) and endpoint is already required to be https //nolint:gosec // loopback-only, gated above",
+							"kind": "inSource"
+						}
+					]
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/replay_cmds.go"
+								},
+								"region": {
+									"endColumn": 53,
+									"endLine": 412,
+									"snippet": {
+										"text": "TLSClientConfig: \u0026tls.Config{InsecureSkipVerify: true}, // #nosec G402 -- loopback-only (target==\"local\" ⇒ 127.0.0.1)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 53,
+									"startLine": 412
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402",
+					"suppressions": [
+						{
+							"justification": "loopback-only (target==\"local\" ⇒ 127.0.0.1)",
+							"kind": "inSource"
+						}
+					]
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 63,
+									"endLine": 7140,
+									"snippet": {
+										"text": "transport.TLSClientConfig = \u0026tls.Config{InsecureSkipVerify: true}"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 63,
+									"startLine": 7140
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/doctor_cmd.go"
+								},
+								"region": {
+									"endColumn": 54,
+									"endLine": 553,
+									"snippet": {
+										"text": "TLSClientConfig: \u0026tls.Config{InsecureSkipVerify: true},"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 54,
+									"startLine": 553
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/doctor_cmd.go"
+								},
+								"region": {
+									"endColumn": 53,
+									"endLine": 367,
+									"snippet": {
+										"text": "TLSClientConfig: \u0026tls.Config{InsecureSkipVerify: true},"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 53,
+									"startLine": 367
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/timetracking/plmclient.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 53,
+									"snippet": {
+										"text": "InsecureSkipVerify: !cfg.VerifySSL,"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 53
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify may be set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/doctor_cmd.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 347,
+									"snippet": {
+										"text": "InsecureSkipVerify: !cfg.VerifySSL,"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 347
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "TLS InsecureSkipVerify may be set to true."
+					},
+					"ruleId": "G402"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/er1source.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 70,
+									"snippet": {
+										"text": "resp, err := client.Do(req)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 70
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "SSRF via taint analysis"
+					},
+					"ruleId": "G704"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/er1source.go"
+								},
+								"region": {
+									"endColumn": 29,
+									"endLine": 63,
+									"snippet": {
+										"text": "req, err := http.NewRequest(\"GET\", endpoint, nil)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 29,
+									"startLine": 63
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "SSRF via taint analysis"
+					},
+					"ruleId": "G704"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 29,
+									"endLine": 1345,
+									"snippet": {
+										"text": "resp, err := httpClient.Do(req)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 29,
+									"startLine": 1345
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "SSRF via taint analysis"
+					},
+					"ruleId": "G704"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 30,
+									"endLine": 1336,
+									"snippet": {
+										"text": "req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 30,
+									"startLine": 1336
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "SSRF via taint analysis"
+					},
+					"ruleId": "G704"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/revoke_cmds.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 234,
+									"snippet": {
+										"text": "resp, err := client.Do(httpReq)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 234
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "SSRF via taint analysis"
+					},
+					"ruleId": "G704"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/revoke_cmds.go"
+								},
+								"region": {
+									"endColumn": 33,
+									"endLine": 225,
+									"snippet": {
+										"text": "httpReq, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 33,
+									"startLine": 225
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "SSRF via taint analysis"
+					},
+					"ruleId": "G704"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/config.go"
+								},
+								"region": {
+									"endColumn": 7,
+									"endLine": 13,
+									"snippet": {
+										"text": "const PlaudTokenEnvVar = \"M3C_PLAUD_TOKEN\""
+									},
+									"sourceLanguage": "go",
+									"startColumn": 7,
+									"startLine": 13
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential hardcoded credentials"
+					},
+					"ruleId": "G101"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/install_trust_mode.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 459,
+									"snippet": {
+										"text": "if err := os.WriteFile(filepath.Join(tmp, skbName), skb, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 459
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/consolidate/fixer.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 103,
+									"snippet": {
+										"text": "if err := os.WriteFile(path, []byte(newContent), info.Mode()); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 103
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/session/session.go"
+								},
+								"region": {
+									"endColumn": 25,
+									"endLine": 99,
+									"snippet": {
+										"text": "b, err := os.ReadFile(filepath.Join(dir, e.Name()))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 25,
+									"startLine": 99
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 321,
+									"snippet": {
+										"text": "if _, err := os.Stat(p); err == nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 321
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/importer/scanner.go"
+								},
+								"region": {
+									"endColumn": 21,
+									"endLine": 60,
+									"snippet": {
+										"text": "err = filepath.Walk(absRoot, func(path string, info os.FileInfo, err error) error {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 21,
+									"startLine": 60
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/importer/scanner.go"
+								},
+								"region": {
+									"endColumn": 22,
+									"endLine": 45,
+									"snippet": {
+										"text": "info, err := os.Stat(root)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 22,
+									"startLine": 45
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/audio.go"
+								},
+								"region": {
+									"endColumn": 28,
+									"endLine": 114,
+									"snippet": {
+										"text": "data, err := os.ReadFile(p)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 28,
+									"startLine": 114
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/audio.go"
+								},
+								"region": {
+									"endColumn": 28,
+									"endLine": 79,
+									"snippet": {
+										"text": "data, err := os.ReadFile(p)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 28,
+									"startLine": 79
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/profile.go"
+								},
+								"region": {
+									"endColumn": 26,
+									"endLine": 386,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 26,
+									"startLine": 386
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/profile.go"
+								},
+								"region": {
+									"endColumn": 18,
+									"endLine": 289,
+									"snippet": {
+										"text": "return os.Remove(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 18,
+									"startLine": 289
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/profile.go"
+								},
+								"region": {
+									"endColumn": 22,
+									"endLine": 286,
+									"snippet": {
+										"text": "if _, err := os.Stat(path); os.IsNotExist(err) {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 22,
+									"startLine": 286
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/profile.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 272,
+									"snippet": {
+										"text": "if err := os.WriteFile(path, []byte(b.String()), 0600); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 272
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/preferences.go"
+								},
+								"region": {
+									"endColumn": 18,
+									"endLine": 102,
+									"snippet": {
+										"text": "_ = os.WriteFile(legacy, append(data, annotation...), 0o600)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 18,
+									"startLine": 102
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/preferences.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 96,
+									"snippet": {
+										"text": "if err := os.WriteFile(canonical, data, 0o600); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 96
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "evaluation/cmd/results-md/main.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 83,
+									"snippet": {
+										"text": "if err := os.WriteFile(mdPath, []byte(b.String()), 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 83
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "evaluation/cmd/results-md/main.go"
+								},
+								"region": {
+									"endColumn": 19,
+									"endLine": 26,
+									"snippet": {
+										"text": "f, err := os.Open(csvPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 19,
+									"startLine": 26
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/translog_cmds.go"
+								},
+								"region": {
+									"endColumn": 25,
+									"endLine": 385,
+									"snippet": {
+										"text": "if err := os.WriteFile(*outPath, append(data, '\\n'), 0o644); err != nil { //nolint:gosec // receipt is public"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 25,
+									"startLine": 385
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 26,
+									"endLine": 1035,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 26,
+									"startLine": 1035
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 22,
+									"endLine": 783,
+									"snippet": {
+										"text": "f, err := os.Create(outFile)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 22,
+									"startLine": 783
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 22,
+									"endLine": 679,
+									"snippet": {
+										"text": "f, err := os.Create(outFile)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 22,
+									"startLine": 679
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 22,
+									"endLine": 381,
+									"snippet": {
+										"text": "f, err := os.Create(outFile)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 22,
+									"startLine": 381
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 26,
+									"endLine": 366,
+									"snippet": {
+										"text": "data, err := os.ReadFile(input)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 26,
+									"startLine": 366
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 22,
+									"endLine": 193,
+									"snippet": {
+										"text": "f, err := os.Create(outFile)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 22,
+									"startLine": 193
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scan_body_cmds.go"
+								},
+								"region": {
+									"endColumn": 25,
+									"endLine": 167,
+									"snippet": {
+										"text": "raw, err := os.ReadFile(skillMD)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 25,
+									"startLine": 167
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scan_body_cmds.go"
+								},
+								"region": {
+									"endColumn": 23,
+									"endLine": 157,
+									"snippet": {
+										"text": "if _, err := os.Stat(p); err == nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 23,
+									"startLine": 157
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scan_body_cmds.go"
+								},
+								"region": {
+									"endColumn": 22,
+									"endLine": 146,
+									"snippet": {
+										"text": "info, err := os.Stat(dir)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 22,
+									"startLine": 146
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/propose_cmds.go"
+								},
+								"region": {
+									"endColumn": 26,
+									"endLine": 261,
+									"snippet": {
+										"text": "body, err := os.ReadFile(skillMD)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 26,
+									"startLine": 261
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/pin_cmds.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 351,
+									"snippet": {
+										"text": "if err := os.WriteFile(staged, content, 0o600); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 351
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/pin_cmds.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 317,
+									"snippet": {
+										"text": "if err := os.WriteFile(target, content, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 317
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/pin_cmds.go"
+								},
+								"region": {
+									"endColumn": 25,
+									"endLine": 311,
+									"snippet": {
+										"text": "if err := os.WriteFile(backup, existing, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 25,
+									"startLine": 311
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/export_kit_cmds.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 190,
+									"snippet": {
+										"text": "if err := os.WriteFile(filepath.Join(*outDir, skbName), skbBytes, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 190
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/audit_security_cmds.go"
+								},
+								"region": {
+									"endColumn": 29,
+									"endLine": 195,
+									"snippet": {
+										"text": "if data, err := os.ReadFile(sidecarPath); err == nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 29,
+									"startLine": 195
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/audit_security_cmds.go"
+								},
+								"region": {
+									"endColumn": 25,
+									"endLine": 104,
+									"snippet": {
+										"text": "if info, err := os.Stat(skillDir); err != nil || !info.IsDir() {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 25,
+									"startLine": 104
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/agentid_cmds.go"
+								},
+								"region": {
+									"endColumn": 26,
+									"endLine": 493,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 26,
+									"startLine": 493
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 21,
+									"endLine": 447,
+									"snippet": {
+										"text": "return os.WriteFile(dst, b, 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 21,
+									"startLine": 447
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 257,
+									"snippet": {
+										"text": "if err := os.WriteFile(filepath.Join(dst, name+\".skb\"), blob, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 257
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/poc-whisper/main.go"
+								},
+								"region": {
+									"endColumn": 30,
+									"endLine": 172,
+									"snippet": {
+										"text": "jsonData, err := os.ReadFile(jsonPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 30,
+									"startLine": 172
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/poc-whisper/main.go"
+								},
+								"region": {
+									"endColumn": 22,
+									"endLine": 53,
+									"snippet": {
+										"text": "if _, err := os.Stat(audioFile); os.IsNotExist(err) {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 22,
+									"startLine": 53
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/poc-recorder/main.go"
+								},
+								"region": {
+									"endColumn": 21,
+									"endLine": 184,
+									"snippet": {
+										"text": "f, err := os.Create(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 21,
+									"startLine": 184
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/poc-recorder/main.go"
+								},
+								"region": {
+									"endColumn": 20,
+									"endLine": 175,
+									"snippet": {
+										"text": "info, _ := os.Stat(output)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 20,
+									"startLine": 175
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 6145,
+									"snippet": {
+										"text": "if err := os.WriteFile(metaPath, metaJSON, 0600); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 6145
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 25,
+									"endLine": 6126,
+									"snippet": {
+										"text": "if err := os.WriteFile(txPath, []byte(transcriptText), 0600); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 25,
+									"startLine": 6126
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 6119,
+									"snippet": {
+										"text": "if err := os.WriteFile(docPath, []byte(compositeDoc), 0600); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 6119
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 6113,
+									"snippet": {
+										"text": "if err := os.WriteFile(audioPath, audioData, 0600); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 6113
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 23,
+									"endLine": 6107,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0700); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 23,
+									"startLine": 6107
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 29,
+									"endLine": 1783,
+									"snippet": {
+										"text": "logFile, err := os.OpenFile(cfg.LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 29,
+									"startLine": 1783
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 1781,
+									"snippet": {
+										"text": "os.MkdirAll(logDir, 0700)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 1781
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 26,
+									"endLine": 951,
+									"snippet": {
+										"text": "info, statErr := os.Stat(output)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 26,
+									"startLine": 951
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/commands_shared.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 580,
+									"snippet": {
+										"text": "if err := os.WriteFile(output, data, 0600); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 580
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/commands_shared.go"
+								},
+								"region": {
+									"endColumn": 31,
+									"endLine": 478,
+									"snippet": {
+										"text": "audioData, err = os.ReadFile(audioPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 31,
+									"startLine": 478
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/docaudit/main.go"
+								},
+								"region": {
+									"endColumn": 23,
+									"endLine": 591,
+									"snippet": {
+										"text": "b, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 23,
+									"startLine": 591
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/docaudit/main.go"
+								},
+								"region": {
+									"endColumn": 23,
+									"endLine": 573,
+									"snippet": {
+										"text": "b, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 23,
+									"startLine": 573
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Path traversal via taint analysis"
+					},
+					"ruleId": "G703",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillbundle/pack.go"
+								},
+								"region": {
+									"endColumn": 31,
+									"endLine": 183,
+									"snippet": {
+										"text": "data, readErr := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 31,
+									"startLine": 183
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Filesystem operation in filepath.Walk/WalkDir callback uses race-prone path; consider root-scoped APIs (e.g. os.Root) to prevent symlink TOCTOU traversal"
+					},
+					"ruleId": "G122",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/poc-whisper/main.go"
+								},
+								"region": {
+									"endColumn": 21,
+									"endLine": 154,
+									"snippet": {
+										"text": "cmd := exec.Command(whisperPath,"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 21,
+									"startLine": 154
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Command injection via taint analysis"
+					},
+					"ruleId": "G702",
+					"ruleIndex": 2
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/transcript/fetcher.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 31,
+									"snippet": {
+										"text": "{Name: \"CONSENT\", Value: \"YES+cb\", Path: \"/\", Domain: \".youtube.com\"},"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 31
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "http.Cookie missing or has insecure Secure, HttpOnly, or SameSite attribute"
+					},
+					"ruleId": "G124",
+					"ruleIndex": 2
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "internal/thinking/api/server.go"
+								},
+								"region": {
+									"endColumn": 17,
+									"endLine": 385,
+									"snippet": {
+										"text": "_, _ = w.Write(row)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 17,
+									"startLine": 385
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "XSS via taint analysis"
+					},
+					"ruleId": "G705"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "internal/thinking/api/auth.go"
+								},
+								"region": {
+									"endColumn": 16,
+									"endLine": 115,
+									"snippet": {
+										"text": "_, _ = w.Write([]byte(fmt.Sprintf(`{\"error\":\"unauthorized\",\"detail\":%q}`, msg)))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 16,
+									"startLine": 115
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "XSS via taint analysis"
+					},
+					"ruleId": "G705"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/report/html.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 146,
+									"snippet": {
+										"text": "return template.HTML(b.String())"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 146
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "The used method does not auto-escape HTML. This can potentially lead to 'Cross-site Scripting' vulnerabilities, in case the attacker controls the input."
+					},
+					"ruleId": "G203"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/whisper/whisper.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 146,
+									"snippet": {
+										"text": "cmd := exec.CommandContext(ctx, whisperPath, args...)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 146
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 514,
+									"snippet": {
+										"text": "cmd = exec.Command(\"rundll32\", \"url.dll,FileProtocolHandler\", url)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 514
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 512,
+									"snippet": {
+										"text": "cmd = exec.Command(\"xdg-open\", url)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 512
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 510,
+									"snippet": {
+										"text": "cmd = exec.Command(\"open\", url)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 510
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/menubar/skillbar.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 496,
+									"snippet": {
+										"text": "if err := exec.Command(\"open\", url).Start(); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 496
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/server.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 477,
+									"snippet": {
+										"text": "cmd = exec.Command(\"rundll32\", \"url.dll,FileProtocolHandler\", url)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 477
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/server.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 475,
+									"snippet": {
+										"text": "cmd = exec.Command(\"xdg-open\", url)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 475
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/server.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 473,
+									"snippet": {
+										"text": "cmd = exec.Command(\"open\", url)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 473
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/backend/git/local.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 155,
+									"snippet": {
+										"text": "out, err := exec.Command(\"git\", \"-C\", path, \"bundle\", \"create\", outPath, \"--all\").CombinedOutput()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 155
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/backend/git/local.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 87,
+									"snippet": {
+										"text": "out, err := exec.Command(\"git\", \"-c\", \"init.defaultBranch=main\", \"init\", \"--bare\", path).CombinedOutput()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 87
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/backend/git/git.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 347,
+									"snippet": {
+										"text": "cmd := exec.Command(gitBin, args...)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 347
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/artifactauth/creds.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 113,
+									"snippet": {
+										"text": "out, err := exec.Command(\"/usr/bin/security\", \"find-generic-password\", \"-s\", service, \"-a\", account, \"-w\").Output()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 113
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/session/session.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 116,
+									"snippet": {
+										"text": "cmd := exec.Command(\"git\", args...)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 116
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/screenshot/capture.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 24,
+									"snippet": {
+										"text": "cmd := exec.Command(name, args...)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 24
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/pocket/merger.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 96,
+									"snippet": {
+										"text": "cmd := exec.Command(ffmpeg,\n\"-f\", \"concat\",\n\"-safe\", \"0\",\n\"-i\", listPath,\n\"-c\", \"copy\",\n\"-y\",\noutputPath,\n)\n"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 89
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 10,
+									"endLine": 719,
+									"snippet": {
+										"text": "return exec.Command(\"xdg-open\", url).Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 10,
+									"startLine": 719
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 10,
+									"endLine": 717,
+									"snippet": {
+										"text": "return exec.Command(\"rundll32\", \"url.dll,FileProtocolHandler\", url).Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 10,
+									"startLine": 717
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 10,
+									"endLine": 715,
+									"snippet": {
+										"text": "return exec.Command(\"open\", url).Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 10,
+									"startLine": 715
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 238,
+									"snippet": {
+										"text": "cmd := exec.Command(chromePath,\n\"--remote-debugging-port=9222\",\n\"--user-data-dir=\"+debugDir,\n\"https://app.plaud.ai\",\n)\n"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 234
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 149,
+									"snippet": {
+										"text": "cmd := exec.Command(chromePath,\n\"--remote-debugging-port=9222\",\n\"--user-data-dir=\"+debugDir,\n\"https://app.plaud.ai\",\n)\n"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 145
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/menubar/app.go"
+								},
+								"region": {
+									"endColumn": 11,
+									"endLine": 887,
+									"snippet": {
+										"text": "_ = exec.Command(\"open\", url).Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 11,
+									"startLine": 887
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/menubar/app.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 869,
+									"snippet": {
+										"text": "_ = exec.Command(\"open\", docURL).Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 869
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/menubar/app.go"
+								},
+								"region": {
+									"endColumn": 11,
+									"endLine": 448,
+									"snippet": {
+										"text": "_ = exec.Command(\"open\", \"-a\", \"Google Chrome\", profURL).Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 11,
+									"startLine": 448
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1login/login.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 142,
+									"snippet": {
+										"text": "return exec.Command(name, args...).Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 142
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/config.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 235,
+									"snippet": {
+										"text": "out, err := exec.CommandContext(ctx, \"/usr/bin/security\", q...).Output()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 235
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/editor.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 510,
+									"snippet": {
+										"text": "cmd = exec.Command(\"rundll32\", \"url.dll,FileProtocolHandler\", url)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 510
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/editor.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 508,
+									"snippet": {
+										"text": "cmd = exec.Command(\"xdg-open\", url)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 508
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/editor.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 506,
+									"snippet": {
+										"text": "cmd = exec.Command(\"open\", url)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 506
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/main.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 268,
+									"snippet": {
+										"text": "cmd = exec.Command(\"xdg-open\", url)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 268
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/main.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 266,
+									"snippet": {
+										"text": "cmd = exec.Command(\"rundll32\", \"url.dll,FileProtocolHandler\", url)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 266
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/main.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 264,
+									"snippet": {
+										"text": "cmd = exec.Command(\"open\", url)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 264
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/poc-whisper/main.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 159,
+									"snippet": {
+										"text": "cmd := exec.Command(whisperPath,\naudioFile,\n\"--model\", model,\n\"--output_format\", \"json\",\n\"--output_dir\", tmpDir,\n)\n"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 154
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 8,
+									"endLine": 4670,
+									"snippet": {
+										"text": "c := exec.Command(\"stty\", arg)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 8,
+									"startLine": 4670
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 10,
+									"endLine": 4083,
+									"snippet": {
+										"text": "return exec.Command(\"open\", url).Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 10,
+									"startLine": 4083
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 4080,
+									"snippet": {
+										"text": "if err := exec.Command(\"open\", \"-a\", \"Google Chrome\", url).Start(); err == nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 4080
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 10,
+									"endLine": 4078,
+									"snippet": {
+										"text": "return exec.Command(\"xdg-open\", url).Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 10,
+									"startLine": 4078
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 10,
+									"endLine": 4076,
+									"snippet": {
+										"text": "return exec.Command(\"rundll32\", \"url.dll,FileProtocolHandler\", url).Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 10,
+									"startLine": 4076
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 803,
+									"snippet": {
+										"text": "cmd := exec.Command(\"bash\", setupArgs...)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 803
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with variable"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/menubar/skillbar.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 451,
+									"snippet": {
+										"text": "if err := exec.Command(\"open\", tmpFile.Name()).Start(); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 451
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with a potential tainted input or cmd arguments"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/menubar/app.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 1138,
+									"snippet": {
+										"text": "_ = exec.Command(\"open\", filepath.Join(home, \".m3c-tools\", \"profiles\")).Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 1138
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with a potential tainted input or cmd arguments"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/menubar/app.go"
+								},
+								"region": {
+									"endColumn": 7,
+									"endLine": 542,
+									"snippet": {
+										"text": "exec.Command(\"open\", a.Config.LogPath).Run()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 7,
+									"startLine": 542
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with a potential tainted input or cmd arguments"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/runner.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 46,
+									"snippet": {
+										"text": "cmd := exec.CommandContext(ctx, r.Skillctl, args...)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 46
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Subprocess launched with a potential tainted input or cmd arguments"
+					},
+					"ruleId": "G204",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/store.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 188,
+									"snippet": {
+										"text": "if _, err := tx.Exec(\"DELETE FROM \" + table); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 188
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "SQL string concatenation"
+					},
+					"ruleId": "G202"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/store.go"
+								},
+								"region": {
+									"endColumn": 24,
+									"endLine": 109,
+									"snippet": {
+										"text": "if _, err := tx.Exec(\"DELETE FROM \" + table); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 24,
+									"startLine": 109
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "SQL string concatenation"
+					},
+					"ruleId": "G202"
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/whisper/whisper.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 250,
+									"snippet": {
+										"text": "data, err := os.ReadFile(jsonPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 250
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/tracking/files.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 109,
+									"snippet": {
+										"text": "file, err := os.Open(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 109
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/verify/verify.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 1038,
+									"snippet": {
+										"text": "blob, err := os.ReadFile(bundlePath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 1038
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/verify/verify.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 974,
+									"snippet": {
+										"text": "blob, err := os.ReadFile(bundlePath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 974
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/verify/trustroots.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 667,
+									"snippet": {
+										"text": "f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 667
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/verify/trustroots.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 598,
+									"snippet": {
+										"text": "data, err := os.ReadFile(abs)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 598
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/verify/emergency.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 195,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 195
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/verify/agent_revocation.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 189,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 189
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/translog/log.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 57,
+									"snippet": {
+										"text": "f, err := os.Open(path) //nolint:gosec // path is operator-provided, not attacker-tainted"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 57
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/signing/verify.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 51,
+									"snippet": {
+										"text": "sig, err := os.ReadFile(sigPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 51
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/signing/sign.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 173,
+									"snippet": {
+										"text": "blob, err := os.ReadFile(bundlePath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 173
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/signing/sign.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 44,
+									"snippet": {
+										"text": "f, err := os.Open(bundlePath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 44
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/signing/keygen.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 242,
+									"snippet": {
+										"text": "f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 242
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/signing/keygen.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 210,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 210
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/signing/keygen.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 171,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 171
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/scanner/trust.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 173,
+									"snippet": {
+										"text": "f, err := os.Open(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 173
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/scanner/tiers.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 74,
+									"snippet": {
+										"text": "data, err := os.ReadFile(skillMDPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 74
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/scanner/scanner.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 357,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 357
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/scanner/scanner.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 311,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 311
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 58,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 58
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/selftrustroots.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 108,
+									"snippet": {
+										"text": "raw, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 108
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/peers.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 71,
+									"snippet": {
+										"text": "raw, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 71
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/install_trust_mode.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 627,
+									"snippet": {
+										"text": "b, err := os.ReadFile(filepath.Join(dir, rel))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 627
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/install_trust_mode.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 548,
+									"snippet": {
+										"text": "raw, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 548
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/install_trust_mode.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 324,
+									"snippet": {
+										"text": "if b, err := os.ReadFile(keyPath); err == nil \u0026\u0026 len(b) == 32 {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 324
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/cross_signing.go"
+								},
+								"region": {
+									"endColumn": 17,
+									"endLine": 131,
+									"snippet": {
+										"text": "data, rerr := os.ReadFile(f)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 17,
+									"startLine": 131
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/attestation_stash.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 73,
+									"snippet": {
+										"text": "b, err := os.ReadFile(filepath.Join(dir, AttestationStashName))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 73
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/propose/gate.go"
+								},
+								"region": {
+									"endColumn": 16,
+									"endLine": 444,
+									"snippet": {
+										"text": "body, err := os.ReadFile(filepath.Join(dir, e.Name()))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 16,
+									"startLine": 444
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/propose/gate.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 392,
+									"snippet": {
+										"text": "body, err := os.ReadFile(skillMDPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 392
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/propose/gate.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 253,
+									"snippet": {
+										"text": "raw, err := os.ReadFile(skillMDPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 253
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/outbox/spool.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 96,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 96
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/outbox/spool.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 72,
+									"snippet": {
+										"text": "f, err := os.OpenFile(filepath.Join(dir, \"spool.jsonl\"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 72
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/offline_verify.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 451,
+									"snippet": {
+										"text": "f, err := os.Open(p)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 451
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/offline_verify.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 388,
+									"snippet": {
+										"text": "blob, err := os.ReadFile(skbPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 388
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/offline_verify.go"
+								},
+								"region": {
+									"endColumn": 21,
+									"endLine": 283,
+									"snippet": {
+										"text": "skbBytes, rerr := os.ReadFile(skbPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 21,
+									"startLine": 283
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/offline_verify.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 234,
+									"snippet": {
+										"text": "b, err := os.ReadFile(filepath.Join(target, registry.ProvenanceSidecarName))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 234
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/offline_verify.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 105,
+									"snippet": {
+										"text": "b, err := os.ReadFile(filepath.Join(target, offlineMetaFile))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 105
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/install.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 817,
+									"snippet": {
+										"text": "f, err := os.Open(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 817
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/install.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 734,
+									"snippet": {
+										"text": "f, err := os.Open(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 734
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/install.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 681,
+									"snippet": {
+										"text": "f, err := os.Open(checksumPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 681
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/delta/seal.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 180,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 180
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/delta/seal.go"
+								},
+								"region": {
+									"endColumn": 17,
+									"endLine": 139,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 17,
+									"startLine": 139
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/consolidate/fixer.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 83,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 83
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/consolidate/fixer.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 52,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 52
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/consolidate/analyzer.go"
+								},
+								"region": {
+									"endColumn": 19,
+									"endLine": 231,
+									"snippet": {
+										"text": "copyData, err := os.ReadFile(copyPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 19,
+									"startLine": 231
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/consolidate/analyzer.go"
+								},
+								"region": {
+									"endColumn": 21,
+									"endLine": 227,
+									"snippet": {
+										"text": "sourceData, err := os.ReadFile(sourcePath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 21,
+									"startLine": 227
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/backend/git/git.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 43,
+									"snippet": {
+										"text": "f, err := os.Open(p)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 43
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/backend/git/format.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 80,
+									"snippet": {
+										"text": "f, err := os.Open(p)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 80
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillbundle/unpack.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 192,
+									"snippet": {
+										"text": "f, err := os.OpenFile(full, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 192
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillbundle/pack.go"
+								},
+								"region": {
+									"endColumn": 20,
+									"endLine": 183,
+									"snippet": {
+										"text": "data, readErr := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 20,
+									"startLine": 183
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillbundle/ignore.go"
+								},
+								"region": {
+									"endColumn": 18,
+									"endLine": 117,
+									"snippet": {
+										"text": "if data, err := os.ReadFile(filepath.Join(skillDir, \".skbignore\")); err == nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 18,
+									"startLine": 117
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/session/session.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 709,
+									"snippet": {
+										"text": "f, err := os.OpenFile(filepath.Join(wdir, \"session-state.log\"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 709
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/session/session.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 99,
+									"snippet": {
+										"text": "b, err := os.ReadFile(filepath.Join(dir, e.Name()))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 99
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/pocket/state.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 108,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 108
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/pocket/staging.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 75,
+									"snippet": {
+										"text": "out, err := os.Create(dst)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 75
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/pocket/staging.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 69,
+									"snippet": {
+										"text": "in, err := os.Open(src)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 69
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/pocket/scanner.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 109,
+									"snippet": {
+										"text": "f, err := os.Open(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 109
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/login.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 181,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 181
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/devapi.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 70,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 70
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/config.go"
+								},
+								"region": {
+									"endColumn": 20,
+									"endLine": 30,
+									"snippet": {
+										"text": "data, readErr := os.ReadFile(tokenFile)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 20,
+									"startLine": 30
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 53,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 53
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/menubar/cache.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 44,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 44
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/m3cproject/descriptor.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 240,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 240
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/importer/import.go"
+								},
+								"region": {
+									"endColumn": 18,
+									"endLine": 331,
+									"snippet": {
+										"text": "dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 18,
+									"startLine": 331
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/importer/import.go"
+								},
+								"region": {
+									"endColumn": 18,
+									"endLine": 320,
+									"snippet": {
+										"text": "srcFile, err := os.Open(src)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 18,
+									"startLine": 320
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/memory.go"
+								},
+								"region": {
+									"endColumn": 17,
+									"endLine": 251,
+									"snippet": {
+										"text": "data, err := os.ReadFile(fpath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 17,
+									"startLine": 251
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/memory.go"
+								},
+								"region": {
+									"endColumn": 17,
+									"endLine": 238,
+									"snippet": {
+										"text": "data, err := os.ReadFile(fpath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 17,
+									"startLine": 238
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/memory.go"
+								},
+								"region": {
+									"endColumn": 17,
+									"endLine": 224,
+									"snippet": {
+										"text": "data, err := os.ReadFile(fpath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 17,
+									"startLine": 224
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/memory.go"
+								},
+								"region": {
+									"endColumn": 17,
+									"endLine": 204,
+									"snippet": {
+										"text": "data, err := os.ReadFile(fpath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 17,
+									"startLine": 204
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/memory.go"
+								},
+								"region": {
+									"endColumn": 23,
+									"endLine": 159,
+									"snippet": {
+										"text": "if metaBytes, err := os.ReadFile(metaPath); err == nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 23,
+									"startLine": 159
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/config.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 349,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 349
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/audio.go"
+								},
+								"region": {
+									"endColumn": 17,
+									"endLine": 114,
+									"snippet": {
+										"text": "data, err := os.ReadFile(p)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 17,
+									"startLine": 114
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/audio.go"
+								},
+								"region": {
+									"endColumn": 17,
+									"endLine": 79,
+									"snippet": {
+										"text": "data, err := os.ReadFile(p)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 17,
+									"startLine": 79
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/draft/draft.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 106,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 106
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/profile.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 386,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 386
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/profile.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 364,
+									"snippet": {
+										"text": "f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 364
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/preferences.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 92,
+									"snippet": {
+										"text": "data, err := os.ReadFile(legacy)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 92
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/auth/store_file.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 97,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 97
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "evaluation/cmd/results-md/main.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 26,
+									"snippet": {
+										"text": "f, err := os.Open(csvPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 26
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/verify_hook_cmds.go"
+								},
+								"region": {
+									"endColumn": 19,
+									"endLine": 885,
+									"snippet": {
+										"text": "if data, err := os.ReadFile(path); err == nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 19,
+									"startLine": 885
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/verify_hook_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 119,
+									"snippet": {
+										"text": "b, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 119
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/verify_hook_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 76,
+									"snippet": {
+										"text": "b, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 76
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/verify_bundle_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 387,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 387
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/verify_bundle_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 285,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 285
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/verdict_cache.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 197,
+									"snippet": {
+										"text": "b, err := os.ReadFile(f)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 197
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/verdict_cache.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 78,
+									"snippet": {
+										"text": "if b, err := os.ReadFile(p); err == nil \u0026\u0026 len(b) \u003e= 32 {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 78
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/translog_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 579,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path) //nolint:gosec // operator-supplied path"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 579
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/translog_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 566,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path) //nolint:gosec // operator-supplied path"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 566
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/session_baseline_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 269,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 269
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 1206,
+									"snippet": {
+										"text": "data, err := os.ReadFile(filepath.Join(home, \".m3c-tools\", \"er1_session.json\"))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 1206
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 1035,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 1035
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scan_body_cmds.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 167,
+									"snippet": {
+										"text": "raw, err := os.ReadFile(skillMD)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 167
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/runbook_cmds.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 218,
+									"snippet": {
+										"text": "raw, err := os.ReadFile(metaPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 218
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/runbook_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 184,
+									"snippet": {
+										"text": "html, err := os.ReadFile(htmlPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 184
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/runbook_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 59,
+									"snippet": {
+										"text": "html, err := os.ReadFile(htmlPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 59
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/revoked_cache.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 462,
+									"snippet": {
+										"text": "b, err := os.ReadFile(filepath.Join(home, \".claude\", \"skills\", name, registry.ProvenanceSidecarName))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 462
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/revoked_cache.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 138,
+									"snippet": {
+										"text": "b, err := os.ReadFile(p)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 138
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/replay_cmds.go"
+								},
+								"region": {
+									"endColumn": 16,
+									"endLine": 389,
+									"snippet": {
+										"text": "data, err := os.ReadFile(p)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 16,
+									"startLine": 389
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/replay_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 350,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 350
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/publish_manifest.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 92,
+									"snippet": {
+										"text": "f, err := os.Open(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 92
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/publish_cmds.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 502,
+									"snippet": {
+										"text": "skb, err := os.ReadFile(bundlePath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 502
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/publish_cmds.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 302,
+									"snippet": {
+										"text": "skb, err := os.ReadFile(skbPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 302
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/propose_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 327,
+									"snippet": {
+										"text": "f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 327
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/propose_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 261,
+									"snippet": {
+										"text": "body, err := os.ReadFile(skillMD)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 261
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/pin_cmds.go"
+								},
+								"region": {
+									"endColumn": 16,
+									"endLine": 322,
+									"snippet": {
+										"text": "back, rerr := os.ReadFile(target)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 16,
+									"startLine": 322
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/pin_cmds.go"
+								},
+								"region": {
+									"endColumn": 23,
+									"endLine": 246,
+									"snippet": {
+										"text": "existing, readErr := os.ReadFile(target)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 23,
+									"startLine": 246
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/pin_cmds.go"
+								},
+								"region": {
+									"endColumn": 19,
+									"endLine": 160,
+									"snippet": {
+										"text": "data, readErr := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 19,
+									"startLine": 160
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/invocation_trail.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 226,
+									"snippet": {
+										"text": "f, err := os.Open(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 226
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/invocation_trail.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 112,
+									"snippet": {
+										"text": "f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 112
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/intent_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 925,
+									"snippet": {
+										"text": "raw, err := os.ReadFile(fromYAML)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 925
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/gate_stats_cmds.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 100,
+									"snippet": {
+										"text": "f, err := os.Open(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 100
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/gate_audit.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 60,
+									"snippet": {
+										"text": "f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 60
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/freshness_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 146,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 146
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/export_kit_cmds.go"
+								},
+								"region": {
+									"endColumn": 16,
+									"endLine": 362,
+									"snippet": {
+										"text": "data, err := os.ReadFile(filepath.Join(dir, e.Name()))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 16,
+									"startLine": 362
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/export_kit_cmds.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 346,
+									"snippet": {
+										"text": "zf, err := os.Create(zipPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 346
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/export_kit_cmds.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 260,
+									"snippet": {
+										"text": "return os.ReadFile(tmpPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 260
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/export_kit_cmds.go"
+								},
+								"region": {
+									"endColumn": 20,
+									"endLine": 153,
+									"snippet": {
+										"text": "metaBytes, err := os.ReadFile(mp)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 20,
+									"startLine": 153
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/enforce_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 61,
+									"snippet": {
+										"text": "b, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 61
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/compliance_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 301,
+									"snippet": {
+										"text": "b, err := os.ReadFile(filepath.Join(dir, \".m3c-provenance.json\"))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 301
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/compliance_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 289,
+									"snippet": {
+										"text": "b, err := os.ReadFile(filepath.Join(dir, \".skillctl-offline.json\"))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 289
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/awareness_cmds.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 242,
+									"snippet": {
+										"text": "f, err := os.Open(inventoryPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 242
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/audit_security_cmds.go"
+								},
+								"region": {
+									"endColumn": 18,
+									"endLine": 195,
+									"snippet": {
+										"text": "if data, err := os.ReadFile(sidecarPath); err == nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 18,
+									"startLine": 195
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/audit_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 464,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 464
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/agentid_revoke_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 120,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 120
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/agentid_gate.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 106,
+									"snippet": {
+										"text": "b, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 106
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/agentid_cmds.go"
+								},
+								"region": {
+									"endColumn": 16,
+									"endLine": 581,
+									"snippet": {
+										"text": "data, rerr := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 16,
+									"startLine": 581
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/agentid_cmds.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 493,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 493
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 440,
+									"snippet": {
+										"text": "b, err := os.ReadFile(src)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 440
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 430,
+									"snippet": {
+										"text": "f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 430
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 374,
+									"snippet": {
+										"text": "b, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 374
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 245,
+									"snippet": {
+										"text": "blob, err := os.ReadFile(skb)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 245
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/poc-whisper/main.go"
+								},
+								"region": {
+									"endColumn": 19,
+									"endLine": 172,
+									"snippet": {
+										"text": "jsonData, err := os.ReadFile(jsonPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 19,
+									"startLine": 172
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/poc-recorder/main.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 184,
+									"snippet": {
+										"text": "f, err := os.Create(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 184
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 26,
+									"endLine": 7612,
+									"snippet": {
+										"text": "audioBytes, readErr := os.ReadFile(stagedPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 26,
+									"startLine": 7612
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 26,
+									"endLine": 6898,
+									"snippet": {
+										"text": "mergedBytes, readErr := os.ReadFile(mergedPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 26,
+									"startLine": 6898
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 26,
+									"endLine": 6735,
+									"snippet": {
+										"text": "audioBytes, readErr := os.ReadFile(stagedPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 26,
+									"startLine": 6735
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 4315,
+									"snippet": {
+										"text": "f, err := os.Open(modelPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 4315
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 16,
+									"endLine": 3730,
+									"snippet": {
+										"text": "imgData, _ := os.ReadFile(imgPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 16,
+									"startLine": 3730
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 18,
+									"endLine": 3703,
+									"snippet": {
+										"text": "imgData, err := os.ReadFile(imgPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 18,
+									"startLine": 3703
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 23,
+									"endLine": 3508,
+									"snippet": {
+										"text": "if data, readErr := os.ReadFile(thumbnailPath); readErr == nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 23,
+									"startLine": 3508
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 20,
+									"endLine": 1456,
+									"snippet": {
+										"text": "audioData, err := os.ReadFile(destFile)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 20,
+									"startLine": 1456
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 1427,
+									"snippet": {
+										"text": "dstF, err := os.Create(destFile)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 1427
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 1423,
+									"snippet": {
+										"text": "srcF, err := os.Open(absPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 1423
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 385,
+									"snippet": {
+										"text": "data, err := os.ReadFile(p)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 385
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/doctor_cmd.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 460,
+									"snippet": {
+										"text": "data, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 460
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/docaudit/main.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 591,
+									"snippet": {
+										"text": "b, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 591
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/docaudit/main.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 573,
+									"snippet": {
+										"text": "b, err := os.ReadFile(path)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 573
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"fixes": [
+						{
+							"artifactChanges": [
+								{
+									"artifactLocation": {
+										"description": {
+											"text": "File requiring changes"
+										}
+									},
+									"replacements": [
+										{
+											"deletedRegion": {
+												"endColumn": 1,
+												"endLine": 1,
+												"startColumn": 1,
+												"startLine": 1
+											}
+										}
+									]
+								}
+							],
+							"description": {
+								"markdown": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal.",
+								"text": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
+							}
+						}
+					],
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/docaudit/main.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 378,
+									"snippet": {
+										"text": "b, err := os.ReadFile(manual)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 378
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential file inclusion via variable"
+					},
+					"ruleId": "G304",
+					"ruleIndex": 3
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 113,
+									"snippet": {
+										"text": "httpSrv := \u0026http.Server{Handler: s.GuardedHandler()}"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 113
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server"
+					},
+					"ruleId": "G112"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/menubar/skillbar.go"
+								},
+								"region": {
+									"endColumn": 10,
+									"endLine": 478,
+									"snippet": {
+										"text": "srv = \u0026http.Server{Handler: mux}"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 10,
+									"startLine": 478
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server"
+					},
+					"ruleId": "G112"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/server.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 96,
+									"snippet": {
+										"text": "httpSrv := \u0026http.Server{Handler: s.GuardedHandler()}"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 96
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server"
+					},
+					"ruleId": "G112"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/editor.go"
+								},
+								"region": {
+									"endColumn": 10,
+									"endLine": 184,
+									"snippet": {
+										"text": "srv := \u0026http.Server{Handler: s.GuardedHandler()}"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 10,
+									"startLine": 184
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server"
+					},
+					"ruleId": "G112"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 10,
+									"endLine": 3276,
+									"snippet": {
+										"text": "srv := \u0026http.Server{\nAddr:    addr,\nHandler: mux,\n}\n"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 10,
+									"startLine": 3273
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server"
+					},
+					"ruleId": "G112"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/devapi.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 142,
+									"snippet": {
+										"text": "data, err := json.MarshalIndent(t, \"\", \"  \")"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 142
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Marshaled struct field \"AccessToken\" (JSON key \"access_token\") matches secret pattern"
+					},
+					"ruleId": "G117",
+					"ruleIndex": 1
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/session/session.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 709,
+									"snippet": {
+										"text": "f, err := os.OpenFile(filepath.Join(wdir, \"session-state.log\"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 709
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect file permissions to be 0600 or less"
+					},
+					"ruleId": "G302",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/importer/tracker.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 184,
+									"snippet": {
+										"text": "f, err := os.OpenFile(t.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 184
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect file permissions to be 0600 or less"
+					},
+					"ruleId": "G302",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 430,
+									"snippet": {
+										"text": "f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 430
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect file permissions to be 0600 or less"
+					},
+					"ruleId": "G302",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/tracking/retryqueue.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 99,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 99
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/tracking/exports.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 58,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 58
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/install_trust_mode.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 412,
+									"snippet": {
+										"text": "if err := os.MkdirAll(skillsDir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 412
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/er1_pull.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 553,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 553
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/er1_pull.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 466,
+									"snippet": {
+										"text": "if err := os.MkdirAll(cacheRoot, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 466
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/backend_pull.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 188,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 188
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/backend_pull.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 122,
+									"snippet": {
+										"text": "if err := os.MkdirAll(cacheRoot, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 122
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/install.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 773,
+									"snippet": {
+										"text": "if err := os.MkdirAll(archDir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 773
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/install.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 762,
+									"snippet": {
+										"text": "if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 762
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/install.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 261,
+									"snippet": {
+										"text": "if err := os.MkdirAll(extractDir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 261
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/delta/seal.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 51,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 51
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/delta/seal.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 43,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 43
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/backend/git/git.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 400,
+									"snippet": {
+										"text": "if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 400
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillbundle/unpack.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 185,
+									"snippet": {
+										"text": "if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 185
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillbundle/unpack.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 180,
+									"snippet": {
+										"text": "if err := os.MkdirAll(full, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 180
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/screenshot/clipboard.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 104,
+									"snippet": {
+										"text": "if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 104
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/screenshot/capture.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 78,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 78
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/pocket/staging.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 15,
+									"snippet": {
+										"text": "if err := os.MkdirAll(destDir, 0755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 15
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/pocket/merger.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 68,
+									"snippet": {
+										"text": "if err := os.MkdirAll(outputDir, 0755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 68
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/pocket/config.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 129,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 129
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/importer/tracker.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 174,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 174
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/importer/import.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 276,
+									"snippet": {
+										"text": "if err := os.MkdirAll(memoryPath, 0755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 276
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/importer/import.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 218,
+									"snippet": {
+										"text": "if err := os.MkdirAll(destDir, 0755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 218
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/importer/import.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 119,
+									"snippet": {
+										"text": "if err := os.MkdirAll(destDir, 0755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 119
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/draft/draft.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 80,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 80
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/thinking-engine/main.go"
+								},
+								"region": {
+									"endColumn": 7,
+									"endLine": 89,
+									"snippet": {
+										"text": "_ = os.MkdirAll(dir, 0o755)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 7,
+									"startLine": 89
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/verify_all_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 309,
+									"snippet": {
+										"text": "if err := os.MkdirAll(qbase, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 309
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/pin_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 301,
+									"snippet": {
+										"text": "if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 301
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/export_kit_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 133,
+									"snippet": {
+										"text": "if err := os.MkdirAll(*outDir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 133
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 444,
+									"snippet": {
+										"text": "if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 444
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 418,
+									"snippet": {
+										"text": "if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 418
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 11,
+									"endLine": 412,
+									"snippet": {
+										"text": "return os.MkdirAll(target, 0o755)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 11,
+									"startLine": 412
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 275,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 275
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 238,
+									"snippet": {
+										"text": "if err := os.MkdirAll(filepath.Dir(skb), 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 238
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 230,
+									"snippet": {
+										"text": "return os.MkdirAll(d, 0o755)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 230
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 128,
+									"snippet": {
+										"text": "if err := os.MkdirAll(filepath.Join(s1, \"poisoned\"), 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 128
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 96,
+									"snippet": {
+										"text": "if err := os.MkdirAll(filepath.Join(sb.Home, \".claude\", \"skills\"), 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 96
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/kata_sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 59,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 59
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/kata_sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 31,
+									"snippet": {
+										"text": "if err := os.MkdirAll(dir, 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 31
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/kata_progress.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 136,
+									"snippet": {
+										"text": "if err := os.MkdirAll(filepath.Dir(s.Path), 0o755); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 136
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect directory permissions to be 0750 or less"
+					},
+					"ruleId": "G301",
+					"ruleIndex": 5
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/install_trust_mode.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 564,
+									"snippet": {
+										"text": "return os.WriteFile(path, out, 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 564
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/install_trust_mode.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 459,
+									"snippet": {
+										"text": "if err := os.WriteFile(filepath.Join(tmp, skbName), skb, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 459
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/er1_pull.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 557,
+									"snippet": {
+										"text": "if err := os.WriteFile(skbPath, skbBytes, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 557
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/backend_pull.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 192,
+									"snippet": {
+										"text": "if err := os.WriteFile(skbPath, skbBytes, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 192
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/registry/attestation_stash.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 67,
+									"snippet": {
+										"text": "return os.WriteFile(filepath.Join(dir, AttestationStashName), b, 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 67
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/offline_verify.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 101,
+									"snippet": {
+										"text": "return os.WriteFile(filepath.Join(target, offlineMetaFile), b, 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 101
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/install.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 294,
+									"snippet": {
+										"text": "if err := os.WriteFile(stashedSkb, blob, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 294
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/install/install.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 227,
+									"snippet": {
+										"text": "if err := os.WriteFile(blobPath, blob, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 227
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/delta/seal.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 95,
+									"snippet": {
+										"text": "if err := os.WriteFile(sealPath, sealData, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 95
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/delta/seal.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 75,
+									"snippet": {
+										"text": "if err := os.WriteFile(invPath, invData, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 75
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/backend/git/git.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 403,
+									"snippet": {
+										"text": "return os.WriteFile(p, data, 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 403
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillbundle/pack.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 129,
+									"snippet": {
+										"text": "if err := os.WriteFile(outFile, finalArchive, 0644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 129
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/recorder/wav.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 184,
+									"snippet": {
+										"text": "return os.WriteFile(path, data, 0644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 184
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/pocket/state.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 61,
+									"snippet": {
+										"text": "if err := os.WriteFile(statePath, data, 0644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 61
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/pocket/merger.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 82,
+									"snippet": {
+										"text": "if err := os.WriteFile(listPath, []byte(strings.Join(lines, \"\\n\")+\"\\n\"), 0644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 82
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/menubar/fetch.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 288,
+									"snippet": {
+										"text": "if err := os.WriteFile(thumbPath, data, 0644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 288
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/importer/import.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 295,
+									"snippet": {
+										"text": "if err := os.WriteFile(tagFilePath, []byte(tagContent), 0644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 295
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/draft/draft.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 92,
+									"snippet": {
+										"text": "if err := os.WriteFile(path, data, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 92
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "evaluation/internal/synth/synth.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 150,
+									"snippet": {
+										"text": "if err := os.WriteFile(path, skb, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 150
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "evaluation/cmd/results-md/main.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 83,
+									"snippet": {
+										"text": "if err := os.WriteFile(mdPath, []byte(b.String()), 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 83
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/verify_all_cmds.go"
+								},
+								"region": {
+									"endColumn": 6,
+									"endLine": 333,
+									"snippet": {
+										"text": "_ = os.WriteFile(dest+\".QUARANTINE.md\", []byte(note), 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 6,
+									"startLine": 333
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/translog_cmds.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 385,
+									"snippet": {
+										"text": "if err := os.WriteFile(*outPath, append(data, '\\n'), 0o644); err != nil { //nolint:gosec // receipt is public"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 385
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/pin_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 317,
+									"snippet": {
+										"text": "if err := os.WriteFile(target, content, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 317
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/pin_cmds.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 311,
+									"snippet": {
+										"text": "if err := os.WriteFile(backup, existing, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 311
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/pin_cmds.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 126,
+									"snippet": {
+										"text": "if err := os.WriteFile(*out, b, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 126
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/export_kit_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 190,
+									"snippet": {
+										"text": "if err := os.WriteFile(filepath.Join(*outDir, skbName), skbBytes, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 190
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/compliance_cmds.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 220,
+									"snippet": {
+										"text": "if err := os.WriteFile(*outPath, []byte(rendered), 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 220
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/agentid_revoke_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 106,
+									"snippet": {
+										"text": "if err := os.WriteFile(*out, append(blob, '\\n'), 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 106
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/agentid_cmds.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 233,
+									"snippet": {
+										"text": "if err := os.WriteFile(*out, append(blob, '\\n'), 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 233
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 447,
+									"snippet": {
+										"text": "return os.WriteFile(dst, b, 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 447
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 305,
+									"snippet": {
+										"text": "return os.WriteFile(path, b, 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 305
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 279,
+									"snippet": {
+										"text": "return os.WriteFile(filepath.Join(dir, \"SKILL.md\"), []byte(body), 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 279
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 270,
+									"snippet": {
+										"text": "return os.WriteFile(filepath.Join(dst, registry.ProvenanceSidecarName), b, 0o644)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 270
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 257,
+									"snippet": {
+										"text": "if err := os.WriteFile(filepath.Join(dst, name+\".skb\"), blob, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 257
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl-demo/kata_sandbox.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 67,
+									"snippet": {
+										"text": "if err := os.WriteFile(path, b, 0o644); err != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 67
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 18,
+									"endLine": 3758,
+									"snippet": {
+										"text": "if writeErr := os.WriteFile(imgPath, data, 0o644); writeErr != nil {"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 18,
+									"startLine": 3758
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Expect WriteFile permissions to be 0600 or less"
+					},
+					"ruleId": "G306",
+					"ruleIndex": 8
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/menubar/fetch.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 92,
+									"snippet": {
+										"text": "log.Printf(\"[fetch] using proxy: %s\", redacted)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 92
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/menubar/app.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 292,
+									"snippet": {
+										"text": "log.Printf(\"[menubar] menu bar state: icon_applied=%v image=%q title=%q icon_path=%q\","
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 292
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 6033,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] upload %s DONE doc_id=%s\", recID, resp.DocID)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 6033
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 6016,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] saved locally to ~/plaud-sync/%s/\", recID[:8])"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 6016
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 6007,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] upload %s FAIL: %v — saving locally\", recID, upErr)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 6007
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 5971,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] %s: no transcript — transcription off, audio only\", recID)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 5971
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 5969,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] %s: no transcript — tagged todo.transcribe (lazy mode)\", recID)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 5969
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 5966,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] %s: no transcript — requesting server transcription (queue mode)\", recID)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 5966
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 5934,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] got Plaud transcript for %s (%d chars, summary %d chars)\", recID, len(tx.Text), len(tx.Summary))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 5934
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 5927,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] no Plaud transcript for %s: %v — transcribe_mode=%s\", recID, txErr, cfg.TranscribeMode)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 5927
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 5914,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] downloaded %d bytes (%s)\", len(audioData), audioFmt)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 5914
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 5909,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] download %s FAIL: %v\", recID, dlErr)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 5909
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 5906,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] downloading audio for %s (%s)...\", recID, rec.Title)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 5906
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 5892,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] get recording %s FAIL: %v\", recID, recErr)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 5892
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 15,
+									"endLine": 5845,
+									"snippet": {
+										"text": "log.Printf(\"[plaud] server check: %d/%d already synced remotely\", serverSynced, len(recordingIDs))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 15,
+									"startLine": 5845
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 4374,
+									"snippet": {
+										"text": "log.Printf(\"[whisper] invalid timeout %q; using default %s\", raw, defaultTimeout)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 4374
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 4280,
+									"snippet": {
+										"text": "log.Printf(\"[whisper] preload disabled by M3C_WHISPER_PRELOAD=%q\", raw)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 4280
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 4261,
+									"snippet": {
+										"text": "log.Printf(\"[screenshot] invalid M3C_SCREENSHOT_FOCUS_DELAY_MS=%q; using default %dms\", raw, defaultDelay/time.Millisecond)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 4261
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 13,
+									"endLine": 4232,
+									"snippet": {
+										"text": "log.Printf(\"[screenshot] invalid M3C_SCREENSHOT_CLIPBOARD_TIMEOUT_SEC=%q; using default %ds\", raw, int(defaultTimeout/time.Second))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 13,
+									"startLine": 4232
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 12,
+									"endLine": 2304,
+									"snippet": {
+										"text": "log.Printf(\"Launching menu bar app (title=%q, icon=%q, log=%q)\", cfg.Title, cfg.IconPath, cfg.LogPath)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 12,
+									"startLine": 2304
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 2062,
+									"snippet": {
+										"text": "log.Printf(\"[timetracking] PLM sync disabled (base=%q key_set=%v device_token=%v)\","
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 2062
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 14,
+									"endLine": 2026,
+									"snippet": {
+										"text": "log.Printf(\"[timetracking] PLM connection: base=%s context=%s ssl=%v\","
+									},
+									"sourceLanguage": "go",
+									"startColumn": 14,
+									"startLine": 2026
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Log injection via taint analysis"
+					},
+					"ruleId": "G706"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/timetracking/store.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 76,
+									"snippet": {
+										"text": "s.db.Exec(\"ALTER TABLE projects ADD COLUMN tags TEXT DEFAULT ''\")"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 76
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/timetracking/store.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 49,
+									"snippet": {
+										"text": "db.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 49
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/timetracking/plmclient.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 177,
+									"snippet": {
+										"text": "io.Copy(io.Discard, io.LimitReader(resp.Body, 1\u003c\u003c20))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 177
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/timetracking/plmclient.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 98,
+									"snippet": {
+										"text": "io.Copy(io.Discard, io.LimitReader(resp.Body, 1\u003c\u003c20))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 98
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/timetracking/gantt.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 98,
+									"snippet": {
+										"text": "h.Write([]byte(projectID))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 98
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 518,
+									"snippet": {
+										"text": "cmd.Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 518
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 502,
+									"snippet": {
+										"text": "w.Write([]byte(`{\"status\":\"ok\",\"service\":\"skillctl-review\"}`))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 502
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 496,
+									"snippet": {
+										"text": "json.NewEncoder(w).Encode(seals)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 496
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 482,
+									"snippet": {
+										"text": "w.Write([]byte(\"[]\"))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 482
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 470,
+									"snippet": {
+										"text": "json.NewEncoder(w).Encode(resp)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 470
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 381,
+									"snippet": {
+										"text": "json.NewEncoder(w).Encode(entry)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 381
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 317,
+									"snippet": {
+										"text": "json.NewEncoder(w).Encode(buildDeltaJSON(d))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 317
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/review/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 245,
+									"snippet": {
+										"text": "w.Write(injectToken(uiHTML, s.token))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 245
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/menubar/skillbar.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 594,
+									"snippet": {
+										"text": "srv.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 594
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/menubar/skillbar.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 576,
+									"snippet": {
+										"text": "w.Write(buf.Bytes())"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 576
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/menubar/skillbar.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 448,
+									"snippet": {
+										"text": "tmpFile.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 448
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/menubar/skillbar.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 443,
+									"snippet": {
+										"text": "os.Remove(tmpFile.Name())"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 443
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/menubar/skillbar.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 442,
+									"snippet": {
+										"text": "tmpFile.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 442
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/store.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 48,
+									"snippet": {
+										"text": "db.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 48
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 481,
+									"snippet": {
+										"text": "cmd.Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 481
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 352,
+									"snippet": {
+										"text": "json.NewEncoder(w).Encode(map[string]interface{}{\n\"status\":     \"rebuilt\",\n\"node_count\": len(graph.Nodes),\n\"edge_count\": len(graph.Edges),\n})\n"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 348
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 316,
+									"snippet": {
+										"text": "w.Write([]byte(`{\"status\":\"ok\",\"service\":\"skillctl-browse\"}`))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 316
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 311,
+									"snippet": {
+										"text": "json.NewEncoder(w).Encode(matches)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 311
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 280,
+									"snippet": {
+										"text": "json.NewEncoder(w).Encode(filtered)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 280
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 258,
+									"snippet": {
+										"text": "json.NewEncoder(w).Encode(g)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 258
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/skillctl/browse/server.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 245,
+									"snippet": {
+										"text": "w.Write(injectToken(uiHTML, s.token))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 245
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/login.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 104,
+									"snippet": {
+										"text": "resp.Body.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 104
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 4,
+									"endLine": 269,
+									"snippet": {
+										"text": "resp.Body.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 4,
+									"startLine": 269
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 249,
+									"snippet": {
+										"text": "os.RemoveAll(debugDir)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 249
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 240,
+									"snippet": {
+										"text": "os.RemoveAll(debugDir)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 240
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/plaud/auth.go"
+								},
+								"region": {
+									"endColumn": 4,
+									"endLine": 176,
+									"snippet": {
+										"text": "resp.Body.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 4,
+									"startLine": 176
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/menubar/app.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 962,
+									"snippet": {
+										"text": "CopyToClipboard(\"\")"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 962
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/menubar/app.go"
+								},
+								"region": {
+									"endColumn": 10,
+									"endLine": 806,
+									"snippet": {
+										"text": "CopyToClipboard(\"Transcript for \" + entry.VideoID)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 10,
+									"startLine": 806
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/menubar/app.go"
+								},
+								"region": {
+									"endColumn": 7,
+									"endLine": 542,
+									"snippet": {
+										"text": "exec.Command(\"open\", a.Config.LogPath).Run()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 7,
+									"startLine": 542
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/device.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 104,
+									"snippet": {
+										"text": "io.Copy(io.Discard, io.LimitReader(resp.Body, 1\u003c\u003c20))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 104
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/device.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 76,
+									"snippet": {
+										"text": "io.Copy(io.Discard, io.LimitReader(resp.Body, 1\u003c\u003c20))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 76
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/config.go"
+								},
+								"region": {
+									"endColumn": 4,
+									"endLine": 369,
+									"snippet": {
+										"text": "os.Setenv(k, v)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 4,
+									"startLine": 369
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/er1/config.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 312,
+									"snippet": {
+										"text": "io.Copy(io.Discard, io.LimitReader(resp.Body, 1\u003c\u003c20))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 312
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/profile.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 373,
+									"snippet": {
+										"text": "f.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 373
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/profile.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 369,
+									"snippet": {
+										"text": "f.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 369
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/healthcheck.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 101,
+									"snippet": {
+										"text": "io.Copy(io.Discard, io.LimitReader(resp.Body, 1\u003c\u003c20))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 101
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/editor.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 514,
+									"snippet": {
+										"text": "cmd.Start()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 514
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/editor.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 498,
+									"snippet": {
+										"text": "json.NewEncoder(w).Encode(map[string]string{\"error\": msg})"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 498
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/editor.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 492,
+									"snippet": {
+										"text": "json.NewEncoder(w).Encode(v)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 492
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/editor.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 485,
+									"snippet": {
+										"text": "w.Write([]byte(`{\"status\":\"ok\",\"service\":\"m3c-settings-editor\"}`))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 485
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "pkg/config/editor.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 257,
+									"snippet": {
+										"text": "w.Write(s.injectToken(editorHTML))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 257
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 1351,
+									"snippet": {
+										"text": "resp.Body.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 1351
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 1350,
+									"snippet": {
+										"text": "io.Copy(io.Discard, resp.Body)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 1350
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 1305,
+									"snippet": {
+										"text": "rows.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 1305
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/scanner_cmds.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 718,
+									"snippet": {
+										"text": "fmt.Scanln(\u0026answer)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 718
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/gossip_revokes.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 127,
+									"snippet": {
+										"text": "be.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 127
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/skillctl/gossip_revokes.go"
+								},
+								"region": {
+									"endColumn": 4,
+									"endLine": 121,
+									"snippet": {
+										"text": "be.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 4,
+									"startLine": 121
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 5,
+									"endLine": 5775,
+									"snippet": {
+										"text": "filesDB.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 5,
+									"startLine": 5775
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 4889,
+									"snippet": {
+										"text": "db.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 4889
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 4814,
+									"snippet": {
+										"text": "json.Unmarshal(body, \u0026listResp)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 4814
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 4321,
+									"snippet": {
+										"text": "f.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 4321
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 3236,
+									"snippet": {
+										"text": "ln.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 3236
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 6,
+									"endLine": 3198,
+									"snippet": {
+										"text": "os.Setenv(\"ER1_DEVICE_TOKEN\", result.DeviceToken)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 6,
+									"startLine": 3198
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 4,
+									"endLine": 3168,
+									"snippet": {
+										"text": "os.Setenv(\"ER1_CONTEXT_ID\", ctxID)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 4,
+									"startLine": 3168
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 4,
+									"endLine": 3067,
+									"snippet": {
+										"text": "os.Setenv(\"ER1_DEVICE_TOKEN\", result.DeviceToken)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 4,
+									"startLine": 3067
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 4,
+									"endLine": 2289,
+									"snippet": {
+										"text": "ttStore.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 4,
+									"startLine": 2289
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 34,
+									"endLine": 2246,
+									"snippet": {
+										"text": "safeGo(\"StarGitHub\", func() { openURL(menubar.GitHubRepoURL) })"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 34,
+									"startLine": 2246
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 3,
+									"endLine": 1781,
+									"snippet": {
+										"text": "os.MkdirAll(logDir, 0700)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 3,
+									"startLine": 1781
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 1740,
+									"snippet": {
+										"text": "os.MkdirAll(dir, 0700)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 1740
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 4,
+									"endLine": 1579,
+									"snippet": {
+										"text": "filesDB.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 4,
+									"startLine": 1579
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 4,
+									"endLine": 126,
+									"snippet": {
+										"text": "os.Setenv(\"ER1_CONTEXT_ID\", dt.ContextID)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 4,
+									"startLine": 126
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/main.go"
+								},
+								"region": {
+									"endColumn": 4,
+									"endLine": 125,
+									"snippet": {
+										"text": "os.Setenv(\"ER1_DEVICE_TOKEN\", dt.Token)"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 4,
+									"startLine": 125
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/doctor_cmd.go"
+								},
+								"region": {
+									"endColumn": 5,
+									"endLine": 574,
+									"snippet": {
+										"text": "resp.Body.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 5,
+									"startLine": 574
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/doctor_cmd.go"
+								},
+								"region": {
+									"endColumn": 5,
+									"endLine": 573,
+									"snippet": {
+										"text": "io.Copy(io.Discard, io.LimitReader(resp.Body, 1\u003c\u003c20))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 5,
+									"startLine": 573
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/doctor_cmd.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 429,
+									"snippet": {
+										"text": "resp.Body.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 429
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/doctor_cmd.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 428,
+									"snippet": {
+										"text": "io.Copy(io.Discard, io.LimitReader(resp.Body, 1\u003c\u003c20))"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 428
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/doctor_cmd.go"
+								},
+								"region": {
+									"endColumn": 2,
+									"endLine": 380,
+									"snippet": {
+										"text": "resp.Body.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 2,
+									"startLine": 380
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				},
+				{
+					"level": "warning",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "cmd/m3c-tools/doctor_cmd.go"
+								},
+								"region": {
+									"endColumn": 4,
+									"endLine": 355,
+									"snippet": {
+										"text": "conn.Close()"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 4,
+									"startLine": 355
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Errors unhandled"
+					},
+					"ruleId": "G104"
+				}
+			],
+			"taxonomies": [
+				{
+					"downloadUri": "https://cwe.mitre.org/data/xml/cwec_v4.4.xml.zip",
+					"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+					"informationUri": "https://cwe.mitre.org/data/published/cwe_v4.4.pdf/",
+					"isComprehensive": true,
+					"language": "en",
+					"minimumRequiredLocalizedDataSemanticVersion": "4.4",
+					"name": "CWE",
+					"organization": "MITRE",
+					"releaseDateUtc": "2021-03-15",
+					"shortDescription": {
+						"text": "The MITRE Common Weakness Enumeration"
+					},
+					"taxa": [
+						{
+							"fullDescription": {
+								"text": "The software does not neutralize or incorrectly neutralizes output that is written to logs."
+							},
+							"guid": "657e5d3f-0f55-3c1a-bac3-364e40b710a2",
+							"helpUri": "https://cwe.mitre.org/data/definitions/117.html",
+							"id": "117",
+							"shortDescription": {
+								"text": "Improper Output Neutralization for Logs"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The software performs a calculation that can produce an integer overflow or wraparound, when the logic assumes that the resulting value will always be larger than the original value. This can introduce other weaknesses when the calculation is used for resource management or execution control."
+							},
+							"guid": "c71e4fa0-720e-3e82-8b67-b2d44d0c604b",
+							"helpUri": "https://cwe.mitre.org/data/definitions/190.html",
+							"id": "190",
+							"shortDescription": {
+								"text": "Integer Overflow or Wraparound"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The software uses external input to construct a pathname that is intended to identify a file or directory that is located underneath a restricted parent directory, but the software does not properly neutralize special elements within the pathname that can cause the pathname to resolve to a location that is outside of the restricted directory."
+							},
+							"guid": "3e718404-88bc-3f17-883e-e85e74078a76",
+							"helpUri": "https://cwe.mitre.org/data/definitions/22.html",
+							"id": "22",
+							"shortDescription": {
+								"text": "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "During installation, installed file permissions are set to allow anyone to modify those files."
+							},
+							"guid": "fca8970d-b44c-3162-a385-cc09266d12a4",
+							"helpUri": "https://cwe.mitre.org/data/definitions/276.html",
+							"id": "276",
+							"shortDescription": {
+								"text": "Incorrect Default Permissions"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The software does not validate, or incorrectly validates, a certificate."
+							},
+							"guid": "09e885ea-951b-3143-801a-241b3aa9e6c9",
+							"helpUri": "https://cwe.mitre.org/data/definitions/295.html",
+							"id": "295",
+							"shortDescription": {
+								"text": "Improper Certificate Validation"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The product uses a Pseudo-Random Number Generator (PRNG) in a security context, but the PRNG's algorithm is not cryptographically strong."
+							},
+							"guid": "0512047f-75a2-3ac3-bb28-97df3a80efbe",
+							"helpUri": "https://cwe.mitre.org/data/definitions/338.html",
+							"id": "338",
+							"shortDescription": {
+								"text": "Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The software checks the state of a resource before using that resource, but the resource's state can change between the check and the use in a way that invalidates the results of the check."
+							},
+							"guid": "2cfefdd6-0467-39aa-9989-3c59fde595cd",
+							"helpUri": "https://cwe.mitre.org/data/definitions/367.html",
+							"id": "367",
+							"shortDescription": {
+								"text": "Time-of-check Time-of-use (TOCTOU) Race Condition"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The software does not properly control the allocation and maintenance of a limited resource, thereby enabling an actor to influence the amount of resources consumed, eventually leading to the exhaustion of available resources."
+							},
+							"guid": "5d980950-93cd-3caf-9057-858ec3c28877",
+							"helpUri": "https://cwe.mitre.org/data/definitions/400.html",
+							"id": "400",
+							"shortDescription": {
+								"text": "Uncontrolled Resource Consumption"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The code contains a class with sensitive data, but the class does not explicitly deny serialization. The data can be accessed by serializing the class through another class."
+							},
+							"guid": "fdc81496-9d22-3cc0-a286-79ad12ba2b74",
+							"helpUri": "https://cwe.mitre.org/data/definitions/499.html",
+							"id": "499",
+							"shortDescription": {
+								"text": "Serializable Class Containing Sensitive Data"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The Secure attribute for a sensitive cookie is not set, which could cause the user agent to send that cookie in plaintext over an HTTP session."
+							},
+							"guid": "6a277b82-d988-3aa0-8c10-d7b40576a735",
+							"helpUri": "https://cwe.mitre.org/data/definitions/614.html",
+							"id": "614",
+							"shortDescription": {
+								"text": "Sensitive Cookie in HTTPS Session Without 'Secure' Attribute"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The software does not properly anticipate or handle exceptional conditions that rarely occur during normal operation of the software."
+							},
+							"guid": "7df38d1d-038e-3ced-8601-8d9265b90a25",
+							"helpUri": "https://cwe.mitre.org/data/definitions/703.html",
+							"id": "703",
+							"shortDescription": {
+								"text": "Improper Check or Handling of Exceptional Conditions"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The software constructs all or part of an OS command using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the intended OS command when it is sent to a downstream component."
+							},
+							"guid": "1a37bf66-7c5a-3aa0-94bb-ffae58a9e01c",
+							"helpUri": "https://cwe.mitre.org/data/definitions/78.html",
+							"id": "78",
+							"shortDescription": {
+								"text": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The software does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users."
+							},
+							"guid": "25e839d4-f25e-382a-9390-cf419bcd5969",
+							"helpUri": "https://cwe.mitre.org/data/definitions/79.html",
+							"id": "79",
+							"shortDescription": {
+								"text": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The software contains hard-coded credentials, such as a password or cryptographic key, which it uses for its own inbound authentication, outbound communication to external components, or encryption of internal data."
+							},
+							"guid": "93d834a1-2cc5-38db-837f-66dfc7d711cc",
+							"helpUri": "https://cwe.mitre.org/data/definitions/798.html",
+							"id": "798",
+							"shortDescription": {
+								"text": "Use of Hard-coded Credentials"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The software constructs all or part of an SQL command using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the intended SQL command when it is sent to a downstream component."
+							},
+							"guid": "6bd55435-166c-3594-bc06-5e0dea916067",
+							"helpUri": "https://cwe.mitre.org/data/definitions/89.html",
+							"id": "89",
+							"shortDescription": {
+								"text": "Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The web server receives a URL or similar request from an upstream component and retrieves the contents of this URL, but it does not sufficiently ensure that the request is being sent to the expected destination."
+							},
+							"guid": "27dd8327-2f38-3be3-af3f-cabc06087edb",
+							"helpUri": "https://cwe.mitre.org/data/definitions/918.html",
+							"id": "918",
+							"shortDescription": {
+								"text": "Server-Side Request Forgery (SSRF)"
+							}
+						}
+					],
+					"version": "4.4"
+				}
+			],
+			"tool": {
+				"driver": {
+					"guid": "8b518d5f-906d-39f9-894b-d327b1a421c5",
+					"informationUri": "https://github.com/securego/gosec/",
+					"name": "gosec",
+					"rules": [
+						{
+							"defaultConfiguration": {
+								"level": "warning"
+							},
+							"fullDescription": {
+								"text": "Errors unhandled"
+							},
+							"help": {
+								"text": "Errors unhandled\nSeverity: LOW\nConfidence: HIGH\n"
+							},
+							"id": "G104",
+							"name": "Improper Check or Handling of Exceptional Conditions",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"LOW"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "7df38d1d-038e-3ced-8601-8d9265b90a25",
+										"id": "703",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Errors unhandled"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "warning"
+							},
+							"fullDescription": {
+								"text": "Log injection via taint analysis"
+							},
+							"help": {
+								"text": "Log injection via taint analysis\nSeverity: LOW\nConfidence: HIGH\n"
+							},
+							"id": "G706",
+							"name": "Improper Output Neutralization for Logs",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"LOW"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "657e5d3f-0f55-3c1a-bac3-364e40b710a2",
+										"id": "117",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Log injection via taint analysis"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server"
+							},
+							"help": {
+								"text": "Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server\nSeverity: MEDIUM\nConfidence: LOW\n"
+							},
+							"id": "G112",
+							"name": "Uncontrolled Resource Consumption",
+							"properties": {
+								"precision": "low",
+								"tags": [
+									"security",
+									"MEDIUM"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "5d980950-93cd-3caf-9057-858ec3c28877",
+										"id": "400",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Marshaled struct field \"AccessToken\" (JSON key \"access_token\") matches secret pattern"
+							},
+							"help": {
+								"text": "Marshaled struct field \"AccessToken\" (JSON key \"access_token\") matches secret pattern\nSeverity: MEDIUM\nConfidence: MEDIUM\n"
+							},
+							"id": "G117",
+							"name": "Serializable Class Containing Sensitive Data",
+							"properties": {
+								"precision": "medium",
+								"tags": [
+									"security",
+									"MEDIUM"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "fdc81496-9d22-3cc0-a286-79ad12ba2b74",
+										"id": "499",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Marshaled struct field \"AccessToken\" (JSON key \"access_token\") matches secret pattern"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "SQL string concatenation"
+							},
+							"help": {
+								"text": "SQL string concatenation\nSeverity: MEDIUM\nConfidence: HIGH\n"
+							},
+							"id": "G202",
+							"name": "Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"MEDIUM"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "6bd55435-166c-3594-bc06-5e0dea916067",
+										"id": "89",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "SQL string concatenation"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "The used method does not auto-escape HTML. This can potentially lead to 'Cross-site Scripting' vulnerabilities, in case the attacker controls the input."
+							},
+							"help": {
+								"text": "The used method does not auto-escape HTML. This can potentially lead to 'Cross-site Scripting' vulnerabilities, in case the attacker controls the input.\nSeverity: MEDIUM\nConfidence: LOW\n"
+							},
+							"id": "G203",
+							"name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+							"properties": {
+								"precision": "low",
+								"tags": [
+									"security",
+									"MEDIUM"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "25e839d4-f25e-382a-9390-cf419bcd5969",
+										"id": "79",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "The used method does not auto-escape HTML. This can potentially lead to 'Cross-site Scripting' vulnerabilities, in case the attacker controls the input."
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Subprocess launched with variable"
+							},
+							"help": {
+								"text": "Subprocess launched with variable\nSeverity: MEDIUM\nConfidence: HIGH\n"
+							},
+							"id": "G204",
+							"name": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"MEDIUM"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "1a37bf66-7c5a-3aa0-94bb-ffae58a9e01c",
+										"id": "78",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Subprocess launched with variable"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Expect directory permissions to be 0750 or less"
+							},
+							"help": {
+								"text": "Expect directory permissions to be 0750 or less\nSeverity: MEDIUM\nConfidence: HIGH\n"
+							},
+							"id": "G301",
+							"name": "Incorrect Default Permissions",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"MEDIUM"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "fca8970d-b44c-3162-a385-cc09266d12a4",
+										"id": "276",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Expect directory permissions to be 0750 or less"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Expect file permissions to be 0600 or less"
+							},
+							"help": {
+								"text": "Expect file permissions to be 0600 or less\nSeverity: MEDIUM\nConfidence: HIGH\n"
+							},
+							"id": "G302",
+							"name": "Incorrect Default Permissions",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"MEDIUM"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "fca8970d-b44c-3162-a385-cc09266d12a4",
+										"id": "276",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Expect file permissions to be 0600 or less"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Potential file inclusion via variable"
+							},
+							"help": {
+								"text": "Potential file inclusion via variable\nSeverity: MEDIUM\nConfidence: HIGH\n"
+							},
+							"id": "G304",
+							"name": "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"MEDIUM"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "3e718404-88bc-3f17-883e-e85e74078a76",
+										"id": "22",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Potential file inclusion via variable"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Expect WriteFile permissions to be 0600 or less"
+							},
+							"help": {
+								"text": "Expect WriteFile permissions to be 0600 or less\nSeverity: MEDIUM\nConfidence: HIGH\n"
+							},
+							"id": "G306",
+							"name": "Incorrect Default Permissions",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"MEDIUM"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "fca8970d-b44c-3162-a385-cc09266d12a4",
+										"id": "276",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Expect WriteFile permissions to be 0600 or less"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "XSS via taint analysis"
+							},
+							"help": {
+								"text": "XSS via taint analysis\nSeverity: MEDIUM\nConfidence: HIGH\n"
+							},
+							"id": "G705",
+							"name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"MEDIUM"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "25e839d4-f25e-382a-9390-cf419bcd5969",
+										"id": "79",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "XSS via taint analysis"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Potential hardcoded credentials"
+							},
+							"help": {
+								"text": "Potential hardcoded credentials\nSeverity: HIGH\nConfidence: LOW\n"
+							},
+							"id": "G101",
+							"name": "Use of Hard-coded Credentials",
+							"properties": {
+								"precision": "low",
+								"tags": [
+									"security",
+									"HIGH"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "93d834a1-2cc5-38db-837f-66dfc7d711cc",
+										"id": "798",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Potential hardcoded credentials"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Filesystem operation in filepath.Walk/WalkDir callback uses race-prone path; consider root-scoped APIs (e.g. os.Root) to prevent symlink TOCTOU traversal"
+							},
+							"help": {
+								"text": "Filesystem operation in filepath.Walk/WalkDir callback uses race-prone path; consider root-scoped APIs (e.g. os.Root) to prevent symlink TOCTOU traversal\nSeverity: HIGH\nConfidence: MEDIUM\n"
+							},
+							"id": "G122",
+							"name": "Time-of-check Time-of-use (TOCTOU) Race Condition",
+							"properties": {
+								"precision": "medium",
+								"tags": [
+									"security",
+									"HIGH"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "2cfefdd6-0467-39aa-9989-3c59fde595cd",
+										"id": "367",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Filesystem operation in filepath.Walk/WalkDir callback uses race-prone path; consider root-scoped APIs (e.g. os.Root) to prevent symlink TOCTOU traversal"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "http.Cookie missing or has insecure Secure, HttpOnly, or SameSite attribute"
+							},
+							"help": {
+								"text": "http.Cookie missing or has insecure Secure, HttpOnly, or SameSite attribute\nSeverity: MEDIUM\nConfidence: HIGH\n"
+							},
+							"id": "G124",
+							"name": "Sensitive Cookie in HTTPS Session Without 'Secure' Attribute",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"MEDIUM"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "6a277b82-d988-3aa0-8c10-d7b40576a735",
+										"id": "614",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "http.Cookie missing or has insecure Secure, HttpOnly, or SameSite attribute"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Command injection via taint analysis"
+							},
+							"help": {
+								"text": "Command injection via taint analysis\nSeverity: HIGH\nConfidence: HIGH\n"
+							},
+							"id": "G702",
+							"name": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"HIGH"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "1a37bf66-7c5a-3aa0-94bb-ffae58a9e01c",
+										"id": "78",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Command injection via taint analysis"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Path traversal via taint analysis"
+							},
+							"help": {
+								"text": "Path traversal via taint analysis\nSeverity: HIGH\nConfidence: HIGH\n"
+							},
+							"id": "G703",
+							"name": "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"HIGH"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "3e718404-88bc-3f17-883e-e85e74078a76",
+										"id": "22",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Path traversal via taint analysis"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "SSRF via taint analysis"
+							},
+							"help": {
+								"text": "SSRF via taint analysis\nSeverity: HIGH\nConfidence: HIGH\n"
+							},
+							"id": "G704",
+							"name": "Server-Side Request Forgery (SSRF)",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"HIGH"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "27dd8327-2f38-3be3-af3f-cabc06087edb",
+										"id": "918",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "SSRF via taint analysis"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "TLS InsecureSkipVerify set to true."
+							},
+							"help": {
+								"text": "TLS InsecureSkipVerify set to true.\nSeverity: HIGH\nConfidence: HIGH\n"
+							},
+							"id": "G402",
+							"name": "Improper Certificate Validation",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"HIGH"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "09e885ea-951b-3143-801a-241b3aa9e6c9",
+										"id": "295",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "TLS InsecureSkipVerify set to true."
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand)"
+							},
+							"help": {
+								"text": "Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand)\nSeverity: HIGH\nConfidence: MEDIUM\n"
+							},
+							"id": "G404",
+							"name": "Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)",
+							"properties": {
+								"precision": "medium",
+								"tags": [
+									"security",
+									"HIGH"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "0512047f-75a2-3ac3-bb28-97df3a80efbe",
+										"id": "338",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand)"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "integer overflow conversion uint32 -\u003e byte"
+							},
+							"help": {
+								"text": "integer overflow conversion uint32 -\u003e byte\nSeverity: HIGH\nConfidence: MEDIUM\n"
+							},
+							"id": "G115",
+							"name": "Integer Overflow or Wraparound",
+							"properties": {
+								"precision": "medium",
+								"tags": [
+									"security",
+									"HIGH"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "c71e4fa0-720e-3e82-8b67-b2d44d0c604b",
+										"id": "190",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "integer overflow conversion uint32 -\u003e byte"
+							}
+						}
+					],
+					"semanticVersion": "dev",
+					"supportedTaxonomies": [
+						{
+							"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+							"name": "CWE"
+						}
+					],
+					"version": "dev"
+				}
+			}
+		}
+	],
+	"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+	"version": "2.1.0"
+}

--- a/pkg/config/initcfg.go
+++ b/pkg/config/initcfg.go
@@ -107,7 +107,9 @@ func CheckAndApplyInitCfg() InitCfgResult {
 
 	// Apply to current process
 	for k, v := range profile.Vars {
-		os.Setenv(k, v)
+		if err := os.Setenv(k, v); err != nil {
+			log.Printf("[config] warning: could not apply %s to the current process: %v", k, err)
+		}
 	}
 
 	// Rename init file so it's not re-processed

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -328,12 +328,16 @@ func (pm *ProfileManager) TestConnection(p *Profile) error {
 	}
 	defer func() {
 		for k, v := range saved {
-			os.Setenv(k, v)
+			if err := os.Setenv(k, v); err != nil {
+				log.Printf("[config] warning: could not restore env %s after connection test: %v", k, err)
+			}
 		}
 	}()
 
 	for k, v := range p.Vars {
-		os.Setenv(k, v)
+		if err := os.Setenv(k, v); err != nil {
+			return fmt.Errorf("apply profile var %s for connection test: %w", k, err)
+		}
 	}
 
 	// SPEC-0143: Device token (loaded at startup) provides auth without API key.

--- a/pkg/er1/queue.go
+++ b/pkg/er1/queue.go
@@ -17,7 +17,11 @@ func DefaultQueuePath() string {
 		home = "."
 	}
 	dir := filepath.Join(home, ".m3c-tools")
-	os.MkdirAll(dir, 0700)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		// Non-fatal: return the path anyway so the caller's subsequent save()
+		// surfaces the real write error, but don't swallow the signal.
+		fmt.Fprintf(os.Stderr, "queue: could not create %s: %v\n", dir, err)
+	}
 	return filepath.Join(dir, "queue.json")
 }
 
@@ -49,13 +53,14 @@ func NewQueue(path string) *Queue {
 	return q
 }
 
-// Add adds an entry to the queue and persists it.
-func (q *Queue) Add(entry QueueEntry) {
+// Add adds an entry to the queue and persists it. It returns an error if the
+// queue could not be persisted, so an enqueue failure is not silently dropped.
+func (q *Queue) Add(entry QueueEntry) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	entry.QueuedAt = time.Now()
 	q.entries = append(q.entries, entry)
-	q.save()
+	return q.save()
 }
 
 // Entries returns a copy of all queue entries.
@@ -74,21 +79,23 @@ func (q *Queue) Len() int {
 	return len(q.entries)
 }
 
-// Remove removes an entry by ID and persists.
-func (q *Queue) Remove(id string) {
+// Remove removes an entry by ID and persists. Returns the persistence error, if
+// any (nil when the id was not present — nothing changed).
+func (q *Queue) Remove(id string) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	for i, e := range q.entries {
 		if e.ID == id {
 			q.entries = append(q.entries[:i], q.entries[i+1:]...)
-			q.save()
-			return
+			return q.save()
 		}
 	}
+	return nil
 }
 
-// UpdateRetry updates retry metadata for an entry.
-func (q *Queue) UpdateRetry(id string, err error) {
+// UpdateRetry updates retry metadata for an entry. Returns the persistence
+// error, if any (nil when the id was not present).
+func (q *Queue) UpdateRetry(id string, err error) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	for i, e := range q.entries {
@@ -98,18 +105,18 @@ func (q *Queue) UpdateRetry(id string, err error) {
 			if err != nil {
 				q.entries[i].LastError = err.Error()
 			}
-			q.save()
-			return
+			return q.save()
 		}
 	}
+	return nil
 }
 
-// Clear removes all entries.
-func (q *Queue) Clear() {
+// Clear removes all entries. Returns the persistence error, if any.
+func (q *Queue) Clear() error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.entries = nil
-	q.save()
+	return q.save()
 }
 
 // EnqueueFailure creates a QueueEntry from a failed upload and persists
@@ -140,7 +147,10 @@ func EnqueueFailure(queuePath string, videoID string, payload *UploadPayload, ta
 	}
 
 	q := NewQueue(queuePath)
-	q.Add(entry)
+	if err := q.Add(entry); err != nil {
+		fmt.Fprintf(os.Stderr, "enqueue failure: persist entry %s: %v\n", entry.ID, err)
+		return nil
+	}
 
 	// Return a copy with QueuedAt set
 	entries := q.Entries()
@@ -162,16 +172,26 @@ func (q *Queue) load() {
 	}
 }
 
-func (q *Queue) save() {
+// save persists the queue to disk. It returns an error so callers can surface a
+// failed persist instead of silently dropping a retry-queue mutation. The error
+// is also logged to stderr (queue mutations are best-effort at most call sites).
+func (q *Queue) save() error {
 	data, err := json.MarshalIndent(q.entries, "", "  ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "queue save error: %v\n", err)
-		return
+		return err
 	}
 	// Ensure parent directory exists
 	dir := filepath.Dir(q.path)
 	if dir != "" && dir != "." {
-		os.MkdirAll(dir, 0700)
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			fmt.Fprintf(os.Stderr, "queue save error: create %s: %v\n", dir, err)
+			return err
+		}
 	}
-	os.WriteFile(q.path, data, 0600)
+	if err := os.WriteFile(q.path, data, 0600); err != nil {
+		fmt.Fprintf(os.Stderr, "queue save error: write %s: %v\n", q.path, err)
+		return err
+	}
+	return nil
 }

--- a/pkg/er1/retry.go
+++ b/pkg/er1/retry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"time"
 )
 
@@ -88,7 +89,9 @@ func (r *RetryRunner) ProcessOnce(ctx context.Context) (successes int, failures 
 
 		// Check if entry exceeded max retries
 		if r.MaxRetries > 0 && entry.RetryCount >= r.MaxRetries {
-			r.Queue.Remove(entry.ID)
+			if err := r.Queue.Remove(entry.ID); err != nil {
+				fmt.Fprintf(os.Stderr, "retry: could not persist removal of %s: %v\n", entry.ID, err)
+			}
 			dropped++
 			if r.OnRetry != nil {
 				r.OnRetry(entry, fmt.Errorf("max retries (%d) exceeded", r.MaxRetries), true)
@@ -100,14 +103,18 @@ func (r *RetryRunner) ProcessOnce(ctx context.Context) (successes int, failures 
 		err := r.UploadFunc(entry)
 		if err == nil {
 			// Success — remove from queue
-			r.Queue.Remove(entry.ID)
+			if rerr := r.Queue.Remove(entry.ID); rerr != nil {
+				fmt.Fprintf(os.Stderr, "retry: could not persist removal of %s: %v\n", entry.ID, rerr)
+			}
 			successes++
 			if r.OnRetry != nil {
 				r.OnRetry(entry, nil, true)
 			}
 		} else {
 			// Failure — update retry count
-			r.Queue.UpdateRetry(entry.ID, err)
+			if uerr := r.Queue.UpdateRetry(entry.ID, err); uerr != nil {
+				fmt.Fprintf(os.Stderr, "retry: could not persist retry update of %s: %v\n", entry.ID, uerr)
+			}
 			failures++
 			if r.OnRetry != nil {
 				r.OnRetry(entry, err, false)

--- a/pkg/httpsafe/redirect.go
+++ b/pkg/httpsafe/redirect.go
@@ -45,6 +45,23 @@ func NoCredentialRedirect(req *http.Request, via []*http.Request) error {
 	return nil
 }
 
+// NoCrossHostRedirect is a stricter CheckRedirect for trust-critical requests
+// (e.g. the skillctl revoke submission and revocation-HEAD fetch): it caps the
+// chain at MaxRedirects and FAILS CLOSED on any redirect whose host differs from
+// the originating request's host. A validated, allow-listed origin therefore
+// cannot be bounced to an attacker-chosen host by a 30x from the registry (or a
+// MITM on a plain-HTTP RFC1918 hop). Same-host port changes are permitted.
+func NoCrossHostRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= MaxRedirects {
+		return fmt.Errorf("stopped after %d redirects", MaxRedirects)
+	}
+	if len(via) > 0 && !sameHost(req, via[0]) {
+		return fmt.Errorf("refusing cross-host redirect to %q (originating host was %q)",
+			req.URL.Hostname(), via[0].URL.Hostname())
+	}
+	return nil
+}
+
 func sameHost(a, b *http.Request) bool {
 	if a == nil || b == nil || a.URL == nil || b.URL == nil {
 		return false

--- a/pkg/httpsafe/redirect.go
+++ b/pkg/httpsafe/redirect.go
@@ -55,9 +55,17 @@ func NoCrossHostRedirect(req *http.Request, via []*http.Request) error {
 	if len(via) >= MaxRedirects {
 		return fmt.Errorf("stopped after %d redirects", MaxRedirects)
 	}
-	if len(via) > 0 && !sameHost(req, via[0]) {
-		return fmt.Errorf("refusing cross-host redirect to %q (originating host was %q)",
-			req.URL.Hostname(), via[0].URL.Hostname())
+	if len(via) > 0 {
+		if !sameHost(req, via[0]) {
+			return fmt.Errorf("refusing cross-host redirect to %q (originating host was %q)",
+				req.URL.Hostname(), via[0].URL.Hostname())
+		}
+		// Refuse an https→http downgrade even on the same host: a redirect must
+		// not drop a trust-critical request onto plaintext (MITM / suppression).
+		if via[0].URL != nil && req.URL != nil && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+			return fmt.Errorf("refusing https→%s downgrade redirect on host %q",
+				req.URL.Scheme, req.URL.Hostname())
+		}
 	}
 	return nil
 }

--- a/pkg/httpsafe/redirect_downgrade_test.go
+++ b/pkg/httpsafe/redirect_downgrade_test.go
@@ -1,0 +1,28 @@
+package httpsafe
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestNoCrossHostRedirect_RejectsSchemeDowngrade pins the challenge-gate LOW fix:
+// even on the SAME host, an https→http downgrade redirect must fail closed, so a
+// trust-path request cannot be dropped onto plaintext (MITM / suppression).
+func TestNoCrossHostRedirect_RejectsSchemeDowngrade(t *testing.T) {
+	mkReq := func(raw string) *http.Request {
+		r, err := http.NewRequest(http.MethodGet, raw, nil)
+		if err != nil {
+			t.Fatalf("NewRequest %s: %v", raw, err)
+		}
+		return r
+	}
+	via := []*http.Request{mkReq("https://registry.example/api")}
+
+	if err := NoCrossHostRedirect(mkReq("http://registry.example/api"), via); err == nil {
+		t.Error("expected refusal of same-host https→http downgrade redirect, got nil")
+	}
+	// A same-host https→https redirect must still be allowed (no over-blocking).
+	if err := NoCrossHostRedirect(mkReq("https://registry.example/other"), via); err != nil {
+		t.Errorf("same-host https→https redirect should be allowed, got %v", err)
+	}
+}

--- a/pkg/httpsafe/redirect_test.go
+++ b/pkg/httpsafe/redirect_test.go
@@ -125,3 +125,75 @@ func TestNoCredentialRedirect_CapsChain(t *testing.T) {
 		t.Error("expected an error after the redirect cap, got nil")
 	}
 }
+
+// TestNoCrossHostRedirect_RejectsCrossHost proves the strict trust-path policy:
+// a redirect to a DIFFERENT host must fail closed (the request must not reach the
+// attacker-chosen host at all).
+func TestNoCrossHostRedirect_RejectsCrossHost(t *testing.T) {
+	const originHost = "registry.test"
+	const attackerHost = "attacker.test"
+
+	reached := false
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer attacker.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://"+attackerHost+"/revoke", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	originAddr := origin.Listener.Addr().String()
+	attackerAddr := attacker.Listener.Addr().String()
+	dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		var d net.Dialer
+		switch addr {
+		case originHost + ":80":
+			addr = originAddr
+		case attackerHost + ":80":
+			addr = attackerAddr
+		}
+		return d.DialContext(ctx, network, addr)
+	}
+
+	c := &http.Client{
+		Timeout:       5 * time.Second,
+		Transport:     &http.Transport{DialContext: dial},
+		CheckRedirect: NoCrossHostRedirect,
+	}
+	req, _ := http.NewRequest("POST", "http://"+originHost+"/revoke", nil)
+	if _, err := c.Do(req); err == nil {
+		t.Fatal("expected a cross-host redirect to be refused, got nil error")
+	}
+	if reached {
+		t.Error("request reached the cross-host redirect target despite NoCrossHostRedirect")
+	}
+}
+
+// TestNoCrossHostRedirect_AllowsSameHost verifies a same-host redirect still
+// follows (the guard must not break legitimate intra-host 30x).
+func TestNoCrossHostRedirect_AllowsSameHost(t *testing.T) {
+	done := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			http.Redirect(w, r, "/end", http.StatusFound)
+			return
+		}
+		done = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := &http.Client{Timeout: 5 * time.Second, CheckRedirect: NoCrossHostRedirect}
+	req, _ := http.NewRequest("GET", srv.URL+"/start", nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("same-host redirect should succeed: %v", err)
+	}
+	_ = resp.Body.Close()
+	if !done {
+		t.Error("same-host redirect did not reach the final handler")
+	}
+}

--- a/pkg/skillctl/delta/seal.go
+++ b/pkg/skillctl/delta/seal.go
@@ -40,7 +40,7 @@ func NewSealStore() (*SealStore, error) {
 		return nil, fmt.Errorf("cannot determine home directory: %w", err)
 	}
 	dir := filepath.Join(home, ".m3c-tools", "skill-seals")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil { // 0700: trust-seal store, owner-only
 		return nil, fmt.Errorf("creating seal store directory: %w", err)
 	}
 	return &SealStore{BaseDir: dir}, nil
@@ -48,7 +48,7 @@ func NewSealStore() (*SealStore, error) {
 
 // NewSealStoreAt creates a SealStore at a specific directory (useful for testing).
 func NewSealStoreAt(dir string) (*SealStore, error) {
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil { // 0700: trust-seal store, owner-only
 		return nil, fmt.Errorf("creating seal store directory: %w", err)
 	}
 	return &SealStore{BaseDir: dir}, nil
@@ -72,7 +72,7 @@ func (s *SealStore) Seal(inventory *model.Inventory, sealedBy string) (*SealReco
 
 	// Write inventory file.
 	invPath := filepath.Join(s.BaseDir, fmt.Sprintf("inventory-%s.json", ts))
-	if err := os.WriteFile(invPath, invData, 0o644); err != nil {
+	if err := os.WriteFile(invPath, invData, 0o600); err != nil { // 0600: trust seal, not world-readable
 		return nil, fmt.Errorf("writing inventory: %w", err)
 	}
 
@@ -92,7 +92,7 @@ func (s *SealStore) Seal(inventory *model.Inventory, sealedBy string) (*SealReco
 		return nil, fmt.Errorf("marshaling seal record: %w", err)
 	}
 	sealPath := filepath.Join(s.BaseDir, fmt.Sprintf("seal-%s.json", ts))
-	if err := os.WriteFile(sealPath, sealData, 0o644); err != nil {
+	if err := os.WriteFile(sealPath, sealData, 0o600); err != nil { // 0600: trust seal, not world-readable
 		return nil, fmt.Errorf("writing seal record: %w", err)
 	}
 

--- a/pkg/skillctl/delta/seal_perms_test.go
+++ b/pkg/skillctl/delta/seal_perms_test.go
@@ -3,6 +3,7 @@ package delta
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -19,6 +20,10 @@ func TestSealFilesAreOwnerOnly(t *testing.T) {
 	record, err := store.Seal(testInventory(), "test-user")
 	if err != nil {
 		t.Fatalf("Seal: %v", err)
+	}
+
+	if runtime.GOOS == "windows" { // POSIX mode bits are not enforced on Windows
+		t.Skip("POSIX mode bits are not enforced on Windows")
 	}
 
 	if info, err := os.Stat(dir); err != nil {

--- a/pkg/skillctl/delta/seal_perms_test.go
+++ b/pkg/skillctl/delta/seal_perms_test.go
@@ -1,0 +1,39 @@
+package delta
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSealFilesAreOwnerOnly pins the challenge-gate MED fix: the scanner's
+// SealStore.Seal writes trust artifacts (the seal record AND the full installed
+// inventory) owner-only (0600), in an owner-only store dir (0700) — never
+// world-readable, matching the review-server seal path.
+func TestSealFilesAreOwnerOnly(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "seals") // fresh → NewSealStoreAt MkdirAll's it
+	store, err := NewSealStoreAt(dir)
+	if err != nil {
+		t.Fatalf("NewSealStoreAt: %v", err)
+	}
+	record, err := store.Seal(testInventory(), "test-user")
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	if info, err := os.Stat(dir); err != nil {
+		t.Fatalf("stat store dir: %v", err)
+	} else if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("store dir mode = %o, want 0700", perm)
+	}
+
+	for _, p := range []string{filepath.Join(dir, record.SealID+".json"), record.InventoryPath} {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %s: %v", p, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("%s mode = %o, want 0600 (trust seal, not world-readable)", filepath.Base(p), perm)
+		}
+	}
+}

--- a/pkg/skillctl/registry/er1_publish.go
+++ b/pkg/skillctl/registry/er1_publish.go
@@ -545,7 +545,11 @@ func er1Get(base string, cfg *er1.Config, path string) (any, error) {
 	}
 	client := &http.Client{Timeout: 15 * time.Second}
 	if !cfg.VerifySSL {
-		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+		// #nosec G402 -- gated: default is ER1_VERIFY_SSL=true (verifies). VerifySSL=false
+		// is honored only for loopback — er1TLSGuard above fails closed for any non-loopback
+		// host, and pkg/er1.applyTLSVerificationPolicy forces verification back on at load
+		// time for non-loopback. Reaching here implies a loopback dev target.
+		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} // #nosec G402 -- loopback-only, gated by er1TLSGuard
 	}
 	req, err := http.NewRequest("GET", base+path, nil)
 	if err != nil {

--- a/pkg/skillctl/registry/er1_room.go
+++ b/pkg/skillctl/registry/er1_room.go
@@ -185,7 +185,11 @@ func er1PostJSON(base string, cfg *er1.Config, path string, payload any) (any, e
 	}
 	client := &http.Client{Timeout: 30 * time.Second}
 	if !cfg.VerifySSL {
-		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+		// #nosec G402 -- gated: default is ER1_VERIFY_SSL=true (verifies). VerifySSL=false
+		// is honored only for loopback — er1TLSGuard above fails closed for any non-loopback
+		// host, and pkg/er1.applyTLSVerificationPolicy forces verification back on at load
+		// time for non-loopback. Reaching here implies a loopback dev target.
+		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} // #nosec G402 -- loopback-only, gated by er1TLSGuard
 	}
 	req, err := http.NewRequest("POST", base+path, bytes.NewReader(body))
 	if err != nil {

--- a/pkg/skillctl/registry/revocation_feed.go
+++ b/pkg/skillctl/registry/revocation_feed.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/kamir/m3c-tools/pkg/httpsafe"
 )
 
 // FetchRevocationHead GETs the signed revocation HEAD from the registry
@@ -35,7 +37,10 @@ func FetchRevocationHead(baseURL, tenantScope string, timeout time.Duration) (ma
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	resp, err := (&http.Client{Timeout: timeout}).Do(req)
+	// Fail closed on a cross-host / https→http-downgrade redirect: a hostile
+	// registry must not bounce this trust-path GET to an attacker host.
+	client := &http.Client{Timeout: timeout, CheckRedirect: httpsafe.NoCrossHostRedirect}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skillctl/review/server.go
+++ b/pkg/skillctl/review/server.go
@@ -440,7 +440,10 @@ func (s *Server) handleSeal(w http.ResponseWriter, r *http.Request) {
 		Total:    len(d.Entries),
 	}
 
-	// Write the seal record to the seal store as a minimal record.
+	// Write the seal record to the seal store as a minimal record. The seal is
+	// the trust artifact for a completed review, so persistence failure MUST be
+	// surfaced (never report a 200 for a seal we did not durably write), and the
+	// file must not be world-readable (0600, not 0644).
 	if s.sealStore != nil {
 		sealRecord := delta.SealRecord{
 			SealID:     resp.SealID,
@@ -452,9 +455,14 @@ func (s *Server) handleSeal(w http.ResponseWriter, r *http.Request) {
 			Deferred:   deferred,
 		}
 		sealData, err := json.MarshalIndent(sealRecord, "", "  ")
-		if err == nil {
-			sealPath := fmt.Sprintf("%s/%s.json", s.sealStore.BaseDir, resp.SealID)
-			os.WriteFile(sealPath, sealData, 0644)
+		if err != nil {
+			http.Error(w, "failed to encode seal record", http.StatusInternalServerError)
+			return
+		}
+		sealPath := fmt.Sprintf("%s/%s.json", s.sealStore.BaseDir, resp.SealID)
+		if err := os.WriteFile(sealPath, sealData, 0600); err != nil {
+			http.Error(w, "failed to persist seal record", http.StatusInternalServerError)
+			return
 		}
 	}
 

--- a/pkg/skillctl/review/server_test.go
+++ b/pkg/skillctl/review/server_test.go
@@ -234,6 +234,46 @@ func TestSealAfterFullReview(t *testing.T) {
 	if resp.SealID == "" {
 		t.Error("seal_id should not be empty")
 	}
+
+	// The seal is a trust artifact: it must be persisted with owner-only
+	// permissions (0600), never world-readable.
+	sealPath := filepath.Join(s.sealStore.BaseDir, resp.SealID+".json")
+	info, err := os.Stat(sealPath)
+	if err != nil {
+		t.Fatalf("seal file not persisted at %s: %v", sealPath, err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("seal file mode = %04o, want 0600 (must not be world-readable)", perm)
+	}
+}
+
+// TestSealPersistFailureReturns500 proves the seal write error is propagated:
+// pointing the seal store at a path that cannot be written must yield a 500,
+// not a false 200.
+func TestSealPersistFailureReturns500(t *testing.T) {
+	s := setupServer(t)
+
+	// Make the seal store BaseDir a path under a regular file so WriteFile fails.
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
+		t.Fatalf("setup blocker: %v", err)
+	}
+	s.sealStore.BaseDir = filepath.Join(blocker, "seals")
+
+	for i := 0; i < 3; i++ {
+		body := strings.NewReader(`{"status":"approved"}`)
+		req := httptest.NewRequest(http.MethodPut, "/api/delta/"+string(rune('0'+i))+"/review", body)
+		w := httptest.NewRecorder()
+		s.handleReviewEntry(w, req)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/seal", nil)
+	w := httptest.NewRecorder()
+	s.handleSeal(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("seal with unwritable store: status = %d, want 500", w.Code)
+	}
 }
 
 func TestListSealsEndpoint(t *testing.T) {

--- a/pkg/skillctl/review/server_test.go
+++ b/pkg/skillctl/review/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -242,8 +243,10 @@ func TestSealAfterFullReview(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seal file not persisted at %s: %v", sealPath, err)
 	}
-	if perm := info.Mode().Perm(); perm != 0600 {
-		t.Errorf("seal file mode = %04o, want 0600 (must not be world-readable)", perm)
+	if runtime.GOOS != "windows" { // POSIX mode bits are not enforced on Windows
+		if perm := info.Mode().Perm(); perm != 0600 {
+			t.Errorf("seal file mode = %04o, want 0600 (must not be world-readable)", perm)
+		}
 	}
 }
 


### PR DESCRIPTION
Gate 1+2 of the WF-001 hardening track. A gosec + errcheck baseline on master surfaced real trust-path issues; this fixes them, and an **adversarial challenge gate** (pentest + security-reviewer lenses) then hardened the fixes further.

## Real findings fixed
- **Trust-seal world-readable** — `review/server.go` **and** the scanner's `delta.SealStore.Seal` sibling both wrote seals (+ full installed inventory) at `0644`. Now `0600` (dir `0700`), errors propagated (no false HTTP 200). Tests assert the perms + the 500-on-write-failure.
- **ER1 retry-queue silently dropped** — `queue.go` `MkdirAll`/`WriteFile` errors were unchecked → lost uploads. `Add/Remove/UpdateRetry/Clear` now return errors; callers log/propagate; enqueue callers nil-guarded.
- **SSRF / redirect escape on the revoke path** — the revoke **submission** POST and the **revocation-HEAD** GET now fail closed on cross-host **and** https→http-downgrade redirects (`httpsafe.NoCrossHostRedirect`, wired into both clients). Trust still derives from the ed25519 signature, not origin.
- **errcheck** — config `os.Setenv`, export/thumbnail writes now handled (log/return/exit), not silently discarded.

## G402 InsecureSkipVerify — verified INTENTIONAL, not fixed away
All four `InsecureSkipVerify` sites are **loopback-only, verify-by-default** (`ER1_VERIFY_SSL` defaults true; `--insecure`/`local` require an explicit opt-out to a loopback target). Annotated `#nosec` with reasons + **regression tests** pinning the default-verifies contract. The pentest lens confirmed no path reaches skip-verify on a non-loopback https endpoint.

## The challenge gate earned its keep
It confirmed the core intents hold (no bypass, tests bite, no fail-open regression) and caught **4 residuals** — an **incomplete** seal fix, a redirect-guard **overclaim** (comment said the HEAD fetch was locked; it wasn't), a same-host **scheme-downgrade** gap, and a nil-deref — all fixed in the final commit, with the honest-baseline note corrected.

## Follow-up (pre-existing, out of scope)
The gate flagged a **pre-existing** MED: the revoked-set fetch (`revoked_cache.go`) **fails OPEN** when the cache is empty / no trust roots configured → revocation can be suppressed. Not introduced here (not in the diff); filed as a WF-001 follow-up to make revoked-set consumers fail **closed** under managed/trust-root config.

Also ships `docs/security/gosec-baseline.md` + `.sarif` (505-finding baseline; no CI gate wired — that decision is pending H1x). Build · vet · all affected suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)