### PR TITLE
feat(skillctl): FR-0109 — audit-event envelope, taxonomy, sink+dispatcher (SPEC-0403)

### DIFF
--- a/pkg/skillctl/auditevent/event.go
+++ b/pkg/skillctl/auditevent/event.go
@@ -1,0 +1,280 @@
+// Package auditevent is the FR-0109 foundation of SPEC-0403 (skillctl Audit
+// Event Layer): the ONE shared, versioned audit-event envelope, its taxonomy,
+// a redaction step, a Sink abstraction and a Dispatcher.
+//
+// SCOPE (FR-0109 only). This package defines WHAT an audit event IS: the
+// envelope (§3), the taxonomy (§4), the default infrastructure-free file sink
+// and the redaction/data-minimization step (§5/§5.1), plus the Event → Dispatcher
+// → Sink seam (§7.2) so transport stays separate from event creation. It does
+// NOT own durability or delivery modes (best-effort / durable / required,
+// FR-0110, §6), the outbox itself (SPEC-0317 owns it, §7.1: this package writes
+// INTO it via a future OutboxSink, it does not build a second store), a Kafka
+// sink (FR-0112, EC-blocked, §7.2) or any CLI verb (skillctl auditlog, FR-0111,
+// §8). The Sink interface below is deliberately shaped so an outbox-backed
+// durable sink slots in without a signature change.
+//
+// RELATION TO SPEC-0383 (§3.1). skillctl.audit.v1 is an EXPRESSION within the
+// decision-event family, not a competitor: audit events are the capability.*
+// stream. This package owns the audit envelope; the transport hull and fleet
+// egress (SPEC-0351 / SPEC-0383 T2) are out of scope here.
+//
+// NOT AN EVIDENCE RECORD (REQ-1.2 / AUD-08). An Event in this package is an
+// accountability record, not cryptographic evidence. It carries no signature in
+// v1 (the optional hash-chain / signature fields of §9 are deferred); a line in
+// a log is never, by itself, verified evidence.
+package auditevent
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// SchemaV1 is the versioned schema tag every v1 audit event carries. It is a
+// value at a fixed field, so a future format change is a value change; not a
+// silent reinterpretation (REQ-3.1 / REQ-4.2).
+const SchemaV1 = "skillctl.audit.v1"
+
+// ErrInvalidEvent is the sentinel wrapped by Validate for every rejection, so
+// callers can errors.Is it without matching on message text.
+var ErrInvalidEvent = errors.New("auditevent: invalid event")
+
+// SkillRef identifies the skill an event concerns (REQ-3.2 skill.{name,version,digest}).
+type SkillRef struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+	Digest  string `json:"digest,omitempty"` // sha256:<hex> of the bundle.
+}
+
+// ActorRef identifies the workload or human that performed the action
+// (REQ-3.2 actor.{type,id}).
+type ActorRef struct {
+	Type string `json:"type,omitempty"` // e.g. workload | human | gate.
+	ID   string `json:"id,omitempty"`
+}
+
+// PrincipalRef identifies the security principal on whose behalf the action ran
+// (REQ-3.2 principal.id).
+type PrincipalRef struct {
+	ID string `json:"id,omitempty"`
+}
+
+// ResourceRef identifies the resource acted upon (REQ-3.2 resource.{type,id}).
+type ResourceRef struct {
+	Type string `json:"type,omitempty"`
+	ID   string `json:"id,omitempty"`
+}
+
+// PolicyRef carries the policy identity and its decision, using the SPEC-0247 /
+// SPEC-0255 vocabulary (allow · deny · quarantine · leave) verbatim so no
+// information is lost when the taxonomy classifies the event (REQ-3.2 / REQ-4.3).
+type PolicyRef struct {
+	ID       string `json:"id,omitempty"`
+	Decision string `json:"decision,omitempty"`
+}
+
+// ReferenceRef identifies a bound reference document by source and digest; never
+// its contents (REQ-3.2 reference.{source,digest}; REQ-5.4 forbids the full doc).
+type ReferenceRef struct {
+	Source string `json:"source,omitempty"`
+	Digest string `json:"digest,omitempty"`
+}
+
+// CapabilityRef identifies the capability an event concerns, against the
+// SPEC-0402 vocabulary (REQ-3.2 capability.{type,name}; REQ-4.3).
+type CapabilityRef struct {
+	Type string `json:"type,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// ErrorRef carries a stable error code and category; never a raw error string
+// that might embed a secret (REQ-3.2 error.{code,category}).
+type ErrorRef struct {
+	Code     string `json:"code,omitempty"`
+	Category string `json:"category,omitempty"`
+}
+
+// Event is the shared, versioned audit envelope (SPEC-0403 §3). The first seven
+// fields are MANDATORY (REQ-3.1); the rest are optional and applied where
+// meaningful (REQ-3.2). Unknown optional fields on the wire are tolerated and
+// preserved in Ext (REQ-3.3); JSON Lines is the canonical representation (REQ-3.4).
+type Event struct {
+	// --- mandatory (REQ-3.1) ---
+
+	Schema    string    `json:"schema"`     // SchemaV1.
+	Timestamp string    `json:"timestamp"`  // RFC3339 UTC, millisecond precision.
+	EventID   string    `json:"event_id"`   // ULID-like, stable per event (AUD-04).
+	EventType EventType `json:"event_type"` // a taxonomy constant (REQ-4.1).
+	Outcome   Outcome   `json:"outcome"`    // success | failure | deny | error.
+	Severity  Severity  `json:"severity"`   // info | notice | warning | error | critical.
+	Producer  string    `json:"producer"`   // e.g. skillctl/0.4.0.
+
+	// --- optional, applied where meaningful (REQ-3.2) ---
+
+	Message       string         `json:"message,omitempty"` // short human-readable note; never a full prompt/response (REQ-5.4).
+	Skill         *SkillRef      `json:"skill,omitempty"`
+	Actor         *ActorRef      `json:"actor,omitempty"`
+	Principal     *PrincipalRef  `json:"principal,omitempty"`
+	InvocationID  string         `json:"invocation_id,omitempty"`
+	SessionID     string         `json:"session_id,omitempty"`
+	CorrelationID string         `json:"correlation_id,omitempty"`
+	Resource      *ResourceRef   `json:"resource,omitempty"`
+	Policy        *PolicyRef     `json:"policy,omitempty"`
+	Reference     *ReferenceRef  `json:"reference,omitempty"`
+	Capability    *CapabilityRef `json:"capability,omitempty"`
+	Error         *ErrorRef      `json:"error,omitempty"`
+
+	// Ext captures extension / unknown top-level fields so an event a newer
+	// producer wrote does not break an older consumer, and a producer's own
+	// extension fields survive a round-trip (REQ-3.3). An Ext key that collides
+	// with a canonical field name is dropped on marshal; a canonical field can
+	// never be shadowed. Ext is NOT emitted under its own key; its entries are
+	// merged at the top level.
+	Ext map[string]json.RawMessage `json:"-"`
+}
+
+// knownEventKeys is the set of canonical top-level JSON keys. UnmarshalJSON
+// removes these from the raw object; whatever remains is an extension field
+// captured in Ext (REQ-3.3). Keep in sync with the struct tags above.
+var knownEventKeys = map[string]struct{}{
+	"schema": {}, "timestamp": {}, "event_id": {}, "event_type": {},
+	"outcome": {}, "severity": {}, "producer": {}, "message": {},
+	"skill": {}, "actor": {}, "principal": {}, "invocation_id": {},
+	"session_id": {}, "correlation_id": {}, "resource": {}, "policy": {},
+	"reference": {}, "capability": {}, "error": {},
+}
+
+// New builds a v1 Event with the mandatory envelope stamped: SchemaV1, an RFC3339
+// millisecond UTC timestamp, and a fresh ULID-like event_id. The optional fields
+// are filled by the caller. Producer is required by Validate; pass e.g.
+// ProducerString(version).
+func New(eventType EventType, outcome Outcome, severity Severity, producer string) *Event {
+	return &Event{
+		Schema:    SchemaV1,
+		Timestamp: time.Now().UTC().Format(timestampLayout),
+		EventID:   NewEventID(),
+		EventType: eventType,
+		Outcome:   outcome,
+		Severity:  severity,
+		Producer:  producer,
+	}
+}
+
+// ProducerString formats a producer tag as "skillctl/<version>" (REQ-3.1). An
+// empty version yields the bare component name.
+func ProducerString(version string) string {
+	if version == "" {
+		return "skillctl"
+	}
+	return "skillctl/" + version
+}
+
+// timestampLayout is RFC3339 with millisecond precision and a Z zone, matching
+// the §3 example (2026-09-03T21:41:22.318Z).
+const timestampLayout = "2006-01-02T15:04:05.000Z07:00"
+
+// Validate enforces the mandatory envelope (REQ-3.1) and the controlled
+// vocabularies (REQ-4.1 event_type, outcome, severity). It returns an error
+// wrapping ErrInvalidEvent. Unknown OPTIONAL fields never fail validation
+// (REQ-3.3); they live in Ext and are ignored here.
+func (e *Event) Validate() error {
+	if e == nil {
+		return fmt.Errorf("%w: nil event", ErrInvalidEvent)
+	}
+	switch {
+	case e.Schema == "":
+		return fmt.Errorf("%w: missing schema", ErrInvalidEvent)
+	case e.Timestamp == "":
+		return fmt.Errorf("%w: missing timestamp", ErrInvalidEvent)
+	case e.EventID == "":
+		return fmt.Errorf("%w: missing event_id", ErrInvalidEvent)
+	case e.EventType == "":
+		return fmt.Errorf("%w: missing event_type", ErrInvalidEvent)
+	case e.Outcome == "":
+		return fmt.Errorf("%w: missing outcome", ErrInvalidEvent)
+	case e.Severity == "":
+		return fmt.Errorf("%w: missing severity", ErrInvalidEvent)
+	case e.Producer == "":
+		return fmt.Errorf("%w: missing producer", ErrInvalidEvent)
+	}
+	if !IsKnownEventType(e.EventType) {
+		return fmt.Errorf("%w: unknown event_type %q", ErrInvalidEvent, e.EventType)
+	}
+	if !IsKnownOutcome(e.Outcome) {
+		return fmt.Errorf("%w: unknown outcome %q", ErrInvalidEvent, e.Outcome)
+	}
+	if !IsKnownSeverity(e.Severity) {
+		return fmt.Errorf("%w: unknown severity %q", ErrInvalidEvent, e.Severity)
+	}
+	return nil
+}
+
+// MarshalJSON emits the canonical single-object form (REQ-3.4). Extension fields
+// in Ext are merged at the top level; a key that collides with a canonical field
+// is dropped so a canonical field is never shadowed. Output key order is
+// deterministic (encoding/json sorts map keys) so two identical events serialize
+// to byte-identical lines.
+func (e Event) MarshalJSON() ([]byte, error) {
+	type alias Event // alias drops the MarshalJSON method and (via json:"-") Ext.
+	base, err := json.Marshal(alias(e))
+	if err != nil {
+		return nil, err
+	}
+	if len(e.Ext) == 0 {
+		return base, nil
+	}
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(base, &merged); err != nil {
+		return nil, err
+	}
+	for k, v := range e.Ext {
+		if _, isCanonical := knownEventKeys[k]; isCanonical {
+			continue // never let an extension key shadow a canonical field.
+		}
+		merged[k] = v
+	}
+	return json.Marshal(merged)
+}
+
+// UnmarshalJSON is tolerant (REQ-3.3): unknown optional fields never fail the
+// parse; they are captured in Ext and survive a re-marshal. Known fields are
+// decoded normally.
+func (e *Event) UnmarshalJSON(data []byte) error {
+	type alias Event
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*e = Event(a)
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	for k := range knownEventKeys {
+		delete(raw, k)
+	}
+	if len(raw) > 0 {
+		e.Ext = raw
+	} else {
+		e.Ext = nil
+	}
+	return nil
+}
+
+// SetExt stores one extension field, marshaling v to JSON. A key that collides
+// with a canonical field name is refused (it would be dropped on marshal anyway).
+func (e *Event) SetExt(key string, v any) error {
+	if _, isCanonical := knownEventKeys[key]; isCanonical {
+		return fmt.Errorf("%w: extension key %q collides with a canonical field", ErrInvalidEvent, key)
+	}
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("auditevent: marshal ext %q: %w", key, err)
+	}
+	if e.Ext == nil {
+		e.Ext = make(map[string]json.RawMessage, 1)
+	}
+	e.Ext[key] = raw
+	return nil
+}

--- a/pkg/skillctl/auditevent/event_test.go
+++ b/pkg/skillctl/auditevent/event_test.go
@@ -1,0 +1,164 @@
+package auditevent
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestEventRoundTripStable proves marshal -> unmarshal -> marshal is byte-stable
+// for a fully-populated envelope, including nested refs and extension fields
+// (REQ-3.4 canonical JSONL, REQ-3.3 extension fields survive).
+func TestEventRoundTripStable(t *testing.T) {
+	e := New(EventSkillVerify, OutcomeSuccess, SeverityInfo, "skillctl/0.4.0")
+	e.Message = "Skill artifact successfully verified"
+	e.Skill = &SkillRef{Name: "compliance-review", Version: "2.3.1", Digest: "sha256:abc"}
+	e.Actor = &ActorRef{Type: "workload", ID: "agent://legal-reviewer"}
+	e.Principal = &PrincipalRef{ID: "principal-1"}
+	e.InvocationID = "inv_123"
+	e.SessionID = "sess_9"
+	e.CorrelationID = "corr_7"
+	e.Resource = &ResourceRef{Type: "skill", ID: "compliance-review"}
+	e.Policy = &PolicyRef{ID: "pol-1", Decision: "allow"}
+	e.Reference = &ReferenceRef{Source: "ref://doc", Digest: "sha256:def"}
+	e.Capability = &CapabilityRef{Type: "egress", Name: "network"}
+	e.Error = &ErrorRef{Code: "none", Category: "none"}
+	if err := e.SetExt("trace_id", "otel-abc"); err != nil {
+		t.Fatalf("SetExt: %v", err)
+	}
+
+	b1, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal 1: %v", err)
+	}
+	var e2 Event
+	if err := json.Unmarshal(b1, &e2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	b2, err := json.Marshal(&e2)
+	if err != nil {
+		t.Fatalf("marshal 2: %v", err)
+	}
+	if !bytes.Equal(b1, b2) {
+		t.Fatalf("round-trip not stable:\n b1=%s\n b2=%s", b1, b2)
+	}
+	// The extension field must have survived into Ext.
+	if _, ok := e2.Ext["trace_id"]; !ok {
+		t.Fatalf("extension field trace_id lost on round-trip; ext=%v", e2.Ext)
+	}
+}
+
+// TestUnknownOptionalFieldTolerated is REQ-3.3: an unknown optional field must
+// NOT invalidate an otherwise valid event, and it must survive a re-marshal.
+func TestUnknownOptionalFieldTolerated(t *testing.T) {
+	raw := `{
+	  "schema": "skillctl.audit.v1",
+	  "timestamp": "2026-09-03T21:41:22.318Z",
+	  "event_id": "01K0000000000000000000TEST",
+	  "event_type": "skill.verify",
+	  "outcome": "success",
+	  "severity": "info",
+	  "producer": "skillctl/9.9.9",
+	  "some_future_field": {"nested": [1,2,3]},
+	  "another_new_scalar": 42
+	}`
+	var e Event
+	if err := json.Unmarshal([]byte(raw), &e); err != nil {
+		t.Fatalf("tolerant unmarshal must not error: %v", err)
+	}
+	if err := e.Validate(); err != nil {
+		t.Fatalf("unknown optional fields must not fail validation: %v", err)
+	}
+	if e.EventType != EventSkillVerify {
+		t.Fatalf("known field corrupted: event_type=%q", e.EventType)
+	}
+	if _, ok := e.Ext["some_future_field"]; !ok {
+		t.Fatalf("unknown field not captured in Ext: %v", e.Ext)
+	}
+	out, err := json.Marshal(&e)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	if !strings.Contains(string(out), "some_future_field") ||
+		!strings.Contains(string(out), "another_new_scalar") {
+		t.Fatalf("extension fields not preserved on re-marshal: %s", out)
+	}
+}
+
+// TestValidateMandatoryFields is the mandatory-field contract (REQ-3.1) plus the
+// controlled vocabularies (REQ-4.1). Every mutation of a valid baseline that
+// drops a mandatory field or uses an unknown vocabulary value must be rejected.
+func TestValidateMandatoryFields(t *testing.T) {
+	base := func() *Event {
+		return &Event{
+			Schema: SchemaV1, Timestamp: "2026-09-03T21:41:22.318Z",
+			EventID: "01K0000000000000000000TEST", EventType: EventSkillVerify,
+			Outcome: OutcomeSuccess, Severity: SeverityInfo, Producer: "skillctl/x",
+		}
+	}
+	if err := base().Validate(); err != nil {
+		t.Fatalf("baseline must be valid: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		mut  func(*Event)
+	}{
+		{"no schema", func(e *Event) { e.Schema = "" }},
+		{"no timestamp", func(e *Event) { e.Timestamp = "" }},
+		{"no event_id", func(e *Event) { e.EventID = "" }},
+		{"no event_type", func(e *Event) { e.EventType = "" }},
+		{"no outcome", func(e *Event) { e.Outcome = "" }},
+		{"no severity", func(e *Event) { e.Severity = "" }},
+		{"no producer", func(e *Event) { e.Producer = "" }},
+		{"unknown event_type", func(e *Event) { e.EventType = "skill.teleport" }},
+		{"unknown outcome", func(e *Event) { e.Outcome = "maybe" }},
+		{"unknown severity", func(e *Event) { e.Severity = "loud" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := base()
+			tc.mut(e)
+			err := e.Validate()
+			if err == nil {
+				t.Fatalf("expected rejection")
+			}
+			if !errors.Is(err, ErrInvalidEvent) {
+				t.Fatalf("error must wrap ErrInvalidEvent: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateNilEvent covers the nil receiver path.
+func TestValidateNilEvent(t *testing.T) {
+	var e *Event
+	if err := e.Validate(); !errors.Is(err, ErrInvalidEvent) {
+		t.Fatalf("nil event must be invalid: %v", err)
+	}
+}
+
+// TestExtCannotShadowCanonicalField proves an extension key colliding with a
+// canonical field is refused by SetExt and dropped on marshal (a canonical field
+// is never overwritten by an extension).
+func TestExtCannotShadowCanonicalField(t *testing.T) {
+	e := New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	if err := e.SetExt("event_type", "attacker.controlled"); err == nil {
+		t.Fatalf("SetExt of a canonical key must error")
+	}
+	// Force a colliding key directly into Ext and prove marshal drops it.
+	e.Ext = map[string]json.RawMessage{"event_type": json.RawMessage(`"attacker.controlled"`)}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["event_type"] != string(EventPolicyAllow) {
+		t.Fatalf("canonical event_type was shadowed by an extension key: %q", got["event_type"])
+	}
+}

--- a/pkg/skillctl/auditevent/eventid.go
+++ b/pkg/skillctl/auditevent/eventid.go
@@ -1,0 +1,107 @@
+package auditevent
+
+// eventid.go: a dependency-free, ULID-like event_id generator (REQ-3.1 /
+// AUD-04). event_id is the stable identity used for dedup downstream (REQ-6.2):
+// a 48-bit millisecond timestamp prefix makes ids time-ordered and lexically
+// sortable, an 80-bit crypto/rand suffix makes them unique. Within a single
+// millisecond the suffix is incremented so ids stay strictly monotonic even
+// under a tight loop. No ULID library is pulled in; the encoding is ~40 lines
+// of stdlib.
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"sync"
+	"time"
+)
+
+// crockford is the Crockford base32 alphabet (no I, L, O, U). 128 bits encode to
+// 26 characters, matching the canonical ULID string form (e.g. 01K...).
+const crockford = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+// idState carries the monotonic generator state behind a mutex.
+var idState struct {
+	mu      sync.Mutex
+	lastMS  uint64
+	lastEnt [10]byte
+}
+
+// Test seams (production defaults). idNow pins the clock; idRandRead pins the
+// entropy source. Both are package-level so a test can make NewEventID
+// deterministic without a build tag.
+var (
+	idNow      = func() time.Time { return time.Now().UTC() }
+	idRandRead = rand.Read
+)
+
+// NewEventID returns a fresh ULID-like 26-character event id. It is safe for
+// concurrent use and strictly monotonic within a process.
+func NewEventID() string {
+	idState.mu.Lock()
+	defer idState.mu.Unlock()
+
+	ms := uint64(idNow().UnixMilli())
+	var ent [10]byte
+
+	if ms <= idState.lastMS {
+		// Same or backwards clock: hold the timestamp and increment the previous
+		// 80-bit entropy as a big-endian counter so the id still advances.
+		ms = idState.lastMS
+		ent = idState.lastEnt
+		incr80(&ent)
+	} else if _, err := idRandRead(ent[:]); err != nil {
+		// crypto/rand should not fail; if it does, derive a non-repeating suffix
+		// from the previous one so ids stay unique rather than aborting.
+		ent = idState.lastEnt
+		incr80(&ent)
+	}
+
+	idState.lastMS = ms
+	idState.lastEnt = ent
+
+	// Assemble 16 bytes: a 48-bit big-endian millisecond timestamp then 80 bits
+	// of entropy. binary.BigEndian keeps the byte extraction inside the stdlib
+	// (no hand-rolled uint64->byte truncation).
+	var b [16]byte
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], ms)
+	copy(b[0:6], ts[2:]) // low 48 bits = the millisecond timestamp.
+	copy(b[6:], ent[:])
+	return encodeULID(b)
+}
+
+// incr80 increments a 10-byte (80-bit) big-endian counter, wrapping on overflow.
+func incr80(e *[10]byte) {
+	for i := len(e) - 1; i >= 0; i-- {
+		e[i]++
+		if e[i] != 0 {
+			return
+		}
+	}
+}
+
+// encodeULID renders 128 bits (16 bytes) as 26 Crockford base32 characters,
+// most-significant bits first. The 130-bit output space is left-padded with two
+// zero bits, so the first character is limited to 0–7; exactly the canonical
+// ULID layout.
+func encodeULID(b [16]byte) string {
+	var out [26]byte
+	for i := 0; i < 26; i++ {
+		var v uint
+		for j := 0; j < 5; j++ {
+			pos := i*5 + j  // position in the 130-bit padded stream.
+			real := pos - 2 // position in the 128-bit value (first 2 bits are pad).
+			v <<= 1
+			if real >= 0 {
+				v |= bitAt(b, real)
+			}
+		}
+		out[i] = crockford[v]
+	}
+	return string(out[:])
+}
+
+// bitAt returns bit k of b, counting k=0 as the most-significant bit of b[0].
+func bitAt(b [16]byte, k int) uint {
+	return uint(b[k/8]>>(7-uint(k%8))) & 1
+}

--- a/pkg/skillctl/auditevent/eventid_test.go
+++ b/pkg/skillctl/auditevent/eventid_test.go
@@ -1,0 +1,101 @@
+package auditevent
+
+import (
+	"sort"
+	"testing"
+	"time"
+)
+
+// restoreIDSeams resets the generator seams and monotonic state after a test
+// that pinned them, so tests stay order-independent.
+func restoreIDSeams(t *testing.T) {
+	t.Helper()
+	realNow, realRand := idNow, idRandRead
+	t.Cleanup(func() {
+		idNow, idRandRead = realNow, realRand
+		idState.mu.Lock()
+		idState.lastMS, idState.lastEnt = 0, [10]byte{}
+		idState.mu.Unlock()
+	})
+}
+
+// TestNewEventIDFormat checks length and alphabet: 26 Crockford base32 chars.
+func TestNewEventIDFormat(t *testing.T) {
+	id := NewEventID()
+	if len(id) != 26 {
+		t.Fatalf("event id length: got %d want 26 (%q)", len(id), id)
+	}
+	for i, r := range id {
+		if strIndex(crockford, byte(r)) < 0 {
+			t.Fatalf("id[%d]=%q not in Crockford alphabet (%q)", i, string(r), id)
+		}
+	}
+}
+
+// TestNewEventIDUniqueAndMonotonic proves ids are unique and lexically sortable
+// in generation order, INCLUDING many draws inside a single pinned millisecond
+// (the monotonic-increment path). This backs AUD-04 (stable, ordered identity).
+func TestNewEventIDUniqueAndMonotonic(t *testing.T) {
+	restoreIDSeams(t)
+	// Pin the clock to one instant so every id shares a timestamp prefix and the
+	// only thing that can advance them is the 80-bit monotonic counter.
+	fixed := time.Date(2099, 1, 2, 3, 4, 5, 0, time.UTC)
+	idNow = func() time.Time { return fixed }
+	// Reset monotonic state so the first draw takes a fresh random suffix.
+	idState.mu.Lock()
+	idState.lastMS, idState.lastEnt = 0, [10]byte{}
+	idState.mu.Unlock()
+
+	const n = 2000
+	ids := make([]string, n)
+	seen := make(map[string]struct{}, n)
+	for i := 0; i < n; i++ {
+		id := NewEventID()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("duplicate id at %d: %q", i, id)
+		}
+		seen[id] = struct{}{}
+		ids[i] = id
+	}
+	if !sort.StringsAreSorted(ids) {
+		t.Fatalf("ids within one millisecond are not monotonically increasing")
+	}
+}
+
+// TestNewEventIDBackwardsClock proves a clock that goes backwards still yields
+// advancing (unique, ordered) ids instead of colliding.
+func TestNewEventIDBackwardsClock(t *testing.T) {
+	restoreIDSeams(t)
+	idState.mu.Lock()
+	idState.lastMS, idState.lastEnt = 0, [10]byte{}
+	idState.mu.Unlock()
+
+	seq := []time.Time{
+		time.Date(2099, 5, 5, 5, 5, 5, 0, time.UTC),
+		time.Date(2099, 5, 5, 5, 5, 4, 0, time.UTC), // one second BACK.
+		time.Date(2099, 5, 5, 5, 5, 3, 0, time.UTC), // and again.
+	}
+	i := 0
+	idNow = func() time.Time { tt := seq[i]; return tt }
+
+	var got []string
+	for i = 0; i < len(seq); i++ {
+		got = append(got, NewEventID())
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Fatalf("backwards clock broke monotonicity: %v", got)
+	}
+	if got[0] == got[1] || got[1] == got[2] {
+		t.Fatalf("backwards clock produced a collision: %v", got)
+	}
+}
+
+// strIndex returns the index of b in s, or -1.
+func strIndex(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/skillctl/auditevent/filesink.go
+++ b/pkg/skillctl/auditevent/filesink.go
@@ -1,0 +1,129 @@
+package auditevent
+
+// filesink.go: the default, infrastructure-free sinks (SPEC-0403 §5). Audit
+// logging is on by default and works with no external infrastructure (REQ-5.1);
+// the standard targets are file, stderr and stdout (REQ-5.2). JSON Lines is the
+// canonical form; one event object per line (REQ-3.4). Files are created with
+// restrictive, platform-appropriate permissions; the landed 0o600 append path
+// is the reference (REQ-5.3), matching cmd/skillctl/gate_audit.go and
+// pkg/skillctl/outbox/spool.go.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// DefaultFileSinkMaxBytes bounds a FileSink's live file; beyond it the file is
+// rotated to "<path>.1" (single generation) so disk use stays bounded, mirroring
+// the SPEC-0255 gate-audit rotation.
+const DefaultFileSinkMaxBytes int64 = 5 << 20 // 5 MiB.
+
+// FileSink appends redacted audit events as JSON Lines to a single file. It is
+// the §5 default local sink. Safe for concurrent Write via an internal mutex.
+type FileSink struct {
+	path     string
+	maxBytes int64
+	mu       sync.Mutex
+}
+
+// NewFileSink returns a FileSink writing JSONL to path. The parent directory is
+// created 0o700 on first Write. maxBytes ≤ 0 selects DefaultFileSinkMaxBytes.
+// An empty path is an error (there is nowhere to write).
+func NewFileSink(path string, maxBytes int64) (*FileSink, error) {
+	if path == "" {
+		return nil, fmt.Errorf("auditevent: file sink needs a path")
+	}
+	if maxBytes <= 0 {
+		maxBytes = DefaultFileSinkMaxBytes
+	}
+	return &FileSink{path: path, maxBytes: maxBytes}, nil
+}
+
+// Name identifies the sink as "file:<path>" for observability (FR-0111).
+func (f *FileSink) Name() string { return "file:" + f.path }
+
+// Write appends one event as a single JSON line. It creates the parent directory
+// (0o700) and the file (0o600) as needed, rotating first if the file has reached
+// maxBytes. A best-effort rotation race only costs one extra line in the old
+// generation; the record is advisory, never load-bearing.
+func (f *FileSink) Write(e *Event) error {
+	if e == nil {
+		return fmt.Errorf("auditevent: file sink: nil event")
+	}
+	line, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("auditevent: file sink: marshal: %w", err)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	dir := filepath.Dir(f.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("auditevent: file sink: mkdir: %w", err)
+	}
+	if fi, err := os.Stat(f.path); err == nil && fi.Size() >= f.maxBytes {
+		_ = os.Rename(f.path, f.path+".1") // best-effort rotation; a lost race is harmless.
+	}
+	// #nosec G304 -- the audit sink path is operator-configured (SPEC-0403 §5,
+	// REQ-5.3), not attacker-influenced; opened append-only 0o600, same pattern
+	// as the landed gate_audit.go / outbox spool sinks.
+	fh, err := os.OpenFile(f.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("auditevent: file sink: open: %w", err)
+	}
+	if _, err := fh.Write(append(line, '\n')); err != nil {
+		_ = fh.Close() // returning the write error; close is best-effort on the failure path.
+		return fmt.Errorf("auditevent: file sink: write: %w", err)
+	}
+	if err := fh.Close(); err != nil {
+		return fmt.Errorf("auditevent: file sink: close: %w", err)
+	}
+	return nil
+}
+
+// Close is a no-op: FileSink holds no long-lived handle (it opens and closes per
+// Write so a rotation or external truncation is always observed).
+func (f *FileSink) Close() error { return nil }
+
+// WriterSink emits redacted audit events as JSON Lines to any io.Writer; the
+// stderr / stdout targets of REQ-5.2. It never closes the underlying writer
+// (stderr/stdout are process-owned). Safe for concurrent Write via a mutex.
+type WriterSink struct {
+	name string
+	w    io.Writer
+	mu   sync.Mutex
+}
+
+// NewWriterSink returns a WriterSink writing JSONL to w. name labels it for
+// observability, e.g. "stderr".
+func NewWriterSink(name string, w io.Writer) *WriterSink {
+	return &WriterSink{name: name, w: w}
+}
+
+// Name identifies the sink for observability (FR-0111).
+func (s *WriterSink) Name() string { return s.name }
+
+// Write emits one event as a single JSON line to the underlying writer.
+func (s *WriterSink) Write(e *Event) error {
+	if e == nil {
+		return fmt.Errorf("auditevent: writer sink: nil event")
+	}
+	line, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("auditevent: writer sink: marshal: %w", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := s.w.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("auditevent: writer sink: write: %w", err)
+	}
+	return nil
+}
+
+// Close is a no-op: the underlying writer is process-owned and not closed here.
+func (s *WriterSink) Close() error { return nil }

--- a/pkg/skillctl/auditevent/filesink_test.go
+++ b/pkg/skillctl/auditevent/filesink_test.go
@@ -1,0 +1,139 @@
+package auditevent
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestFileSinkWritesJSONL proves the default sink writes one well-formed JSON
+// object per line (REQ-3.4) to a temp dir, with the parent directory created.
+func TestFileSinkWritesJSONL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "audit.jsonl") // parent must be created.
+	fs, err := NewFileSink(path, 0)
+	if err != nil {
+		t.Fatalf("NewFileSink: %v", err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+
+	want := []EventType{EventSkillVerify, EventPolicyDeny, EventInvocationComplete}
+	var ids []string
+	for _, et := range want {
+		e := New(et, OutcomeSuccess, SeverityInfo, "skillctl/x")
+		ids = append(ids, e.EventID)
+		if err := fs.Write(e); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	f, err := os.Open(path) //nolint:gosec // test-controlled temp path.
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	var got []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var e Event
+		if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
+			t.Fatalf("line is not valid JSON: %v (%q)", err, sc.Text())
+		}
+		if err := e.Validate(); err != nil {
+			t.Fatalf("persisted line is not a valid event: %v", err)
+		}
+		got = append(got, e.EventID)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(got) != len(ids) {
+		t.Fatalf("line count: got %d want %d", len(got), len(ids))
+	}
+	for i := range ids {
+		if got[i] != ids[i] {
+			t.Fatalf("line %d id: got %q want %q (order/content mismatch)", i, got[i], ids[i])
+		}
+	}
+}
+
+// TestFileSinkRotates proves the file is rotated to "<path>.1" once it reaches
+// maxBytes, bounding disk use.
+func TestFileSinkRotates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	fs, err := NewFileSink(path, 1) // 1 byte cap: rotate before the 2nd write.
+	if err != nil {
+		t.Fatalf("NewFileSink: %v", err)
+	}
+	e := New(EventSkillVerify, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	if err := fs.Write(e); err != nil {
+		t.Fatalf("write 1: %v", err)
+	}
+	if err := fs.Write(e); err != nil {
+		t.Fatalf("write 2: %v", err)
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Fatalf("expected rotated generation %q: %v", path+".1", err)
+	}
+}
+
+// TestFileSinkPerms proves the file is created 0600 (REQ-5.3) on POSIX. Skipped
+// on Windows where the numeric mode is not the relevant control (ACLs are).
+func TestFileSinkPerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX mode bits not meaningful on Windows (ACL discussion, REQ-5.3)")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	fs, err := NewFileSink(path, 0)
+	if err != nil {
+		t.Fatalf("NewFileSink: %v", err)
+	}
+	if err := fs.Write(New(EventConfigChange, OutcomeSuccess, SeverityInfo, "skillctl/x")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Fatalf("file perms: got %o want 0600", got)
+	}
+}
+
+// TestFileSinkEmptyPath proves an empty path is refused.
+func TestFileSinkEmptyPath(t *testing.T) {
+	if _, err := NewFileSink("", 0); err == nil {
+		t.Fatalf("empty path must be an error")
+	}
+}
+
+// TestWriterSinkJSONL proves the stream sink emits one JSON line per event.
+func TestWriterSinkJSONL(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewWriterSink("stderr", &buf)
+	if err := s.Write(New(EventSkillVerify, OutcomeSuccess, SeverityInfo, "skillctl/x")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := s.Write(New(EventPolicyDeny, OutcomeDeny, SeverityWarning, "skillctl/x")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	lines := 0
+	sc := bufio.NewScanner(&buf)
+	for sc.Scan() {
+		var e Event
+		if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
+			t.Fatalf("not JSONL: %v", err)
+		}
+		lines++
+	}
+	if lines != 2 {
+		t.Fatalf("want 2 JSONL lines, got %d", lines)
+	}
+}

--- a/pkg/skillctl/auditevent/gatemap.go
+++ b/pkg/skillctl/auditevent/gatemap.go
@@ -1,0 +1,102 @@
+package auditevent
+
+// gatemap.go: the SPEC-0403 §4 mapping. The existing SPEC-0255 gate-audit.jsonl
+// line (cmd/skillctl's gateEvent) is projected onto the shared envelope. The §4
+// note is explicit: the gateEvent (ts · source · skill · decision · reason ·
+// exit_code · content_digest · online · cache_hit · session_id) becomes
+// policy.allow / policy.deny / policy.evaluate carrying the §3 envelope, and the
+// original SPEC-0247/SPEC-0255 verdict (allow · deny · quarantine · leave) is
+// preserved verbatim in policy.decision (REQ-4.3) so nothing is lost.
+//
+// SCOPE (FR-0109). This is a PURE mapping function proven by a golden test. It
+// does NOT rewire cmd/skillctl/gate_audit.go: that runtime change (and the
+// gate-stats dual-read of pre-migration lines, O6) is FR-0110. GateEvent is
+// mirrored here rather than imported because gateEvent lives in package main.
+
+import "fmt"
+
+// GateEvent mirrors cmd/skillctl's gateEvent, one line of gate-audit.jsonl
+// (SPEC-0255). The JSON tags match the on-disk field names so a real recorded
+// line unmarshals straight into it.
+type GateEvent struct {
+	Ts            string `json:"ts"`             // RFC3339 UTC.
+	Source        string `json:"source"`         // "hook" | "sweep".
+	Skill         string `json:"skill"`          // skill name.
+	Decision      string `json:"decision"`       // allow | deny | quarantine | leave.
+	Reason        string `json:"reason"`         // human-readable reason.
+	ExitCode      int    `json:"exit_code"`      // gate exit code.
+	ContentDigest string `json:"content_digest"` // sha256:<hex> of the bundle.
+	Online        bool   `json:"online"`         // the online chain ran (hook path).
+	CacheHit      bool   `json:"cache_hit"`      // a verdict-cache hit served it (hook path).
+	SessionID     string `json:"session_id"`     // Claude Code session id.
+}
+
+// FromGateEvent maps one recorded gate decision onto the shared audit envelope.
+// producer is the caller's producer tag (e.g. ProducerString(version)); the
+// event's timestamp is taken from the recorded line and a fresh event_id is
+// minted (a gate line has no id of its own). The gate-runtime-only telemetry
+// (exit_code, online, cache_hit) is carried as extension fields (REQ-3.3) rather
+// than forced into the core taxonomy. An unknown decision string is an error.
+func FromGateEvent(g GateEvent, producer string) (*Event, error) {
+	eventType, outcome, severity, err := classifyGateDecision(g.Decision)
+	if err != nil {
+		return nil, err
+	}
+
+	e := &Event{
+		Schema:    SchemaV1,
+		Timestamp: g.Ts,
+		EventID:   NewEventID(),
+		EventType: eventType,
+		Outcome:   outcome,
+		Severity:  severity,
+		Producer:  producer,
+		SessionID: g.SessionID,
+		Actor:     &ActorRef{Type: "gate", ID: g.Source},
+		// Preserve the exact SPEC-0247/SPEC-0255 verdict; event_type is the
+		// taxonomy classification, policy.decision is the source vocabulary.
+		Policy: &PolicyRef{Decision: g.Decision},
+	}
+	if g.Skill != "" || g.ContentDigest != "" {
+		e.Skill = &SkillRef{Name: g.Skill, Digest: g.ContentDigest}
+	}
+	if g.Reason != "" {
+		e.Message = g.Reason
+	}
+	// Gate-runtime telemetry becomes extension fields, keyed under a "gate."
+	// prefix so they never collide with a canonical field. SetExt of a bool or
+	// int cannot fail.
+	_ = e.SetExt("gate.exit_code", g.ExitCode) //nolint:errcheck // marshaling an int cannot fail.
+	_ = e.SetExt("gate.online", g.Online)      //nolint:errcheck // marshaling a bool cannot fail.
+	_ = e.SetExt("gate.cache_hit", g.CacheHit) //nolint:errcheck // marshaling a bool cannot fail.
+
+	if err := e.Validate(); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// classifyGateDecision maps a SPEC-0255 verdict to (event_type, outcome,
+// severity):
+//
+//	allow      -> policy.allow    success  info     (the gate permitted the skill)
+//	deny       -> policy.deny     deny     warning  (the gate refused it)
+//	quarantine -> policy.deny     deny     warning  (isolation is a deny-class action)
+//	leave      -> policy.evaluate success  info     (a sweep that took no action)
+//
+// quarantine and leave collapse onto policy.deny / policy.evaluate per the §4
+// note; the exact verdict survives in policy.decision so the collapse is lossless.
+func classifyGateDecision(decision string) (EventType, Outcome, Severity, error) {
+	switch decision {
+	case "allow":
+		return EventPolicyAllow, OutcomeSuccess, SeverityInfo, nil
+	case "deny":
+		return EventPolicyDeny, OutcomeDeny, SeverityWarning, nil
+	case "quarantine":
+		return EventPolicyDeny, OutcomeDeny, SeverityWarning, nil
+	case "leave":
+		return EventPolicyEvaluate, OutcomeSuccess, SeverityInfo, nil
+	default:
+		return "", "", "", fmt.Errorf("%w: unknown gate decision %q", ErrInvalidEvent, decision)
+	}
+}

--- a/pkg/skillctl/auditevent/gatemap_test.go
+++ b/pkg/skillctl/auditevent/gatemap_test.go
@@ -1,0 +1,80 @@
+package auditevent
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// TestGateDecisionMapping is the §4 mapping table: every SPEC-0255 verdict maps
+// to the right taxonomy type, outcome and severity, and the original verdict is
+// preserved verbatim in policy.decision (REQ-4.3, lossless collapse).
+func TestGateDecisionMapping(t *testing.T) {
+	cases := []struct {
+		decision string
+		wantType EventType
+		wantOut  Outcome
+		wantSev  Severity
+	}{
+		{"allow", EventPolicyAllow, OutcomeSuccess, SeverityInfo},
+		{"deny", EventPolicyDeny, OutcomeDeny, SeverityWarning},
+		{"quarantine", EventPolicyDeny, OutcomeDeny, SeverityWarning},
+		{"leave", EventPolicyEvaluate, OutcomeSuccess, SeverityInfo},
+	}
+	for _, tc := range cases {
+		t.Run(tc.decision, func(t *testing.T) {
+			g := GateEvent{Ts: "2026-09-03T21:41:22Z", Source: "hook", Skill: "s", Decision: tc.decision}
+			e, err := FromGateEvent(g, "skillctl/test")
+			if err != nil {
+				t.Fatalf("FromGateEvent: %v", err)
+			}
+			if e.EventType != tc.wantType || e.Outcome != tc.wantOut || e.Severity != tc.wantSev {
+				t.Fatalf("mapping %q: got (%s,%s,%s) want (%s,%s,%s)",
+					tc.decision, e.EventType, e.Outcome, e.Severity, tc.wantType, tc.wantOut, tc.wantSev)
+			}
+			if e.Policy == nil || e.Policy.Decision != tc.decision {
+				t.Fatalf("original verdict not preserved in policy.decision: %+v", e.Policy)
+			}
+			if err := e.Validate(); err != nil {
+				t.Fatalf("mapped event invalid: %v", err)
+			}
+		})
+	}
+}
+
+// TestGateUnknownDecisionRejected proves an unknown verdict is an error, not a
+// silently mis-typed event.
+func TestGateUnknownDecisionRejected(t *testing.T) {
+	_, err := FromGateEvent(GateEvent{Ts: "t", Decision: "explode"}, "skillctl/test")
+	if !errors.Is(err, ErrInvalidEvent) {
+		t.Fatalf("unknown decision must error with ErrInvalidEvent: %v", err)
+	}
+}
+
+// TestGateEventGolden pins the full envelope for a realistic recorded deny line.
+// The event_id is overwritten with a fixed value (id generation is proven
+// separately in eventid_test); everything else is the mapping's output.
+func TestGateEventGolden(t *testing.T) {
+	line := `{"ts":"2026-09-03T21:41:22Z","source":"hook","skill":"compliance-review",` +
+		`"decision":"deny","reason":"revoked bundle","exit_code":2,` +
+		`"content_digest":"sha256:abc","online":true,"cache_hit":false,"session_id":"sess_9"}`
+
+	var g GateEvent
+	if err := json.Unmarshal([]byte(line), &g); err != nil {
+		t.Fatalf("unmarshal gate line: %v", err)
+	}
+	e, err := FromGateEvent(g, "skillctl/0.4.0")
+	if err != nil {
+		t.Fatalf("FromGateEvent: %v", err)
+	}
+	e.EventID = "01GOLDENGATEEVENT000000000" // pin the only non-deterministic field.
+
+	got, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"actor":{"type":"gate","id":"hook"},"event_id":"01GOLDENGATEEVENT000000000","event_type":"policy.deny","gate.cache_hit":false,"gate.exit_code":2,"gate.online":true,"message":"revoked bundle","outcome":"deny","policy":{"decision":"deny"},"producer":"skillctl/0.4.0","schema":"skillctl.audit.v1","session_id":"sess_9","severity":"warning","skill":{"name":"compliance-review","digest":"sha256:abc"},"timestamp":"2026-09-03T21:41:22Z"}`
+	if string(got) != want {
+		t.Fatalf("golden mismatch:\n got=%s\nwant=%s", got, want)
+	}
+}

