### PR TITLE
chore(lint): errcheck exceptions at the call-site, not by operation-class (H2)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,53 +7,31 @@ linters:
     - unused
     - errcheck
 
+  settings:
+    errcheck:
+      # The ONLY retained class-level exception: formatted output to a writer
+      # (fmt.Fprint/Fprintf/Fprintln). These are ~1,300 CLI stdout/stderr and
+      # already-committed HTTP-response writes — a whole benign class that cannot
+      # lose durable data or corrupt state (the same family errcheck excludes
+      # upstream by default). Annotating each site would bury the signal.
+      # Everything RISK-BEARING (Close/Write/MkdirAll/Setenv/Remove/Exec/…) is
+      # NOT excluded here — those carry a call-site //nolint:errcheck with a
+      # concrete reason, per the "exception at the call site, not by operation
+      # class" rule. Matched by function identity, not by brittle source text.
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+
   exclusions:
-    # Don't lint test files with errcheck — tests intentionally skip error checks.
     rules:
+      # Don't lint test files with errcheck — tests intentionally skip error checks.
       - linters: [errcheck]
         path: _test\.go$
-      # Ignore unchecked Close/Remove/cleanup in defer statements.
+      # Ignore unchecked Close/Remove/cleanup in defer statements
+      # (deferred cleanup is idiomatically ignorable).
       - linters: [errcheck]
         source: "defer "
-      # Ignore unchecked os.MkdirAll / os.WriteFile / os.Setenv (fire-and-forget).
-      - linters: [errcheck]
-        source: "os\\.(MkdirAll|WriteFile|Remove|RemoveAll|Setenv|Unsetenv)\\("
-      # Ignore CopyToClipboard (best-effort UI operation).
-      - linters: [errcheck]
-        source: "CopyToClipboard\\("
-      # Ignore exec.Command().Run() in fire-and-forget UI code.
-      - linters: [errcheck]
-        source: "exec\\.Command\\("
-      # Ignore process signal/kill in cleanup.
-      - linters: [errcheck]
-        source: "\\.(Signal|Kill)\\("
-      # Ignore unchecked Close() calls (cleanup, nothing useful on error).
-      - linters: [errcheck]
-        source: "\\.Close\\(\\)"
-      # Ignore unchecked HTTP response writes (client may have disconnected).
-      - linters: [errcheck]
-        source: "w\\.Write\\("
-      # Ignore unchecked JSON encoder writes to HTTP responses.
-      - linters: [errcheck]
-        source: "json\\.NewEncoder\\("
-      # Ignore unchecked fmt.Fprint*/Scanln (writing to stdout/stderr).
-      - linters: [errcheck]
-        source: "fmt\\.(Fprint|Fprintln|Fprintf|Scanln)\\("
-      # Ignore unchecked io.Copy to discard (draining response bodies).
-      - linters: [errcheck]
-        source: "io\\.Copy\\("
-      # Ignore unchecked json.Unmarshal when result is best-effort.
-      - linters: [errcheck]
-        source: "json\\.Unmarshal\\("
-      # Ignore fire-and-forget URL opening.
-      - linters: [errcheck]
-        source: "openURL\\("
-      # Ignore migration-style ALTER TABLE (idempotent, may fail on re-run).
-      - linters: [errcheck]
-        source: "\\.Exec\\("
-      # Ignore unchecked cmd.Start() for launching browsers/editors.
-      - linters: [errcheck]
-        source: "cmd\\.Start\\("
       # Allow WriteString(fmt.Sprintf(...)) — stylistic, not a bug.
       - linters: [staticcheck]
         text: "QF1012"

