### PR TITLE
feat(release): Release Evidence Bundle / Trust Binder (H10 capstone)

### DIFF
--- a/.github/workflows/skillctl-release.yml
+++ b/.github/workflows/skillctl-release.yml
@@ -386,3 +386,209 @@ jobs:
     uses: ./.github/workflows/skillctl-smoke-matrix.yml
     with:
       tag: ${{ github.ref_name }}
+
+  # 7) EVIDENCE — H10 capstone (WF-001 "Trust Binder"). ASSEMBLE the Release
+  #    Evidence Bundle: one signed, machine-readable proof that these exact
+  #    artifacts came from THIS commit AND passed the mandatory gate-set G at
+  #    time T. It is an INDEX of evidence, not a second copy: references[] POINT
+  #    at the already-produced cosign bundle / SLSA provenance / SBOM by URL +
+  #    digest — nothing is re-embedded or re-verified here, so the SLSA L3 build
+  #    isolation is untouched.
+  #
+  #    Runs LAST (after the draft AND the post-draft smoke gate) so platform-smoke
+  #    can be recorded honestly. Holds NO signing identity (contents:read only):
+  #    ASSEMBLY IS ISOLATED FROM SIGNING — only the downstream evidence-sign job
+  #    signs. checks:read lets it read the release commit's CI check-run
+  #    conclusions: the CI-plane gates (unit-tests/race/e2e/lint/gosec/
+  #    govulncheck/gitleaks) ran in ci.yml + gosec.yml on this commit BEFORE the
+  #    tag, so they are GATHERED (an unmatched/unreachable check → skip, i.e.
+  #    "not confirmed", never a silent pass), not asserted. The release-plane
+  #    gates come from this run's needs.<job>.result.
+  #
+  #    enterprise_ready is RECOMPUTED inside the tool from the gate results under
+  #    the fixed policy G (12 required + threat-model-delta advisory); a strict
+  #    consumer recomputes it again. This job never trusts a stored bool.
+  evidence:
+    name: Assemble release-evidence bundle (Trust Binder)
+    needs: [docs-gate, build, provenance, cosign, verify, release, smoke]
+    # Run whenever the draft was cut (release succeeded) EVEN IF the post-draft
+    # smoke gate failed — a red smoke must be recorded as platform-smoke:fail /
+    # enterprise_ready:false, not suppress the evidence entirely.
+    if: ${{ !cancelled() && needs.release.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: read   # read the release commit's CI check-run conclusions
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.6"
+
+      - name: Download binaries + SHA256SUMS
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: skillctl-dist
+          path: dist
+
+      - name: Assemble release-evidence.json (+ in-toto statement)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROV_NAME: ${{ needs.provenance.outputs.provenance-name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DOCAUDIT_RESULT: ${{ needs['docs-gate'].result }}
+          SBOM_RESULT: ${{ needs.build.result }}
+          SLSA_RESULT: ${{ needs.verify.result }}
+          COSIGN_RESULT: ${{ needs.cosign.result }}
+          SMOKE_RESULT: ${{ needs.smoke.result }}
+        run: |
+          set -euo pipefail
+
+          # --- CI-plane gates: read THIS commit's check-run conclusions -------
+          # ci.yml + gosec.yml run on the branch/PR before the tag; their checks
+          # attach to this commit SHA. An absent/in-progress/unmatched check
+          # resolves to "skip" (not confirmed), never a silent pass.
+          declare -A CONCL
+          RAW="$(gh api --paginate \
+                   -H 'Accept: application/vnd.github+json' \
+                   "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs" \
+                   --jq '.check_runs[] | [.name, (.conclusion // "")] | @tsv' 2>/dev/null || true)"
+          while IFS=$'\t' read -r cname cconcl; do
+            [ -n "$cname" ] && CONCL["$cname"]="$cconcl"
+          done <<< "$RAW"
+          resolve() {
+            local v="${CONCL[$1]:-}"
+            if [ -z "$v" ]; then v=skip; fi
+            printf '%s' "$v"
+          }
+
+          # --- checksums reference tamper-evidence: sha256 of SHA256SUMS -------
+          CHECKSUMS_SHA="$(sha256sum dist/SHA256SUMS | awk '{print $1}')"
+
+          # --- gate-set G (CI-plane gathered by check-name; release-plane from
+          #     needs.<job>.result; threat-model-delta advisory) ---------------
+          GATES=(
+            -gate "unit-tests=$(resolve 'Unit Tests')"
+            -gate "e2e=$(resolve 'Unit Tests'),note=runs as a step inside the Unit Tests job"
+            -gate "race=$(resolve 'skillctl Security Tests (-race)')"
+            -gate "lint=$(resolve 'Lint & Vet')"
+            -gate "gosec-sast=$(resolve 'gosec SAST (SARIF -> Code Scanning)')"
+            -gate "govulncheck-cve=$(resolve 'govulncheck (reachable CVEs)')"
+            -gate "gitleaks-secret=$(resolve 'gitleaks (secret scan)')"
+            -gate "docaudit=${DOCAUDIT_RESULT}"
+            -gate "sbom=${SBOM_RESULT},note=CycloneDX SBOM is a blocking step of the build job"
+            -gate "slsa-provenance=${SLSA_RESULT},note=slsa-verifier verify-artifact gate over the isolated L3 generator provenance"
+            -gate "cosign-signature=${COSIGN_RESULT}"
+            -gate "platform-smoke=${SMOKE_RESULT}"
+            -gate "threat-model-delta=skip,evidence=https://github.com/kamir/m3c-tools-maintenance/tree/main/CISO-WORK/scans,note=manual security-triad review; off-CI (advisory)"
+          )
+
+          go run ./cmd/release-evidence \
+            -commit "${GITHUB_SHA}" \
+            -tag "${GITHUB_REF_NAME}" \
+            -repo "${GITHUB_REPOSITORY}" \
+            -run-url "${RUN_URL}" \
+            -channel skillctl \
+            -artifacts dist/SHA256SUMS \
+            -checksums-sha256 "${CHECKSUMS_SHA}" \
+            -provenance-name "${PROV_NAME}" \
+            -sbom-name skillctl.sbom.cdx.json \
+            -schema docs/security/release-evidence.schema.json \
+            -out dist/release-evidence.json \
+            -intoto dist/release-evidence.intoto.json \
+            "${GATES[@]}"
+
+          echo "::group::release-evidence.json"
+          cat dist/release-evidence.json
+          echo "::endgroup::"
+
+      - name: Upload release-evidence (unsigned bundle + statement)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-evidence
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            dist/release-evidence.json
+            dist/release-evidence.intoto.json
+
+  # 8) EVIDENCE-SIGN — keyless cosign sign-blob of the assembled bundle, with the
+  #    SAME OIDC identity that signs SHA256SUMS (install.sh already pins it).
+  #    Holds ONLY id-token:write (no contents:write, runs no build): SIGNING IS
+  #    ISOLATED to this job, mirroring the `cosign` job. Verifies its own
+  #    signature in-job as a gate before publishing the bundle.
+  evidence-sign:
+    name: Sign release-evidence (cosign keyless)
+    needs: [evidence]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # keyless cosign OIDC — isolated to this job
+    steps:
+      - name: Download release-evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-evidence
+          path: dist
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+
+      - name: cosign sign-blob release-evidence.json (GitHub OIDC)
+        working-directory: dist
+        run: cosign sign-blob --yes release-evidence.json --bundle release-evidence.json.cosign.bundle
+
+      # Gate: the bundle must verify against THIS workflow's OIDC identity — the
+      # same identity install.sh pins for SHA256SUMS.
+      - name: Verify the cosign signature in-job (gate)
+        working-directory: dist
+        run: |
+          cosign verify-blob release-evidence.json \
+            --bundle release-evidence.json.cosign.bundle \
+            --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/\.github/workflows/skillctl-release\.yml@refs/tags/skillctl/v" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+      - name: Upload cosign bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-evidence-cosign
+          if-no-files-found: error
+          retention-days: 7
+          path: dist/release-evidence.json.cosign.bundle
+
+  # 9) EVIDENCE-ATTACH — attach the bundle + its cosign bundle + the in-toto
+  #    statement to the EXISTING draft (contents:write only; runs no build, holds
+  #    no signing identity). `gh release upload --clobber` adds assets surgically
+  #    without touching the draft's name/body. The bundle is produced AFTER the
+  #    draft is cut (it must record the post-draft smoke gate), so it is attached
+  #    here rather than in the release job's initial `files:` list.
+  evidence-attach:
+    name: Attach release-evidence to the draft
+    needs: [evidence, evidence-sign]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # add assets to the existing draft release
+    steps:
+      - name: Download release-evidence (bundle + statement)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-evidence
+          path: dist
+
+      - name: Download release-evidence cosign bundle
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-evidence-cosign
+          path: dist
+
+      - name: Attach to the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release upload "${GITHUB_REF_NAME}" \
+            dist/release-evidence.json \
+            dist/release-evidence.json.cosign.bundle \
+            dist/release-evidence.intoto.json \
+            --clobber

--- a/cmd/release-evidence/main.go
+++ b/cmd/release-evidence/main.go
@@ -1,0 +1,807 @@
+// Command release-evidence assembles the Release Evidence Bundle (the "Trust
+// Binder") for an m3c-tools / skillctl release — H10 of the WF-001 hardening
+// track.
+//
+// It answers ONE question in machine-readable, signable form: did this exact set
+// of release artifacts come from commit X AND pass the mandatory gate-set G at
+// time T? It is an INDEX of evidence, not a second copy of it: the bundle POINTS
+// at the already-produced cosign bundle / SLSA provenance / SBOM by URL (+digest)
+// rather than re-embedding or re-verifying them, which keeps the SLSA L3 build
+// isolation intact (assembly runs in a no-signing job; only a downstream cosign
+// step signs the assembled bundle).
+//
+// Design decision H10d:
+//   - agent (not human) schema; in-toto + cosign-keyless framing;
+//   - `summary.enterprise_ready` is RECOMPUTED here from the gate results under a
+//     fixed policy G — never taken on trust from an input. A strict CONSUMER is
+//     expected to recompute it again against its own policy; this tool's job is to
+//     compute the honest value and make the inputs auditable.
+//
+// The `required` set (gate-set G) is POLICY and lives in the registry below — it
+// is NOT caller-overridable. A caller supplies only each gate's STATUS (+ optional
+// evidence URL / note). This is deliberate: it prevents a caller from marking a
+// required gate `required:false` to fake enterprise-readiness.
+//
+// Zero external dependencies (stdlib only), matching the repo's zero-dep core.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	toolName      = "release-evidence"
+	toolVersion   = "0.1.0"
+	schemaVersion = "0.1.0"
+	predicateType = "https://m3c-tools.dev/attestations/release-evidence/v0"
+	intotoType    = "https://in-toto.io/Statement/v1"
+	policyID      = "trust-binder/policy@v0"
+	policyRule    = "enterprise_ready = every REQUIRED gate (set G) has status==pass; " +
+		"a required gate that is fail OR skip => not ready. Advisory gates (required:false) " +
+		"never block. The required set is fixed by policy, not by the caller. A strict " +
+		"verifier RECOMPUTES this from `gates` under its own policy rather than trusting the bool."
+)
+
+// gateMeta is the FIXED, policy-owned metadata for a gate. Only `status` (and
+// optional evidence/note) come from the caller; everything here is baked in so
+// the gate-set G and its required-ness cannot be forged through inputs.
+type gateMeta struct {
+	id            string
+	name          string
+	kind          string
+	required      bool
+	verifiability string
+	evidenceType  string
+}
+
+// registry is the mandatory gate-set G (H10d). Order is presentational and
+// mirrors the H10p prototype. The `required` column IS policy G:
+//
+//	12 required (the now-real gates) + threat-model-delta advisory.
+//
+// If a gate id here drifts from the shipped JSON-schema enum, the -schema
+// cross-check fails the build (keeps schema and policy in lockstep).
+var registry = []gateMeta{
+	{"unit-tests", "Unit Tests", "test", true, "trust-ci", "ci-log"},
+	{"race", "skillctl Security Tests (-race)", "test", true, "trust-ci", "ci-log"},
+	{"e2e", "e2e tests (allow-list)", "test", true, "trust-ci", "ci-log"},
+	{"lint", "Lint & Vet", "test", true, "trust-ci", "ci-log"},
+	{"gosec-sast", "gosec SAST", "sast", true, "trust-ci", "ci-log"},
+	{"govulncheck-cve", "govulncheck (reachable CVEs)", "sca", true, "trust-ci", "ci-log"},
+	{"gitleaks-secret", "gitleaks (secret scan)", "secret", true, "trust-ci", "ci-log"},
+	{"sbom", "CycloneDX SBOM", "sbom", true, "re-verify", "release-asset"},
+	{"docaudit", "skillctl CLI/manual consistency (docaudit)", "docs", true, "trust-ci", "ci-log"},
+	{"slsa-provenance", "SLSA L3 provenance + slsa-verifier gate", "provenance", true, "re-verify", "attestation"},
+	{"cosign-signature", "cosign sign-blob SHA256SUMS (keyless OIDC)", "signature", true, "re-verify", "attestation"},
+	{"platform-smoke", "Per-platform runtime smoke of the signed binary", "smoke", true, "trust-ci", "ci-log"},
+	{"threat-model-delta", "Threat-model / security-triad delta", "threat-model", false, "reference", "external"},
+}
+
+func registryByID() map[string]gateMeta {
+	m := make(map[string]gateMeta, len(registry))
+	for _, g := range registry {
+		m[g.id] = g
+	}
+	return m
+}
+
+// ---- schema structs (JSON field order = output order) -----------------------
+
+type Bundle struct {
+	SchemaVersion string       `json:"schema_version"`
+	PredicateType string       `json:"predicate_type,omitempty"`
+	BundleID      string       `json:"bundle_id,omitempty"`
+	Subject       Subject      `json:"subject"`
+	ProducedAt    string       `json:"produced_at"`
+	GeneratedBy   *GeneratedBy `json:"generated_by,omitempty"`
+	Policy        *Policy      `json:"policy,omitempty"`
+	Gates         []Gate       `json:"gates"`
+	References    []Reference  `json:"references,omitempty"`
+	Summary       Summary      `json:"summary"`
+}
+
+type Subject struct {
+	Repo            string     `json:"repo"`
+	SourceURI       string     `json:"source_uri,omitempty"`
+	Commit          string     `json:"commit"`
+	Tag             string     `json:"tag"`
+	Channel         string     `json:"channel,omitempty"`
+	ArtifactDigests []Artifact `json:"artifact_digests"`
+}
+
+type Artifact struct {
+	Name   string `json:"name"`
+	Digest Digest `json:"digest"`
+}
+
+type Digest struct {
+	SHA256 string `json:"sha256"`
+}
+
+type GeneratedBy struct {
+	Tool        string `json:"tool,omitempty"`
+	Version     string `json:"version,omitempty"`
+	WorkflowRun string `json:"workflow_run,omitempty"`
+}
+
+type Policy struct {
+	ID   string `json:"id"`
+	Rule string `json:"rule,omitempty"`
+}
+
+type Gate struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Kind          string `json:"kind"`
+	Status        string `json:"status"`
+	Required      bool   `json:"required"`
+	EvidenceRef   string `json:"evidence_ref,omitempty"`
+	EvidenceType  string `json:"evidence_type,omitempty"`
+	Verifiability string `json:"verifiability,omitempty"`
+	Note          string `json:"note,omitempty"`
+}
+
+type Reference struct {
+	Type   string `json:"type"`
+	URI    string `json:"uri"`
+	SHA256 string `json:"sha256,omitempty"`
+}
+
+type Summary struct {
+	RequiredTotal   int      `json:"required_total"`
+	RequiredPassed  int      `json:"required_passed"`
+	RequiredFailed  int      `json:"required_failed"`
+	Skipped         int      `json:"skipped"`
+	EnterpriseReady bool     `json:"enterprise_ready"`
+	Caveats         []string `json:"caveats,omitempty"`
+}
+
+// Statement is the in-toto v1 wrapper: subject = the artifact digests, predicate
+// = the Bundle. Cheap framing so the bundle can be attached as an attestation
+// tied to the same subjects as the SLSA provenance.
+type Statement struct {
+	Type          string     `json:"_type"`
+	Subject       []Artifact `json:"subject"`
+	PredicateType string     `json:"predicateType"`
+	Predicate     *Bundle    `json:"predicate"`
+}
+
+// ---- caller-supplied gate result --------------------------------------------
+
+type gateInput struct {
+	ID       string `json:"id"`
+	Status   string `json:"status"`
+	Evidence string `json:"evidence,omitempty"`
+	Note     string `json:"note,omitempty"`
+}
+
+// ---- options (buildBundle input; keeps main() thin + the logic testable) -----
+
+type options struct {
+	commit, tag, repo, runURL string
+	channel                   string
+	sourceURI                 string
+	provenanceName            string
+	sbomName                  string
+	checksumsSHA256           string
+	producedAt                string
+	toolVersion               string
+	artifacts                 []Artifact
+	gates                     []gateInput
+	extraRefs                 []Reference
+	autoRefs                  bool
+}
+
+var (
+	reSHA1     = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	reSHA256   = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	reSemver   = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
+	reRepo     = regexp.MustCompile(`^[^/\s]+/[^/\s]+$`)
+	validStat  = map[string]bool{"pass": true, "fail": true, "skip": true}
+	validKind  = map[string]bool{"test": true, "sast": true, "sca": true, "secret": true, "provenance": true, "signature": true, "sbom": true, "docs": true, "smoke": true, "threat-model": true}
+	validRefTy = map[string]bool{"checksums": true, "cosign-bundle": true, "slsa-provenance": true, "sbom": true, "ed25519-sig": true, "pubkey": true}
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(argv []string) int {
+	fs := flag.NewFlagSet(toolName, flag.ContinueOnError)
+
+	var (
+		commit    = fs.String("commit", "", "full 40-hex release commit SHA (required)")
+		tag       = fs.String("tag", "", "release tag, e.g. skillctl/v0.5.0 (required)")
+		repo      = fs.String("repo", "", "owner/name, e.g. kamir/m3c-tools (required)")
+		runURL    = fs.String("run-url", "", "URL of the CI run assembling this bundle")
+		channel   = fs.String("channel", "skillctl", "release channel: product|skillctl")
+		out       = fs.String("out", "release-evidence.json", "output path for the bundle JSON")
+		intoto    = fs.String("intoto", "", "if set, also write an in-toto Statement wrapping the bundle to this path")
+		sourceURI = fs.String("source-uri", "", "git+https source URI (default git+https://github.com/<repo>)")
+		schemaP   = fs.String("schema", "docs/security/release-evidence.schema.json", "JSON-schema to cross-check the gate-id enum against (soft-skip if absent)")
+		provName  = fs.String("provenance-name", "multiple.intoto.jsonl", "SLSA provenance asset filename (for evidence + references)")
+		sbomName  = fs.String("sbom-name", "skillctl.sbom.cdx.json", "SBOM asset filename (for evidence + references)")
+		sumsSHA   = fs.String("checksums-sha256", "", "sha256 of SHA256SUMS, for the checksums reference (tamper-evident pointer)")
+		producedA = fs.String("produced-at", "", "RFC3339 assembly time (default: now, UTC)")
+		toolVer   = fs.String("tool-version", toolVersion, "version stamped into generated_by")
+		artFile   = fs.String("artifacts", "", "path to a SHA256SUMS file to parse into subject.artifact_digests")
+		gatesFile = fs.String("gates-file", "", "path to a JSON array of {id,status,evidence,note} gate results")
+		noRefs    = fs.Bool("no-auto-refs", false, "do not auto-build the standard references[] index")
+	)
+	var gateFlags multiFlag
+	var artFlags multiFlag
+	var refFlags multiFlag
+	fs.Var(&gateFlags, "gate", "repeatable: id=status[,evidence=url][,note=text] (status accepts GitHub needs.*.result too)")
+	fs.Var(&artFlags, "artifact", "repeatable: name=<sha256> (alternative/supplement to -artifacts)")
+	fs.Var(&refFlags, "reference", "repeatable extra reference: type=uri[,sha256=hex]")
+
+	if err := fs.Parse(argv); err != nil {
+		return 2
+	}
+
+	opts := options{
+		commit:          strings.TrimSpace(*commit),
+		tag:             strings.TrimSpace(*tag),
+		repo:            strings.TrimSpace(*repo),
+		runURL:          strings.TrimSpace(*runURL),
+		channel:         strings.TrimSpace(*channel),
+		sourceURI:       strings.TrimSpace(*sourceURI),
+		provenanceName:  strings.TrimSpace(*provName),
+		sbomName:        strings.TrimSpace(*sbomName),
+		checksumsSHA256: strings.TrimSpace(*sumsSHA),
+		producedAt:      strings.TrimSpace(*producedA),
+		toolVersion:     strings.TrimSpace(*toolVer),
+		autoRefs:        !*noRefs,
+	}
+
+	// Gate results: file first, then -gate flags (flags win on duplicate id).
+	var gerr error
+	if *gatesFile != "" {
+		opts.gates, gerr = loadGatesFile(*gatesFile)
+		if gerr != nil {
+			fmt.Fprintf(os.Stderr, "release-evidence: %v\n", gerr)
+			return 1
+		}
+	}
+	for _, g := range gateFlags {
+		gi, err := parseGateFlag(g)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "release-evidence: -gate %q: %v\n", g, err)
+			return 1
+		}
+		opts.gates = upsertGate(opts.gates, gi)
+	}
+
+	// Artifact digests: SHA256SUMS file first, then -artifact flags.
+	if *artFile != "" {
+		arts, err := parseChecksums(*artFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "release-evidence: -artifacts %q: %v\n", *artFile, err)
+			return 1
+		}
+		opts.artifacts = append(opts.artifacts, arts...)
+	}
+	for _, a := range artFlags {
+		art, err := parseArtifactFlag(a)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "release-evidence: -artifact %q: %v\n", a, err)
+			return 1
+		}
+		opts.artifacts = append(opts.artifacts, art)
+	}
+	for _, r := range refFlags {
+		ref, err := parseReferenceFlag(r)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "release-evidence: -reference %q: %v\n", r, err)
+			return 1
+		}
+		opts.extraRefs = append(opts.extraRefs, ref)
+	}
+
+	// Cross-check the shipped schema's gate-id enum against the registry, so the
+	// policy set G and the schema never silently drift. Soft-skip if absent.
+	if err := crossCheckSchema(*schemaP); err != nil {
+		fmt.Fprintf(os.Stderr, "release-evidence: schema cross-check: %v\n", err)
+		return 1
+	}
+
+	b, err := buildBundle(opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "release-evidence: %v\n", err)
+		return 1
+	}
+	if err := validate(b); err != nil {
+		fmt.Fprintf(os.Stderr, "release-evidence: invalid bundle: %v\n", err)
+		return 1
+	}
+
+	if err := writeJSON(*out, b); err != nil {
+		fmt.Fprintf(os.Stderr, "release-evidence: write %q: %v\n", *out, err)
+		return 1
+	}
+	if *intoto != "" {
+		st := &Statement{Type: intotoType, Subject: b.Subject.ArtifactDigests, PredicateType: predicateType, Predicate: b}
+		if err := writeJSON(*intoto, st); err != nil {
+			fmt.Fprintf(os.Stderr, "release-evidence: write %q: %v\n", *intoto, err)
+			return 1
+		}
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"release-evidence: %s — enterprise_ready=%v (required %d/%d pass, %d skipped) -> %s\n",
+		b.BundleID, b.Summary.EnterpriseReady, b.Summary.RequiredPassed, b.Summary.RequiredTotal, b.Summary.Skipped, *out)
+	return 0
+}
+
+// buildBundle assembles the bundle from options. It ALWAYS emits one gate per
+// registry entry (a gate with no supplied result is recorded as skip with a
+// note), so the gate-set G is complete and enterprise_ready is honest.
+func buildBundle(o options) (*Bundle, error) {
+	if o.commit == "" || o.tag == "" || o.repo == "" {
+		return nil, errors.New("-commit, -tag and -repo are all required")
+	}
+	if o.channel == "" {
+		o.channel = "skillctl"
+	}
+	if o.sourceURI == "" {
+		o.sourceURI = "git+https://github.com/" + o.repo
+	}
+	if o.producedAt == "" {
+		o.producedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	if o.toolVersion == "" {
+		o.toolVersion = toolVersion
+	}
+
+	base := "https://github.com/" + o.repo + "/releases/download/" + o.tag
+
+	// index caller results by id (normalising status).
+	supplied := make(map[string]gateInput, len(o.gates))
+	for _, g := range o.gates {
+		id := strings.TrimSpace(g.ID)
+		st, err := normalizeStatus(g.Status)
+		if err != nil {
+			return nil, fmt.Errorf("gate %q: %w", id, err)
+		}
+		g.ID, g.Status = id, st
+		supplied[id] = g
+	}
+	// reject results for unknown gate ids (typo / drift protection).
+	known := registryByID()
+	for id := range supplied {
+		if _, ok := known[id]; !ok {
+			return nil, fmt.Errorf("gate %q is not in the policy gate-set G", id)
+		}
+	}
+
+	gates := make([]Gate, 0, len(registry))
+	for _, m := range registry {
+		g := Gate{
+			ID: m.id, Name: m.name, Kind: m.kind, Required: m.required,
+			EvidenceType: m.evidenceType, Verifiability: m.verifiability,
+		}
+		if in, ok := supplied[m.id]; ok {
+			g.Status = in.Status
+			g.EvidenceRef = strings.TrimSpace(in.Evidence)
+			g.Note = strings.TrimSpace(in.Note)
+		} else {
+			g.Status = "skip"
+			g.Note = "no gate result supplied at assembly time"
+		}
+		if g.EvidenceRef == "" {
+			g.EvidenceRef = defaultEvidence(m, base, o)
+		}
+		gates = append(gates, g)
+	}
+
+	b := &Bundle{
+		SchemaVersion: schemaVersion,
+		PredicateType: predicateType,
+		BundleID:      o.repo + "@" + o.tag,
+		Subject: Subject{
+			Repo:            o.repo,
+			SourceURI:       o.sourceURI,
+			Commit:          o.commit,
+			Tag:             o.tag,
+			Channel:         o.channel,
+			ArtifactDigests: o.artifacts,
+		},
+		ProducedAt:  o.producedAt,
+		GeneratedBy: &GeneratedBy{Tool: toolName, Version: o.toolVersion, WorkflowRun: o.runURL},
+		Policy:      &Policy{ID: policyID, Rule: policyRule},
+		Gates:       gates,
+		References:  buildReferences(o, base),
+		Summary:     computeSummary(gates),
+	}
+	return b, nil
+}
+
+// defaultEvidence supplies a sensible evidence_ref when the caller gave none:
+// asset-backed (re-verify) gates point at their release asset; everything else
+// points at the assembling run.
+func defaultEvidence(m gateMeta, base string, o options) string {
+	switch m.id {
+	case "sbom":
+		return base + "/" + o.sbomName
+	case "slsa-provenance":
+		return base + "/" + o.provenanceName
+	case "cosign-signature":
+		return base + "/SHA256SUMS.cosign.bundle"
+	default:
+		return o.runURL
+	}
+}
+
+// buildReferences emits the evidence INDEX — pointers (not copies) at the
+// aggregate artifacts a verifier can fetch + re-verify. For the skillctl channel
+// this is the standard six-asset set; extra/override refs are appended.
+func buildReferences(o options, base string) []Reference {
+	var refs []Reference
+	if o.autoRefs && o.channel == "skillctl" {
+		refs = append(refs,
+			Reference{Type: "checksums", URI: base + "/SHA256SUMS", SHA256: o.checksumsSHA256},
+			Reference{Type: "cosign-bundle", URI: base + "/SHA256SUMS.cosign.bundle"},
+			Reference{Type: "slsa-provenance", URI: base + "/" + o.provenanceName},
+			Reference{Type: "sbom", URI: base + "/" + o.sbomName},
+			Reference{Type: "ed25519-sig", URI: base + "/SHA256SUMS.sig"},
+			Reference{Type: "pubkey", URI: base + "/skillctl-release.pub"},
+		)
+	}
+	return append(refs, o.extraRefs...)
+}
+
+// computeSummary RECOMPUTES enterprise_ready from the gate results under policy G.
+// This is the trust-bearing function: the stored bool is derived here, never
+// taken from an input.
+func computeSummary(gates []Gate) Summary {
+	var s Summary
+	var caveats []string
+	for _, g := range gates {
+		if g.Status == "skip" {
+			s.Skipped++
+		}
+		if g.Required {
+			s.RequiredTotal++
+			switch g.Status {
+			case "pass":
+				s.RequiredPassed++
+			case "fail":
+				s.RequiredFailed++
+			}
+		} else if g.Status != "pass" {
+			caveats = append(caveats, fmt.Sprintf("%s (%s, advisory) — not counted toward enterprise_ready.", g.ID, g.Status))
+		}
+	}
+	// enterprise_ready: no required failure AND every required gate passed (a
+	// required skip lands in neither passed nor failed, so it fails this test).
+	s.EnterpriseReady = s.RequiredFailed == 0 && s.RequiredPassed == s.RequiredTotal
+	s.Caveats = caveats
+	return s
+}
+
+// validate re-checks the assembled bundle against the schema's load-bearing
+// constraints (stdlib-only structural validation) and confirms the stored
+// summary matches an independent recompute.
+func validate(b *Bundle) error {
+	if !reSemver.MatchString(b.SchemaVersion) {
+		return fmt.Errorf("schema_version %q is not semver", b.SchemaVersion)
+	}
+	if !reRepo.MatchString(b.Subject.Repo) {
+		return fmt.Errorf("subject.repo %q must be owner/name", b.Subject.Repo)
+	}
+	if !reSHA1.MatchString(b.Subject.Commit) {
+		return fmt.Errorf("subject.commit %q must be a 40-hex sha", b.Subject.Commit)
+	}
+	if strings.TrimSpace(b.Subject.Tag) == "" {
+		return errors.New("subject.tag is empty")
+	}
+	if b.Subject.Channel != "" && b.Subject.Channel != "product" && b.Subject.Channel != "skillctl" {
+		return fmt.Errorf("subject.channel %q must be product|skillctl", b.Subject.Channel)
+	}
+	if len(b.Subject.ArtifactDigests) < 1 {
+		return errors.New("subject.artifact_digests must have at least one entry")
+	}
+	for _, a := range b.Subject.ArtifactDigests {
+		if strings.TrimSpace(a.Name) == "" {
+			return errors.New("artifact_digests: empty name")
+		}
+		if !reSHA256.MatchString(a.Digest.SHA256) {
+			return fmt.Errorf("artifact %q: digest.sha256 %q must be 64-hex", a.Name, a.Digest.SHA256)
+		}
+	}
+	if strings.TrimSpace(b.ProducedAt) == "" {
+		return errors.New("produced_at is empty")
+	}
+	if _, err := time.Parse(time.RFC3339, b.ProducedAt); err != nil {
+		return fmt.Errorf("produced_at %q is not RFC3339: %w", b.ProducedAt, err)
+	}
+	known := registryByID()
+	seen := map[string]bool{}
+	for _, g := range b.Gates {
+		if _, ok := known[g.ID]; !ok {
+			return fmt.Errorf("gate id %q not in enum", g.ID)
+		}
+		if seen[g.ID] {
+			return fmt.Errorf("duplicate gate id %q", g.ID)
+		}
+		seen[g.ID] = true
+		if !validStat[g.Status] {
+			return fmt.Errorf("gate %q: status %q must be pass|fail|skip", g.ID, g.Status)
+		}
+		if !validKind[g.Kind] {
+			return fmt.Errorf("gate %q: kind %q invalid", g.ID, g.Kind)
+		}
+	}
+	for _, r := range b.References {
+		if !validRefTy[r.Type] {
+			return fmt.Errorf("reference type %q invalid", r.Type)
+		}
+		if strings.TrimSpace(r.URI) == "" {
+			return fmt.Errorf("reference %q: empty uri", r.Type)
+		}
+		if r.SHA256 != "" && !reSHA256.MatchString(r.SHA256) {
+			return fmt.Errorf("reference %q: sha256 %q must be 64-hex", r.Type, r.SHA256)
+		}
+	}
+	// summary integrity: an independent recompute MUST equal the stored summary.
+	want := computeSummary(b.Gates)
+	if want.RequiredTotal != b.Summary.RequiredTotal ||
+		want.RequiredPassed != b.Summary.RequiredPassed ||
+		want.RequiredFailed != b.Summary.RequiredFailed ||
+		want.Skipped != b.Summary.Skipped ||
+		want.EnterpriseReady != b.Summary.EnterpriseReady {
+		return errors.New("summary does not match an independent recompute of the gates")
+	}
+	return nil
+}
+
+// ---- parsing helpers --------------------------------------------------------
+
+// multiFlag collects a repeatable string flag.
+type multiFlag []string
+
+func (m *multiFlag) String() string     { return strings.Join(*m, ",") }
+func (m *multiFlag) Set(v string) error { *m = append(*m, v); return nil }
+
+// normalizeStatus maps the pass/fail/skip vocabulary AND GitHub's
+// needs.<job>.result vocabulary (success/failure/cancelled/skipped) to the
+// canonical status. Unknown/empty -> skip (honest "not confirmed", never a
+// silent pass); cancelled/timed_out -> fail (a required gate that was cut is not
+// ready).
+func normalizeStatus(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "pass", "passed", "success", "succeeded":
+		return "pass", nil
+	case "fail", "failed", "failure", "cancelled", "canceled", "timed_out", "action_required":
+		return "fail", nil
+	case "skip", "skipped", "neutral", "", "null":
+		return "skip", nil
+	default:
+		return "", fmt.Errorf("unrecognised status %q", s)
+	}
+}
+
+// parseGateFlag parses `id=status[,evidence=url][,note=text]`. `note` is greedy:
+// everything after `,note=` is the note (so it may contain commas). The optional
+// `evidence` segment therefore precedes any note.
+func parseGateFlag(s string) (gateInput, error) {
+	head, rest, _ := strings.Cut(s, ",")
+	id, status, ok := strings.Cut(head, "=")
+	if !ok || strings.TrimSpace(id) == "" || strings.TrimSpace(status) == "" {
+		return gateInput{}, errors.New("want id=status[,evidence=url][,note=text]")
+	}
+	gi := gateInput{ID: strings.TrimSpace(id), Status: strings.TrimSpace(status)}
+
+	// Peel a greedy note off the end first, so a comma-bearing note survives.
+	if i := strings.Index(rest, "note="); i >= 0 {
+		gi.Note = strings.TrimSpace(rest[i+len("note="):])
+		rest = strings.TrimRight(rest[:i], ", ")
+	}
+	for _, part := range splitTopComma(rest) {
+		if part == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(part, "=")
+		if !ok {
+			return gateInput{}, fmt.Errorf("bad key=value segment %q", part)
+		}
+		switch strings.TrimSpace(k) {
+		case "evidence":
+			gi.Evidence = strings.TrimSpace(v)
+		default:
+			return gateInput{}, fmt.Errorf("unknown segment key %q (want evidence= or note=)", k)
+		}
+	}
+	return gi, nil
+}
+
+// splitTopComma splits on commas; used for the optional evidence segment(s).
+func splitTopComma(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, ",")
+}
+
+func parseArtifactFlag(s string) (Artifact, error) {
+	name, sha, ok := strings.Cut(s, "=")
+	name, sha = strings.TrimSpace(name), strings.TrimSpace(sha)
+	if !ok || name == "" || !reSHA256.MatchString(sha) {
+		return Artifact{}, errors.New("want name=<64-hex sha256>")
+	}
+	return Artifact{Name: name, Digest: Digest{SHA256: sha}}, nil
+}
+
+func parseReferenceFlag(s string) (Reference, error) {
+	head, rest, _ := strings.Cut(s, ",")
+	ty, uri, ok := strings.Cut(head, "=")
+	ty, uri = strings.TrimSpace(ty), strings.TrimSpace(uri)
+	if !ok || !validRefTy[ty] || uri == "" {
+		return Reference{}, errors.New("want type=uri[,sha256=hex] with a valid reference type")
+	}
+	ref := Reference{Type: ty, URI: uri}
+	for _, part := range splitTopComma(rest) {
+		if part == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(part, "=")
+		if !ok || strings.TrimSpace(k) != "sha256" {
+			return Reference{}, fmt.Errorf("unknown reference segment %q", part)
+		}
+		ref.SHA256 = strings.TrimSpace(v)
+	}
+	return ref, nil
+}
+
+// parseChecksums parses a `sha256␠␠name` (GNU coreutils) SHA256SUMS file into
+// artifact digests.
+func parseChecksums(path string) ([]Artifact, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var out []Artifact
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return nil, fmt.Errorf("malformed SHA256SUMS line: %q", line)
+		}
+		sha := strings.ToLower(fields[0])
+		name := strings.TrimPrefix(strings.Join(fields[1:], " "), "*") // coreutils binary marker
+		if !reSHA256.MatchString(sha) {
+			return nil, fmt.Errorf("bad sha256 in SHA256SUMS line: %q", line)
+		}
+		out = append(out, Artifact{Name: name, Digest: Digest{SHA256: sha}})
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, errors.New("no checksum lines found")
+	}
+	return out, nil
+}
+
+func loadGatesFile(path string) ([]gateInput, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var arr []gateInput
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return nil, fmt.Errorf("gates-file %q: expected a JSON array of {id,status,...}: %w", path, err)
+	}
+	return arr, nil
+}
+
+func upsertGate(gs []gateInput, gi gateInput) []gateInput {
+	for i := range gs {
+		if gs[i].ID == gi.ID {
+			gs[i] = gi
+			return gs
+		}
+	}
+	return append(gs, gi)
+}
+
+// crossCheckSchema loads the shipped JSON-schema and asserts its gate-id enum is
+// exactly the registry set — so policy G and the schema cannot drift. A missing
+// file is a soft skip (the tool must still run where the schema isn't checked out).
+func crossCheckSchema(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "release-evidence: schema %q absent — skipping gate-id cross-check\n", path)
+			return nil
+		}
+		return err
+	}
+	// Navigate properties.gates.items.properties.id.enum without a schema lib.
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parse %q: %w", path, err)
+	}
+	enum, err := digEnum(doc)
+	if err != nil {
+		return fmt.Errorf("%q: %w", path, err)
+	}
+	want := map[string]bool{}
+	for _, g := range registry {
+		want[g.id] = true
+	}
+	got := map[string]bool{}
+	for _, e := range enum {
+		got[e] = true
+	}
+	var missing, extra []string
+	for id := range want {
+		if !got[id] {
+			missing = append(missing, id)
+		}
+	}
+	for id := range got {
+		if !want[id] {
+			extra = append(extra, id)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	if len(missing) > 0 || len(extra) > 0 {
+		return fmt.Errorf("registry vs schema gate-id enum drift (in-registry-not-schema=%v, in-schema-not-registry=%v)", missing, extra)
+	}
+	return nil
+}
+
+func digEnum(doc map[string]any) ([]string, error) {
+	step := func(m map[string]any, k string) (map[string]any, error) {
+		v, ok := m[k].(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("missing object at .%s", k)
+		}
+		return v, nil
+	}
+	var err error
+	m := doc
+	for _, k := range []string{"properties", "gates", "items", "properties", "id"} {
+		if m, err = step(m, k); err != nil {
+			return nil, err
+		}
+	}
+	raw, ok := m["enum"].([]any)
+	if !ok {
+		return nil, errors.New("no enum at properties.gates.items.properties.id")
+	}
+	out := make([]string, 0, len(raw))
+	for _, e := range raw {
+		s, ok := e.(string)
+		if !ok {
+			return nil, errors.New("non-string in gate-id enum")
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func writeJSON(path string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}

--- a/cmd/release-evidence/main_test.go
+++ b/cmd/release-evidence/main_test.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// baseOpts is a minimal, valid set of assembly options. Each test overrides only
+// what it exercises. producedAt is fixed so runs are deterministic.
+func baseOpts() options {
+	return options{
+		commit:         "464e47d0c0ffee1234567890abcdef0123456789",
+		tag:            "skillctl/v0.5.0",
+		repo:           "kamir/m3c-tools",
+		runURL:         "https://github.com/kamir/m3c-tools/actions/runs/9900112233",
+		channel:        "skillctl",
+		producedAt:     "2026-09-03T09:14:22Z",
+		toolVersion:    "0.1.0-test",
+		autoRefs:       true,
+		provenanceName: "multiple.intoto.jsonl",
+		sbomName:       "skillctl.sbom.cdx.json",
+		artifacts: []Artifact{
+			{Name: "skillctl-linux-amd64", Digest: Digest{SHA256: strings.Repeat("a", 64)}},
+		},
+	}
+}
+
+// allRequiredPass returns a gate-result set where every REQUIRED gate passes and
+// the sole advisory gate (threat-model-delta) is skipped.
+func allRequiredPass() []gateInput {
+	var gs []gateInput
+	for _, m := range registry {
+		st := "pass"
+		if !m.required {
+			st = "skip"
+		}
+		gs = append(gs, gateInput{ID: m.id, Status: st})
+	}
+	return gs
+}
+
+func TestRecompute_AllRequiredPass_IsReady(t *testing.T) {
+	o := baseOpts()
+	o.gates = allRequiredPass()
+
+	b, err := buildBundle(o)
+	if err != nil {
+		t.Fatalf("buildBundle: %v", err)
+	}
+	if err := validate(b); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !b.Summary.EnterpriseReady {
+		t.Fatalf("enterprise_ready = false, want true when every required gate passes")
+	}
+	if b.Summary.RequiredFailed != 0 {
+		t.Fatalf("required_failed = %d, want 0", b.Summary.RequiredFailed)
+	}
+	if b.Summary.RequiredPassed != b.Summary.RequiredTotal {
+		t.Fatalf("required_passed %d != required_total %d", b.Summary.RequiredPassed, b.Summary.RequiredTotal)
+	}
+	// Sanity: policy G currently has 12 required gates.
+	if b.Summary.RequiredTotal != 12 {
+		t.Fatalf("required_total = %d, want 12 (gate-set G)", b.Summary.RequiredTotal)
+	}
+}
+
+func TestRecompute_OneRequiredFail_NotReady(t *testing.T) {
+	o := baseOpts()
+	gs := allRequiredPass()
+	// Flip one REQUIRED gate to fail.
+	flipped := false
+	for i := range gs {
+		if gs[i].ID == "gosec-sast" { // required:true under policy G
+			gs[i].Status = "fail"
+			flipped = true
+		}
+	}
+	if !flipped {
+		t.Fatal("test setup: gosec-sast not found in gate set")
+	}
+	o.gates = gs
+
+	b, err := buildBundle(o)
+	if err != nil {
+		t.Fatalf("buildBundle: %v", err)
+	}
+	if b.Summary.EnterpriseReady {
+		t.Fatalf("enterprise_ready = true, want false when a required gate fails")
+	}
+	if b.Summary.RequiredFailed != 1 {
+		t.Fatalf("required_failed = %d, want 1", b.Summary.RequiredFailed)
+	}
+}
+
+func TestRecompute_RequiredSkip_NotReady(t *testing.T) {
+	o := baseOpts()
+	gs := allRequiredPass()
+	for i := range gs {
+		if gs[i].ID == "platform-smoke" { // required:true under policy G
+			gs[i].Status = "skip"
+		}
+	}
+	o.gates = gs
+
+	b, err := buildBundle(o)
+	if err != nil {
+		t.Fatalf("buildBundle: %v", err)
+	}
+	if b.Summary.EnterpriseReady {
+		t.Fatalf("enterprise_ready = true, want false when a required gate is skipped")
+	}
+	if b.Summary.RequiredFailed != 0 {
+		t.Fatalf("required_failed = %d, want 0 (a skip is not a fail)", b.Summary.RequiredFailed)
+	}
+}
+
+// A caller supplying results for only SOME gates: the missing required gates
+// default to skip, so the bundle is complete and not enterprise-ready.
+func TestMissingGate_DefaultsToSkip_NotReady(t *testing.T) {
+	o := baseOpts()
+	o.gates = []gateInput{{ID: "unit-tests", Status: "pass"}}
+
+	b, err := buildBundle(o)
+	if err != nil {
+		t.Fatalf("buildBundle: %v", err)
+	}
+	if len(b.Gates) != len(registry) {
+		t.Fatalf("emitted %d gates, want %d (one per registry entry)", len(b.Gates), len(registry))
+	}
+	if b.Summary.EnterpriseReady {
+		t.Fatal("enterprise_ready = true, want false when most required gates are unsupplied (skip)")
+	}
+}
+
+// GitHub needs.<job>.result vocabulary must normalise into the bundle.
+func TestNormalizeStatus_GitHubResults(t *testing.T) {
+	cases := map[string]string{
+		"success": "pass", "pass": "pass", "SUCCESS": "pass",
+		"failure": "fail", "cancelled": "fail", "timed_out": "fail",
+		"skipped": "skip", "": "skip", "neutral": "skip",
+	}
+	for in, want := range cases {
+		got, err := normalizeStatus(in)
+		if err != nil {
+			t.Fatalf("normalizeStatus(%q): %v", in, err)
+		}
+		if got != want {
+			t.Errorf("normalizeStatus(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if _, err := normalizeStatus("bogus"); err == nil {
+		t.Error("normalizeStatus(bogus): want error, got nil")
+	}
+}
+
+func TestBuildBundle_RejectsUnknownGateID(t *testing.T) {
+	o := baseOpts()
+	o.gates = []gateInput{{ID: "not-a-real-gate", Status: "pass"}}
+	if _, err := buildBundle(o); err == nil {
+		t.Fatal("want error for an unknown gate id, got nil")
+	}
+}
+
+func TestBuildBundle_RequiresCoreFields(t *testing.T) {
+	o := baseOpts()
+	o.commit = ""
+	if _, err := buildBundle(o); err == nil {
+		t.Fatal("want error when -commit is empty, got nil")
+	}
+}
+
+// The assembled bundle must round-trip through JSON with all required top-level
+// keys present, and carry the fixed predicate/policy identity.
+func TestBundle_ShapeAndRoundTrip(t *testing.T) {
+	o := baseOpts()
+	o.gates = allRequiredPass()
+	o.checksumsSHA256 = strings.Repeat("b", 64)
+
+	b, err := buildBundle(o)
+	if err != nil {
+		t.Fatalf("buildBundle: %v", err)
+	}
+	if err := validate(b); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if b.PredicateType != predicateType {
+		t.Errorf("predicate_type = %q, want %q", b.PredicateType, predicateType)
+	}
+	if b.BundleID != "kamir/m3c-tools@skillctl/v0.5.0" {
+		t.Errorf("bundle_id = %q", b.BundleID)
+	}
+	if b.Policy == nil || b.Policy.ID != policyID {
+		t.Errorf("policy.id missing/wrong: %+v", b.Policy)
+	}
+	// references index must be present with the checksums digest wired in.
+	var haveChecksums bool
+	for _, r := range b.References {
+		if r.Type == "checksums" {
+			haveChecksums = true
+			if r.SHA256 != strings.Repeat("b", 64) {
+				t.Errorf("checksums reference sha256 = %q", r.SHA256)
+			}
+		}
+	}
+	if !haveChecksums {
+		t.Error("references[] missing the checksums pointer")
+	}
+
+	data, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back map[string]json.RawMessage
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"schema_version", "subject", "produced_at", "gates", "summary"} {
+		if _, ok := back[k]; !ok {
+			t.Errorf("required top-level key %q missing from output", k)
+		}
+	}
+}
+
+// parseGateFlag must keep an evidence URL (with its `=`/`:`) intact.
+func TestParseGateFlag_EvidenceURLIntact(t *testing.T) {
+	gi, err := parseGateFlag("cosign-signature=success,evidence=https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.5.0/SHA256SUMS.cosign.bundle?x=1")
+	if err != nil {
+		t.Fatalf("parseGateFlag: %v", err)
+	}
+	if gi.ID != "cosign-signature" || gi.Status != "success" {
+		t.Fatalf("parsed id/status wrong: %+v", gi)
+	}
+	if !strings.HasPrefix(gi.Evidence, "https://") || !strings.Contains(gi.Evidence, "x=1") {
+		t.Fatalf("evidence URL mangled: %q", gi.Evidence)
+	}
+}
+
+func TestParseChecksums(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/SHA256SUMS"
+	content := strings.Repeat("a", 64) + "  skillctl-linux-amd64\n" +
+		strings.Repeat("c", 64) + "  skillctl-windows-amd64.exe\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	arts, err := parseChecksums(path)
+	if err != nil {
+		t.Fatalf("parseChecksums: %v", err)
+	}
+	if len(arts) != 2 {
+		t.Fatalf("got %d artifacts, want 2", len(arts))
+	}
+	if arts[1].Name != "skillctl-windows-amd64.exe" {
+		t.Errorf("artifact name = %q", arts[1].Name)
+	}
+}
+
+// validate must reject a bundle whose stored summary was tampered to claim
+// readiness that the gates do not support.
+func TestValidate_RejectsTamperedSummary(t *testing.T) {
+	o := baseOpts()
+	gs := allRequiredPass()
+	for i := range gs {
+		if gs[i].ID == "lint" {
+			gs[i].Status = "fail"
+		}
+	}
+	o.gates = gs
+	b, err := buildBundle(o)
+	if err != nil {
+		t.Fatalf("buildBundle: %v", err)
+	}
+	// Forge the stored bool.
+	b.Summary.EnterpriseReady = true
+	if err := validate(b); err == nil {
+		t.Fatal("validate accepted a tampered summary; want error")
+	}
+}

--- a/docs/security/release-evidence.schema.json
+++ b/docs/security/release-evidence.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/kamir/m3c-tools/spec/release-evidence.schema.json",
+  "title": "Release Evidence Bundle (Trust Binder)",
+  "description": "Machine-readable proof that a set of release artifacts came from commit X AND passed gate-set G at time T. One instance per release tag. Designed to be signed as a detached cosign blob AND/OR wrapped as an in-toto predicate tied to the existing SLSA provenance.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "subject", "produced_at", "gates", "summary"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "SemVer of THIS bundle schema.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "predicate_type": {
+      "type": "string",
+      "description": "in-toto predicateType URI when this bundle is embedded as a statement predicate.",
+      "const": "https://m3c-tools.dev/attestations/release-evidence/v0"
+    },
+    "bundle_id": {
+      "type": "string",
+      "description": "Stable id for this evidence bundle, e.g. <repo>@<tag>."
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "commit", "tag", "artifact_digests"],
+      "properties": {
+        "repo": { "type": "string", "description": "owner/name" },
+        "source_uri": { "type": "string", "description": "git+https URI, matches the SLSA provenance --source-uri." },
+        "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$", "description": "Full 40-char release commit SHA." },
+        "tag": { "type": "string", "description": "Release tag, e.g. skillctl/v0.5.0 or v1.2.0." },
+        "channel": { "type": "string", "enum": ["product", "skillctl"], "description": "Which release workflow produced these artifacts." },
+        "artifact_digests": {
+          "type": "array",
+          "minItems": 1,
+          "description": "One entry per published binary/asset. Mirrors the in-toto subject shape so this list can be reused as the statement subjects.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "digest"],
+            "properties": {
+              "name": { "type": "string" },
+              "digest": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["sha256"],
+                "properties": { "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" } }
+              }
+            }
+          }
+        }
+      }
+    },
+    "produced_at": { "type": "string", "format": "date-time", "description": "T — when this bundle was assembled (UTC, RFC3339)." },
+    "generated_by": {
+      "type": "object",
+      "description": "What assembled the bundle (for reproducibility / non-repudiation).",
+      "additionalProperties": false,
+      "properties": {
+        "tool": { "type": "string" },
+        "version": { "type": "string" },
+        "workflow_run": { "type": "string", "description": "URL of the CI run that assembled the bundle." }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "description": "The ruleset that decides which gates are required and what enterprise_ready means. A verifier re-evaluates enterprise_ready against a named policy rather than trusting the stored bool.",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string", "description": "Policy identifier, e.g. trust-binder/policy@v0-prototype." },
+        "rule": { "type": "string", "description": "Human-readable decision rule for enterprise_ready." }
+      }
+    },
+    "gates": {
+      "type": "array",
+      "description": "Gate-set G. Order is presentational; identity is `id`.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name", "status", "required", "kind"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable machine id.",
+            "enum": [
+              "unit-tests", "race", "e2e", "lint", "gosec-sast",
+              "govulncheck-cve", "gitleaks-secret", "sbom", "docaudit",
+              "slsa-provenance", "cosign-signature", "platform-smoke",
+              "threat-model-delta"
+            ]
+          },
+          "name": { "type": "string", "description": "Human label; SHOULD match the CI job name so a consumer can find it in the run." },
+          "kind": {
+            "type": "string",
+            "enum": ["test", "sast", "sca", "secret", "provenance", "signature", "sbom", "docs", "smoke", "threat-model"],
+            "description": "Evidence family, for policy grouping."
+          },
+          "status": { "type": "string", "enum": ["pass", "fail", "skip"] },
+          "required": { "type": "boolean", "description": "Whether this gate counts toward enterprise_ready under `policy`." },
+          "evidence_ref": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to the concrete evidence: a CI run/job, a release asset, or an attestation. This is the human/audit landing point."
+          },
+          "evidence_type": {
+            "type": "string",
+            "enum": ["ci-log", "release-asset", "attestation", "external"],
+            "description": "Shape of evidence_ref, so a consumer knows whether it is re-verifiable (attestation/asset) or a pointer (ci-log)."
+          },
+          "verifiability": {
+            "type": "string",
+            "enum": ["re-verify", "reference", "trust-ci"],
+            "description": "re-verify: an offline consumer can cryptographically re-check (cosign bundle, SLSA provenance, SBOM digest). reference: points at signed-elsewhere evidence. trust-ci: only a CI-run log attests it (pass/fail is asserted, not re-provable offline)."
+          },
+          "tool": { "type": "string" },
+          "version": { "type": "string" },
+          "completed_at": { "type": "string", "format": "date-time" },
+          "note": { "type": "string", "description": "Why skipped / caveats / roadmap." }
+        }
+      }
+    },
+    "references": {
+      "type": "array",
+      "description": "Aggregate evidence artifacts this bundle POINTS AT (does not re-embed). Lets a verifier fetch + re-verify without re-listing per-gate.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "uri"],
+        "properties": {
+          "type": { "type": "string", "enum": ["checksums", "cosign-bundle", "slsa-provenance", "sbom", "ed25519-sig", "pubkey"] },
+          "uri": { "type": "string", "format": "uri" },
+          "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$", "description": "Digest of the referenced artifact, so the pointer is itself tamper-evident." }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required_total", "required_passed", "enterprise_ready"],
+      "properties": {
+        "required_total": { "type": "integer", "minimum": 0 },
+        "required_passed": { "type": "integer", "minimum": 0 },
+        "required_failed": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "enterprise_ready": {
+          "type": "boolean",
+          "description": "Convenience bool = (required_failed == 0 AND every required gate status==pass) under `policy`. A strict verifier RECOMPUTES this from `gates` + its own policy rather than trusting the stored value."
+        },
+        "caveats": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Gates that a stricter enterprise policy would demand but are currently required:false (e.g. gosec, threat-model-delta)."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The WF-001 capstone (reviewer's P1 #6): a signed, machine-readable manifest proving "this release passed gate-set G at time T".

**`cmd/release-evidence`** (stdlib, 11 tests) assembles `release-evidence.json` from `-commit/-tag/-repo/-run-url` + `-gate id=status` (accepts GitHub `needs.<job>.result` vocab) + `-artifacts SHA256SUMS`. **Integrity:** the required gate-set G is a **fixed registry, not caller-overridable** (a caller supplies only status → can't fake readiness); `enterprise_ready` is **recomputed** (every required gate == pass), and `validate()` **rejects a forged** `enterprise_ready`. Schema at `docs/security/release-evidence.schema.json`; `-intoto` emits an in-toto v1 Statement.

**Wiring in `skillctl-release.yml`** — 3 isolated, least-privilege jobs:
- `evidence` (no signing identity) — `needs:[docs-gate,build,provenance,cosign,verify,release,smoke]`, runs on `!cancelled() && release==success` (records a red smoke, never suppresses it); gathers release-plane gates from `needs.*.result` + CI-plane gates (unit/race/e2e/lint/gosec/govulncheck/gitleaks) from the commit's check-runs (unmatched → skip, never a silent pass).
- `evidence-sign` (`id-token:write`) — cosign sign-blob keyless, **same OIDC identity that signs SHA256SUMS**, verified in-job.
- `evidence-attach` (`contents:write`) — `gh release upload --clobber` attaches the JSON + cosign bundle (+ in-toto) to the draft.

**References, not re-verification:** `references[]` index the existing SHA256SUMS / cosign bundle / SLSA `multiple.intoto.jsonl` / SBOM by digest — nothing re-embedded; assembly holds no signing identity → SLSA-L3 isolation intact.

Deviation (flagged): the bundle is produced AFTER `smoke` (to record the platform-smoke gate) and attached via `gh release upload --clobber` rather than the `release` job's `files:` list — keeps the H9 draft-first/smoke-after model. To confirm on the first real cut: `gh release upload <tag> --clobber` resolves the draft by tag. Build/test/gofmt/pin-guard/bash-syntax green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)