--- a/pkg/skillctl/auditevent/misc_test.go
+++ b/pkg/skillctl/auditevent/misc_test.go
@@ -1,0 +1,89 @@
+package auditevent
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+)
+
+// TestProducerString covers both branches of the producer-tag helper.
+func TestProducerString(t *testing.T) {
+	if got := ProducerString("0.4.0"); got != "skillctl/0.4.0" {
+		t.Errorf("ProducerString: got %q", got)
+	}
+	if got := ProducerString(""); got != "skillctl" {
+		t.Errorf("ProducerString empty: got %q", got)
+	}
+}
+
+// TestNewStampsEnvelope proves the constructor fills the mandatory envelope so a
+// New-built event validates without further setup.
+func TestNewStampsEnvelope(t *testing.T) {
+	e := New(EventSkillExecute, OutcomeSuccess, SeverityInfo, ProducerString("1.0"))
+	if e.Schema != SchemaV1 || e.Timestamp == "" || e.EventID == "" {
+		t.Fatalf("New did not stamp the envelope: %+v", e)
+	}
+	if err := e.Validate(); err != nil {
+		t.Fatalf("New event must validate: %v", err)
+	}
+}
+
+// TestSinkNamesAndClose covers the Name/Close surface used for observability.
+func TestSinkNamesAndClose(t *testing.T) {
+	fs, err := NewFileSink(filepath.Join(t.TempDir(), "a.jsonl"), 0)
+	if err != nil {
+		t.Fatalf("NewFileSink: %v", err)
+	}
+	if fs.Name() == "" || fs.Name()[:5] != "file:" {
+		t.Errorf("FileSink.Name: %q", fs.Name())
+	}
+	if err := fs.Close(); err != nil {
+		t.Errorf("FileSink.Close: %v", err)
+	}
+	ws := NewWriterSink("stderr", &bytes.Buffer{})
+	if ws.Name() != "stderr" {
+		t.Errorf("WriterSink.Name: %q", ws.Name())
+	}
+	if err := ws.Close(); err != nil {
+		t.Errorf("WriterSink.Close: %v", err)
+	}
+}
+
+// TestSinkNilEventGuards covers the nil-event guard on both concrete sinks.
+func TestSinkNilEventGuards(t *testing.T) {
+	fs, err := NewFileSink(filepath.Join(t.TempDir(), "a.jsonl"), 0)
+	if err != nil {
+		t.Fatalf("NewFileSink: %v", err)
+	}
+	if err := fs.Write(nil); err == nil {
+		t.Errorf("FileSink.Write(nil) must error")
+	}
+	ws := NewWriterSink("w", &bytes.Buffer{})
+	if err := ws.Write(nil); err == nil {
+		t.Errorf("WriterSink.Write(nil) must error")
+	}
+}
+
+// TestRedactNilEvent proves Redact tolerates a nil event.
+func TestRedactNilEvent(t *testing.T) {
+	DefaultRedactor().Redact(nil) // must not panic.
+}
+
+// TestIsRedactedValueEdges exercises the idempotency guard's boundaries: a
+// non-string value, a real value that merely starts with the prefix but is the
+// wrong length, and a non-hex tail are all treated as NOT already redacted.
+func TestIsRedactedValueEdges(t *testing.T) {
+	cases := map[string]bool{
+		`123`:                    false, // not a string.
+		`"sha256:abcdef012345"`:  true,  // 12 hex.
+		`"sha256:abcdef01234"`:   false, // 11 chars, wrong length.
+		`"sha256:zzzzzzzzzzzz"`:  false, // non-hex tail.
+		`"[REDACTED]"`:           true,  // the drop marker.
+		`"just a normal string"`: false,
+	}
+	for raw, want := range cases {
+		if got := isRedactedValue([]byte(raw)); got != want {
+			t.Errorf("isRedactedValue(%s): got %v want %v", raw, got, want)
+		}
+	}
+}

