### PR TITLE
fix(ci): sieben Step-Namen quoten, pin-guard und windows-gate liefen nicht mehr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,33 @@ jobs:
       - name: No U+2014 EM DASH in the tracked tree
         run: ./scripts/check-no-emdash.sh
 
+      # A workflow file that does not PARSE never runs, so no guard living
+      # inside .github/workflows can catch its own file being broken. This step
+      # lives in ci.yml and parses its siblings, which is the only arrangement
+      # that works. It exists because a punctuation sweep once turned seven step
+      # names into `name: Guard: ...`, invalid YAML, and pin-guard.yml plus
+      # windows-gate.yml silently stopped running for four merges.
+      - name: Every workflow file is valid YAML
+        run: |
+          python3 - <<'PY'
+          import glob, sys, yaml
+          files = sorted(glob.glob(".github/workflows/*.yml") + glob.glob(".github/workflows/*.yaml"))
+          if not files:
+              sys.exit("no workflow files found: the glob is wrong, not the tree")
+          bad = 0
+          for f in files:
+              try:
+                  yaml.safe_load(open(f, encoding="utf-8"))
+              except Exception as e:
+                  print(f"INVALID {f}: {str(e).splitlines()[0]}")
+                  bad += 1
+          print(f"{len(files)} workflow files checked, {bad} invalid")
+          if bad:
+              print("An unquoted colon in a step name is the usual cause: "
+                    'name: Foo: bar  ->  name: "Foo: bar"')
+              sys.exit(1)
+          PY
+
   docs-gate:
     name: CLI/manual consistency (docaudit)
     # Pure-stdlib AST gate: it only PARSES cmd/m3c-tools and cmd/skillctl, so it

--- a/.github/workflows/pin-guard.yml
+++ b/.github/workflows/pin-guard.yml
@@ -74,7 +74,7 @@ jobs:
           echo "OK: every 'uses:' ref is pinned to a 40-hex commit SHA."
 
       # (2) CD-T2: no floating @latest anywhere in the workflows.
-      - name: Guard: no @latest refs
+      - name: "Guard: no @latest refs"
         run: |
           set -euo pipefail
           # Exclude this guard file: it contains the literal token by necessity.
@@ -96,7 +96,7 @@ jobs:
       # `permissions: { contents: write, id-token: write }` (indented under a job)
       # is never examined. Allowed top-level values: `read`, `none`, `{}`,
       # `read-all`. Rejected: `write-all` and any `: write` scope.
-      - name: Guard: top-level permissions present AND read-only (least privilege)
+      - name: "Guard: top-level permissions present AND read-only (least privilege)"
         run: |
           set -euo pipefail
           bad=""
@@ -131,7 +131,7 @@ jobs:
           echo "OK: every workflow declares a read-only top-level permissions block (writes are per-job)."
 
       # (4) CD-T7: every upload-artifact step sets retention-days.
-      - name: Guard: upload-artifact steps set retention-days
+      - name: "Guard: upload-artifact steps set retention-days"
         run: |
           set -euo pipefail
           bad=""

--- a/.github/workflows/windows-gate.yml
+++ b/.github/workflows/windows-gate.yml
@@ -219,7 +219,7 @@ jobs:
         with:
           name: win-trust-json-${{ github.sha }}
 
-      - name: Parity: Windows executed-count must not trail Linux beyond self-skips
+      - name: "Parity: Windows executed-count must not trail Linux beyond self-skips"
         run: |
           python3 scripts/windows-trust-parity.py lin-trust.json win-trust.json
 
@@ -253,7 +253,7 @@ jobs:
           Write-Host "PASS: help output OK"
         shell: pwsh
 
-      - name: Smoke: m3c-tools unknown command exits non-zero
+      - name: "Smoke: m3c-tools unknown command exits non-zero"
         run: |
           $proc = Start-Process -FilePath "build\m3c-tools-windows-amd64.exe" `
             -ArgumentList "unknown-command-xyz" `
@@ -265,14 +265,14 @@ jobs:
           Write-Host "PASS: unknown command exits with code $($proc.ExitCode)"
         shell: pwsh
 
