### PR TITLE
fix(skillctl): H-F1 — revocation fail-closed on the enforcement hot path (WF-001 last gate)

### DIFF
--- a/cmd/skillctl/gossip_revokes_test.go
+++ b/cmd/skillctl/gossip_revokes_test.go
@@ -159,7 +159,7 @@ func TestFetchRevokedWithGossipUnions(t *testing.T) {
 	}
 	writeRevokedCache(home, map[string]struct{}{gd(8): {}})
 
-	set, _ := fetchRevokedWithGossip(home)
+	set, _, _ := fetchRevokedWithGossip(home)
 	if _, ok := set[gd(9)]; !ok {
 		t.Error("gossiped revoke not unioned into the sweep set")
 	}

--- a/cmd/skillctl/revoke_feed_cmds.go
+++ b/cmd/skillctl/revoke_feed_cmds.go
@@ -71,11 +71,12 @@ func runRevokeFeed(args []string, stdout, stderr io.Writer) int {
 			len(set), epoch, issuedAt, online)
 		if ferr != nil {
 			// WF-001 H-F1 — MANAGED fail-closed: the revoked-set fetch was unavailable
-			// and no fresh cache bounds staleness. Surface it (non-zero exit) so an
-			// operator refreshing the feed sees revocation could NOT be confirmed and
-			// the sweep will fail managed skills closed — rather than a misleading OK.
-			fmt.Fprintf(stderr, "skillctl revoke feed --refresh: revocation unavailable under managed trust roots (fail-closed): %v\n", ferr)
-			return exitGeneric
+			// and no fresh cache bounds staleness. Surface it with the SAME semantic
+			// exit code the sweep + hook use (exitRevocationStale / 22), not the generic
+			// 1, so an operator script keying on 22 catches this fail-closed signal at
+			// all three sites — rather than a misleading OK.
+			fmt.Fprintf(stderr, "skillctl revoke feed --refresh: revocation unavailable under managed trust roots (fail-closed, exit %d): %v\n", exitRevocationStale, ferr)
+			return exitRevocationStale
 		}
 		return exitOK
 	}

--- a/cmd/skillctl/revoke_feed_cmds.go
+++ b/cmd/skillctl/revoke_feed_cmds.go
@@ -65,10 +65,18 @@ func runRevokeFeed(args []string, stdout, stderr io.Writer) int {
 		if fetchRevocationHeadFn == nil {
 			fetchRevocationHeadFn = fetchRevocationHeadOnline
 		}
-		set, online := fetchRevokedOnline(home)
+		set, online, ferr := fetchRevokedOnline(home)
 		epoch, issuedAt := readRevokedCacheHead(home)
 		fmt.Fprintf(stdout, "refreshed: %d revoked digest(s), epoch=%d issued_at=%q online=%v\n",
 			len(set), epoch, issuedAt, online)
+		if ferr != nil {
+			// WF-001 H-F1 — MANAGED fail-closed: the revoked-set fetch was unavailable
+			// and no fresh cache bounds staleness. Surface it (non-zero exit) so an
+			// operator refreshing the feed sees revocation could NOT be confirmed and
+			// the sweep will fail managed skills closed — rather than a misleading OK.
+			fmt.Fprintf(stderr, "skillctl revoke feed --refresh: revocation unavailable under managed trust roots (fail-closed): %v\n", ferr)
+			return exitGeneric
+		}
 		return exitOK
 	}
 

--- a/cmd/skillctl/revoked_cache.go
+++ b/cmd/skillctl/revoked_cache.go
@@ -292,6 +292,40 @@ func readRevokedCache(home string, ttl time.Duration) (map[string]struct{}, bool
 // nor while a within-TTL cache still bounds staleness (the grace window).
 var errRevokedSetUnavailable = errors.New("revoked-set unavailable under managed trust roots and no fresh cache (fail-closed)")
 
+// selfTrustPosture classifies the host's REVOCATION trust posture from
+// ~/.claude/trust-roots.yaml (WF-001 R01-C), distinguishing three states so a
+// same-uid attacker cannot downgrade a managed host to fail-open by corrupting
+// the file:
+//
+//   - ABSENT  → unmanaged (genuine dev / first-run): returns (nil, false). The
+//     caller may fail-OPEN.
+//   - PRESENT + valid → managed: returns (tr, true) with the pinned key loaded.
+//   - PRESENT but unparseable/invalid (tampering) → managed: returns (nil, true).
+//     The caller must fail-CLOSED even though no key could be loaded — mirroring
+//     loadGatePolicyW's present-but-broken gate-policy.yaml rule.
+//
+// Only an ABSENT file yields the fail-open posture; every other outcome is treated
+// as managed.
+func selfTrustPosture() (*registry.SelfTrustRoots, bool) {
+	tr, err := registry.LoadSelfTrustRoots("")
+	if err == nil && tr != nil && len(tr.PubKey()) != 0 {
+		return tr, true // present + valid → managed
+	}
+	if trustRootsAbsent(err) {
+		return nil, false // absent → unmanaged (fail-open OK)
+	}
+	// present-but-unparseable/invalid, or a degenerate load with no usable key →
+	// treat as managed so corruption cannot downgrade to fail-open.
+	return nil, true
+}
+
+// trustRootsAbsent reports whether a LoadSelfTrustRoots error means the file is
+// simply NOT THERE (absent) — as opposed to present-but-broken. LoadSelfTrustRoots
+// wraps the os error with %w, so errors.Is sees through it.
+func trustRootsAbsent(err error) bool {
+	return err != nil && (errors.Is(err, os.ErrNotExist) || errors.Is(err, registry.ErrTrustRootsMissing))
+}
+
 // sweepRevokedFn is the seam the sweep uses to obtain the revoked set; tests
 // stub it. Production = fetchRevokedWithGossip. Returns (set, fetchedOnline, err)
 // where a non-nil err is the managed fail-closed signal (errRevokedSetUnavailable).
@@ -316,6 +350,47 @@ func fetchRevokedWithGossip(home string) (map[string]struct{}, bool, error) {
 		out[d] = struct{}{}
 	}
 	return out, online, err
+}
+
+// hotPathRevokedTimeout is the HARD wall-clock bound the verify-hook HOT PATH gives
+// a stale-cache revoked-set refresh (WF-001 R01-A). It is deliberately shorter than
+// er1Get's own 15s client timeout: the underlying fetch may keep running (a bounded,
+// self-terminating background goroutine) but the tool call itself never blocks
+// longer than this.
+const hotPathRevokedTimeout = 3 * time.Second
+
+// hotPathRevokedFn is the seam the verify-hook hot path uses to refresh the revoked
+// set when the cache is STALE. Production = boundedHotPathRevoked. Returns
+// (set, online, err); err==errRevokedSetUnavailable is the managed fail-closed
+// signal the caller denies on. Tests stub it to exercise the deny/allow paths
+// without a network.
+var hotPathRevokedFn = boundedHotPathRevoked
+
+// boundedHotPathRevoked wraps fetchRevokedWithGossip in hotPathRevokedTimeout so a
+// slow / hostile / dead registry cannot stall a per-invocation tool call. A timeout
+// is treated as "revocation unavailable": fail CLOSED (errRevokedSetUnavailable)
+// ONLY under managed config — mirroring fetchRevokedOnline — and best-effort empty
+// otherwise, so a dev/unmanaged host is never blocked by a slow network.
+func boundedHotPathRevoked(home string) (map[string]struct{}, bool, error) {
+	type res struct {
+		set    map[string]struct{}
+		online bool
+		err    error
+	}
+	ch := make(chan res, 1) // buffered: the goroutine never blocks even after we time out
+	go func() {
+		s, o, e := fetchRevokedWithGossip(home)
+		ch <- res{s, o, e}
+	}()
+	select {
+	case r := <-ch:
+		return r.set, r.online, r.err
+	case <-time.After(hotPathRevokedTimeout):
+		if _, managed := selfTrustPosture(); managed {
+			return map[string]struct{}{}, false, errRevokedSetUnavailable
+		}
+		return map[string]struct{}{}, false, nil
+	}
 }
 
 // fetchRevocationHeadFn is the seam that fetches a signed revocation HEAD from