--- a/pkg/skillctl/auditevent/redaction.go
+++ b/pkg/skillctl/auditevent/redaction.go
@@ -1,0 +1,146 @@
+package auditevent
+
+// redaction.go: data minimization (SPEC-0403 §5.1). Audit logs MUST NOT carry
+// passwords, private keys, access/refresh tokens, authorization headers, raw
+// credentials, secret env vars, FULL LLM prompts, FULL LLM responses, FULL
+// reference documents, or PII unless policy demands it (REQ-5.4). Where a
+// sensitive value is needed for correlation, a digest or stable pseudonym is
+// used instead (REQ-5.5). Redaction is policy-driven and configurable (REQ-5.6).
+//
+// SCOPE (FR-0109). This is the foundation: a configurable key-pattern scrub over
+// extension fields plus a size cap on the free-text Message (the field into
+// which a full prompt/response would most easily leak). The canonical struct
+// fields are digest-shaped by design (SkillRef.Digest, ReferenceRef.Digest);
+// they carry identifiers, never contents; so there is nothing to scrub there.
+// Deeper content classification is a policy concern layered on top later.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+)
+
+// RedactionMode selects how a matched sensitive value is neutralized.
+type RedactionMode int
+
+const (
+	// RedactDrop replaces a matched value with a fixed marker; nothing about the
+	// original survives.
+	RedactDrop RedactionMode = iota
+	// RedactHash replaces a matched value with "sha256:<12 hex>"; a stable
+	// pseudonym that still permits correlation (REQ-5.5) without exposing the
+	// value.
+	RedactHash
+)
+
+// RedactedMarker is the placeholder RedactDrop substitutes for a sensitive value.
+const RedactedMarker = "[REDACTED]"
+
+// DefaultMaxMessageBytes caps the free-text Message so a full prompt/response
+// cannot silently ride along in it (REQ-5.4). Oversized messages are truncated.
+const DefaultMaxMessageBytes = 4096
+
+// truncationMarker is appended to a Message truncated by the size cap.
+const truncationMarker = "…[truncated]"
+
+// Redactor minimizes an Event before it reaches any sink. The zero value does
+// nothing; use DefaultRedactor for the standard policy.
+type Redactor struct {
+	// SensitiveKeyPatterns are lowercase substrings; any Ext key whose lowercased
+	// name contains one is redacted (REQ-5.4/5.6).
+	SensitiveKeyPatterns []string
+	// Mode selects drop vs. hash for a matched value.
+	Mode RedactionMode
+	// MaxMessageBytes caps Event.Message; 0 disables the cap.
+	MaxMessageBytes int
+}
+
+// defaultSensitiveKeyPatterns enumerates the categories REQ-5.4 forbids, matched
+// as case-insensitive substrings of an extension-field key.
+var defaultSensitiveKeyPatterns = []string{
+	"password", "passwd", "secret", "token", "authorization", "auth_header",
+	"api_key", "apikey", "access_key", "private_key", "privatekey", "credential",
+	"prompt", "completion", "response_body", "refresh", "cookie", "bearer",
+}
+
+// DefaultRedactor returns the standard §5.1 policy: hash the values of
+// sensitively-named extension fields (so correlation survives, REQ-5.5) and cap
+// the free-text Message at DefaultMaxMessageBytes.
+func DefaultRedactor() Redactor {
+	patterns := make([]string, len(defaultSensitiveKeyPatterns))
+	copy(patterns, defaultSensitiveKeyPatterns)
+	return Redactor{
+		SensitiveKeyPatterns: patterns,
+		Mode:                 RedactHash,
+		MaxMessageBytes:      DefaultMaxMessageBytes,
+	}
+}
+
+// Redact minimizes e in place: it scrubs sensitively-named extension fields and
+// caps the Message length. It is idempotent; running it twice is a no-op after
+// the first; and safe on a nil-Ext event.
+func (r Redactor) Redact(e *Event) {
+	if e == nil {
+		return
+	}
+	for key, raw := range e.Ext {
+		if r.isSensitiveKey(key) {
+			e.Ext[key] = r.redactValue(raw)
+		}
+	}
+	if r.MaxMessageBytes > 0 && len(e.Message) > r.MaxMessageBytes {
+		e.Message = e.Message[:r.MaxMessageBytes] + truncationMarker
+	}
+}
+
+// isSensitiveKey reports whether key contains any configured sensitive substring.
+func (r Redactor) isSensitiveKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, p := range r.SensitiveKeyPatterns {
+		if p != "" && strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// redactValue neutralizes one raw JSON value per the configured mode, returning a
+// JSON string token. An already-redacted value is left unchanged so Redact is
+// idempotent.
+func (r Redactor) redactValue(raw json.RawMessage) json.RawMessage {
+	if isRedactedValue(raw) {
+		return raw
+	}
+	if r.Mode == RedactHash {
+		sum := sha256.Sum256(raw)
+		token := "sha256:" + hex.EncodeToString(sum[:])[:12]
+		out, _ := json.Marshal(token) //nolint:errcheck // marshaling a constant string cannot fail.
+		return out
+	}
+	out, _ := json.Marshal(RedactedMarker) //nolint:errcheck // marshaling a constant string cannot fail.
+	return out
+}
+
+// isRedactedValue reports whether raw is already a redaction token (the drop
+// marker or a "sha256:<12 hex>" pseudonym), so a second Redact pass is a no-op.
+func isRedactedValue(raw json.RawMessage) bool {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return false // not a JSON string; never a redaction token.
+	}
+	if s == RedactedMarker {
+		return true
+	}
+	const prefix = "sha256:"
+	if !strings.HasPrefix(s, prefix) || len(s) != len(prefix)+12 {
+		return false
+	}
+	for i := len(prefix); i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/skillctl/auditevent/redaction_test.go
+++ b/pkg/skillctl/auditevent/redaction_test.go
@@ -1,0 +1,105 @@
+package auditevent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRedactHashScrubsSensitiveExt proves the default redactor replaces the value
+// of a sensitively-named extension field with a sha256 pseudonym, so the raw
+// secret never reaches a sink (REQ-5.4) while correlation survives (REQ-5.5).
+func TestRedactHashScrubsSensitiveExt(t *testing.T) {
+	e := New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	secret := "Bearer sk-super-secret-token-value"
+	for _, k := range []string{"authorization", "api_key", "refresh_token", "user_password"} {
+		if err := e.SetExt(k, secret); err != nil {
+			t.Fatalf("SetExt %q: %v", k, err)
+		}
+	}
+	// A non-sensitive field must be left alone.
+	if err := e.SetExt("gate.exit_code", 0); err != nil {
+		t.Fatalf("SetExt: %v", err)
+	}
+
+	DefaultRedactor().Redact(e)
+
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "super-secret") {
+		t.Fatalf("secret survived redaction: %s", b)
+	}
+	for _, k := range []string{"authorization", "api_key", "refresh_token", "user_password"} {
+		var v string
+		if err := json.Unmarshal(e.Ext[k], &v); err != nil {
+			t.Fatalf("ext %q not a string after redaction: %v", k, err)
+		}
+		if !strings.HasPrefix(v, "sha256:") {
+			t.Fatalf("ext %q not pseudonymized: %q", k, v)
+		}
+	}
+	// The non-sensitive field is untouched.
+	if string(e.Ext["gate.exit_code"]) != "0" {
+		t.Fatalf("non-sensitive field was altered: %s", e.Ext["gate.exit_code"])
+	}
+}
+
+// TestRedactDropMode proves the drop mode replaces the value with the fixed
+// marker rather than a hash.
+func TestRedactDropMode(t *testing.T) {
+	e := New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	if err := e.SetExt("db_password", "hunter2"); err != nil {
+		t.Fatalf("SetExt: %v", err)
+	}
+	r := Redactor{SensitiveKeyPatterns: []string{"password"}, Mode: RedactDrop}
+	r.Redact(e)
+	var v string
+	if err := json.Unmarshal(e.Ext["db_password"], &v); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if v != RedactedMarker {
+		t.Fatalf("drop mode did not apply marker: %q", v)
+	}
+}
+
+// TestRedactMessageCap proves an oversized Message is truncated (data
+// minimization: a full LLM prompt/response cannot silently ride along, REQ-5.4).
+func TestRedactMessageCap(t *testing.T) {
+	e := New(EventSkillExecute, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	e.Message = strings.Repeat("A", DefaultMaxMessageBytes+500)
+	DefaultRedactor().Redact(e)
+	// After truncation the field is exactly the cap of raw content plus the
+	// marker; the 500 excess bytes must be gone.
+	if !strings.HasSuffix(e.Message, truncationMarker) {
+		t.Fatalf("message not marked as truncated: ...%q", tail(e.Message))
+	}
+	if got := strings.Count(e.Message, "A"); got != DefaultMaxMessageBytes {
+		t.Fatalf("raw content not minimized to the cap: kept %d 'A's, want %d", got, DefaultMaxMessageBytes)
+	}
+}
+
+// TestRedactIdempotent proves running the default redactor twice is a no-op on
+// the already-redacted value.
+func TestRedactIdempotent(t *testing.T) {
+	e := New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	if err := e.SetExt("access_token", "abc123"); err != nil {
+		t.Fatalf("SetExt: %v", err)
+	}
+	r := DefaultRedactor()
+	r.Redact(e)
+	first := string(e.Ext["access_token"])
+	r.Redact(e)
+	second := string(e.Ext["access_token"])
+	if first != second {
+		t.Fatalf("redaction not idempotent: %q -> %q", first, second)
+	}
+}
+
+func tail(s string) string {
+	if len(s) <= 20 {
+		return s
+	}
+	return s[len(s)-20:]
+}

--- a/pkg/skillctl/auditevent/sink.go
+++ b/pkg/skillctl/auditevent/sink.go
@@ -1,0 +1,102 @@
+package auditevent
+
+// sink.go: the Event → Dispatcher → Sink seam (SPEC-0403 §7.2, REQ-7.2). Event
+// creation is separated from transport: the core carries NO broker-specific
+// semantics. This file holds the local sink abstraction and a fan-out Dispatcher.
+//
+// WHY THE INTERFACE IS SHAPED THIS WAY (forward-compat with FR-0110). A Sink
+// receives the STRUCTURED *Event, not pre-serialized bytes, so a future
+// outbox-backed durable sink (FR-0110) can project the event onto the
+// SPEC-0317 audit_events columns (event_id, event_type, occurred_at, …) without
+// re-parsing JSON, while a file/stream sink serializes it itself. Delivery MODES
+// (best-effort / durable / required, §6) are a Dispatcher-level policy, NOT a
+// Sink concern: a Sink only reports whether its Write succeeded; the Dispatcher
+// decides what a failure means. FR-0110 therefore adds mode handling here and an
+// OutboxSink implementing this same interface; no signature change.
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sink is a destination for redacted audit events. Implementations MUST be safe
+// for the Dispatcher to call Write on from one goroutine at a time; they need not
+// be internally concurrent.
+type Sink interface {
+	// Write emits or persists one already-redacted, already-validated event. A
+	// returned error means this sink did not accept the event; the Dispatcher's
+	// mode decides whether that is fatal (FR-0110). Write MUST NOT mutate e.
+	Write(e *Event) error
+	// Name identifies the sink for observability (audit.sink.* events, FR-0111).
+	Name() string
+	// Close releases the sink's resources. It MUST be safe to call once; calling
+	// Write after Close may error.
+	Close() error
+}
+
+// Dispatcher redacts an event, validates it, and fans it out to every configured
+// sink. In FR-0109 it is best-effort by construction: a sink failure is collected
+// and returned but never panics and never blocks; this preserves the SPEC-0255
+// decision-invariance default for the gate hot path (REQ-6.4). The explicit
+// best-effort / durable / required delivery modes (§6) arrive in FR-0110; this
+// type is their attachment point.
+type Dispatcher struct {
+	redactor Redactor
+	sinks    []Sink
+}
+
+// NewDispatcher builds a Dispatcher applying r to every event before fan-out.
+// Pass DefaultRedactor() unless a policy supplies its own (REQ-5.6).
+func NewDispatcher(r Redactor, sinks ...Sink) *Dispatcher {
+	return &Dispatcher{redactor: r, sinks: sinks}
+}
+
+// Dispatch redacts e in place (so no un-redacted copy lingers), stamps any
+// missing mandatory envelope fields, validates, then writes to every sink.
+//
+// It returns an error if the event is invalid (no sink is written in that case)
+// or if one or more sinks failed (the event was still offered to the others).
+// A caller on the decision hot path (the gate) treats this as advisory and
+// ignores the result; logging never changes a decision by default (REQ-6.4).
+func (d *Dispatcher) Dispatch(e *Event) error {
+	if e == nil {
+		return fmt.Errorf("%w: nil event", ErrInvalidEvent)
+	}
+	// Ergonomic defaults so a producer that forgot the envelope still emits a
+	// well-formed line; an explicitly-set field is never overwritten.
+	if e.Schema == "" {
+		e.Schema = SchemaV1
+	}
+	if e.Timestamp == "" {
+		e.Timestamp = idNow().Format(timestampLayout)
+	}
+	if e.EventID == "" {
+		e.EventID = NewEventID()
+	}
+
+	d.redactor.Redact(e)
+
+	if err := e.Validate(); err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, s := range d.sinks {
+		if err := s.Write(e); err != nil {
+			errs = append(errs, fmt.Errorf("sink %q: %w", s.Name(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Close closes every sink, joining any errors. Sinks are closed even if an
+// earlier one failed.
+func (d *Dispatcher) Close() error {
+	var errs []error
+	for _, s := range d.sinks {
+		if err := s.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("sink %q: %w", s.Name(), err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/pkg/skillctl/auditevent/sink_test.go
+++ b/pkg/skillctl/auditevent/sink_test.go
@@ -1,0 +1,132 @@
+package auditevent
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// recordingSink captures the JSON bytes of every event written to it (the state
+// AT write time), for assertions.
+type recordingSink struct {
+	name  string
+	lines [][]byte
+}
+
+func (r *recordingSink) Name() string { return r.name }
+func (r *recordingSink) Write(e *Event) error {
+	b, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	r.lines = append(r.lines, b)
+	return nil
+}
+func (r *recordingSink) Close() error { return nil }
+
+// failingSink always fails Write, to prove the Dispatcher collects and continues.
+type failingSink struct{ closed bool }
+
+func (f *failingSink) Name() string { return "failing" }
+func (f *failingSink) Write(*Event) error {
+	return errors.New("boom")
+}
+func (f *failingSink) Close() error { f.closed = true; return nil }
+
+// TestDispatchFanOutAndErrorCollection proves an event reaches every sink and a
+// single sink failure is collected (not swallowed, not fatal to the others).
+func TestDispatchFanOutAndErrorCollection(t *testing.T) {
+	rec1 := &recordingSink{name: "rec1"}
+	rec2 := &recordingSink{name: "rec2"}
+	fail := &failingSink{}
+	d := NewDispatcher(DefaultRedactor(), rec1, fail, rec2)
+
+	e := New(EventSkillVerify, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	err := d.Dispatch(e)
+	if err == nil || !strings.Contains(err.Error(), "failing") {
+		t.Fatalf("expected a collected error naming the failing sink, got %v", err)
+	}
+	if len(rec1.lines) != 1 || len(rec2.lines) != 1 {
+		t.Fatalf("both healthy sinks must have received the event: rec1=%d rec2=%d",
+			len(rec1.lines), len(rec2.lines))
+	}
+}
+
+// TestDispatchStampsDefaults proves a producer that leaves the envelope basics
+// blank still emits a well-formed, valid event (schema/timestamp/event_id filled).
+func TestDispatchStampsDefaults(t *testing.T) {
+	rec := &recordingSink{name: "rec"}
+	d := NewDispatcher(Redactor{}, rec)
+
+	e := &Event{EventType: EventPolicyAllow, Outcome: OutcomeSuccess, Severity: SeverityInfo, Producer: "skillctl/x"}
+	if err := d.Dispatch(e); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if e.Schema != SchemaV1 || e.Timestamp == "" || e.EventID == "" {
+		t.Fatalf("defaults not stamped: %+v", e)
+	}
+	var got Event
+	if err := json.Unmarshal(rec.lines[0], &got); err != nil {
+		t.Fatalf("unmarshal recorded line: %v", err)
+	}
+	if err := got.Validate(); err != nil {
+		t.Fatalf("recorded event is not valid: %v", err)
+	}
+}
+
+// TestDispatchRedactsBeforeWrite proves redaction happens BEFORE any sink sees
+// the event: a secret placed in a sensitive ext field never reaches a sink.
+func TestDispatchRedactsBeforeWrite(t *testing.T) {
+	rec := &recordingSink{name: "rec"}
+	d := NewDispatcher(DefaultRedactor(), rec)
+
+	e := New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	if err := e.SetExt("authorization", "Bearer top-secret-xyz"); err != nil {
+		t.Fatalf("SetExt: %v", err)
+	}
+	if err := d.Dispatch(e); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if strings.Contains(string(rec.lines[0]), "top-secret-xyz") {
+		t.Fatalf("secret reached the sink un-redacted: %s", rec.lines[0])
+	}
+}
+
+// TestDispatchRejectsInvalidWithoutWriting proves an invalid event is rejected
+// and NO sink is written (validation precedes fan-out).
+func TestDispatchRejectsInvalidWithoutWriting(t *testing.T) {
+	rec := &recordingSink{name: "rec"}
+	d := NewDispatcher(Redactor{}, rec)
+
+	e := &Event{EventType: "skill.teleport", Outcome: OutcomeSuccess, Severity: SeverityInfo, Producer: "skillctl/x"}
+	err := d.Dispatch(e)
+	if !errors.Is(err, ErrInvalidEvent) {
+		t.Fatalf("expected ErrInvalidEvent, got %v", err)
+	}
+	if len(rec.lines) != 0 {
+		t.Fatalf("no sink should be written for an invalid event; got %d", len(rec.lines))
+	}
+}
+
+// TestDispatchNil covers the nil-event guard.
+func TestDispatchNil(t *testing.T) {
+	d := NewDispatcher(Redactor{})
+	if err := d.Dispatch(nil); !errors.Is(err, ErrInvalidEvent) {
+		t.Fatalf("nil event must error: %v", err)
+	}
+}
+
+// TestDispatcherCloseClosesAllSinks proves Close reaches every sink even past a
+// failure.
+func TestDispatcherCloseClosesAllSinks(t *testing.T) {
+	fail := &failingSink{}
+	rec := &recordingSink{name: "rec"}
+	d := NewDispatcher(Redactor{}, fail, rec)
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if !fail.closed {
+		t.Fatalf("Close did not reach the failing sink")
+	}
+}

--- a/pkg/skillctl/auditevent/taxonomy.go
+++ b/pkg/skillctl/auditevent/taxonomy.go
@@ -1,0 +1,159 @@
+package auditevent
+
+// taxonomy.go: the SPEC-0403 §4 event taxonomy: stable, hierarchical event-type
+// names, plus the outcome and severity vocabularies. Event semantics MUST NOT
+// change silently within a schema version (REQ-4.2). The types below reuse
+// already-defined decision vocabularies and DO NOT invent a second one (REQ-4.3):
+// policy.* ↔ SPEC-0247/SPEC-0255, capability.* ↔ SPEC-0402 §3/§7, reference.* ↔
+// SPEC-0401 §3 + SPEC-0402 §5, evidence.* ↔ SPEC-0402 §6, revocation.* ↔
+// FR-0045/SPEC-0279.
+
+// TaxonomyVersion tracks the taxonomy independently of the wire schema tag so an
+// additive taxonomy revision is a visible bump, not a silent redefinition
+// (REQ-4.2). It is "1" while SchemaV1 is in force; adding a new event type is a
+// minor, semantics-preserving change.
+const TaxonomyVersion = "1"
+
+// EventType is a hierarchical, dotted taxonomy name (REQ-4.1). It is a distinct
+// string type so a typo in a producer is a compile error against the constants
+// below, not a silent unknown type.
+type EventType string
+
+// The initial taxonomy (REQ-4.1). Grouped by domain. These string values are a
+// STABLE contract pinned by a test; renaming one is a breaking change requiring
+// a schema-version bump.
+const (
+	// skill lifecycle.
+	EventSkillVerify  EventType = "skill.verify"
+	EventSkillInstall EventType = "skill.install"
+	EventSkillRemove  EventType = "skill.remove"
+	EventSkillExecute EventType = "skill.execute"
+
+	// signature verification.
+	EventSignatureVerify EventType = "signature.verify"
+	EventSignatureReject EventType = "signature.reject"
+
+	// provenance verification.
+	EventProvenanceVerify EventType = "provenance.verify"
+	EventProvenanceReject EventType = "provenance.reject"
+
+	// revocation (↔ FR-0045/SPEC-0279).
+	EventRevocationCheck  EventType = "revocation.check"
+	EventRevocationDetect EventType = "revocation.detect"
+
+	// trust roots.
+	EventTrustrootLoad   EventType = "trustroot.load"
+	EventTrustrootChange EventType = "trustroot.change"
+
+	// policy (↔ SPEC-0247/SPEC-0255).
+	EventPolicyEvaluate EventType = "policy.evaluate"
+	EventPolicyAllow    EventType = "policy.allow"
+	EventPolicyDeny     EventType = "policy.deny"
+
+	// capability (↔ SPEC-0402 §3/§7).
+	EventCapabilityRequest EventType = "capability.request"
+	EventCapabilityGrant   EventType = "capability.grant"
+	EventCapabilityDeny    EventType = "capability.deny"
+	EventCapabilityDrift   EventType = "capability.drift"
+
+	// reference binding (↔ SPEC-0401 §3 + SPEC-0402 §5).
+	EventReferenceBind    EventType = "reference.bind"
+	EventReferenceResolve EventType = "reference.resolve"
+	EventReferenceReject  EventType = "reference.reject"
+
+	// invocation lifecycle.
+	EventInvocationStart    EventType = "invocation.start"
+	EventInvocationComplete EventType = "invocation.complete"
+	EventInvocationFail     EventType = "invocation.fail"
+
+	// evidence (↔ SPEC-0402 §6).
+	EventEvidenceCreate EventType = "evidence.create"
+	EventEvidenceExport EventType = "evidence.export"
+
+	// the audit subsystem's own health (REQ-8.1; emission wired in FR-0111).
+	EventAuditSinkConnect  EventType = "audit.sink.connect"
+	EventAuditSinkFail     EventType = "audit.sink.fail"
+	EventAuditQueueEnqueue EventType = "audit.queue.enqueue"
+	EventAuditQueueFlush   EventType = "audit.queue.flush"
+
+	// configuration.
+	EventConfigChange EventType = "config.change"
+)
+
+// knownEventTypes is the closed set for the current TaxonomyVersion. Validate
+// and IsKnownEventType consult it so an unknown type fails closed (REQ-4.1/4.2).
+var knownEventTypes = map[EventType]struct{}{
+	EventSkillVerify: {}, EventSkillInstall: {}, EventSkillRemove: {}, EventSkillExecute: {},
+	EventSignatureVerify: {}, EventSignatureReject: {},
+	EventProvenanceVerify: {}, EventProvenanceReject: {},
+	EventRevocationCheck: {}, EventRevocationDetect: {},
+	EventTrustrootLoad: {}, EventTrustrootChange: {},
+	EventPolicyEvaluate: {}, EventPolicyAllow: {}, EventPolicyDeny: {},
+	EventCapabilityRequest: {}, EventCapabilityGrant: {}, EventCapabilityDeny: {}, EventCapabilityDrift: {},
+	EventReferenceBind: {}, EventReferenceResolve: {}, EventReferenceReject: {},
+	EventInvocationStart: {}, EventInvocationComplete: {}, EventInvocationFail: {},
+	EventEvidenceCreate: {}, EventEvidenceExport: {},
+	EventAuditSinkConnect: {}, EventAuditSinkFail: {}, EventAuditQueueEnqueue: {}, EventAuditQueueFlush: {},
+	EventConfigChange: {},
+}
+
+// IsKnownEventType reports whether t is part of the current taxonomy version.
+func IsKnownEventType(t EventType) bool {
+	_, ok := knownEventTypes[t]
+	return ok
+}
+
+// KnownEventTypes returns every event type in the current taxonomy version. The
+// returned slice is a copy the caller may sort or mutate freely.
+func KnownEventTypes() []EventType {
+	out := make([]EventType, 0, len(knownEventTypes))
+	for t := range knownEventTypes {
+		out = append(out, t)
+	}
+	return out
+}
+
+// Outcome describes how the audited action resolved (mandatory, REQ-3.1).
+type Outcome string
+
+// The outcome vocabulary. deny is distinct from failure so a policy denial (a
+// working system refusing an action) is not confused with an operation that
+// failed, and error marks an internal/transport fault (e.g. audit.sink.fail).
+const (
+	OutcomeSuccess Outcome = "success" // the action completed / verified.
+	OutcomeFailure Outcome = "failure" // a verification or operation failed (e.g. signature.reject).
+	OutcomeDeny    Outcome = "deny"    // a policy/capability decision to refuse.
+	OutcomeError   Outcome = "error"   // an internal or transport fault.
+)
+
+var knownOutcomes = map[Outcome]struct{}{
+	OutcomeSuccess: {}, OutcomeFailure: {}, OutcomeDeny: {}, OutcomeError: {},
+}
+
+// IsKnownOutcome reports whether o is part of the outcome vocabulary.
+func IsKnownOutcome(o Outcome) bool {
+	_, ok := knownOutcomes[o]
+	return ok
+}
+
+// Severity ranks the operational importance of an event (mandatory, REQ-3.1).
+type Severity string
+
+// The severity vocabulary, low to high.
+const (
+	SeverityInfo     Severity = "info"
+	SeverityNotice   Severity = "notice"
+	SeverityWarning  Severity = "warning"
+	SeverityError    Severity = "error"
+	SeverityCritical Severity = "critical"
+)
+
+var knownSeverities = map[Severity]struct{}{
+	SeverityInfo: {}, SeverityNotice: {}, SeverityWarning: {}, SeverityError: {}, SeverityCritical: {},
+}
+
+// IsKnownSeverity reports whether s is part of the severity vocabulary.
+func IsKnownSeverity(s Severity) bool {
+	_, ok := knownSeverities[s]
+	return ok
+}

--- a/pkg/skillctl/auditevent/taxonomy_test.go
+++ b/pkg/skillctl/auditevent/taxonomy_test.go
@@ -1,0 +1,106 @@
+package auditevent
+
+import "testing"
+
+// TestTaxonomyStringsPinned pins the exact string value of every taxonomy
+// constant (REQ-4.2: event semantics MUST NOT change silently within a schema
+// version). A rename or typo of any wire value fails this test loudly.
+func TestTaxonomyStringsPinned(t *testing.T) {
+	want := map[EventType]string{
+		EventSkillVerify:        "skill.verify",
+		EventSkillInstall:       "skill.install",
+		EventSkillRemove:        "skill.remove",
+		EventSkillExecute:       "skill.execute",
+		EventSignatureVerify:    "signature.verify",
+		EventSignatureReject:    "signature.reject",
+		EventProvenanceVerify:   "provenance.verify",
+		EventProvenanceReject:   "provenance.reject",
+		EventRevocationCheck:    "revocation.check",
+		EventRevocationDetect:   "revocation.detect",
+		EventTrustrootLoad:      "trustroot.load",
+		EventTrustrootChange:    "trustroot.change",
+		EventPolicyEvaluate:     "policy.evaluate",
+		EventPolicyAllow:        "policy.allow",
+		EventPolicyDeny:         "policy.deny",
+		EventCapabilityRequest:  "capability.request",
+		EventCapabilityGrant:    "capability.grant",
+		EventCapabilityDeny:     "capability.deny",
+		EventCapabilityDrift:    "capability.drift",
+		EventReferenceBind:      "reference.bind",
+		EventReferenceResolve:   "reference.resolve",
+		EventReferenceReject:    "reference.reject",
+		EventInvocationStart:    "invocation.start",
+		EventInvocationComplete: "invocation.complete",
+		EventInvocationFail:     "invocation.fail",
+		EventEvidenceCreate:     "evidence.create",
+		EventEvidenceExport:     "evidence.export",
+		EventAuditSinkConnect:   "audit.sink.connect",
+		EventAuditSinkFail:      "audit.sink.fail",
+		EventAuditQueueEnqueue:  "audit.queue.enqueue",
+		EventAuditQueueFlush:    "audit.queue.flush",
+		EventConfigChange:       "config.change",
+	}
+	for c, s := range want {
+		if string(c) != s {
+			t.Errorf("taxonomy value drift: got %q want %q", string(c), s)
+		}
+		if !IsKnownEventType(c) {
+			t.Errorf("%q not reported as known", s)
+		}
+	}
+	// The whole §4 initial taxonomy is present and nothing extra slipped in.
+	if got := len(KnownEventTypes()); got != len(want) {
+		t.Fatalf("taxonomy size drift: got %d want %d (update REQ-4.1 + this test together)", got, len(want))
+	}
+}
+
+// TestTaxonomyVersionPinned pins the taxonomy version and schema tag together.
+func TestTaxonomyVersionPinned(t *testing.T) {
+	if TaxonomyVersion != "1" {
+		t.Errorf("TaxonomyVersion drift: %q", TaxonomyVersion)
+	}
+	if SchemaV1 != "skillctl.audit.v1" {
+		t.Errorf("SchemaV1 drift: %q", SchemaV1)
+	}
+}
+
+// TestUnknownTaxonomyRejected proves the closed set fails closed.
+func TestUnknownTaxonomyRejected(t *testing.T) {
+	if IsKnownEventType("skill.teleport") {
+		t.Errorf("unknown event type reported known")
+	}
+	if IsKnownOutcome("maybe") {
+		t.Errorf("unknown outcome reported known")
+	}
+	if IsKnownSeverity("loud") {
+		t.Errorf("unknown severity reported known")
+	}
+}
+
+// TestOutcomeAndSeverityPinned pins the two other controlled vocabularies.
+func TestOutcomeAndSeverityPinned(t *testing.T) {
+	outcomes := map[Outcome]string{
+		OutcomeSuccess: "success", OutcomeFailure: "failure",
+		OutcomeDeny: "deny", OutcomeError: "error",
+	}
+	for c, s := range outcomes {
+		if string(c) != s {
+			t.Errorf("outcome drift: got %q want %q", string(c), s)
+		}
+		if !IsKnownOutcome(c) {
+			t.Errorf("outcome %q not known", s)
+		}
+	}
+	sevs := map[Severity]string{
+		SeverityInfo: "info", SeverityNotice: "notice", SeverityWarning: "warning",
+		SeverityError: "error", SeverityCritical: "critical",
+	}
+	for c, s := range sevs {
+		if string(c) != s {
+			t.Errorf("severity drift: got %q want %q", string(c), s)
+		}
+		if !IsKnownSeverity(c) {
+			t.Errorf("severity %q not known", s)
+		}
+	}
+}


### PR DESCRIPTION
## FR-0109 — shared audit-event envelope, taxonomy, sink + dispatcher (SPEC-0403 foundation)

First implementation chunk of the now-**Accepted** SPEC-0403 (audit event layer). A self-contained, **stdlib-only, zero-new-dependency** library — new package `pkg/skillctl/auditevent`. No behavior change to any existing producer yet (that's FR-0110).

### What it is
- **Envelope `skillctl.audit.v1`** (§3): mandatory `schema·timestamp·event_id·event_type·outcome·severity·producer` + the REQ-3.2 optional refs; **tolerant unmarshal preserving unknown optional fields** (REQ-3.3); key-stable canonical JSONL (REQ-3.4); documented as an expression of the SPEC-0383 `capability.*` family, not a competing envelope (REQ-3.5).
- **Taxonomy** (§4): 32 pinned `event_type` constants over the existing decision vocabularies (no second vocabulary), closed-set-validated, version-stamped.
- **Event→Dispatcher→Sink** split (§7.2) with `FileSink` (default infra-free JSONL, `O_APPEND` 0600, size rotation) + `WriterSink`. `Sink.Write(*Event)` takes the **structured event, not bytes**, so an `OutboxSink` (delegating to the existing `pkg/skillctl/outbox` — **no second store**, §7.1) slots in for FR-0110.
- **Redaction** (§5.1): `DefaultRedactor` hashes sensitively-named extension fields with a correlation-preserving sha256 pseudonym + caps free-text `Message` at 4096 B against full-prompt/response leakage; idempotent.
- **gateEvent → envelope mapping** (`FromGateEvent`, §4): proves the design (byte-exact golden test) — the SPEC-0255 `gateEvent` maps to `policy.allow/deny/evaluate`, verdict preserved verbatim in `policy.decision`. **`gate_audit.go` runtime is untouched** (the actual rewiring is FR-0110).

### Constraints honored (the SPEC's already-made decisions)
No second durable store · no KafkaSink (FR-0112, EC-blocked) · no CLI (FR-0111) · stdlib-only (`event_id` = ULID-like via `crypto/rand`, no ULID dep).

### Verified
`go build`/`go vet`/`gofmt`/`-race` clean · **92.4% coverage** on the new package · full skillctl+cmd suites not regressed · **`scripts/gosec-diff-gate.sh` PASS (0 new findings)** — the live #175 gate · gitleaks clean. Independently re-verified hermetically (ER1 env unset).

### Deferred (later FRs, with SPEC refs)
`OutboxSink` + best-effort/durable/required delivery modes → **FR-0110** (§6/§7.1) · Kafka → **FR-0112** (§7.2, EC) · `skillctl auditlog` CLI → **FR-0111** (§8) · hash-chain fields → §9 · O6 gate-stats clean-cut wiring → **FR-0110**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