-      - name: Smoke: skillctl help (trust CLI runs on Windows)
+      - name: "Smoke: skillctl help (trust CLI runs on Windows)"
         run: |
           $out = & "build\skillctl-windows-amd64.exe" --help 2>&1
           Write-Host $out
           Write-Host "PASS: skillctl binary executes on Windows"
         shell: pwsh
 
-      - name: Smoke: init.cfg generation
+      - name: "Smoke: init.cfg generation"
         run: |
           # Build a fresh binary for this smoke test
           go build -o build\m3c-tools-test.exe .\cmd\m3c-tools

--- a/docs/security/codeql-backlog.md
+++ b/docs/security/codeql-backlog.md
@@ -143,6 +143,27 @@ The baseline was regenerated with the pinned `gosec@v2.29.0`, not hand-edited.
 
 ---
 
+## A gate that could not see itself
+
+The em dash sweep quoted one step name in `pin-guard.yml` and one in
+`windows-gate.yml` (a `:` inserted into an unquoted YAML scalar changes the
+document), but left five more of the same shape unquoted. Both files became
+invalid YAML, so **both workflows silently stopped running for four merges**.
+The verification that was supposed to catch it used
+`glob.glob("**/*.yml", recursive=True)`, which does not descend into
+dot-directories, so `.github/workflows/` was never re-checked.
+
+Two lessons, both now enforced rather than remembered:
+
+- A workflow file that does not parse never runs, so no guard inside
+  `.github/workflows` can catch its own file being broken. The
+  "Every workflow file is valid YAML" step therefore lives in `ci.yml` and
+  parses its siblings.
+- When a glob returns nothing, that is a bug in the glob, not a clean tree. The
+  step exits non-zero if it finds zero workflow files.
+
+---
+
 ## Repository posture, as measured
 
 Two facts worth stating plainly, because they change what "the gate is green"


### PR DESCRIPTION
## Was kaputt war

Der Em-Dash-Sweep (#176) hat in Step-Namen einen Doppelpunkt eingesetzt. In `pin-guard.yml` und `windows-gate.yml` habe ich je **einen** gequotet und dabei **fuenf weitere derselben Form uebersehen**:

```yaml
- name: Guard: no @latest refs        # kein gueltiges YAML
```

Beide Workflows sind seither **gar nicht mehr gestartet**, vier Merges lang (#176, #180, #183, #181). Sichtbar nur als Lauf mit `0s` und "This run likely failed because of a workflow file issue", also genau die Form, die man beim Ueberfliegen der Checkliste nicht sieht: der Check taucht auf keinem PR mehr als rot auf, er taucht gar nicht mehr auf.

`pin-guard.yml` ist der CD-T1/T2/T6/T7-Supply-Chain-Guard (SHA-Pinning, kein `@latest`, Least-Privilege-`permissions`, `retention-days`). Der lag vier Merges lang still.

## Warum die Pruefung es nicht gefangen hat

Die YAML-Validierung nach dem Sweep benutzte:

```python
glob.glob("**/*.yml", recursive=True)
```

Das steigt **nicht in Punkt-Verzeichnisse** ab. `.github/workflows/` war nach der ersten Korrektur also nie wieder in der Menge, und der Lauf meldete "clean" ueber eine leere Menge.

## Was jetzt drin ist

1. Alle sieben Namen gequotet. Alle 15 Workflow-Dateien parsen wieder.
2. Neuer Schritt **"Every workflow file is valid YAML"** im `prose-gate`-Job von `ci.yml`.

Der Schritt muss in `ci.yml` liegen und nicht in einem `.github/workflows`-Guard: **eine Datei, die nicht parst, laeuft nicht, kann sich also nicht selbst pruefen.** `pin-guard.yml` konnte seinen eigenen Bruch strukturell nicht sehen. Der Schritt bricht ausserdem ab, wenn der Glob **null** Dateien findet, denn genau das war der Fehler: eine leere Menge ist ein Glob-Bug, kein sauberer Baum.

## Verifikation

```
15 workflow files checked, 0 invalid
```

Der Beweis, dass es beisst, steht im Verlauf: `pin-guard.yml` war auf jedem Commit ab `chore/no-em-dash` rot und davor gruen.

Dokumentiert in `docs/security/codeql-backlog.md`, Abschnitt "A gate that could not see itself".

🤖 Generated with [Claude Code](https://claude.com/claude-code)