### PR TITLE
style: pick the mark each sentence needs, in the lines #182 swept

### DIFF
--- a/.claude/skills/bug-report/SKILL.md
+++ b/.claude/skills/bug-report/SKILL.md
@@ -65,8 +65,8 @@ Get the next id deterministically: do not count files yourself:
 ./scripts/bugtracker.sh next-id      # -> BUG-0213  (a ceiling, not a claim)
 ```
 
-After writing the file, **claim the number**, reading a ceiling allocates
-nothing:
+After writing the file, **claim the number**: reading a ceiling allocates
+nothing.
 
 ```bash
 ./scripts/bugtracker.sh claim BUG-0213

--- a/.claude/skills/feature-request/SKILL.md
+++ b/.claude/skills/feature-request/SKILL.md
@@ -84,8 +84,8 @@ that names it.
 ./scripts/bugtracker.sh next-id FR      # -> FR-0096  (a ceiling, not a claim)
 ```
 
-Write the file, then **claim the number**, reading a ceiling allocates nothing,
-and two sessions asking at the same moment get the same answer:
+Write the file, then **claim the number**: reading a ceiling allocates nothing,
+and two sessions asking at the same moment get the same answer.
 
 ```bash
 ./scripts/bugtracker.sh claim FR-0096

--- a/docs/bug-tracking.md
+++ b/docs/bug-tracking.md
@@ -66,7 +66,7 @@ scripts/bugtracker.sh <command> [args]
 
 | Command | Purpose |
 |---------|---------|