--- a/cmd/m3c-tools/doctor_cmd.go
+++ b/cmd/m3c-tools/doctor_cmd.go
@@ -352,7 +352,7 @@ func doctorConnectivity() diag.Section {
 				Name: "TLS handshake", Status: diag.Fail, Detail: fmt.Sprintf("%s — %v", tlsAddr, err),
 			})
 		} else {
-			conn.Close()
+			conn.Close() //nolint:errcheck // best-effort close of a diagnostic-only TLS connection
 			s.Checks = append(s.Checks, diag.Check{
 				Name: "TLS handshake", Status: diag.OK,
 				Detail: fmt.Sprintf("%s (%s)", tlsAddr, elapsed.Round(time.Millisecond)),
@@ -377,7 +377,7 @@ func doctorConnectivity() diag.Section {
 		})
 		return s
 	}
-	resp.Body.Close()
+	resp.Body.Close() //nolint:errcheck // best-effort close of the read-only diagnostic response body
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
 		s.Checks = append(s.Checks, diag.Check{
 			Name: "ER1 /health", Status: diag.OK,
@@ -425,8 +425,8 @@ func doctorConnectivity() diag.Section {
 		})
 		return s
 	}
-	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
-	resp.Body.Close()
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20)) //nolint:errcheck // draining the response body for connection reuse; the data is discarded
+	resp.Body.Close()                                     //nolint:errcheck // best-effort close of the read-only diagnostic response body
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -570,8 +570,8 @@ func doctorPlaud() diag.Section {
 					Detail: fmt.Sprintf("unreachable (%v)", err),
 				})
 			} else {
-				io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
-				resp.Body.Close()
+				io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20)) //nolint:errcheck // draining the response body for connection reuse; the data is discarded
+				resp.Body.Close()                                     //nolint:errcheck // best-effort close of the read-only diagnostic response body
 				if resp.StatusCode >= 200 && resp.StatusCode < 400 {
 					s.Checks = append(s.Checks, diag.Check{
 						Name: "Plaud sync API", Status: diag.OK,

--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -122,8 +122,8 @@ func main() {
 	// This enables uploads via Bearer auth without API key.
 	if cfg := er1.LoadConfig(); cfg.ContextID != "" {
 		if dt, err := auth.Load(auth.DeviceID(), strings.SplitN(cfg.ContextID, "___", 2)[0]); err == nil && dt != nil && !dt.IsExpired() {
-			os.Setenv("ER1_DEVICE_TOKEN", dt.Token)
-			os.Setenv("ER1_CONTEXT_ID", dt.ContextID)
+			os.Setenv("ER1_DEVICE_TOKEN", dt.Token)   //nolint:errcheck // in-process env propagation; the durable device-token store is the source of truth and the key is a constant
+			os.Setenv("ER1_CONTEXT_ID", dt.ContextID) //nolint:errcheck // in-process env propagation; the durable device-token store is the source of truth and the key is a constant
 			log.Printf("[auth] device token loaded for user=%s", truncateForLog(dt.UserID, 20))
 		}
 	}
@@ -1576,7 +1576,7 @@ func cmdImportRetry() {
 	}
 	defer func() {
 		if filesDB != nil {
-			filesDB.Close()
+			filesDB.Close() //nolint:errcheck // best-effort close of the read-only tracking DB on cleanup
 		}
 	}()
 
@@ -1737,7 +1737,7 @@ func cmdImportReset(args []string) {
 func defaultFilesDBPath() string {
 	home, _ := os.UserHomeDir()
 	dir := filepath.Join(home, ".m3c-tools")
-	os.MkdirAll(dir, 0700)
+	os.MkdirAll(dir, 0700) //nolint:errcheck // best-effort dir create; a real failure surfaces when the DB at this path is opened
 	return filepath.Join(dir, "tracking.db")
 }
 
@@ -1778,7 +1778,7 @@ func cmdMenubar(args []string) {
 	// Open log file for writing so "Open Log File" has something to show.
 	// Ensure log directory exists
 	if logDir := filepath.Dir(cfg.LogPath); logDir != "" && logDir != "." {
-		os.MkdirAll(logDir, 0700)
+		os.MkdirAll(logDir, 0700) //nolint:errcheck // best-effort dir create; a real failure surfaces when the log file below is opened
 	}
 	logFile, err := os.OpenFile(cfg.LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
@@ -2243,7 +2243,7 @@ func cmdMenubar(args []string) {
 		case menubar.ActionPocketSync:
 			safeGo("PocketSync", func() { menubarHandlePocketSync(app) })
 		case menubar.ActionStarGitHub:
-			safeGo("StarGitHub", func() { openURL(menubar.GitHubRepoURL) })
+			safeGo("StarGitHub", func() { openURL(menubar.GitHubRepoURL) }) //nolint:errcheck // fire-and-forget UI action: open the GitHub repo in a browser
 		}
 	}
 
@@ -2286,7 +2286,7 @@ func cmdMenubar(args []string) {
 			ttSyncer.Stop(5 * time.Second)
 		}
 		if ttStore != nil {
-			ttStore.Close()
+			ttStore.Close() //nolint:errcheck // best-effort close of the time-tracking store on shutdown
 		}
 		log.Printf("[timetracking] shutdown complete")
 	})
@@ -3064,7 +3064,7 @@ func completeER1Login(app *menubar.App, contextID string, result *loginCallbackR
 		} else {
 			log.Printf("[auth] device token saved for user=%s device=%s", truncateForLog(result.UserID, 20), auth.DeviceID())
 			// Set the token as the active API key so uploads use Bearer auth.
-			os.Setenv("ER1_DEVICE_TOKEN", result.DeviceToken)
+			os.Setenv("ER1_DEVICE_TOKEN", result.DeviceToken) //nolint:errcheck // in-process env propagation; auth.Save above is the checked durable write and the key is a constant
 		}
 	}
 
@@ -3165,7 +3165,7 @@ func cmdLogin() {
 			if err := savePersistedER1Session(ctxID); err != nil {
 				log.Printf("[auth] persist session failed: %v", err)
 			}
-			os.Setenv("ER1_CONTEXT_ID", ctxID)
+			os.Setenv("ER1_CONTEXT_ID", ctxID) //nolint:errcheck // in-process env propagation; savePersistedER1Session above is the checked durable write and the key is a constant
 
 			// Also save to active profile.
 			pm := config.NewProfileManager()
@@ -3195,7 +3195,7 @@ func cmdLogin() {
 				if err := auth.Save(dt); err != nil {
 					log.Printf("[auth] save device token failed: %v", err)
 				} else {
-					os.Setenv("ER1_DEVICE_TOKEN", result.DeviceToken)
+					os.Setenv("ER1_DEVICE_TOKEN", result.DeviceToken) //nolint:errcheck // in-process env propagation; auth.Save above is the checked durable write and the key is a constant
 					fmt.Printf("Device token saved for user=%s device=%s\n", truncateForLog(result.UserID, 20), auth.DeviceID())
 				}
 			}
@@ -3233,7 +3233,7 @@ func startER1LoginCallbackServer() (*http.Server, string, <-chan loginCallbackRe
 	// Generate a random nonce so only the legitimate ER1 redirect can hit the callback.
 	nonce := make([]byte, 16)
 	if _, err := rand.Read(nonce); err != nil {
-		ln.Close()
+		ln.Close() //nolint:errcheck // best-effort close of the just-opened listener on this error path
 		return nil, "", nil, nil, fmt.Errorf("generate callback nonce: %w", err)
 	}
 	callbackPath := "/m3c-login-" + hex.EncodeToString(nonce)
@@ -4325,7 +4325,7 @@ func maybePreloadWhisper() {
 			return
 		}
 		n, _ := io.Copy(io.Discard, f)
-		f.Close()
+		f.Close() //nolint:errcheck // best-effort close of a read-only file opened only to warm the OS cache
 
 		log.Printf("[whisper] preload done in %s (read %.0fMB into OS cache)",
 			time.Since(start).Round(time.Millisecond), float64(n)/(1024*1024))
@@ -4818,7 +4818,7 @@ func cmdPlaudDebugAPI() {
 			Dur     int64  `json:"duration"`
 		} `json:"data_file_list"`
 	}
-	json.Unmarshal(body, &listResp)
+	json.Unmarshal(body, &listResp) //nolint:errcheck // debug endpoint explorer; an empty list on parse failure is acceptable here
 	fmt.Printf("Total recordings in list: %d\n", len(listResp.DataFileList))
 
 	// Find one untranscribed and one transcribed recording.
@@ -4893,7 +4893,7 @@ func cmdPlaudDev(args []string) {
 	// SHARED consumer format so the menubar and `plaud dev` agree.
 	if db, err := tracking.OpenFilesDB(defaultFilesDBPath()); err == nil {
 		migratePlaudDevLedger(db)
-		db.Close()
+		db.Close() //nolint:errcheck // best-effort close after a one-time idempotent ledger migration
 	}
 
 	switch args[0] {
@@ -5779,7 +5779,7 @@ func cmdPlaudSync(recordingID string, force bool, customTags string, filter stri
 				fmt.Printf("Retrying %d recordings with missing ER1 doc_id.\n", retryCount)
 			}
 			if filesDB != nil {
-				filesDB.Close()
+				filesDB.Close() //nolint:errcheck // best-effort close of the read-only tracking DB before syncing
 			}
 			fmt.Printf("Syncing %d new recordings (of %d after filter).\n", len(ids), len(recordings))
 			if len(ids) == 0 {

--- a/cmd/skillctl/gossip_revokes.go
+++ b/cmd/skillctl/gossip_revokes.go
@@ -118,13 +118,13 @@ func gossipRevokedDigests(peers *registry.Peers) (map[string]struct{}, []peerGos
 		}
 		gl, ok := be.(artifact.GovernanceLog)
 		if !ok {
-			be.Close()
+			be.Close() //nolint:errcheck // best-effort close of a read-only artifact backend on this branch
 			rep.Status = "no signed event log"
 			reports = append(reports, rep)
 			continue
 		}
 		page, err := gl.Events(ctx, artifact.ListFilter{}, artifact.Page{})
-		be.Close()
+		be.Close() //nolint:errcheck // best-effort close of a read-only artifact backend after reading events
 		if err != nil {
 			rep.Status = "read error (fail-open): " + err.Error()
 			reports = append(reports, rep)

--- a/cmd/skillctl/scanner_cmds.go
+++ b/cmd/skillctl/scanner_cmds.go
@@ -715,7 +715,7 @@ func cmdConsolidate(args []string) {
 		}
 		fmt.Fprintf(os.Stderr, "\nFound %d annotation gaps. Apply frontmatter fixes? [y/N] ", len(rpt.AnnotationGaps))
 		var answer string
-		fmt.Scanln(&answer)
+		fmt.Scanln(&answer) //nolint:errcheck // an empty answer on read failure (e.g. EOF) is treated as "no", the safe default
 		if answer == "y" || answer == "Y" || answer == "yes" {
 			fixed, skipped, err := consolidate.FixAnnotationGaps(rpt.AnnotationGaps)
 			if err != nil {
@@ -1302,7 +1302,7 @@ func cmdSyncUsage(args []string) {
 		}
 		pending = append(pending, r)
 	}
-	rows.Close()
+	rows.Close() //nolint:errcheck // best-effort close of already-iterated read-only rows
 
 	if len(pending) == 0 {
 		fmt.Println("No unsynced usage events.")
@@ -1347,9 +1347,8 @@ func cmdSyncUsage(args []string) {
 			fmt.Fprintf(os.Stderr, "  [FAIL] id=%d (%s): %v\n", r.ID, r.SkillID, err)
 			continue
 		}
-		io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck // draining the response body for connection reuse; the data is discarded
+		resp.Body.Close()              //nolint:errcheck // best-effort close of the read-only response body
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			now := time.Now().UTC().Format(time.RFC3339)
 			_, err := db.Exec("UPDATE skill_usage SET synced = 1, synced_at = ? WHERE id = ?", now, r.ID)

--- a/pkg/config/editor.go
+++ b/pkg/config/editor.go
@@ -254,7 +254,7 @@ func (s *EditorServer) handleUI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write(s.injectToken(editorHTML))
+	w.Write(s.injectToken(editorHTML)) //nolint:errcheck // best-effort write to an HTTP response (client may have disconnected)
 }
 
 // injectToken inserts the launch token into the served HTML as a meta tag.
@@ -482,20 +482,20 @@ func (s *EditorServer) testProfile(w http.ResponseWriter, name string) {
 // handleHealth returns a simple health check response.
 func (s *EditorServer) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"status":"ok","service":"m3c-settings-editor"}`))
+	w.Write([]byte(`{"status":"ok","service":"m3c-settings-editor"}`)) //nolint:errcheck // best-effort write to an HTTP response (client may have disconnected)
 }
 
 // ── Helpers ──
 
 func jsonOK(w http.ResponseWriter, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(v)
+	json.NewEncoder(w).Encode(v) //nolint:errcheck // best-effort JSON write to an HTTP response (client may have disconnected)
 }
 
 func jsonError(w http.ResponseWriter, msg string, code int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+	json.NewEncoder(w).Encode(map[string]string{"error": msg}) //nolint:errcheck // best-effort JSON write to an HTTP response (client may have disconnected)
 }
 
 // openEditorBrowser opens the given URL in the default browser.
@@ -511,5 +511,5 @@ func openEditorBrowser(url string) {
 	default:
 		return
 	}
-	cmd.Start()
+	cmd.Start() //nolint:errcheck // fire-and-forget UI action: open the settings editor in a browser
 }

--- a/pkg/config/healthcheck.go
+++ b/pkg/config/healthcheck.go
@@ -98,7 +98,7 @@ func healthCheckER1(apiURL, verifySSLStr string) error {
 		return fmt.Errorf("ER1 server unreachable: %w", err)
 	}
 	defer resp.Body.Close()
-	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20)) //nolint:errcheck // draining the response body for connection reuse; the data is discarded
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
 		return nil

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -366,11 +366,11 @@ func (pm *ProfileManager) writeActiveProfile(name string) error {
 		return fmt.Errorf("open active-profile file: %w", err)
 	}
 	if _, err := f.WriteString(name + "\n"); err != nil {
-		f.Close()
+		f.Close() //nolint:errcheck // best-effort close on error path; the write error is already returned below
 		return fmt.Errorf("write active-profile: %w", err)
 	}
 	if err := f.Sync(); err != nil {
-		f.Close()
+		f.Close() //nolint:errcheck // best-effort close on error path; the sync error is already returned below
 		return fmt.Errorf("sync active-profile: %w", err)
 	}
 	if err := f.Close(); err != nil {

--- a/pkg/er1/config.go
+++ b/pkg/er1/config.go
@@ -309,7 +309,7 @@ func (c *Config) HealthCheck() error {
 		return fmt.Errorf("ER1 server unreachable: %w", err)
 	}
 	defer resp.Body.Close()
-	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20)) //nolint:errcheck // draining the response body for connection reuse; the data is discarded
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -366,7 +366,7 @@ func LoadDotenv(path string) error {
 			v = v[1 : len(v)-1]
 		}
 		if os.Getenv(k) == "" {
-			os.Setenv(k, v)
+			os.Setenv(k, v) //nolint:errcheck // best-effort .env->process env; a malformed key is simply skipped, same as an absent line
 		}
 	}
 	return nil

--- a/pkg/er1/device.go
+++ b/pkg/er1/device.go
@@ -1,9 +1,10 @@
 // device.go — Device pairing and heartbeat client for SPEC-0126.
 //
 // Talks to the aims-core device management endpoints:
-//   POST /api/v2/devices/pair       — idempotent device pairing (upsert)
-//   POST /api/v2/devices/heartbeat  — update sync state after batch
-//   GET  /api/v2/devices            — list paired devices
+//
+//	POST /api/v2/devices/pair       — idempotent device pairing (upsert)
+//	POST /api/v2/devices/heartbeat  — update sync state after batch
+//	GET  /api/v2/devices            — list paired devices
 package er1
 
 import (
@@ -73,7 +74,7 @@ func PairDevice(ctx context.Context, baseURL, apiKey string, req PairRequest) er
 		return fmt.Errorf("pair device request: %w", err)
 	}
 	defer resp.Body.Close()
-	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20)) //nolint:errcheck // draining the response body for connection reuse; the data is discarded
 
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
 		return nil
@@ -101,7 +102,7 @@ func DeviceHeartbeat(ctx context.Context, baseURL, apiKey string, req HeartbeatR
 		return fmt.Errorf("heartbeat request: %w", err)
 	}
 	defer resp.Body.Close()
-	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20)) //nolint:errcheck // draining the response body for connection reuse; the data is discarded
 
 	if resp.StatusCode == http.StatusOK {
 		return nil

--- a/pkg/menubar/app.go
+++ b/pkg/menubar/app.go
@@ -539,7 +539,7 @@ func (a *App) buildHelpMenu() menuet.MenuItem {
 					Text:  "Open Log File",
 					Image: iconLogFile,
 					Clicked: func() {
-						exec.Command("open", a.Config.LogPath).Run()
+						exec.Command("open", a.Config.LogPath).Run() //nolint:errcheck // fire-and-forget UI action: open the log file in the default app
 						a.fireAction(ActionOpenLog, a.Config.LogPath)
 					},
 				},
@@ -803,7 +803,7 @@ func (a *App) buildHistoryMenu() menuet.MenuItem {
 							{
 								Text: "Copy Transcript",
 								Clicked: func() {
-									CopyToClipboard("Transcript for " + entry.VideoID)
+									CopyToClipboard("Transcript for " + entry.VideoID) //nolint:errcheck // best-effort UI clipboard write
 									a.fireAction(ActionCopyTranscript, entry.VideoID)
 								},
 							},
@@ -959,7 +959,7 @@ func (a *App) ShowTranscriptResult(videoID string, snippets, chars int) bool {
 		Buttons: []string{"Close", "🗑 Trash"},
 	})
 	if result.Button == 1 { // Trash
-		CopyToClipboard("")
+		CopyToClipboard("") //nolint:errcheck // best-effort UI clipboard clear
 		a.notify("Cleared", "Clipboard cleared")
 		return false
 	}

--- a/pkg/plaud/auth.go
+++ b/pkg/plaud/auth.go
@@ -173,7 +173,7 @@ func extractTokenWithAutoLaunch() (string, error) {
 		client := &http.Client{Timeout: 2 * time.Second}
 		resp, err := client.Get("http://127.0.0.1:9222/json")
 		if err == nil {
-			resp.Body.Close()
+			resp.Body.Close() //nolint:errcheck // best-effort close of a read-only CDP readiness-probe response
 			cdpReady = true
 			break
 		}
@@ -237,7 +237,7 @@ func LaunchChromeForPlaud() (cleanup func(), err error) {
 		"https://app.plaud.ai",
 	)
 	if err := cmd.Start(); err != nil {
-		os.RemoveAll(debugDir)
+		os.RemoveAll(debugDir) //nolint:errcheck // best-effort cleanup of the temp Chrome profile dir on this error path
 		return nil, fmt.Errorf("failed to launch Chrome: %w", err)
 	}
 
@@ -246,7 +246,7 @@ func LaunchChromeForPlaud() (cleanup func(), err error) {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
-		os.RemoveAll(debugDir)
+		os.RemoveAll(debugDir) //nolint:errcheck // best-effort cleanup of the temp Chrome profile dir
 	}
 	return cleanup, nil
 }
@@ -266,7 +266,7 @@ func WaitForCDPReady(timeout time.Duration, progress ProgressFunc) bool {
 		client := &http.Client{Timeout: 2 * time.Second}
 		resp, err := client.Get("http://127.0.0.1:9222/json")
 		if err == nil {
-			resp.Body.Close()
+			resp.Body.Close() //nolint:errcheck // best-effort close of a read-only CDP readiness-probe response
 			return true
 		}
 	}
@@ -378,7 +378,6 @@ func sanitizePlaudToken(tok string) string {
 	}
 	return tok
 }
-
 
 // extractTokenOsascript uses macOS osascript/JXA to read localStorage from Chrome.
 func extractTokenOsascript() (string, error) {

--- a/pkg/plaud/login.go
+++ b/pkg/plaud/login.go
@@ -101,7 +101,7 @@ func postAccessToken(base, email, password string) (string, error) {
 			return "", fmt.Errorf("plaud: login request: %w", err)
 		}
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-		resp.Body.Close()
+		resp.Body.Close() //nolint:errcheck // best-effort close of the read-only response body already read above
 
 		var r struct {
 			Status      int    `json:"status"`

--- a/pkg/skillctl/browse/server.go
+++ b/pkg/skillctl/browse/server.go
@@ -242,7 +242,7 @@ func (s *Server) handleUI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write(injectToken(uiHTML, s.token))
+	w.Write(injectToken(uiHTML, s.token)) //nolint:errcheck // best-effort write to an HTTP response (client may have disconnected)
 }
 
 func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
@@ -255,7 +255,7 @@ func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
 	s.mu.RUnlock()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(g)
+	json.NewEncoder(w).Encode(g) //nolint:errcheck // best-effort JSON write to an HTTP response (client may have disconnected)
 }
 
 func (s *Server) handleFilter(w http.ResponseWriter, r *http.Request) {
@@ -277,7 +277,7 @@ func (s *Server) handleFilter(w http.ResponseWriter, r *http.Request) {
 	filtered := filterGraph(g, projects, types, categories, tags)
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(filtered)
+	json.NewEncoder(w).Encode(filtered) //nolint:errcheck // best-effort JSON write to an HTTP response (client may have disconnected)
 }
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
@@ -308,12 +308,12 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(matches)
+	json.NewEncoder(w).Encode(matches) //nolint:errcheck // best-effort JSON write to an HTTP response (client may have disconnected)
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"status":"ok","service":"skillctl-browse"}`))
+	w.Write([]byte(`{"status":"ok","service":"skillctl-browse"}`)) //nolint:errcheck // best-effort write to an HTTP response (client may have disconnected)
 }
 
 func (s *Server) handleRebuild(w http.ResponseWriter, r *http.Request) {
@@ -345,7 +345,7 @@ func (s *Server) handleRebuild(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck // best-effort JSON write to an HTTP response (client may have disconnected)
 		"status":     "rebuilt",
 		"node_count": len(graph.Nodes),
 		"edge_count": len(graph.Edges),
@@ -478,5 +478,5 @@ func openBrowserURL(url string) {
 	default:
 		return
 	}
-	cmd.Start()
+	cmd.Start() //nolint:errcheck // fire-and-forget UI action: open the browse UI in a browser
 }

--- a/pkg/skillctl/browse/store.go
+++ b/pkg/skillctl/browse/store.go
@@ -45,7 +45,7 @@ func OpenGraphStore(dbPath string) (*GraphStore, error) {
 
 	s := &GraphStore{db: db, dbPath: dbPath}
 	if err := s.migrate(); err != nil {
-		db.Close()
+		db.Close() //nolint:errcheck // best-effort close of the just-opened DB on this error path
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
 	return s, nil

--- a/pkg/skillctl/menubar/skillbar.go
+++ b/pkg/skillctl/menubar/skillbar.go
@@ -439,13 +439,13 @@ func (sb *SkillBar) openReport() {
 	}
 
 	if err := report.GenerateHTML(tmpFile, inv); err != nil {
-		tmpFile.Close()
-		os.Remove(tmpFile.Name())
+		tmpFile.Close()           //nolint:errcheck // best-effort close on error path before removing the temp file
+		os.Remove(tmpFile.Name()) //nolint:errcheck // best-effort removal of the temp report file on error path
 		log.Printf("[skillbar] generate HTML: %v", err)
 		sb.showNotification("Skill Monitor", fmt.Sprintf("Error generating report: %v", err))
 		return
 	}
-	tmpFile.Close()
+	tmpFile.Close() //nolint:errcheck // best-effort close of an ephemeral temp report file opened only for browser display
 
 	// Open in default browser.
 	if err := exec.Command("open", tmpFile.Name()).Start(); err != nil {
@@ -573,7 +573,7 @@ func (sb *SkillBar) handleReviewPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	buf.WriteString("</body></html>")
-	w.Write(buf.Bytes())
+	w.Write(buf.Bytes()) //nolint:errcheck // best-effort write to an HTTP response (client may have disconnected)
 }
 
 // --- Utilities ---
@@ -591,7 +591,7 @@ func (sb *SkillBar) shutdown() {
 	sb.mu.Unlock()
 
 	if srv != nil {
-		srv.Close()
+		srv.Close() //nolint:errcheck // best-effort close of the review HTTP server on shutdown
 	}
 }
 

--- a/pkg/skillctl/review/server.go
+++ b/pkg/skillctl/review/server.go
@@ -242,7 +242,7 @@ func (s *Server) handleUI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write(injectToken(uiHTML, s.token))
+	w.Write(injectToken(uiHTML, s.token)) //nolint:errcheck // best-effort write to an HTTP response (client may have disconnected)
 }
 
 // injectToken inserts the launch token into the served HTML as a meta tag.
@@ -314,7 +314,7 @@ func (s *Server) handleGetDelta(w http.ResponseWriter, r *http.Request) {
 	s.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(buildDeltaJSON(d))
+	json.NewEncoder(w).Encode(buildDeltaJSON(d)) //nolint:errcheck // best-effort JSON write to an HTTP response (client may have disconnected)
 }
 
 // reviewRequest is the JSON body for updating a review status.
@@ -378,7 +378,7 @@ func (s *Server) handleReviewEntry(w http.ResponseWriter, r *http.Request) {
 
 	entry := entryJSON{Index: idx, DeltaEntry: s.report.Entries[idx]}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(entry)
+	json.NewEncoder(w).Encode(entry) //nolint:errcheck // best-effort JSON write to an HTTP response (client may have disconnected)
 }
 
 // sealResponse is the JSON returned after sealing.
@@ -467,7 +467,7 @@ func (s *Server) handleSeal(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	json.NewEncoder(w).Encode(resp) //nolint:errcheck // best-effort JSON write to an HTTP response (client may have disconnected)
 }
 
 // handleListSeals returns all seal records.
@@ -479,7 +479,7 @@ func (s *Server) handleListSeals(w http.ResponseWriter, r *http.Request) {
 
 	if s.sealStore == nil {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte("[]"))
+		w.Write([]byte("[]")) //nolint:errcheck // best-effort write to an HTTP response (client may have disconnected)
 		return
 	}
 
@@ -493,13 +493,13 @@ func (s *Server) handleListSeals(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(seals)
+	json.NewEncoder(w).Encode(seals) //nolint:errcheck // best-effort JSON write to an HTTP response (client may have disconnected)
 }
 
 // handleHealth returns a simple health check response.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"status":"ok","service":"skillctl-review"}`))
+	w.Write([]byte(`{"status":"ok","service":"skillctl-review"}`)) //nolint:errcheck // best-effort write to an HTTP response (client may have disconnected)
 }
 
 // openBrowser opens the given URL in the default browser.
@@ -515,5 +515,5 @@ func openBrowser(url string) {
 	default:
 		return
 	}
-	cmd.Start()
+	cmd.Start() //nolint:errcheck // fire-and-forget UI action: open the review UI in a browser
 }

--- a/pkg/timetracking/plmclient.go
+++ b/pkg/timetracking/plmclient.go
@@ -95,7 +95,7 @@ func (c *PLMClient) HealthCheck() error {
 		return fmt.Errorf("health check request failed: %w", err)
 	}
 	defer resp.Body.Close()
-	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20)) //nolint:errcheck // draining the response body for connection reuse; the data is discarded
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -174,7 +174,7 @@ func (c *PLMClient) PostTimeEvent(event Event) error {
 		return fmt.Errorf("post time event: %w", err)
 	}
 	defer resp.Body.Close()
-	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20)) //nolint:errcheck // draining the response body for connection reuse; the data is discarded
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("post time event HTTP %d", resp.StatusCode)

--- a/pkg/timetracking/store.go
+++ b/pkg/timetracking/store.go
@@ -46,7 +46,7 @@ func OpenStore(dbPath string) (*Store, error) {
 
 	s := &Store{db: db}
 	if err := s.migrate(); err != nil {
-		db.Close()
+		db.Close() //nolint:errcheck // best-effort close of the just-opened DB on this error path
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
 	return s, nil
@@ -73,7 +73,7 @@ func (s *Store) migrate() error {
 	}
 
 	// Add tags column (safe to call multiple times — ignore "duplicate column" error).
-	s.db.Exec("ALTER TABLE projects ADD COLUMN tags TEXT DEFAULT ''")
+	s.db.Exec("ALTER TABLE projects ADD COLUMN tags TEXT DEFAULT ''") //nolint:errcheck // idempotent migration; a "duplicate column" error on re-run is expected and intentionally ignored
 
 	_, err = s.db.Exec(`
 		CREATE TABLE IF NOT EXISTS events (


### PR DESCRIPTION
Gate 2 of WF-001 — the enterprise rule: **exception at the call site, not by operation class.**

`.golangci.yml`: removed all the operation-class errcheck `source:` regexes (the blanket os.WriteFile/MkdirAll/Exec/json.Unmarshal/.Close()/… suppressions); kept the `_test.go` + `defer ` exclusions + the staticcheck QF1012 line.

**Finding:** the real count was ~1418, not ~40 — golangci-lint's default `max-same-issues: 3` was hiding the bulk. Two populations:
- **72 risk-bearing** (Close/Setenv/MkdirAll/RemoveAll/io.Copy/w.Write/json.Encode/cmd.Start/Exec/Unmarshal/Scanln) → **all 72 annotated at the call site** with a concrete `//nolint:errcheck // <reason>` (no bare directives). **0 fixes needed** — PR #156 already fixed the genuine bugs (ER1 queue writes, trust-seal, config Setenv).
- **1346 `fmt.Fprint/Fprintf/Fprintln`** (CLI stdout/stderr + already-committed HTTP-response writes) → a whole-class-benign category errcheck excludes by default. **Kept one class exception, but converted from the brittle source-TEXT regex to errcheck's typed `exclude-functions`** (matches function identity, not arbitrary text).

**Judgment call for review:** hand-annotating 1346 print statements isn't reviewable and wasn't the intent behind the rule (which targets durable-write/close ops). The typed `fmt.Fprint*` exclusion is the pragmatic middle — every *risk-bearing* op is per-site. If you'd rather annotate all 1346 (or drop the print exclusion entirely), say so.

golangci-lint 0 issues (also with the cap fully lifted) · build · vet · test-unit green. 3 bisect-safe commits (annotations before the policy switch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)