### PR TITLE
fix(fixtures): isolate the throwaway repos from an inherited git environment

### DIFF
--- a/scripts/bugtracker.test.sh
+++ b/scripts/bugtracker.test.sh
@@ -11,6 +11,27 @@
 #
 set -euo pipefail
 
+# Fixtures legen Wegwerf-git-Repos an. Als Hook geerbte GIT_*-Variablen wuerden
+# jeden git-Aufruf hier auf das AUFRUFENDE Repo umlenken — in
+# m3c-tools-maintenance hat genau das 3076 Loeschungen in einen echten Index
+# geschrieben (BUG-0213, zurueckgenommen, kein Datenverlust). Ein Fixture, das
+# ein echtes Repo anfassen kann, ist eine Waffe, kein Test.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+      GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_PREFIX
+
+# in_throwaway DIR — bricht ab, wenn git auf ein FREMDES Repo zeigt. Muss VOR
+# dem ersten Schreibbefehl laufen: schon `git init` und `git config` schreiben,
+# und `git config user.email` landete beim ersten Anlauf in der Config des
+# echten Repos. "Noch kein Repo" ist in Ordnung — das ist der Normalfall vor
+# `git init`. Pfade aufgeloest vergleichen (macOS: /var -> /private/var).
+in_throwaway() {
+  local want have
+  want=$(cd "$1" 2>/dev/null && pwd -P) || { echo "FATAL: $1 fehlt" >&2; exit 2; }
+  have=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+  [ "$have" = "$want" ] || { echo "FATAL: git zeigt auf $have, nicht auf $want" >&2; exit 2; }
+}
+
+
 BT="$(cd "$(dirname "$0")" && pwd)/bugtracker.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -65,7 +86,9 @@ is "next-id FR on an empty tree" "$("$BT" next-id FR)" "FR-0001"
 GITBUGS="$TMP/gitmaint"
 mkdir -p "$GITBUGS/bug-reports"
 ( cd "$GITBUGS"
+  in_throwaway "$GITBUGS"     # VOR dem ersten Schreibbefehl
   git init -q -b master; git config user.email t@t; git config user.name t
+  in_throwaway "$GITBUGS"
   printf '# FR-0001\n' > bug-reports/FR-0001-on-master.md
   git add -A >/dev/null; git commit -qm one
   # someone else's unmerged work: a file that exists on no other checkout
@@ -250,7 +273,7 @@ is "the FR issue closed as completed" "$(grep -c 'issue close 88 .* --reason com
 
 # a throwaway checkout whose origin is a DIFFERENT repository
 OTHER="$TMP/other-checkout"
-mkdir -p "$OTHER"; ( cd "$OTHER"; git init -q; git remote add origin https://github.com/someone/unrelated.git )
+mkdir -p "$OTHER"; ( cd "$OTHER"; in_throwaway "$OTHER"; git init -q; in_throwaway "$OTHER"; git remote add origin https://github.com/someone/unrelated.git )
 
 : > "$GH_CALLS"
 ( cd "$OTHER" && M3C_BUG_REPO= "$BT" close 213 --status wontfix >/dev/null 2>&1 )

--- a/tools/boundary-gate.test.sh
+++ b/tools/boundary-gate.test.sh
@@ -12,6 +12,27 @@
 #
 set -euo pipefail
 
+# Fixtures legen Wegwerf-git-Repos an. Als Hook geerbte GIT_*-Variablen wuerden
+# jeden git-Aufruf hier auf das AUFRUFENDE Repo umlenken — in
+# m3c-tools-maintenance hat genau das 3076 Loeschungen in einen echten Index
+# geschrieben (BUG-0213, zurueckgenommen, kein Datenverlust). Ein Fixture, das
+# ein echtes Repo anfassen kann, ist eine Waffe, kein Test.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+      GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_PREFIX
+
+# in_throwaway DIR — bricht ab, wenn git auf ein FREMDES Repo zeigt. Muss VOR
+# dem ersten Schreibbefehl laufen: schon `git init` und `git config` schreiben,
+# und `git config user.email` landete beim ersten Anlauf in der Config des
+# echten Repos. "Noch kein Repo" ist in Ordnung — das ist der Normalfall vor
+# `git init`. Pfade aufgeloest vergleichen (macOS: /var -> /private/var).
+in_throwaway() {
+  local want have
+  want=$(cd "$1" 2>/dev/null && pwd -P) || { echo "FATAL: $1 fehlt" >&2; exit 2; }
+  have=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+  [ "$have" = "$want" ] || { echo "FATAL: git zeigt auf $have, nicht auf $want" >&2; exit 2; }
+}
+
+
 HERE="$(cd "$(dirname "$0")" && pwd)"
 GATE="$HERE/boundary-gate.sh"
 PATTERNS="$HERE/leak-patterns.txt"
@@ -23,7 +44,9 @@ mkdir -p "$REPO/tools" "$REPO/cmd" "$REPO/docs"
 cp "$GATE" "$REPO/tools/boundary-gate.sh"
 cp "$PATTERNS" "$REPO/tools/leak-patterns.txt"
 cd "$REPO"
+in_throwaway "$REPO"          # VOR dem ersten Schreibbefehl
 git init -q; git config user.email t@t; git config user.name t
+in_throwaway "$REPO"
 
 pass=0; fail=0
 ok()  { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }

--- a/tools/id-xref-lint.test.sh
+++ b/tools/id-xref-lint.test.sh
@@ -9,6 +9,27 @@
 #
 set -euo pipefail
 
+# Fixtures legen Wegwerf-git-Repos an. Als Hook geerbte GIT_*-Variablen wuerden
+# jeden git-Aufruf hier auf das AUFRUFENDE Repo umlenken — in
+# m3c-tools-maintenance hat genau das 3076 Loeschungen in einen echten Index
+# geschrieben (BUG-0213, zurueckgenommen, kein Datenverlust). Ein Fixture, das
+# ein echtes Repo anfassen kann, ist eine Waffe, kein Test.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+      GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_PREFIX
+
+# in_throwaway DIR — bricht ab, wenn git auf ein FREMDES Repo zeigt. Muss VOR
+# dem ersten Schreibbefehl laufen: schon `git init` und `git config` schreiben,
+# und `git config user.email` landete beim ersten Anlauf in der Config des
+# echten Repos. "Noch kein Repo" ist in Ordnung — das ist der Normalfall vor
+# `git init`. Pfade aufgeloest vergleichen (macOS: /var -> /private/var).
+in_throwaway() {
+  local want have
+  want=$(cd "$1" 2>/dev/null && pwd -P) || { echo "FATAL: $1 fehlt" >&2; exit 2; }
+  have=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+  [ "$have" = "$want" ] || { echo "FATAL: git zeigt auf $have, nicht auf $want" >&2; exit 2; }
+}
+
+
 LINT="$(cd "$(dirname "$0")" && pwd)/id-xref-lint.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -23,8 +44,10 @@ mkdir -p "$TMP/registry/SPEC" "$TMP/registry/ADR"
 REPO="$TMP/repo"
 mkdir -p "$REPO/docs"
 cd "$REPO"
+in_throwaway "$REPO"          # VOR dem ersten Schreibbefehl
 git init -q
 git config user.email t@t; git config user.name t
+in_throwaway "$REPO"
 
 # resolvable + id-only + benign compounds/sub-refs  -> PASS (no finding)
 cat > docs/good.md <<'EOF'


### PR DESCRIPTION
Alle drei Fixture-Suiten legen Wegwerf-git-Repos an. Als pre-commit-Hook ausgeführt erben sie `GIT_DIR` und Freunde — **jeder `git`-Aufruf darin zielt dann auf das aufrufende Repo.**

Im Schwester-Repo ist das bereits passiert: `git init` re-initialisierte das echte Repo, `git rm --cached` stellte **3076 Löschungen** in dessen Index (dort BUG-0213; zurückgenommen, kein Datenverlust).

Hier läuft heute nichts als Hook. Das ist keine Verteidigung — es ist der einzige Grund, warum es noch nicht gezündet hat, und diese Fixtures sind das Naheliegendste, was jemand als Nächstes so verdrahtet.

## Zwei Schichten, weil eine allein nicht reicht

1. `unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE …` entfernt die Vererbung.
2. `in_throwaway DIR` bricht ab, wenn `git` woanders hinzeigt — der Gürtel zum Hosenträger, für die nächste Variable, die git einführt und niemand unsettet.

## Die Reihenfolge ist der eigentliche Punkt

Der erste Anlauf setzte die Wache **nach** `git init; git config user.email t@t`. Das sah sauber aus, weil `git status` nichts zeigte — während `git config` die Wegwerf-Identität des Fixtures in die **geteilte Config des echten Repos** geschrieben hatte. Worktrees teilen sich `.git/config`; `git status` kann das prinzipiell nicht sehen.

Sie ist damit in einen **gemergten Commit** im Schwester-Repo gelangt, bevor es auffiel.

> Eine Prüfung, die nach dem Schaden läuft, ist eine Obduktion, keine Wache.

## Verifikation von der Fehlerseite

Mit entferntem `unset` und geerbtem `GIT_DIR`:

```
Exit: 2
FATAL: git zeigt auf /Users/…/.wt-harden, nicht auf /private/var/…/repo
Config nachher: (leer)        ← vorher wurde hier t@t hineingeschrieben
Status-Änderungen: 0
```

Mit `unset` laufen alle drei in **beiden** Modi — normal und mit geerbtem `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`: **13, 80 und 9** Zusicherungen.

**Ein Fixture, das ein echtes Repo anfassen kann, ist eine Waffe, kein Test.**

## Verifikation

`boundary-gate` clean · `id-xref-lint` clean · `check-docs.sh` PASS · `docaudit -cli all` PASS · alle drei Suiten in beiden Modi grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)