-| `next-id [BUG\|FR] [--no-fetch]` | Next free id of that kind (default `BUG`). Use it instead of counting files, see [Allocating an id](#allocating-an-id). |
+| `next-id [BUG\|FR] [--no-fetch]` | Next free id of that kind (default `BUG`). Use it instead of counting files: see [Allocating an id](#allocating-an-id). |
 | `claim <ID>` | Record the id in the shared slot table. **This** is what allocates it. |
 | `path <ID>` | Resolve the analysis file. |
 | `status <ID> [STATUS]` | Read, or set, the canonical status. |
@@ -107,7 +107,7 @@ pull.
 ### Claiming it
 
 `next-id` only **reads**. Two sessions asking in the same moment still get the
-same number, because reading a ceiling records nothing, that is exactly how one
+same number, because reading a ceiling records nothing; that is exactly how one
 id was handed out twice. The write is a separate step:
 
 ```bash
@@ -118,7 +118,7 @@ scripts/bugtracker.sh claim FR-0105       # now it is allocated
 
 `claim` appends the id and its **filename** to the shared slot table named by
 `$M3C_SLOT_TABLE`, and refuses when the number already belongs to a different
-file, naming who holds it, and that the later one yields.
+file, naming who holds it and that the later one yields.
 
 Two honest limits:
 

--- a/scripts/bugtracker.sh
+++ b/scripts/bugtracker.sh
@@ -51,7 +51,7 @@
 #
 # ALLOCATION IS A WRITE, NOT A READ. `next-id` only READS: it takes the ceiling
 # from every claim it can see, which still lets two sessions asking at the same
-# moment receive the same number, that is how FR-0096 was handed out twice.
+# moment receive the same number; that is how FR-0096 was handed out twice.
 # `claim` is the write. Until an id is recorded in the shared slot table
 # ($M3C_SLOT_TABLE) it is not allocated.
 #
@@ -226,7 +226,7 @@ EOF
   esac
 
   local next; next=$(printf '%s-%04d' "$kind" "$((max + 1))")
-  note "next-id: $next is NOT yet allocated, reading a ceiling is not a claim.
+  note "next-id: $next is NOT yet allocated: reading a ceiling is not a claim.
   Write the report, then: $(basename "$0") claim $next"
   printf '%s\n' "$next"
 }
@@ -388,7 +388,7 @@ cmd_open() {
 
 slot_table() {
   local t=${M3C_SLOT_TABLE:-}
-  [ -n "$t" ] || die "M3C_SLOT_TABLE is not set, there is nowhere to record the claim.
+  [ -n "$t" ] || die "M3C_SLOT_TABLE is not set. There is nowhere to record the claim.
   Point it at the shared slot table, the same file the slot checker reads.
   Until a number is written there it is NOT allocated: a number that exists only
   in your working copy, or in a conversation, is one someone else can be handed a
@@ -419,7 +419,7 @@ cmd_claim() {
   row="| $num | \`$base\` | angelegt $(date +%Y-%m-%d) | belegt via bugtracker.sh claim |"
   printf '%s\n' "$row" >> "$table"
   echo "$id claimed in $(basename "$table")"
-  note "claim: durable only once the slot table is COMMITTED, until then it lives
+  note "claim: durable only once the slot table is COMMITTED; until then it lives
   in one working copy, which is the narrower carrier the rule warns about."
 }
 

--- a/scripts/bugtracker.test.sh
+++ b/scripts/bugtracker.test.sh
@@ -12,17 +12,17 @@
 set -euo pipefail
 
 # Fixtures legen Wegwerf-git-Repos an. Als Hook geerbte GIT_*-Variablen wuerden
-# jeden git-Aufruf hier auf das AUFRUFENDE Repo umlenken, in
+# jeden git-Aufruf hier auf das AUFRUFENDE Repo umlenken. In
 # m3c-tools-maintenance hat genau das 3076 Loeschungen in einen echten Index
 # geschrieben (BUG-0213, zurueckgenommen, kein Datenverlust). Ein Fixture, das
 # ein echtes Repo anfassen kann, ist eine Waffe, kein Test.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
       GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_PREFIX
 
-# in_throwaway DIR, bricht ab, wenn git auf ein FREMDES Repo zeigt. Muss VOR
+# in_throwaway DIR: bricht ab, wenn git auf ein FREMDES Repo zeigt. Muss VOR
 # dem ersten Schreibbefehl laufen: schon `git init` und `git config` schreiben,
 # und `git config user.email` landete beim ersten Anlauf in der Config des
-# echten Repos. "Noch kein Repo" ist in Ordnung, das ist der Normalfall vor
+# echten Repos. "Noch kein Repo" ist in Ordnung; das ist der Normalfall vor
 # `git init`. Pfade aufgeloest vergleichen (macOS: /var -> /private/var).
 in_throwaway() {
   local want have
@@ -341,7 +341,7 @@ refuses "a malformed Repo value is rejected, not passed to gh" "$BT" open 217
 # --- claim: die Vergabe wird ein Schreibvorgang -------------------------------
 #
 # next-id LIEST nur. Zwei Sessions, die im selben Moment fragen, bekommen dieselbe
-# Zahl, so wurde FR-0096 zweimal vergeben. claim ist der Schreibvorgang.
+# Zahl; so wurde FR-0096 zweimal vergeben. claim ist der Schreibvorgang.
 
 CLAIMED="$BUGS/BUG-0300-nimmt-eine-nummer.md"
 printf '# BUG-0300\n\n- **Status:** open\n' > "$CLAIMED"

--- a/tools/boundary-gate.test.sh
+++ b/tools/boundary-gate.test.sh
@@ -13,17 +13,17 @@
 set -euo pipefail
 
 # Fixtures legen Wegwerf-git-Repos an. Als Hook geerbte GIT_*-Variablen wuerden
-# jeden git-Aufruf hier auf das AUFRUFENDE Repo umlenken, in
+# jeden git-Aufruf hier auf das AUFRUFENDE Repo umlenken. In
 # m3c-tools-maintenance hat genau das 3076 Loeschungen in einen echten Index
 # geschrieben (BUG-0213, zurueckgenommen, kein Datenverlust). Ein Fixture, das
 # ein echtes Repo anfassen kann, ist eine Waffe, kein Test.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
       GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_PREFIX
 
-# in_throwaway DIR, bricht ab, wenn git auf ein FREMDES Repo zeigt. Muss VOR
+# in_throwaway DIR: bricht ab, wenn git auf ein FREMDES Repo zeigt. Muss VOR
 # dem ersten Schreibbefehl laufen: schon `git init` und `git config` schreiben,
 # und `git config user.email` landete beim ersten Anlauf in der Config des
-# echten Repos. "Noch kein Repo" ist in Ordnung, das ist der Normalfall vor
+# echten Repos. "Noch kein Repo" ist in Ordnung; das ist der Normalfall vor
 # `git init`. Pfade aufgeloest vergleichen (macOS: /var -> /private/var).
 in_throwaway() {
   local want have

--- a/tools/id-xref-lint.test.sh
+++ b/tools/id-xref-lint.test.sh
@@ -10,17 +10,17 @@
 set -euo pipefail
 
 # Fixtures legen Wegwerf-git-Repos an. Als Hook geerbte GIT_*-Variablen wuerden
-# jeden git-Aufruf hier auf das AUFRUFENDE Repo umlenken, in
+# jeden git-Aufruf hier auf das AUFRUFENDE Repo umlenken. In
 # m3c-tools-maintenance hat genau das 3076 Loeschungen in einen echten Index
 # geschrieben (BUG-0213, zurueckgenommen, kein Datenverlust). Ein Fixture, das
 # ein echtes Repo anfassen kann, ist eine Waffe, kein Test.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
       GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_PREFIX
 
-# in_throwaway DIR, bricht ab, wenn git auf ein FREMDES Repo zeigt. Muss VOR
+# in_throwaway DIR: bricht ab, wenn git auf ein FREMDES Repo zeigt. Muss VOR
 # dem ersten Schreibbefehl laufen: schon `git init` und `git config` schreiben,
 # und `git config user.email` landete beim ersten Anlauf in der Config des
-# echten Repos. "Noch kein Repo" ist in Ordnung, das ist der Normalfall vor
+# echten Repos. "Noch kein Repo" ist in Ordnung; das ist der Normalfall vor
 # `git init`. Pfade aufgeloest vergleichen (macOS: /var -> /private/var).
 in_throwaway() {
   local want have


### PR DESCRIPTION
Kleiner Nachzug zu #182.

#182 hat die Geviertstriche beseitigt, die die claim-Arbeit auf master hinterlassen hatte, und den Prosa-Gate wieder grün gemacht. Das war die dringende Hälfte, und sie war richtig.

Ersetzt wurde allerdings durch **Kommas** — und genau das schließt CODESTYLE aus:

> Never a blind swap to a hyphen: pick the punctuation the clause needs.

Ein Komma ist dieselbe Falle, einen Schritt weiter. Bei 21 Zeilen sind so überwiegend Komma-Splices entstanden:

```
"**claim the number**, reading a ceiling allocates nothing:"
"records nothing, that is exactly how one id was handed out twice"
"M3C_SLOT_TABLE is not set, there is nowhere to record the claim"
"Use it instead of counting files, see [Allocating an id]"
```

In zwei Fällen zeigt zusätzlich ein Doppelpunkt ins Leere, weil der Satzteil, den er ankündigte, hinter ein Komma gerutscht ist.

## Was dieser PR tut

Jede Zeile bekommt die Satzzeichen, die ihre beiden Hälften verlangen, nach der Tabelle in CODESTYLE:

| Der Strich tat dies | Jetzt |
|---|---|
| Etikett, dann Entfaltung | `:` |
| zwei eng verbundene Teilsätze | `;` |
| zwei eigenständige Aussagen | `.` |
| Nachtrag | `,` |

Das Umschreiben *ist* der Zweck der Regel, nicht das bloße Verschwinden des Strichs — so steht es auch in der Begründung von CODESTYLE.

## Verifikation

`check-no-emdash.sh` grün vor und nach der Änderung · `bugtracker.test.sh` 91/91 · `boundary-gate.test.sh` 13/13 · `id-xref-lint.test.sh` 9/9 · `check-docs.sh` PASS · `docaudit -cli all` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)