@@ -343,14 +418,23 @@ var fetchRevocationHeadFn func(cfg *er1.Config, ctx string, pub ed25519.PublicKe
 // On the happy path a signed HEAD is adopted (freshness + rollback) and its
 // epoch/issued_at persisted for the gate (FR-0045 D3/D4).
 func fetchRevokedOnline(home string) (map[string]struct{}, bool, error) {
-	tr, err := registry.LoadSelfTrustRoots("")
-	if err != nil || tr == nil || len(tr.PubKey()) == 0 {
-		// UNMANAGED / dev: no self-trust-roots configured → best-effort fail-open.
+	tr, managed := selfTrustPosture()
+	if !managed {
+		// UNMANAGED / dev / first-run: the trust-roots file is ABSENT → best-effort
+		// fail-open (return the cache, possibly empty, no error).
 		cached, _ := readRevokedCache(home, revokedCacheTTL)
 		return cached, false, nil
 	}
-	// MANAGED from here: a fetch failure must fail CLOSED (bounded by the grace
-	// window) rather than silently degrade to an empty/stale revoked set.
+	if tr == nil {
+		// MANAGED via a PRESENT-BUT-CORRUPT trust-roots file (WF-001 R01-C): the file
+		// exists but is unparseable/invalid, so we cannot load the pinned key. A same-
+		// uid attacker must NOT be able to downgrade a managed host to fail-open by
+		// corrupting trust-roots.yaml (mirrors gate-policy.yaml's present-but-broken →
+		// fail-closed rule). Fail CLOSED (grace-bounded) rather than fetch/verify.
+		return revokedUnavailableUnderManaged(home)
+	}
+	// MANAGED + valid pinned key from here: a fetch failure must fail CLOSED (bounded
+	// by the AUTHENTICATED grace window) rather than degrade to an empty/stale set.
 	cfg, err := resolveER1Config(envOr("ER1_TARGET", "prod"))
 	if err != nil {
 		return revokedUnavailableUnderManaged(home)
@@ -381,10 +465,44 @@ func fetchRevokedOnline(home string) (map[string]struct{}, bool, error) {
 // only on a SUCCESSFUL fetch, so continuous failure ages it out of the window.)
 func revokedUnavailableUnderManaged(home string) (map[string]struct{}, bool, error) {
 	cached, fresh := readRevokedCache(home, revokedCacheTTL)
-	if fresh {
-		return cached, false, nil // grace window: bounded last-known-good stands
+	// WF-001 R01-B — the grace window must be AUTHENTICATED. readRevokedCache's
+	// `fresh` derives purely from the UNSIGNED, same-uid-writable fetched_at, so a
+	// forged {digests:[],fetched_at:now} would ride grace forever with an EMPTY set,
+	// suppressing every revoke. Require, in addition to the plain-TTL freshness, a
+	// pinned-key-authenticated basis (graceAuthenticated) before opening the window.
+	if fresh && graceAuthenticated(home, cached) {
+		return cached, false, nil // grace window: AUTHENTICATED last-known-good stands
 	}
 	return cached, false, errRevokedSetUnavailable
+}
+
+// graceAuthenticated reports whether the last-known-good cache may ride the managed
+// grace window on an AUTHENTICATED basis (WF-001 R01-B). It defeats a forged plain
+// fetched_at (and a stripped revoked set under an otherwise-valid HEAD). ALL of:
+//
+//  1. a signed revocation HEAD is present and RE-VERIFIES against the pinned key
+//     (verifiedAdoptedHead) — an unsigned/forged timestamp alone never opens grace;
+//  2. its AUTHENTICATED issued_at is within revokedCacheTTL of now (recent SIGNED
+//     contact, not merely a recent local write);
+//  3. the cached revoked set BINDS to the HEAD's revoked_set_root (the digests were
+//     not stripped/truncated under an otherwise-valid HEAD).
+//
+// A pre-D2 install with no signed HEAD therefore gets NO grace (fail-closed once
+// the cache is stale + fetch unavailable) — the coordinator-accepted "require a
+// verified signed HEAD present, else fail-closed" posture.
+func graceAuthenticated(home string, cached map[string]struct{}) bool {
+	head, ok := verifiedAdoptedHead(home)
+	if !ok {
+		return false // no pinned-key-verified HEAD → no authenticated freshness
+	}
+	issued, err := registry.HeadIssuedAt(head)
+	if err != nil || sweepClockFn().UTC().Sub(issued) > revokedCacheTTL {
+		return false // stale (or unparseable) AUTHENTICATED anchor
+	}
+	if registry.VerifyRevocationHeadSet(head, setToSortedSlice(cached)) != nil {
+		return false // cached set does not bind to the signed HEAD (stripped digests)
+	}
+	return true
 }
 
 // applyFetchedRevokedSet reconciles a freshly-fetched revoked set with the signed

--- a/cmd/skillctl/revoked_cache.go
+++ b/cmd/skillctl/revoked_cache.go
@@ -284,6 +284,28 @@ func readRevokedCache(home string, ttl time.Duration) (map[string]struct{}, bool
 	return set, fresh
 }
 
+// revocationAdopted reports whether this host has EVER pulled revocation data —
+// i.e. a revoked-cache file exists on disk (fresh OR stale). It distinguishes an
+// ADOPTED host (subscribed to a revocation feed, whose cache may have gone stale)
+// from an UN-ADOPTED host — pre-D2 / kill-switch-only / first-run — that never
+// pulled a feed at all.
+//
+// It is the precondition that scopes the R01-A hot-path fail-closed: only an
+// ADOPTED managed host fails closed on a stale/unavailable revoked set (it HAS a
+// feed that could be blackholed to suppress a revoke). An un-adopted host has
+// nothing to suppress, so failing it closed would brick a managed install that
+// never subscribed — exactly the pre-D2 brick the kill-switch tests guard. This
+// mirrors revocationSnapshotStale's "no-op unless a signed anchor exists" gating.
+//
+// readRevokedCache collapses "file absent" and "file present-but-stale" into a
+// single !fresh, so a dedicated existence check is required here. NOTE: a same-uid
+// DELETE of the cache file looks un-adopted → fail-open; that is the already-
+// accepted same-uid trust-substrate residual (R01-C delete), NOT a new
+// non-same-uid hole (a network blackhole leaves the file in place → still adopted).
+func revocationAdopted(home string) bool {
+	return fileExists(revokedCachePath(home))
+}
+
 // errRevokedSetUnavailable is the typed fail-CLOSED signal (WF-001 H-F1 / R01):
 // under MANAGED config (self-trust-roots configured) the live revoked-set fetch
 // was unavailable AND there is no fresh last-known-good cache to bound staleness,

--- a/cmd/skillctl/revoked_cache.go
+++ b/cmd/skillctl/revoked_cache.go
@@ -9,9 +9,20 @@ package main
 // short-TTL cache the offline gate consults so revocation also propagates to the
 // fast per-invocation path until the next sweep.
 //
-// Fail-OPEN on fetch: if the registry is unreachable / unconfigured we fall back
-// to the cache (or empty). We only ever quarantine a digest that is DEFINITELY
-// in a verified revoked set — a fetch failure never false-quarantines.
+// Fail policy on fetch depends on TRUST POSTURE (WF-001 H-F1 / R01):
+//   - UNMANAGED (no self-trust-roots configured — local dev / first run): best-
+//     effort fail-OPEN. Fall back to the cache (possibly empty), no error. Keeps
+//     the keygen/pack/sign/verify-sig offline flows and first-run working.
+//   - MANAGED (self-trust-roots configured): a fetch failure with NO fresh last-
+//     known-good cache to bound staleness surfaces errRevokedSetUnavailable, so
+//     the trust-decision caller (the sweep) fails CLOSED instead of treating
+//     "no revokes fetched" as "nothing revoked". That closes the revocation-
+//     SUPPRESSION hole where blocking the network / a hostile 5xx / a dead-host
+//     redirect hid a KNOWN-revoked digest. A within-TTL cache is the grace
+//     window: while fresh, revocation is still bounded, so we stay fail-open.
+// We only quarantine a digest DEFINITELY in a verified revoked set — OR, under
+// managed config with the revoked set unavailable and no fresh cache, every
+// managed bundle we can no longer prove is un-revoked.
 
 import (
 	"crypto/ed25519"
@@ -273,8 +284,17 @@ func readRevokedCache(home string, ttl time.Duration) (map[string]struct{}, bool
 	return set, fresh
 }
 
+// errRevokedSetUnavailable is the typed fail-CLOSED signal (WF-001 H-F1 / R01):
+// under MANAGED config (self-trust-roots configured) the live revoked-set fetch
+// was unavailable AND there is no fresh last-known-good cache to bound staleness,
+// so a trust-decision consumer MUST NOT treat "no revokes fetched" as "nothing
+// revoked". It is NEVER returned on the unmanaged/dev path (best-effort fail-open)
+// nor while a within-TTL cache still bounds staleness (the grace window).
+var errRevokedSetUnavailable = errors.New("revoked-set unavailable under managed trust roots and no fresh cache (fail-closed)")
+
 // sweepRevokedFn is the seam the sweep uses to obtain the revoked set; tests
-// stub it. Production = fetchRevokedWithGossip. Returns (set, fetchedOnline).
+// stub it. Production = fetchRevokedWithGossip. Returns (set, fetchedOnline, err)
+// where a non-nil err is the managed fail-closed signal (errRevokedSetUnavailable).
 var sweepRevokedFn = fetchRevokedWithGossip
 
 // fetchRevokedWithGossip is the production seam: the online/cached revoked set
@@ -282,8 +302,12 @@ var sweepRevokedFn = fetchRevokedWithGossip
 // revoked by any governance-contributing peer is enforced even without pulling
 // from it. Union is the fail-closed direction; the gossip set only grows, so an
 // HTTP refresh can never drop a gossiped revoke.
-func fetchRevokedWithGossip(home string) (map[string]struct{}, bool) {
-	set, online := fetchRevokedOnline(home)
+//
+// The online-fetch error is PROPAGATED unchanged: gossip only UNIONS additional
+// revokes (it never repairs an unavailable online set), so a managed-unavailable
+// online fetch stays fail-closed even when the gossip union is non-empty.
+func fetchRevokedWithGossip(home string) (map[string]struct{}, bool, error) {
+	set, online, err := fetchRevokedOnline(home)
 	out := make(map[string]struct{}, len(set))
 	for d := range set {
 		out[d] = struct{}{}
@@ -291,7 +315,7 @@ func fetchRevokedWithGossip(home string) (map[string]struct{}, bool) {
 	for d := range loadGossipedRevoked(home) {
 		out[d] = struct{}{}
 	}
-	return out, online
+	return out, online, err
 }
 
 // fetchRevocationHeadFn is the seam that fetches a signed revocation HEAD from
@@ -302,29 +326,65 @@ func fetchRevokedWithGossip(home string) (map[string]struct{}, bool) {
 var fetchRevocationHeadFn func(cfg *er1.Config, ctx string, pub ed25519.PublicKey) (map[string]any, bool)
 
 // fetchRevokedOnline fetches the live verified revoked-digest set and refreshes
-// the cache. Fail-OPEN on availability: any fetch error → the cached set
-// (possibly stale/empty), online=false. Never returns an error — revocation
-// enforcement is best-effort availability, exactly as the offline-verify tradeoff
-// documents. When a signed HEAD is available it is adopted (freshness +
-// rollback), and its epoch/issued_at are persisted for the gate (FR-0045 D3/D4).
-func fetchRevokedOnline(home string) (map[string]struct{}, bool) {
+// the cache. Its FAIL POLICY is trust-posture-dependent (WF-001 H-F1 / R01 — see
+// the file header):
+//
+//   - UNMANAGED (self-trust-roots absent/unreadable → local dev / first run):
+//     best-effort fail-OPEN. Return the cache (possibly empty), online=false, and
+//     NO error, so offline keygen/pack/sign/verify-sig and first-run keep working.
+//   - MANAGED (self-trust-roots configured): on ANY fetch/config failure — or a
+//     fetched set the signed HEAD proves truncated/forged (F1) — return the fail-
+//     CLOSED signal errRevokedSetUnavailable, UNLESS a within-TTL last-known-good
+//     cache still bounds staleness (the grace window), in which case that cached
+//     set stands (online=false, no error). The sole trust-decision caller (the
+//     sweep) treats a non-nil error as deny/quarantine rather than "nothing
+//     revoked", closing the revocation-suppression hole.
+//
+// On the happy path a signed HEAD is adopted (freshness + rollback) and its
+// epoch/issued_at persisted for the gate (FR-0045 D3/D4).
+func fetchRevokedOnline(home string) (map[string]struct{}, bool, error) {
 	tr, err := registry.LoadSelfTrustRoots("")
 	if err != nil || tr == nil || len(tr.PubKey()) == 0 {
+		// UNMANAGED / dev: no self-trust-roots configured → best-effort fail-open.
 		cached, _ := readRevokedCache(home, revokedCacheTTL)
-		return cached, false
+		return cached, false, nil
 	}
+	// MANAGED from here: a fetch failure must fail CLOSED (bounded by the grace
+	// window) rather than silently degrade to an empty/stale revoked set.
 	cfg, err := resolveER1Config(envOr("ER1_TARGET", "prod"))
 	if err != nil {
-		cached, _ := readRevokedCache(home, revokedCacheTTL)
-		return cached, false
+		return revokedUnavailableUnderManaged(home)
 	}
 	ctx := envOr("ER1_CONTEXT", "skills")
 	set, err := registry.FetchRevokedDigests(cfg, ctx, tr.PubKey())
 	if err != nil {
-		cached, _ := readRevokedCache(home, revokedCacheTTL)
-		return cached, false
+		return revokedUnavailableUnderManaged(home)
 	}
-	return applyFetchedRevokedSet(home, cfg, ctx, tr.PubKey(), set)
+	set, online := applyFetchedRevokedSet(home, cfg, ctx, tr.PubKey(), set)
+	if !online {
+		// applyFetchedRevokedSet REFUSED the fetched set: the signed HEAD verified
+		// but bound a different revoked_set_root (F1), i.e. the fetched set is
+		// truncated/forged. Under managed config that is a fail-closed condition,
+		// subject to the same grace window as an unreachable registry.
+		return revokedUnavailableUnderManaged(home)
+	}
+	return set, true, nil
+}
+
+// revokedUnavailableUnderManaged is the MANAGED fail-closed path. The live fetch
+// was unavailable (or the fetched set was refused). A within-TTL last-known-good
+// cache is the GRACE WINDOW: while it is fresh, revocation staleness is still
+// bounded (same revokedCacheTTL the offline gate trusts a cached revoked set for),
+// so we return it with online=false and NO error. Only once the cache is also
+// STALE/ABSENT — no bounded snapshot at all — do we surface errRevokedSetUnavailable
+// so the trust-decision caller fails closed. (The cache's FetchedAt is refreshed
+// only on a SUCCESSFUL fetch, so continuous failure ages it out of the window.)
+func revokedUnavailableUnderManaged(home string) (map[string]struct{}, bool, error) {
+	cached, fresh := readRevokedCache(home, revokedCacheTTL)
+	if fresh {
+		return cached, false, nil // grace window: bounded last-known-good stands
+	}
+	return cached, false, errRevokedSetUnavailable
 }
 
 // applyFetchedRevokedSet reconciles a freshly-fetched revoked set with the signed

--- a/cmd/skillctl/revoked_cache.go
+++ b/cmd/skillctl/revoked_cache.go
@@ -293,19 +293,23 @@ func readRevokedCache(home string, ttl time.Duration) (map[string]struct{}, bool
 var errRevokedSetUnavailable = errors.New("revoked-set unavailable under managed trust roots and no fresh cache (fail-closed)")
 
 // selfTrustPosture classifies the host's REVOCATION trust posture from
-// ~/.claude/trust-roots.yaml (WF-001 R01-C), distinguishing three states so a
-// same-uid attacker cannot downgrade a managed host to fail-open by corrupting
-// the file:
+// ~/.claude/trust-roots.yaml (WF-001 R01-C), distinguishing three states:
 //
 //   - ABSENT  → unmanaged (genuine dev / first-run): returns (nil, false). The
-//     caller may fail-OPEN.
+//     caller may fail-OPEN. This is correct by design for first-run/dev.
 //   - PRESENT + valid → managed: returns (tr, true) with the pinned key loaded.
 //   - PRESENT but unparseable/invalid (tampering) → managed: returns (nil, true).
 //     The caller must fail-CLOSED even though no key could be loaded — mirroring
 //     loadGatePolicyW's present-but-broken gate-policy.yaml rule.
 //
-// Only an ABSENT file yields the fail-open posture; every other outcome is treated
-// as managed.
+// SCOPE OF THE GUARANTEE (no overclaim): this closes CORRUPTION as a downgrade
+// vector — a same-uid actor who mangles the file cannot flip a managed host to
+// fail-open, it fails CLOSED instead. It does NOT close DELETION: `rm
+// trust-roots.yaml` yields the ABSENT (unmanaged → fail-open) state, indistinguish-
+// able here from a genuine first-run. A same-uid DELETE of the trust-roots file is
+// therefore the ACCEPTED same-uid-substrate residual (consistent with FR-0045 / the
+// g5 same-uid scope), NOT claimed closed. Tombstone-based delete-detection is a
+// possible future hardening, deliberately out of scope here.
 func selfTrustPosture() (*registry.SelfTrustRoots, bool) {
 	tr, err := registry.LoadSelfTrustRoots("")
 	if err == nil && tr != nil && len(tr.PubKey()) != 0 {
@@ -485,7 +489,11 @@ func revokedUnavailableUnderManaged(home string) (map[string]struct{}, bool, err
 //  2. its AUTHENTICATED issued_at is within revokedCacheTTL of now (recent SIGNED
 //     contact, not merely a recent local write);
 //  3. the cached revoked set BINDS to the HEAD's revoked_set_root (the digests were
-//     not stripped/truncated under an otherwise-valid HEAD).
+//     not stripped/truncated under an otherwise-valid HEAD);
+//  4. its epoch is NOT below the persisted monotonic high-water floor (WF-001 R01-B
+//     rollback guard) — a validly-signed but ROLLED-BACK HEAD (older epoch, issued_at
+//     still <12h) must not open grace and undo an already-adopted revoke. This is the
+//     same high-water clamp readRevokedCacheHead applies (~:257-262).
 //
 // A pre-D2 install with no signed HEAD therefore gets NO grace (fail-closed once
 // the cache is stale + fetch unavailable) — the coordinator-accepted "require a
@@ -498,6 +506,14 @@ func graceAuthenticated(home string, cached map[string]struct{}) bool {
 	issued, err := registry.HeadIssuedAt(head)
 	if err != nil || sweepClockFn().UTC().Sub(issued) > revokedCacheTTL {
 		return false // stale (or unparseable) AUTHENTICATED anchor
+	}
+	// Rollback guard: a signed-but-replayed OLDER HEAD (epoch below the persisted
+	// high-water) must not ride grace, or it would resurrect a revoked bundle for a
+	// TTL window. Reuse the high-water floor readRevokedCacheHead maintains.
+	if epoch, herr := registry.HeadEpoch(head); herr != nil {
+		return false // unreadable epoch → cannot prove monotonicity → fail-closed
+	} else if floor, _ := readRevokedCacheHead(home); epoch < floor {
+		return false // rolled-back HEAD below the high-water floor
 	}
 	if registry.VerifyRevocationHeadSet(head, setToSortedSlice(cached)) != nil {
 		return false // cached set does not bind to the signed HEAD (stripped digests)

--- a/cmd/skillctl/revoked_cache_failclosed_test.go
+++ b/cmd/skillctl/revoked_cache_failclosed_test.go
@@ -238,6 +238,30 @@ func TestRevokedUnavailableUnderManaged_AuthenticatedGrace(t *testing.T) {
 			t.Fatalf("a signed HEAD older than the TTL must NOT open grace; got %v", err)
 		}
 	})
+
+	// R01-B rollback BITE — a validly-signed but ROLLED-BACK HEAD (epoch below the
+	// persisted high-water, issued_at still <12h, set binds) must NOT open grace, or
+	// it would resurrect an already-adopted revoke for a TTL window. Everything else
+	// is deliberately valid so the ONLY thing keeping grace shut is the epoch clamp:
+	// remove the clamp in graceAuthenticated and this test opens grace (err==nil) and
+	// FAILS.
+	t.Run("rolled-back HEAD below high-water floor -> fail closed", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		setUserProfile(t, home)
+		pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+		writeSelfTrustRootsKey(t, home, pub)
+		dg := headTestDigest('a')
+		set := map[string]struct{}{dg: {}}
+		// Establish high-water epoch 2 in the unsigned json (also writes a FRESH
+		// fetched_at + the {dg} set that binds to the head below).
+		writeRevokedCacheHead(home, set, 2, sweepClockFn().UTC().Format(time.RFC3339))
+		// Present a validly-signed epoch-1 HEAD with a fresh issued_at (the replay).
+		installSignedHead(t, home, priv, 1, sweepClockFn().UTC(), []string{dg})
+		if _, _, err := revokedUnavailableUnderManaged(home); !errors.Is(err, errRevokedSetUnavailable) {
+			t.Fatalf("a rolled-back (epoch 1 < high-water 2) signed HEAD must NOT open grace; got %v", err)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/skillctl/revoked_cache_failclosed_test.go
+++ b/cmd/skillctl/revoked_cache_failclosed_test.go
@@ -9,14 +9,21 @@ package main
 // revoked digest was not blocked: revocation was silently suppressed by making the
 // fetch fail.
 //
-// The fix makes the revoked-set consumers fail CLOSED under MANAGED (self-trust-
-// root) config while keeping the UNMANAGED/dev path fail-open. These tests pin
-// both halves so the fail-open cannot regress.
+// The full closure has four parts, each pinned below and each verified to BITE
+// (the test fails when its fix is reverted):
+//   R01-A  hot-path (verify-hook) fails closed under managed on a stale/empty cache
+//   R01-B  the grace window is AUTHENTICATED (signed HEAD), not a forgeable timestamp
+//   R01-C  a present-but-corrupt trust-roots.yaml fails closed (not fail-open)
+//   sweep  the sweep consumer fails closed (test-theater fixed to assert exit 22)
+//
+// while the UNMANAGED/dev path stays fail-open (no spurious hard-deny).
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -24,64 +31,53 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
 )
 
-// THREAT-R01 (consumer / sweep) — the trust-decision caller fails CLOSED.
-//
-// With a MANAGED host whose revoked-set fetch is unavailable and whose cache is
-// empty (sweepRevokedFn returns errRevokedSetUnavailable), the sweep must
-// QUARANTINE the managed skill rather than read the empty set as "nothing
-// revoked". This is the exact suppression vector the wave-1 challenge gate
-// flagged: a KNOWN-revoked digest must NOT be allowed to keep running just
-// because the fetch was made to fail.
+// ---------------------------------------------------------------------------
+// sweep consumer (test-theater FIXED)
+// ---------------------------------------------------------------------------
+
+// THREAT-R01 (consumer / sweep) — the trust-decision caller fails CLOSED, and the
+// assertion now BITES: it requires the quarantine to come from the R01 fail-closed
+// branch (exit 22 / reason names the cause), not from the fixture's incidental
+// blob-vs-sidecar digest mismatch (exit 10). Both the offline path and the online
+// verify are stubbed to PASS, so ONLY the R01 branch can quarantine — reverting it
+// makes the skill verify clean and the test FAIL.
 func TestSweep_RevocationUnavailableUnderManaged_FailsClosed(t *testing.T) {
 	home := t.TempDir()
-	// A managed, otherwise-fine skill whose digest is NOT in any (empty) local set.
 	writeSidecarDigest(t, home, "er1-push", "sha256:beef")
 
-	// Simulate MANAGED + revoked-set fetch unavailable + empty cache.
+	stubRootsOK(t)
+	stubVerify(t, exitOK, "ok", nil) // sweepVerifyManagedFn → clean
+	origOffline := verifyManagedOfflineFn
+	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return exitOK, "verified", true }
+	t.Cleanup(func() { verifyManagedOfflineFn = origOffline })
+
 	orig := sweepRevokedFn
 	sweepRevokedFn = func(string) (map[string]struct{}, bool, error) {
-		return map[string]struct{}{}, false, errRevokedSetUnavailable
+		return map[string]struct{}{}, false, errRevokedSetUnavailable // managed + unavailable + empty
 	}
 	t.Cleanup(func() { sweepRevokedFn = orig })
 
-	code, out := runSweep(t, home, "--quarantine")
-	_ = code
+	rep := runSweepReport(t, home, "--quarantine")
+	e := findEntry(t, rep, "er1-push")
+	if e.State != "quarantined" || e.Exit != exitRevocationStale {
+		t.Fatalf("managed skill must FAIL CLOSED via the R01 branch (state=quarantined exit=%d); got state=%q exit=%d reason=%q",
+			exitRevocationStale, e.State, e.Exit, e.Reason)
+	}
+	if !containsAll(e.Reason, "revocation", "WF-001") {
+		t.Fatalf("quarantine reason must name the fail-closed cause; got %q", e.Reason)
+	}
 	if q, _ := quarantined(t, home, "er1-push"); !q {
-		t.Fatalf("managed skill must FAIL CLOSED (be quarantined) when revocation is unavailable under managed trust roots; not quarantined.\nout=\n%s", out)
+		t.Fatalf("--quarantine must physically move the skill")
 	}
 }
 
-// THREAT-R01 (report-only) — the fail-closed is advisory without --quarantine, so
-// the SessionStart sweep does not destructively move skills, but the state IS
-// surfaced (RevocationUnavailable) for observability.
-func TestSweep_RevocationUnavailableUnderManaged_ReportOnly(t *testing.T) {
-	home := t.TempDir()
-	writeSidecarDigest(t, home, "er1-push", "sha256:beef")
-
-	orig := sweepRevokedFn
-	sweepRevokedFn = func(string) (map[string]struct{}, bool, error) {
-		return map[string]struct{}{}, false, errRevokedSetUnavailable
-	}
-	t.Cleanup(func() { sweepRevokedFn = orig })
-
-	// No --quarantine → report-only: NOT physically moved, but reported closed.
-	_, out := runSweep(t, home) // report-only
-	if q, _ := quarantined(t, home, "er1-push"); q {
-		t.Fatalf("report-only sweep must NOT physically move the skill; it was quarantined")
-	}
-	if !containsAll(out, "fail", "revocation") {
-		t.Fatalf("report-only sweep must SURFACE the fail-closed state; out=\n%s", out)
-	}
-}
-
-// THREAT-R01 (negative / no spurious deny) — UNMANAGED / dev must still work.
-//
-// When the revoked-set fetch returns cleanly with nothing revoked and NO error
-// (the unmanaged/dev best-effort path), a managed-looking skill must NOT be
-// quarantined. Guards against the fix over-reaching into a hard deny that would
-// break first-run / offline dev.
+// THREAT-R01 (negative / no spurious deny) — UNMANAGED / clean fetch must NOT
+// quarantine a managed-looking skill.
 func TestSweep_UnmanagedCleanFetch_NoSpuriousDeny(t *testing.T) {
 	home := t.TempDir()
 	writeSidecarDigest(t, home, "er1-push", "sha256:beef")
@@ -91,97 +87,211 @@ func TestSweep_UnmanagedCleanFetch_NoSpuriousDeny(t *testing.T) {
 
 	orig := sweepRevokedFn
 	sweepRevokedFn = func(string) (map[string]struct{}, bool, error) {
-		return map[string]struct{}{}, false, nil // unmanaged/clean: nothing revoked, no error
+		return map[string]struct{}{}, false, nil // clean: nothing revoked, no error
 	}
 	t.Cleanup(func() { sweepRevokedFn = orig })
 
 	_, out := runSweep(t, home, "--quarantine")
 	if q, _ := quarantined(t, home, "er1-push"); q {
-		t.Fatalf("clean unmanaged fetch must NOT quarantine (no spurious hard-deny); out=\n%s", out)
+		t.Fatalf("clean fetch must NOT quarantine (no spurious hard-deny); out=\n%s", out)
 	}
 }
 
-// fetchRevokedOnline (real function) — UNMANAGED branch stays fail-OPEN.
-//
-// No self-trust-roots.yaml under $HOME → fetchRevokedOnline must return the cache
-// with online=false and NO error, so offline keygen/pack/sign/verify-sig + first
-// run keep working.
-func TestFetchRevokedOnline_UnmanagedFailOpen(t *testing.T) {
+// ---------------------------------------------------------------------------
+// R01-A — verify-hook HOT PATH
+// ---------------------------------------------------------------------------
+
+// R01-A (crux) — a KNOWN-revoked managed skill is DENIED per-invocation on a
+// stale/empty cache, because the hot path now refreshes the revoked set instead of
+// skipping the check between sweeps. BITE: revert the R01-A block → stale cache is
+// skipped → the (stubbed-allow) skill is ALLOWED → assertDeny fails.
+func TestVerifyHook_HotPath_RevokedOnStaleCache_Denied(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)  // no ~/.claude/trust-roots.yaml here → unmanaged
-	setUserProfile(t, home) // WIN-T8: keep a shipping-style resolve scoped to temp
+	t.Setenv("HOME", home)
+	setUserProfile(t, home)
+	writeSelfTrustRoots(t, home) // MANAGED → the hot path consults the fetch
+	writeSidecarDigest(t, home, "er1-push", "sha256:beef")
+	stubHookVerifyAllow(t) // the ONLY possible deny is the revocation check
+
+	// No fresh cache on disk → hot path refreshes; the fetch reports the digest revoked.
+	orig := hotPathRevokedFn
+	hotPathRevokedFn = func(string) (map[string]struct{}, bool, error) {
+		return map[string]struct{}{"sha256:beef": {}}, true, nil
+	}
+	t.Cleanup(func() { hotPathRevokedFn = orig })
+
+	code, out, _ := feed(t, `{"tool_name":"Skill","tool_input":{"skill":"er1-push"}}`)
+	assertDeny(t, code, out, "revoked")
+}
+
+// R01-A (fail-closed on unavailable) — a managed host whose hot-path refresh is
+// UNAVAILABLE denies rather than runs against an unprovable revocation state.
+func TestVerifyHook_HotPath_UnavailableUnderManaged_Denied(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	setUserProfile(t, home)
+	writeSelfTrustRoots(t, home)
+	writeSidecarDigest(t, home, "er1-push", "sha256:beef")
+	stubHookVerifyAllow(t)
+
+	orig := hotPathRevokedFn
+	hotPathRevokedFn = func(string) (map[string]struct{}, bool, error) {
+		return map[string]struct{}{}, false, errRevokedSetUnavailable
+	}
+	t.Cleanup(func() { hotPathRevokedFn = orig })
+
+	code, out, _ := feed(t, `{"tool_name":"Skill","tool_input":{"skill":"er1-push"}}`)
+	assertDeny(t, code, out, "revocation authority unavailable")
+}
+
+// R01-A (no spurious deny + latency guard) — a FRESH cache within grace allows and
+// the hot path does NOT fetch (zero added latency on the normal path). BITE for the
+// latency guard: if the fetch ran on a fresh cache, `called` trips.
+func TestVerifyHook_HotPath_FreshCache_NoFetch_Allowed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	setUserProfile(t, home)
+	writeSelfTrustRoots(t, home)
+	writeSidecarDigest(t, home, "er1-push", "sha256:beef")
+	stubHookVerifyAllow(t)
+	writeRevokedCache(home, map[string]struct{}{"sha256:dead": {}}) // fresh; not our digest
+
+	called := false
+	orig := hotPathRevokedFn
+	hotPathRevokedFn = func(string) (map[string]struct{}, bool, error) {
+		called = true
+		return map[string]struct{}{}, false, errRevokedSetUnavailable
+	}
+	t.Cleanup(func() { hotPathRevokedFn = orig })
+
+	code, out, _ := feed(t, `{"tool_name":"Skill","tool_input":{"skill":"er1-push"}}`)
+	assertAllow(t, code, out)
+	if called {
+		t.Fatalf("hot path fetched despite a FRESH cache — must add no latency to normal invocations")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// R01-B — AUTHENTICATED grace window
+// ---------------------------------------------------------------------------
+
+func TestRevokedUnavailableUnderManaged_AuthenticatedGrace(t *testing.T) {
+	t.Run("empty cache -> fail closed", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		setUserProfile(t, home)
+		if _, online, err := revokedUnavailableUnderManaged(home); !errors.Is(err, errRevokedSetUnavailable) || online {
+			t.Fatalf("empty cache must fail closed; got online=%v err=%v", online, err)
+		}
+	})
+
+	// R01-B BITE — a forged {digests:[],fetched_at:now} (unsigned, same-uid-writable)
+	// must NOT open the grace window: without a pinned-key-verified signed HEAD, an
+	// attacker could otherwise ride grace forever with an EMPTY set. Reverting R01-B
+	// (grace = plain fetched_at freshness) makes this return nil and the test FAIL.
+	t.Run("R01-B forged fresh fetched_at, no signed HEAD -> fail closed", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		setUserProfile(t, home)
+		writeSelfTrustRoots(t, home)                   // MANAGED, but no signed HEAD persisted
+		writeRevokedCache(home, map[string]struct{}{}) // fresh fetched_at, EMPTY set (the forgery)
+		if _, _, err := revokedUnavailableUnderManaged(home); !errors.Is(err, errRevokedSetUnavailable) {
+			t.Fatalf("forged fresh timestamp without a signed HEAD must NOT open grace; got %v", err)
+		}
+	})
+
+	// Positive — an AUTHENTICATED basis (verified signed HEAD, recent issued_at,
+	// cached set binds to the HEAD's revoked_set_root) DOES open grace.
+	t.Run("verified signed HEAD + bound fresh set -> grace open", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		setUserProfile(t, home)
+		pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+		writeSelfTrustRootsKey(t, home, pub)
+		dg := headTestDigest('a')
+		set := map[string]struct{}{dg: {}}
+		installSignedHead(t, home, priv, 1, sweepClockFn().UTC(), []string{dg})
+		writeRevokedCache(home, set) // fresh + set binds to the HEAD root
+		got, _, err := revokedUnavailableUnderManaged(home)
+		if err != nil {
+			t.Fatalf("authenticated grace must open; got %v", err)
+		}
+		if _, ok := got[dg]; !ok {
+			t.Fatalf("grace path must return the last-known-good set")
+		}
+	})
+
+	// A verified signed HEAD whose authenticated issued_at is PAST the TTL does not
+	// open grace (freshness is judged on the AUTHENTICATED anchor, not fetched_at).
+	t.Run("signed HEAD past TTL -> fail closed", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		setUserProfile(t, home)
+		pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+		writeSelfTrustRootsKey(t, home, pub)
+		dg := headTestDigest('a')
+		set := map[string]struct{}{dg: {}}
+		old := sweepClockFn().UTC().Add(-2 * revokedCacheTTL)
+		installSignedHead(t, home, priv, 1, old, []string{dg})
+		writeRevokedCache(home, set) // fetched_at fresh, but the SIGNED anchor is old
+		if _, _, err := revokedUnavailableUnderManaged(home); !errors.Is(err, errRevokedSetUnavailable) {
+			t.Fatalf("a signed HEAD older than the TTL must NOT open grace; got %v", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// R01-C — present-but-corrupt trust-roots.yaml
+// ---------------------------------------------------------------------------
+
+// R01-C — a PRESENT-but-unparseable trust-roots.yaml is tampering, not "unmanaged":
+// it must fail CLOSED, not silently downgrade to fail-open. BITE: reverting R01-C
+// (treating any LoadSelfTrustRoots error as unmanaged) returns nil and this FAILS.
+func TestFetchRevokedOnline_CorruptTrustRoots_FailsClosed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	setUserProfile(t, home)
+	dir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "trust-roots.yaml"), []byte("{{{ not: [valid yaml"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := fetchRevokedOnline(home); !errors.Is(err, errRevokedSetUnavailable) {
+		t.Fatalf("present-but-corrupt trust-roots must fail CLOSED (not fail-open); got %v", err)
+	}
+}
+
+// The ABSENT case stays fail-OPEN (genuine unmanaged / first-run) — the counterpart
+// to R01-C that guards against over-reaching into a hard deny.
+func TestFetchRevokedOnline_AbsentTrustRoots_FailOpen(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home) // no ~/.claude/trust-roots.yaml
+	setUserProfile(t, home)
 	_, online, err := fetchRevokedOnline(home)
 	if err != nil {
-		t.Fatalf("unmanaged fetch must be fail-OPEN (nil error); got %v", err)
+		t.Fatalf("absent trust-roots (unmanaged) must be fail-OPEN (nil error); got %v", err)
 	}
 	if online {
 		t.Fatalf("unmanaged fetch cannot be 'online' with no trust roots")
 	}
 }
 
-// revokedUnavailableUnderManaged (helper) — the GRACE WINDOW.
-//
-//   - empty/absent cache → fail-CLOSED (errRevokedSetUnavailable);
-//   - fresh cache (within TTL) → fail-OPEN (nil error): last-known-good still
-//     bounds staleness;
-//   - stale cache (past TTL) → fail-CLOSED again.
-func TestRevokedUnavailableUnderManaged_GraceWindow(t *testing.T) {
-	t.Run("empty cache -> fail closed", func(t *testing.T) {
-		home := t.TempDir()
-		_, online, err := revokedUnavailableUnderManaged(home)
-		if !errors.Is(err, errRevokedSetUnavailable) {
-			t.Fatalf("empty cache must fail closed; got err=%v", err)
-		}
-		if online {
-			t.Fatalf("must not report online on the fail-closed path")
-		}
-	})
+// ---------------------------------------------------------------------------
+// fetchRevokedOnline — MANAGED branch end-to-end (real code path, unreachable reg)
+// ---------------------------------------------------------------------------
 
-	t.Run("fresh cache -> grace window (fail open)", func(t *testing.T) {
-		home := t.TempDir()
-		writeRevokedCache(home, map[string]struct{}{"sha256:beef": {}}) // fetched_at = now → fresh
-		set, _, err := revokedUnavailableUnderManaged(home)
-		if err != nil {
-			t.Fatalf("a within-TTL last-known-good cache is the grace window; must not fail closed; got %v", err)
-		}
-		if _, ok := set["sha256:beef"]; !ok {
-			t.Fatalf("grace-window path must return the cached last-known-good set")
-		}
-	})
-
-	t.Run("stale cache -> fail closed", func(t *testing.T) {
-		home := t.TempDir()
-		p := revokedCachePath(home)
-		if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
-			t.Fatal(err)
-		}
-		// A long-past fetched_at → outside revokedCacheTTL → no grace.
-		stale := `{"digests":["sha256:beef"],"fetched_at":"2000-01-01T00:00:00Z"}`
-		if err := os.WriteFile(p, []byte(stale), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if _, _, err := revokedUnavailableUnderManaged(home); !errors.Is(err, errRevokedSetUnavailable) {
-			t.Fatalf("a stale (past-TTL) cache must fail closed; got err=%v", err)
-		}
-	})
-}
-
-// fetchRevokedOnline (real function) — MANAGED branch, end-to-end.
-//
-// With a real self-trust-roots.yaml (managed) and a registry that is unreachable,
-// the live fetch fails: with an empty cache fetchRevokedOnline must surface
-// errRevokedSetUnavailable (fail-closed); with a fresh cache it must ride the
-// grace window (nil error, last-known-good returned). This proves the managed-vs-
-// unmanaged distinction on the REAL code path, not just the helper.
-func TestFetchRevokedOnline_ManagedUnavailable_FailsClosed(t *testing.T) {
+func TestFetchRevokedOnline_ManagedUnavailable_EndToEnd(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	setUserProfile(t, home)
-	writeSelfTrustRoots(t, home) // → MANAGED
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	writeSelfTrustRootsKey(t, home, pub) // MANAGED
 
 	// A guaranteed-dead registry endpoint (a just-closed httptest port → dial
-	// refused, no hang), reached via ER1_TARGET. An API key is present so
-	// resolveER1Config succeeds and the failure is at the fetch, not the config.
+	// refused, no hang). An API key is present so resolveER1Config succeeds and the
+	// failure is at the fetch, not the config.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	dead := srv.URL
 	srv.Close()
@@ -190,34 +300,33 @@ func TestFetchRevokedOnline_ManagedUnavailable_FailsClosed(t *testing.T) {
 
 	t.Run("empty cache -> fail closed", func(t *testing.T) {
 		if _, _, err := fetchRevokedOnline(home); !errors.Is(err, errRevokedSetUnavailable) {
-			t.Fatalf("managed + unreachable registry + empty cache must fail closed; got err=%v", err)
+			t.Fatalf("managed + unreachable registry + empty cache must fail closed; got %v", err)
 		}
 	})
 
-	t.Run("fresh cache -> grace window", func(t *testing.T) {
-		writeRevokedCache(home, map[string]struct{}{"sha256:beef": {}}) // fresh
-		set, _, err := fetchRevokedOnline(home)
+	t.Run("authenticated fresh snapshot -> grace window", func(t *testing.T) {
+		dg := headTestDigest('b')
+		set := map[string]struct{}{dg: {}}
+		installSignedHead(t, home, priv, 2, sweepClockFn().UTC(), []string{dg})
+		writeRevokedCache(home, set)
+		got, _, err := fetchRevokedOnline(home)
 		if err != nil {
-			t.Fatalf("managed + unreachable registry + FRESH cache must ride the grace window (nil err); got %v", err)
+			t.Fatalf("managed + unreachable registry + AUTHENTICATED fresh snapshot must ride grace (nil err); got %v", err)
 		}
-		if _, ok := set["sha256:beef"]; !ok {
-			t.Fatalf("grace-window path must return the cached last-known-good set")
+		if _, ok := got[dg]; !ok {
+			t.Fatalf("grace path must return the last-known-good set")
 		}
 	})
 }
 
-// --- helpers ---
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
 
-// writeSelfTrustRoots writes a minimal-but-valid ~/.claude/trust-roots.yaml so
-// LoadSelfTrustRoots succeeds → the host is treated as MANAGED. Only pubkey_b64
-// is required (registry defaults to "self", governance to "green", fingerprint is
-// recomputed on load).
-func writeSelfTrustRoots(t *testing.T, home string) {
+// writeSelfTrustRootsKey writes a minimal-but-valid ~/.claude/trust-roots.yaml
+// pinning `pub` → the host is treated as MANAGED and `pub` is the verification key.
+func writeSelfTrustRootsKey(t *testing.T, home string, pub ed25519.PublicKey) {
 	t.Helper()
-	pub, _, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
 	dir := filepath.Join(home, ".claude")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatal(err)
@@ -228,11 +337,71 @@ func writeSelfTrustRoots(t *testing.T, home string) {
 	}
 }
 
+// writeSelfTrustRoots pins a throwaway key (when the test does not need to sign a HEAD).
+func writeSelfTrustRoots(t *testing.T, home string) {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSelfTrustRootsKey(t, home, pub)
+}
+
+// installSignedHead builds, signs (with priv), and PERSISTS a revocation HEAD to
+// ~/.claude/skillctl/revoked-head.signed.json so verifiedAdoptedHead re-verifies it
+// against the pinned key. Digests must be full sha256 tokens (validateDigest).
+func installSignedHead(t *testing.T, home string, priv ed25519.PrivateKey, epoch int, issuedAt time.Time, digests []string) {
+	t.Helper()
+	head, err := registry.BuildRevocationHead(registry.RevocationHeadInput{Epoch: epoch, IssuedAt: issuedAt, Digests: digests})
+	if err != nil {
+		t.Fatalf("build head: %v", err)
+	}
+	if _, err := registry.SignEnvelopeSignature(priv, head); err != nil {
+		t.Fatalf("sign head: %v", err)
+	}
+	persistSignedHead(home, head)
+}
+
 // setUserProfile mirrors HOME into USERPROFILE (WIN-T8) so the temp home is honored
 // on every platform's userHome() resolution. Inert on non-Windows.
 func setUserProfile(t *testing.T, home string) {
 	t.Helper()
 	t.Setenv("USERPROFILE", home)
+}
+
+// stubHookVerifyAllow makes the managed verify chain PASS so the ONLY possible deny
+// in a verify-hook test is the revocation check under test.
+func stubHookVerifyAllow(t *testing.T) {
+	t.Helper()
+	ov, oo := verifyManagedFn, verifyManagedOfflineFn
+	verifyManagedFn = func(string, gatePolicy) (int, string) { return exitOK, "ok" }
+	verifyManagedOfflineFn = func(string, gatePolicy, string) (int, string, bool) { return exitOK, "ok", true }
+	t.Cleanup(func() { verifyManagedFn = ov; verifyManagedOfflineFn = oo })
+}
+
+// runSweepReport runs `verify --all --json ...` and returns the parsed report
+// (stdout captured separately so the JSON parses cleanly).
+func runSweepReport(t *testing.T, home string, args ...string) sweepReport {
+	t.Helper()
+	t.Setenv("HOME", home)
+	var out, errb bytes.Buffer
+	_ = runVerify(append([]string{"--all", "--json"}, args...), &out, &errb)
+	var rep sweepReport
+	if err := json.Unmarshal(out.Bytes(), &rep); err != nil {
+		t.Fatalf("sweep --json not parseable: %v\nstdout=%s\nstderr=%s", err, out.String(), errb.String())
+	}
+	return rep
+}
+
+func findEntry(t *testing.T, rep sweepReport, name string) sweepEntry {
+	t.Helper()
+	for _, e := range rep.Entries {
+		if e.Skill == name {
+			return e
+		}
+	}
+	t.Fatalf("no sweep entry for %q; entries=%+v", name, rep.Entries)
+	return sweepEntry{}
 }
 
 func containsAll(s string, subs ...string) bool {

--- a/cmd/skillctl/revoked_cache_failclosed_test.go
+++ b/cmd/skillctl/revoked_cache_failclosed_test.go
@@ -101,19 +101,21 @@ func TestSweep_UnmanagedCleanFetch_NoSpuriousDeny(t *testing.T) {
 // R01-A — verify-hook HOT PATH
 // ---------------------------------------------------------------------------
 
-// R01-A (crux) — a KNOWN-revoked managed skill is DENIED per-invocation on a
-// stale/empty cache, because the hot path now refreshes the revoked set instead of
-// skipping the check between sweeps. BITE: revert the R01-A block → stale cache is
-// skipped → the (stubbed-allow) skill is ALLOWED → assertDeny fails.
+// R01-A (crux) — a KNOWN-revoked managed skill is DENIED per-invocation on a stale
+// cache, because the hot path refreshes the revoked set instead of skipping the
+// check between sweeps. The host is ADOPTED (a revoked-cache file exists, gone
+// stale) — the scenario the fix must catch. BITE: revert the R01-A block → the
+// stale cache is skipped → the (stubbed-allow) skill is ALLOWED → assertDeny fails.
 func TestVerifyHook_HotPath_RevokedOnStaleCache_Denied(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	setUserProfile(t, home)
 	writeSelfTrustRoots(t, home) // MANAGED → the hot path consults the fetch
 	writeSidecarDigest(t, home, "er1-push", "sha256:beef")
-	stubHookVerifyAllow(t) // the ONLY possible deny is the revocation check
+	writeStaleRevokedCache(t, home, "sha256:old") // ADOPTED (feed pulled once) but stale
+	stubHookVerifyAllow(t)                        // the ONLY possible deny is the revocation check
 
-	// No fresh cache on disk → hot path refreshes; the fetch reports the digest revoked.
+	// Adopted + stale → hot path refreshes; the fetch reports the digest revoked.
 	orig := hotPathRevokedFn
 	hotPathRevokedFn = func(string) (map[string]struct{}, bool, error) {
 		return map[string]struct{}{"sha256:beef": {}}, true, nil
@@ -124,14 +126,16 @@ func TestVerifyHook_HotPath_RevokedOnStaleCache_Denied(t *testing.T) {
 	assertDeny(t, code, out, "revoked")
 }
 
-// R01-A (fail-closed on unavailable) — a managed host whose hot-path refresh is
-// UNAVAILABLE denies rather than runs against an unprovable revocation state.
+// R01-A (fail-closed on unavailable) — an ADOPTED managed host whose hot-path
+// refresh is UNAVAILABLE (feed blackholed: stale cache file still present) denies
+// rather than runs against an unprovable revocation state.
 func TestVerifyHook_HotPath_UnavailableUnderManaged_Denied(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	setUserProfile(t, home)
 	writeSelfTrustRoots(t, home)
 	writeSidecarDigest(t, home, "er1-push", "sha256:beef")
+	writeStaleRevokedCache(t, home, "sha256:old") // ADOPTED but stale (blackholed feed)
 	stubHookVerifyAllow(t)
 
 	orig := hotPathRevokedFn
@@ -142,6 +146,36 @@ func TestVerifyHook_HotPath_UnavailableUnderManaged_Denied(t *testing.T) {
 
 	code, out, _ := feed(t, `{"tool_name":"Skill","tool_input":{"skill":"er1-push"}}`)
 	assertDeny(t, code, out, "revocation authority unavailable")
+}
+
+// R01-A (pre-D2 NOT bricked) — an UN-ADOPTED managed host (self-trust-roots present
+// but NO revoked-cache file: kill-switch-only / never pulled a feed) must ALLOW and
+// must NOT even attempt the fetch — nothing to suppress, so no brick and no latency.
+// This is the exact regression the hermetic CI caught (managed + no cache → the old
+// code fetched → unreachable → deny). BITE: drop the `!revocationAdopted` guard →
+// the fetch runs → errRevokedSetUnavailable → DENY → this test fails.
+func TestVerifyHook_HotPath_UnadoptedManaged_NoBrick(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	setUserProfile(t, home)
+	writeSelfTrustRoots(t, home) // MANAGED
+	writeSidecarDigest(t, home, "er1-push", "sha256:beef")
+	stubHookVerifyAllow(t)
+	// NO revoked-cache file written → un-adopted.
+
+	called := false
+	orig := hotPathRevokedFn
+	hotPathRevokedFn = func(string) (map[string]struct{}, bool, error) {
+		called = true
+		return map[string]struct{}{}, false, errRevokedSetUnavailable
+	}
+	t.Cleanup(func() { hotPathRevokedFn = orig })
+
+	code, out, _ := feed(t, `{"tool_name":"Skill","tool_input":{"skill":"er1-push"}}`)
+	assertAllow(t, code, out)
+	if called {
+		t.Fatalf("an UN-ADOPTED managed host must NOT fetch on the hot path (nothing to suppress; must not brick pre-D2)")
+	}
 }
 
 // R01-A (no spurious deny + latency guard) — a FRESH cache within grace allows and
@@ -346,6 +380,23 @@ func TestFetchRevokedOnline_ManagedUnavailable_EndToEnd(t *testing.T) {
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
+
+// writeStaleRevokedCache writes a revoked-cache file with a long-past fetched_at,
+// so the host reads as ADOPTED (the file exists — a feed was pulled at least once)
+// but the cache is STALE (past revokedCacheTTL → readRevokedCache !fresh). Used to
+// reproduce the "adopted host, feed gone stale/blackholed" scenario R01-A must
+// still fail closed on.
+func writeStaleRevokedCache(t *testing.T, home string, digests ...string) {
+	t.Helper()
+	p := revokedCachePath(home)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := json.Marshal(revokedCacheFile{Digests: digests, FetchedAt: "2000-01-01T00:00:00Z"})
+	if err := os.WriteFile(p, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
 
 // writeSelfTrustRootsKey writes a minimal-but-valid ~/.claude/trust-roots.yaml
 // pinning `pub` → the host is treated as MANAGED and `pub` is the verification key.

--- a/cmd/skillctl/revoked_cache_failclosed_test.go
+++ b/cmd/skillctl/revoked_cache_failclosed_test.go
@@ -1,0 +1,245 @@
+package main
+
+// Regression tests for WF-001 H-F1 / THREAT-R01 — revocation-SUPPRESSION.
+//
+// The bug: fetchRevokedOnline "failed OPEN on availability" — on ANY fetch error
+// it returned the (possibly EMPTY) cache with online=false and NEVER an error. On
+// a fresh machine, or after an attacker clears the cache and blocks the network /
+// serves a hostile 5xx / redirects to a dead host, the empty set meant a KNOWN-
+// revoked digest was not blocked: revocation was silently suppressed by making the
+// fetch fail.
+//
+// The fix makes the revoked-set consumers fail CLOSED under MANAGED (self-trust-
+// root) config while keeping the UNMANAGED/dev path fail-open. These tests pin
+// both halves so the fail-open cannot regress.
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// THREAT-R01 (consumer / sweep) — the trust-decision caller fails CLOSED.
+//
+// With a MANAGED host whose revoked-set fetch is unavailable and whose cache is
+// empty (sweepRevokedFn returns errRevokedSetUnavailable), the sweep must
+// QUARANTINE the managed skill rather than read the empty set as "nothing
+// revoked". This is the exact suppression vector the wave-1 challenge gate
+// flagged: a KNOWN-revoked digest must NOT be allowed to keep running just
+// because the fetch was made to fail.
+func TestSweep_RevocationUnavailableUnderManaged_FailsClosed(t *testing.T) {
+	home := t.TempDir()
+	// A managed, otherwise-fine skill whose digest is NOT in any (empty) local set.
+	writeSidecarDigest(t, home, "er1-push", "sha256:beef")
+
+	// Simulate MANAGED + revoked-set fetch unavailable + empty cache.
+	orig := sweepRevokedFn
+	sweepRevokedFn = func(string) (map[string]struct{}, bool, error) {
+		return map[string]struct{}{}, false, errRevokedSetUnavailable
+	}
+	t.Cleanup(func() { sweepRevokedFn = orig })
+
+	code, out := runSweep(t, home, "--quarantine")
+	_ = code
+	if q, _ := quarantined(t, home, "er1-push"); !q {
+		t.Fatalf("managed skill must FAIL CLOSED (be quarantined) when revocation is unavailable under managed trust roots; not quarantined.\nout=\n%s", out)
+	}
+}
+
+// THREAT-R01 (report-only) — the fail-closed is advisory without --quarantine, so
+// the SessionStart sweep does not destructively move skills, but the state IS
+// surfaced (RevocationUnavailable) for observability.
+func TestSweep_RevocationUnavailableUnderManaged_ReportOnly(t *testing.T) {
+	home := t.TempDir()
+	writeSidecarDigest(t, home, "er1-push", "sha256:beef")
+
+	orig := sweepRevokedFn
+	sweepRevokedFn = func(string) (map[string]struct{}, bool, error) {
+		return map[string]struct{}{}, false, errRevokedSetUnavailable
+	}
+	t.Cleanup(func() { sweepRevokedFn = orig })
+
+	// No --quarantine → report-only: NOT physically moved, but reported closed.
+	_, out := runSweep(t, home) // report-only
+	if q, _ := quarantined(t, home, "er1-push"); q {
+		t.Fatalf("report-only sweep must NOT physically move the skill; it was quarantined")
+	}
+	if !containsAll(out, "fail", "revocation") {
+		t.Fatalf("report-only sweep must SURFACE the fail-closed state; out=\n%s", out)
+	}
+}
+
+// THREAT-R01 (negative / no spurious deny) — UNMANAGED / dev must still work.
+//
+// When the revoked-set fetch returns cleanly with nothing revoked and NO error
+// (the unmanaged/dev best-effort path), a managed-looking skill must NOT be
+// quarantined. Guards against the fix over-reaching into a hard deny that would
+// break first-run / offline dev.
+func TestSweep_UnmanagedCleanFetch_NoSpuriousDeny(t *testing.T) {
+	home := t.TempDir()
+	writeSidecarDigest(t, home, "er1-push", "sha256:beef")
+
+	stubRootsOK(t)
+	stubVerify(t, exitOK, "ok", nil)
+
+	orig := sweepRevokedFn
+	sweepRevokedFn = func(string) (map[string]struct{}, bool, error) {
+		return map[string]struct{}{}, false, nil // unmanaged/clean: nothing revoked, no error
+	}
+	t.Cleanup(func() { sweepRevokedFn = orig })
+
+	_, out := runSweep(t, home, "--quarantine")
+	if q, _ := quarantined(t, home, "er1-push"); q {
+		t.Fatalf("clean unmanaged fetch must NOT quarantine (no spurious hard-deny); out=\n%s", out)
+	}
+}
+
+// fetchRevokedOnline (real function) — UNMANAGED branch stays fail-OPEN.
+//
+// No self-trust-roots.yaml under $HOME → fetchRevokedOnline must return the cache
+// with online=false and NO error, so offline keygen/pack/sign/verify-sig + first
+// run keep working.
+func TestFetchRevokedOnline_UnmanagedFailOpen(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)  // no ~/.claude/trust-roots.yaml here → unmanaged
+	setUserProfile(t, home) // WIN-T8: keep a shipping-style resolve scoped to temp
+	_, online, err := fetchRevokedOnline(home)
+	if err != nil {
+		t.Fatalf("unmanaged fetch must be fail-OPEN (nil error); got %v", err)
+	}
+	if online {
+		t.Fatalf("unmanaged fetch cannot be 'online' with no trust roots")
+	}
+}
+
+// revokedUnavailableUnderManaged (helper) — the GRACE WINDOW.
+//
+//   - empty/absent cache → fail-CLOSED (errRevokedSetUnavailable);
+//   - fresh cache (within TTL) → fail-OPEN (nil error): last-known-good still
+//     bounds staleness;
+//   - stale cache (past TTL) → fail-CLOSED again.
+func TestRevokedUnavailableUnderManaged_GraceWindow(t *testing.T) {
+	t.Run("empty cache -> fail closed", func(t *testing.T) {
+		home := t.TempDir()
+		_, online, err := revokedUnavailableUnderManaged(home)
+		if !errors.Is(err, errRevokedSetUnavailable) {
+			t.Fatalf("empty cache must fail closed; got err=%v", err)
+		}
+		if online {
+			t.Fatalf("must not report online on the fail-closed path")
+		}
+	})
+
+	t.Run("fresh cache -> grace window (fail open)", func(t *testing.T) {
+		home := t.TempDir()
+		writeRevokedCache(home, map[string]struct{}{"sha256:beef": {}}) // fetched_at = now → fresh
+		set, _, err := revokedUnavailableUnderManaged(home)
+		if err != nil {
+			t.Fatalf("a within-TTL last-known-good cache is the grace window; must not fail closed; got %v", err)
+		}
+		if _, ok := set["sha256:beef"]; !ok {
+			t.Fatalf("grace-window path must return the cached last-known-good set")
+		}
+	})
+
+	t.Run("stale cache -> fail closed", func(t *testing.T) {
+		home := t.TempDir()
+		p := revokedCachePath(home)
+		if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		// A long-past fetched_at → outside revokedCacheTTL → no grace.
+		stale := `{"digests":["sha256:beef"],"fetched_at":"2000-01-01T00:00:00Z"}`
+		if err := os.WriteFile(p, []byte(stale), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := revokedUnavailableUnderManaged(home); !errors.Is(err, errRevokedSetUnavailable) {
+			t.Fatalf("a stale (past-TTL) cache must fail closed; got err=%v", err)
+		}
+	})
+}
+
+// fetchRevokedOnline (real function) — MANAGED branch, end-to-end.
+//
+// With a real self-trust-roots.yaml (managed) and a registry that is unreachable,
+// the live fetch fails: with an empty cache fetchRevokedOnline must surface
+// errRevokedSetUnavailable (fail-closed); with a fresh cache it must ride the
+// grace window (nil error, last-known-good returned). This proves the managed-vs-
+// unmanaged distinction on the REAL code path, not just the helper.
+func TestFetchRevokedOnline_ManagedUnavailable_FailsClosed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	setUserProfile(t, home)
+	writeSelfTrustRoots(t, home) // → MANAGED
+
+	// A guaranteed-dead registry endpoint (a just-closed httptest port → dial
+	// refused, no hang), reached via ER1_TARGET. An API key is present so
+	// resolveER1Config succeeds and the failure is at the fetch, not the config.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	dead := srv.URL
+	srv.Close()
+	t.Setenv("ER1_TARGET", dead)
+	t.Setenv("ER1_API_KEY", "test-key")
+
+	t.Run("empty cache -> fail closed", func(t *testing.T) {
+		if _, _, err := fetchRevokedOnline(home); !errors.Is(err, errRevokedSetUnavailable) {
+			t.Fatalf("managed + unreachable registry + empty cache must fail closed; got err=%v", err)
+		}
+	})
+
+	t.Run("fresh cache -> grace window", func(t *testing.T) {
+		writeRevokedCache(home, map[string]struct{}{"sha256:beef": {}}) // fresh
+		set, _, err := fetchRevokedOnline(home)
+		if err != nil {
+			t.Fatalf("managed + unreachable registry + FRESH cache must ride the grace window (nil err); got %v", err)
+		}
+		if _, ok := set["sha256:beef"]; !ok {
+			t.Fatalf("grace-window path must return the cached last-known-good set")
+		}
+	})
+}
+
+// --- helpers ---
+
+// writeSelfTrustRoots writes a minimal-but-valid ~/.claude/trust-roots.yaml so
+// LoadSelfTrustRoots succeeds → the host is treated as MANAGED. Only pubkey_b64
+// is required (registry defaults to "self", governance to "green", fingerprint is
+// recomputed on load).
+func writeSelfTrustRoots(t *testing.T, home string) {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "registry: self\npubkey_b64: " + base64.StdEncoding.EncodeToString(pub) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "trust-roots.yaml"), []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// setUserProfile mirrors HOME into USERPROFILE (WIN-T8) so the temp home is honored
+// on every platform's userHome() resolution. Inert on non-Windows.
+func setUserProfile(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("USERPROFILE", home)
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !strings.Contains(strings.ToLower(s), strings.ToLower(sub)) {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/skillctl/revoked_cache_test.go
+++ b/cmd/skillctl/revoked_cache_test.go
@@ -80,8 +80,8 @@ func TestSweep_RevokedBundle_Quarantined(t *testing.T) {
 	writeSidecarDigest(t, home, "er1-push", "sha256:dead")
 
 	orig := sweepRevokedFn
-	sweepRevokedFn = func(string) (map[string]struct{}, bool) {
-		return map[string]struct{}{"sha256:dead": {}}, true
+	sweepRevokedFn = func(string) (map[string]struct{}, bool, error) {
+		return map[string]struct{}{"sha256:dead": {}}, true, nil
 	}
 	t.Cleanup(func() { sweepRevokedFn = orig })
 

--- a/cmd/skillctl/verify_all_cmds.go
+++ b/cmd/skillctl/verify_all_cmds.go
@@ -74,14 +74,18 @@ type sweepEntry struct {
 }
 
 type sweepReport struct {
-	SkillsDir   string       `json:"skills_dir"`
-	Total       int          `json:"total"`
-	Verified    int          `json:"verified"`
-	Quarantined int          `json:"quarantined"`
-	Unverified  int          `json:"unverified"`
-	Skipped     int          `json:"skipped"`
-	RootsError  string       `json:"roots_error,omitempty"`
-	Entries     []sweepEntry `json:"entries"`
+	SkillsDir   string `json:"skills_dir"`
+	Total       int    `json:"total"`
+	Verified    int    `json:"verified"`
+	Quarantined int    `json:"quarantined"`
+	Unverified  int    `json:"unverified"`
+	Skipped     int    `json:"skipped"`
+	RootsError  string `json:"roots_error,omitempty"`
+	// RevocationUnavailable is the WF-001 H-F1 fail-closed signal: under managed
+	// self-trust-root config the revoked-set fetch was unavailable AND no fresh
+	// cache bounds staleness, so managed skills are failed CLOSED this sweep.
+	RevocationUnavailable string       `json:"revocation_unavailable,omitempty"`
+	Entries               []sweepEntry `json:"entries"`
 }
 
 // runVerifyAll implements `skillctl verify --all`.
@@ -143,12 +147,24 @@ func runVerifyAll(args []string, stdout, stderr io.Writer) int {
 	pol := loadGatePolicy()
 	start := sweepClockFn()
 
-	// SPEC-0266 F1: fetch the live revoked-digest set once (fail-open — a fetch
-	// failure yields the cached/empty set, never a false quarantine). The sweep
-	// is the revocation authority: a managed skill whose bundle digest is revoked
-	// is quarantined regardless of its §7 result, and the set is cached so the
+	// SPEC-0266 F1: fetch the live revoked-digest set once. The sweep is the
+	// revocation authority: a managed skill whose bundle digest is revoked is
+	// quarantined regardless of its §7 result, and the set is cached so the
 	// per-invocation offline gate denies it too until the next sweep.
-	revoked, _ := sweepRevokedFn(home)
+	//
+	// WF-001 H-F1 / R01 — a non-nil error is the MANAGED fail-CLOSED signal: under
+	// self-trust-root config the revoked-set fetch was unavailable AND no fresh
+	// last-known-good cache bounds staleness, so we can no longer prove any managed
+	// bundle is un-revoked. We must NOT read the (empty/stale) set as "nothing
+	// revoked" — that is exactly the revocation-suppression the wave-1 challenge
+	// gate flagged (block the network / hostile 5xx → empty set → known-revoked
+	// digest runs). The UNMANAGED/dev path returns err==nil (best-effort fail-open),
+	// so this never bricks a default machine. See the per-skill fail-closed branch.
+	revoked, _, revErr := sweepRevokedFn(home)
+	revUnavailable := revErr != nil
+	if revUnavailable {
+		rep.RevocationUnavailable = revErr.Error()
+	}
 
 	for _, e := range entries {
 		name := e.Name()
@@ -173,6 +189,25 @@ func runVerifyAll(args []string, stdout, stderr io.Writer) int {
 				rep.Skipped++
 				rep.Entries = append(rep.Entries, sweepEntry{Skill: name, State: "skipped", Reason: "unmanaged (no .skb) — not skillctl-installed"})
 			}
+			continue
+		}
+
+		// WF-001 H-F1 / R01 — REVOCATION-SUPPRESSION FAIL-CLOSED. The managed
+		// revoked-set fetch was unavailable AND no fresh last-known-good cache
+		// bounds staleness (see fetchRevokedOnline / revokedUnavailableUnderManaged),
+		// so we cannot prove THIS managed bundle is not revoked. Fail CLOSED — quar-
+		// antine rather than let the empty/stale set read as "nothing revoked" (the
+		// pre-fix fail-open: block the network → known-revoked digest still runs).
+		// Only reached under managed config (self-trust-roots present); the unmanaged
+		// path returns err==nil, so a default/dev machine never lands here. In report-
+		// only mode this is advisory (quarantineOrReport does not move anything until
+		// --quarantine). Placed BEFORE the definite-revoke check because the cached
+		// set here is stale and cannot be trusted as authoritative.
+		if revUnavailable {
+			rep.Entries = append(rep.Entries, quarantineOrReport(home, name, *quarantine,
+				fmt.Sprintf("revocation authority unavailable under managed trust roots and no fresh cache — failing closed (cannot confirm this bundle is not revoked; WF-001 H-F1): %v", revErr),
+				exitRevocationStale, &rep))
+			recordVerdict(home, name, *sessionID, exitRevocationStale, "", sweepClockFn())
 			continue
 		}
 
@@ -378,6 +413,10 @@ func emitSweepJSON(w io.Writer, rep sweepReport) {
 func printSweepHuman(w io.Writer, rep sweepReport, doQuarantine bool) {
 	if rep.RootsError != "" {
 		fmt.Fprintf(w, "⚠ trust roots unavailable: %s\n  → managed skills reported 'unverified' (not quarantined).\n", rep.RootsError)
+	}
+	if rep.RevocationUnavailable != "" {
+		fmt.Fprintf(w, "⛔ revocation authority unavailable under managed trust roots + no fresh cache: %s\n  → managed skills FAIL CLOSED (WF-001 H-F1)%s.\n",
+			rep.RevocationUnavailable, map[bool]string{true: " — quarantined", false: " — report-only, pass --quarantine to move them out"}[doQuarantine])
 	}
 	for _, e := range rep.Entries {
 		var mark string

--- a/cmd/skillctl/verify_hook_cmds.go
+++ b/cmd/skillctl/verify_hook_cmds.go
@@ -202,6 +202,11 @@ func refusalCodeForHook(exitCode int, reason string) string {
 	// mandate stale case so the Art.12 trail separates the two channels.
 	case strings.Contains(reason, "bundle_revocation_stale"):
 		return "bundle_revocation_stale"
+	// WF-001 H-F1 / R01-A — the managed revoked-set was unavailable on the hot path
+	// with no authenticated grace (fail-closed). Distinct from the plain-stale case:
+	// here we had NO trustworthy snapshot at all, not merely an old one.
+	case strings.Contains(reason, "bundle_revocation_unavailable_managed"):
+		return "bundle_revocation_unavailable"
 	// Both the mandate path ("agentid_emergency_list_untrusted") and the
 	// unconditional runtime path ("agent_emergency_list_untrusted") match this
 	// common substring → a present-but-forged emergency file's fail-closed deny.
@@ -502,14 +507,42 @@ func runVerifyHook(stdin io.Reader, stdout, stderr io.Writer) (code int) {
 			fmt.Sprintf("skillctl: BLOCKED '%s' — offline 'locked' state (exit %d): the host is managed-enterprise but has NO trust basis (no trust roots, self/ER1 roots, or provenance sidecar), so offline_policy denies all non-allowlisted managed skills. Restore a trust root or a signed offline checkpoint.", skill, exitOfflineLocked))
 	}
 
-	// SPEC-0266 F1: a bundle revoked AFTER install is denied by the offline gate
-	// too, via the sweep-maintained revoked-digest cache (consulted only while
-	// fresh — the sweep is the authority that refreshes it online).
+	// SPEC-0266 F1 + WF-001 H-F1 / R01-A — bundle-revocation at the HOT PATH.
+	// A bundle revoked AFTER install must be denied PER-INVOCATION, not only at the
+	// SessionStart sweep. The cache is consulted while FRESH (the sweep refreshes
+	// it); the pre-fix code SKIPPED the check on a stale/empty cache, so a revoked
+	// skill kept executing between sweeps (the crux R01-A the challenge gate found).
+	// Close that under MANAGED config: on a stale/empty cache attempt ONE BOUNDED
+	// online refresh on the hot path, and fail CLOSED when the managed revoked set
+	// is unavailable (no authenticated grace). The refresh runs ONLY when the cache
+	// is stale — the fresh path adds ZERO latency to a normal invocation.
 	if home != "" {
-		if revset, fresh := readRevokedCache(home, revokedCacheTTL); fresh {
+		revset, fresh := readRevokedCache(home, revokedCacheTTL)
+		if !fresh {
+			// Stale/empty cache. Only MANAGED hosts refresh + fail-closed here; an
+			// UNMANAGED/dev host keeps the ORIGINAL behaviour — a stale cache is NOT
+			// used (the sweep is the authority) — so first-run and offline dev are
+			// untouched (no spurious deny). selfTrustPosture is a local file read.
+			if _, managed := selfTrustPosture(); !managed {
+				revset = nil // unmanaged: do not enforce a stale cache
+			} else {
+				// hotPathRevokedFn returns errRevokedSetUnavailable ONLY under managed
+				// config with no authenticated grace (see fetchRevokedOnline /
+				// revokedUnavailableUnderManaged / boundedHotPathRevoked). On success it
+				// also refreshes the cache, so the next invocation rides the fresh path.
+				set, _, ferr := hotPathRevokedFn(home)
+				if errors.Is(ferr, errRevokedSetUnavailable) {
+					audReason = "bundle_revocation_unavailable_managed"
+					return emitDeny(stdout, stderr,
+						fmt.Sprintf("skillctl: BLOCKED '%s' — revocation authority unavailable under managed trust roots and no fresh signed snapshot (exit %d, fail-closed, WF-001 H-F1): refusing to run against a revocation state we cannot prove current. Restore registry reachability or refresh the signed revocation HEAD (`skillctl revoke feed --refresh`).", skill, exitRevocationStale))
+				}
+				revset = set
+			}
+		}
+		if revset != nil {
 			if dig := installedSkillDigest(home, skill); dig != "" {
 				if _, bad := revset[dig]; bad {
-					audReason = "revoked (BundleRevokedEvent; offline cache)"
+					audReason = "revoked (BundleRevokedEvent)"
 					return emitDeny(stdout, stderr,
 						fmt.Sprintf("skillctl: BLOCKED '%s' — bundle revoked (exit %d); a BundleRevokedEvent was published for this digest. Run `skillctl verify --all` to refresh + quarantine.", skill, exitBundleRevoked))
 				}

--- a/cmd/skillctl/verify_hook_cmds.go
+++ b/cmd/skillctl/verify_hook_cmds.go
@@ -519,12 +519,21 @@ func runVerifyHook(stdin io.Reader, stdout, stderr io.Writer) (code int) {
 	if home != "" {
 		revset, fresh := readRevokedCache(home, revokedCacheTTL)
 		if !fresh {
-			// Stale/empty cache. Only MANAGED hosts refresh + fail-closed here; an
-			// UNMANAGED/dev host keeps the ORIGINAL behaviour — a stale cache is NOT
-			// used (the sweep is the authority) — so first-run and offline dev are
-			// untouched (no spurious deny). selfTrustPosture is a local file read.
-			if _, managed := selfTrustPosture(); !managed {
-				revset = nil // unmanaged: do not enforce a stale cache
+			// Stale/empty cache. The managed fail-closed refresh engages ONLY for a
+			// MANAGED host that has ADOPTED a revocation feed (a revoked-cache file
+			// exists — the sweep pulled one at least once). Two exemptions keep a stale
+			// cache from being used AND skip the fetch entirely (no deny, no latency):
+			//   - UNMANAGED/dev — the sweep is the authority; first-run/offline dev
+			//     must stay working;
+			//   - UN-ADOPTED managed (no revoked-cache file at all) — pre-D2 /
+			//     kill-switch-only hosts that never subscribed to a feed have NOTHING
+			//     to suppress, so failing them closed would brick them (the pre-D2
+			//     brick the kill-switch tests guard). A blackholed ADOPTED host still
+			//     has its (now-stale) cache FILE → adopted → the fail-closed engages,
+			//     so R01-A is preserved. Mirrors revocationSnapshotStale's "no-op
+			//     unless a signed anchor exists" precondition below.
+			if _, managed := selfTrustPosture(); !managed || !revocationAdopted(home) {
+				revset = nil // unmanaged, or un-adopted managed: do not enforce / do not fetch
 			} else {
 				// hotPathRevokedFn returns errRevokedSetUnavailable ONLY under managed
 				// config with no authenticated grace (see fetchRevokedOnline /


### PR DESCRIPTION
## H-F1 — Revocation fail-closed on the enforcement hot path (WF-001, last gate)

Closes the final WF-001 enterprise-hardening gate: a **revoked managed skill can no longer be executed by suppressing the revocation set** (network blackhole, stale cache, or a truncated/forged fetched set). Maps to `THREAT_MODEL.md` **R01** (revocation-bypass).

### The hole (before)
On the per-invocation verify hook, a *stale* revoked cache under managed trust roots fell through to `cachedAllow` — an attacker who blackholed the registry (so the cache never refreshed) could keep running a skill that had already been revoked. The sweep discarded the `online` bool (`revoked, _ := …`) and silently used last-known-good, so a **truncated/forged** fetched set (set-root mismatch) was accepted rather than escalated.

### The closure
- **Hot path** (`verify_hook_cmds.go`): under managed + stale cache, do a **bounded 3 s** online refresh; if the set is unavailable and there is no *authenticated* grace, `emitDeny(exitRevocationStale=22)` — **before** `cachedAllow`. The fresh path performs **no fetch** (zero added latency).
- **Bounded refresh** (`revoked_cache.go`): `boundedHotPathRevoked` (3 s timeout, buffered channel → no goroutine leak; inner fetch self-terminates on the 15 s client timeout). `fetchRevokedOnline` now returns `(set, online, error)`; a set-root mismatch (F1: truncated/forged set) returns `online=false` and escalates to the fail-closed path instead of silently using last-known-good.
- **Authenticated grace** (`graceAuthenticated`): grace opens only on a **verified signed HEAD** + authenticated `issued_at` (<12 h) + set-root binding **+ a monotonic epoch floor** (this PR) — see R01-B below. Unforgeable by a same-uid `fetched_at` rewrite.
- **Corrupt trust-roots** (`selfTrustPosture`): a present-but-unparseable trust-roots file is treated as **managed → fail-closed** (not silently downgraded to unmanaged/fail-open).
- **Sweep** (`verify_all_cmds.go`): per-skill fail-closed (exit 22) on the unavailable signal; test no longer relies on an incidental digest-mismatch exit.

### Pre-PR polish (this branch, `35f25ea`)
1. **R01-B epoch-floor rollback guard** — `graceAuthenticated` now also requires `HeadEpoch(head) >= readRevokedCacheHead(home).epoch` (the same high-water clamp the reader applies). A validly-signed but **rolled-back** HEAD (epoch below high-water, `issued_at` still fresh) can no longer resurrect an already-adopted revoke for a TTL window. Unreadable epoch → fail-closed. New bite subtest establishes high-water epoch 2, presents a signed epoch-1 HEAD, asserts grace stays closed (verified it opens when the clamp is removed).
2. **R01-C doc honesty** — reworded the `selfTrustPosture` comment: corruption fails closed (the closed vector); genuine absence is unmanaged/fail-open **by design** (first-run/dev); a same-uid **delete** of `trust-roots.yaml` yields the absent state and is the **accepted same-uid-substrate residual** (FR-0045 / g5 scope), explicitly **not** claimed closed. No behavior change.
3. **Exit-code consistency** — `revoke feed --refresh` now returns `exitRevocationStale` (22) on the managed fail-closed signal (was 1), so operator scripts keying on 22 catch all three sites (sweep + hook + feed).

### Adversarial re-gate (2 lenses, both CLEARED)
- **infosec-pentest-agent**: "the flagged hot-path hole is genuinely closed" — bounded refresh, real `emitDeny` before `cachedAllow`, no new SSRF client / goroutine leak / hang, corrupt-roots solid, no pre-D2 brick.
- **security-reviewer**: **"CLEARED — safe to merge"** — all sub-fixes real, every claimed test bites (each reverted in an isolated throwaway worktree → matching test FAILs), no silent fail-open reintroduced, and the change **strengthens** the pre-existing F1 (truncated-set) handling. Full regression: 32 packages `ok`.

The first re-gate (before `790dfaa`) **refuted** an earlier "closure" claim (the hook path still ran revoked skills, grace was forgeable, corrupt-roots downgraded, test-theater) — all fixed in `790dfaa`, re-gate re-run clean.

### Accepted residuals (same-uid substrate ceiling — FR-0045 / g5, documented not fixed)
These require an attacker already executing as the same uid that owns the trust store, i.e. the accepted substrate ceiling ("fail-closed vs feed/transport, **not** same-uid tamper-proof" — the S-claim is scoped accordingly), and are **not** regressions of this fix:
- hot-path *fresh*-cache (`fetched_at` <12 h) is trusted without a signature (identical to pre-fix; the sweep re-authenticates or fails closed);
- same-uid **delete** of `trust-roots.yaml` → absent → unmanaged (tombstone delete-detection = future hardening);
- `installedSkillDigest` resolves from sidecars only (`dig==""` skips membership if both sidecars are removed) — `.skb`-hash fallback is follow-up;
- unmanaged/allowlist `allow()` returns before the revoked check.
- pre-existing `er1Get` default-redirect X-API-KEY leak (fix belongs in `er1Get`, out of scope here).

### Verification
`go build ./...` · `go vet ./cmd/skillctl/...` · `go test -count=1 ./cmd/skillctl/... ./pkg/skillctl/...` — 32 packages `ok`, 0 failures. gofmt-clean. No merge conflicts with current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
