### PR TITLE
fix(install): pin the one-liners to a commit, not to a tag object

### DIFF
--- a/.github/workflows/boundary-gate.yml
+++ b/.github/workflows/boundary-gate.yml
@@ -46,3 +46,10 @@ jobs:
 
       - name: id-xref-lint fixtures (including the registry-absent degrade)
         run: bash tools/id-xref-lint.test.sh
+
+      # Lives here rather than in the prose gate because it needs the FULL
+      # history: a pin is by definition an older commit, and a shallow clone
+      # cannot tell a commit from a tag object. That distinction is the whole
+      # check (BUG-0215).
+      - name: install pins resolve to commits, digests match
+        run: bash scripts/check-install-pins.sh

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ m3c-tools doctor                        # verify connectivity & config
 ```bash
 # macOS / Linux / Windows, signed installer: fetches the right binary from the
 # signed skillctl/v* release and verifies cosign/OIDC provenance + SHA-256 first.
-curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/tools/skillctl-install.sh | bash
 
 skillctl keygen --out ~/.config/m3c/skill-keys/mykey            # ed25519 → mykey.priv + mykey.pub
 skillctl pack --skill ./my-skill -o my-skill.skb --name my-skill --version 1.0.0
@@ -171,7 +171,7 @@ The **scripted one-liners** fetch the right binary for your host, **verify cosig
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.ps1 | iex
+irm https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/tools/skillctl-install.ps1 | iex
 ```
 
 Installs `skillctl` to `%LOCALAPPDATA%\Programs\skillctl` after verifying cosign provenance +
@@ -181,7 +181,7 @@ use **one or the other**, not both, so you don't end up with two `skillctl.exe` 
 
 **macOS / Linux:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/tools/skillctl-install.sh | bash
 ```
 
 Override the target dir or release with `INSTALL_DIR=…` / `RELEASE_BASE=…` (default `~/.local/bin`).
@@ -190,7 +190,7 @@ digest, with an **ed25519 fallback** for hosts without cosign, see the
 [skillctl quickstart](docs/quickstart-skillctl.md#1-install).
 
 **Bootstrap integrity.** The one-liner URLs are pinned to the **immutable commit
-`82c8328`**, not the mutable `master` branch, where a single rewrite could swap the
+`f43eb49`**, not the mutable `master` branch, where a single rewrite could swap the
 bootstrap script *and* every pin inside it (a TOFU trap). Verify the fetched bytes
 out-of-band before trusting them. Expected SHA-256:
 
@@ -203,7 +203,7 @@ Verify-then-run instead of piping straight to `iex` / `bash`:
 
 ```powershell
 # Windows
-$u = 'https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.ps1'
+$u = 'https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/tools/skillctl-install.ps1'
 $f = "$env:TEMP\skillctl-install.ps1"; irm $u -OutFile $f
 if ((Get-FileHash $f -Algorithm SHA256).Hash -ne '9E8CEEC9D2C87B4F5A7136653E8CA69224FA6579A55DA221D9E2FE875F9924C8') { throw 'SHA-256 mismatch' }
 & $f
@@ -211,7 +211,7 @@ if ((Get-FileHash $f -Algorithm SHA256).Hash -ne '9E8CEEC9D2C87B4F5A7136653E8CA6
 
 ```bash
 # macOS / Linux
-u='https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.sh'
+u='https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/tools/skillctl-install.sh'
 f=$(mktemp); curl -fsSL "$u" -o "$f"
 echo 'adf9d768a376ee921f9df728546de072a2b3f14e9616e10bf3419fef520034a9  '"$f" | shasum -a 256 -c - && bash "$f"
 ```

--- a/docs/acceptance-skillctl-lifecycle.md
+++ b/docs/acceptance-skillctl-lifecycle.md
@@ -58,16 +58,16 @@ Prerequisites on **both** machines (see [manual §Installation](manual-skillctl.
 ```bash
 # Install skillctl (signed one-liner; verifies cosign provenance + SHA-256):
 #   macOS/Linux:
-curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/tools/skillctl-install.sh | bash
 #   Windows (PowerShell):
-#   irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.ps1 | iex
+#   irm https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/tools/skillctl-install.ps1 | iex
 
 skillctl version          # MUST print a real skillctl/vX.Y.Z, NOT "dev" (see Troubleshooting)
 skillctl login --base-url https://onboarding.guide   # ER1 device pairing (FR-0043)
 skillctl login --status
 ```
 
-> **Bootstrap integrity.** The installer URLs are pinned to the **immutable commit `82c8328`**
+> **Bootstrap integrity.** The installer URLs are pinned to the **immutable commit `f43eb49`**
 > (not the mutable `master` branch: one rewrite there could swap the bootstrap script *and* every
 > pin inside it). Verify the fetched bytes out-of-band, expected SHA-256:
 > `tools/skillctl-install.ps1` → `9e8ceec9d2c87b4f5a7136653e8ca69224fa6579a55da221d9e2fe875f9924c8`,
@@ -94,15 +94,15 @@ straight from here):
 
 ```powershell
 # 1) Install skillctl (verifies cosign provenance + SHA-256, no admin):
-irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.ps1 | iex
+irm https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/tools/skillctl-install.ps1 | iex
 
 # 2) Download + run the lifecycle smoke (keygen -> pack -> sign -> verify -> trust -> tamper):
 $q = "$env:TEMP\skillctl-quickstart.ps1"
-irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/scripts/skillctl-quickstart-windows.ps1 -OutFile $q
+irm https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/scripts/skillctl-quickstart-windows.ps1 -OutFile $q
 powershell -ExecutionPolicy Bypass -File $q
 ```
 
-> **Pinned + verifiable.** Both URLs above are pinned to the **immutable commit `82c8328`**.
+> **Pinned + verifiable.** Both URLs above are pinned to the **immutable commit `f43eb49`**.
 > Expected SHA-256: `tools/skillctl-install.ps1` → `9e8ceec9d2c87b4f5a7136653e8ca69224fa6579a55da221d9e2fe875f9924c8`;
 > `scripts/skillctl-quickstart-windows.ps1` → `74b8ca8dbc7b6cae932bb9c1e016628aaac9c678db3ac7cb9159204dc5d7e27c`.
 > Verify the fetched bytes (`Get-FileHash <file> -Algorithm SHA256`) before running.

--- a/docs/quickstart-skillctl.md
+++ b/docs/quickstart-skillctl.md
@@ -28,7 +28,7 @@ no admin rights required.
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.ps1 | iex
+irm https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/tools/skillctl-install.ps1 | iex
 ```
 
 Installs to `%LOCALAPPDATA%\Programs\skillctl` after verifying cosign provenance + SHA-256.
@@ -39,12 +39,12 @@ two `skillctl.exe` on your `PATH`.
 
 **macOS / Linux:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/tools/skillctl-install.sh | bash
 ```
 
 Override the target dir or the release with `INSTALL_DIR=…` / `RELEASE_BASE=…`.
 
-**Bootstrap integrity.** The one-liner URLs are pinned to the **immutable commit `82c8328`**
+**Bootstrap integrity.** The one-liner URLs are pinned to the **immutable commit `f43eb49`**
 (not the mutable `master` branch, where one rewrite could swap the bootstrap script *and* every
 pin inside it). Verify the fetched bytes out-of-band before trusting them, expected SHA-256:
 `tools/skillctl-install.ps1` → `9e8ceec9d2c87b4f5a7136653e8ca69224fa6579a55da221d9e2fe875f9924c8`;

--- a/docs/releasing-skillctl-windows.md
+++ b/docs/releasing-skillctl-windows.md
@@ -75,18 +75,18 @@ gh run watch $(gh run list --workflow=skillctl-windows-smoke.yml --limit 1 --jso
 **(b) Real Windows PowerShell: the true acceptance (after Step 2 publishes):**
 ```powershell
 # 1) one-click install: verifies cosign provenance + SHA-256, installs to %LOCALAPPDATA%\Programs\skillctl:
-irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/tools/skillctl-install.ps1 | iex
+irm https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/tools/skillctl-install.ps1 | iex
 
 # 2) open a NEW terminal (PATH was updated), then:
 skillctl version        # -> skillctl/v0.3.1
 
 # 3) walk the packaged lifecycle smoke (keygen -> pack -> sign -> verify -> trust -> tamper):
 $q = "$env:TEMP\skillctl-qs.ps1"
-irm https://raw.githubusercontent.com/kamir/m3c-tools/82c832882e8683fa3824ce65db01d945af639c50/scripts/skillctl-quickstart-windows.ps1 -OutFile $q
+irm https://raw.githubusercontent.com/kamir/m3c-tools/f43eb496685a9f9cbc5b9a28046f568e70ee7dd9/scripts/skillctl-quickstart-windows.ps1 -OutFile $q
 powershell -ExecutionPolicy Bypass -File $q
 ```
 
-> **Bootstrap integrity.** These URLs are pinned to the **immutable commit `82c8328`**, not the
+> **Bootstrap integrity.** These URLs are pinned to the **immutable commit `f43eb49`**, not the
 > mutable `master` branch (where one rewrite could swap the bootstrap script *and* every pin
 > inside it). Expected SHA-256: `tools/skillctl-install.ps1` →
 > `9e8ceec9d2c87b4f5a7136653e8ca69224fa6579a55da221d9e2fe875f9924c8`;

--- a/scripts/check-install-pins.sh
+++ b/scripts/check-install-pins.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# check-install-pins.sh: every pinned raw.githubusercontent URL in the docs must
+# point at a real, published COMMIT, and the SHA-256 next to it must match the
+# bytes at that pin.
+#
+# Why this exists (BUG-0215): the install one-liners were pinned to
+# 82c8328..., which is the object id of the ANNOTATED TAG skillctl/v0.4.0, not
+# of the commit it points at. `git rev-parse <tag>` hands you the tag object;
+# raw.githubusercontent.com only serves commits. Every published install
+# one-liner returned 404, on Windows and Unix alike, and nothing noticed: the
+# release runbook says to pin `git rev-parse origin/master`, but no check ever
+# read what was actually written.
+#
+# A rule nobody checks is a request. This is the check.
+#
+# It is deliberately OFFLINE: it reads git objects, not the network, so it is
+# deterministic in CI and cannot pass because a proxy cached a 200. It needs the
+# full history (fetch-depth: 0), because a pin is by definition an older commit.
+#
+# Usage: ./scripts/check-install-pins.sh
+# Exit:  0 every pin resolves and every digest matches - 1 a finding - 2 setup error
+#
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; NC=$'\033[0m'
+fail=0
+emit() { printf '%s%s\n' "$1" "$NC"; fail=1; }
+
+# owner/repo of this checkout, so a fork does not check the upstream pins.
+origin=$(git config --get remote.origin.url 2>/dev/null || true)
+origin=${origin%.git}; origin=${origin#git@github.com:}; origin=${origin#https://github.com/}
+[ -n "$origin" ] || { echo "check-install-pins: no origin remote" >&2; exit 2; }
+
+pins=$(git grep -hoE "raw\.githubusercontent\.com/$origin/[0-9a-f]{40}/[^ )\"'\`]+" -- '*.md' \
+       | sort -u || true)
+if [ -z "$pins" ]; then
+  echo "check-install-pins: no pinned URLs found (nothing to check)"
+  exit 0
+fi
+
+# --- Durchgang 1: Pins aufloesen, Digests sammeln ---------------------------
+#
+# Zwei Durchgaenge, weil Regel (b) unten die Digests ALLER gepinnten Dateien
+# braucht: die beiden Einzeiler stehen in den Dokumenten direkt untereinander,
+# und ein Fenster um die eine URL sieht zwangslaeufig den Digest der anderen.
+# Die erste Fassung dieser Pruefung meldete genau das als Fehler.
+n=0
+ALLWANT=""
+PINS=""
+while IFS= read -r pin; do
+  [ -n "$pin" ] || continue
+  rest=${pin#raw.githubusercontent.com/$origin/}
+  sha=${rest%%/*}
+  path=${rest#*/}
+  n=$((n + 1))
+
+  # 1. Der Pin muss ein COMMIT sein. Genau das ging in Produktion schief: ein
+  #    Tag-Objekt hat eine gueltige 40-Hex-Id und wird von niemandem serviert.
+  type=$(git cat-file -t "$sha" 2>/dev/null || echo missing)
+  case "$type" in
+    commit) ;;
+    tag)
+      emit "${RED}FAIL $path: pinned to a TAG object ($sha)"
+      emit "${RED}     raw.githubusercontent serves commits only. Use: git rev-parse ${sha}^{commit}"
+      continue ;;
+    missing)
+      emit "${RED}FAIL $path: pinned object $sha is not in this clone"
+      emit "${RED}     A pin is an older commit; this check needs the full history (fetch-depth: 0)."
+      continue ;;
+    *)
+      emit "${RED}FAIL $path: pinned object $sha is a $type, not a commit"
+      continue ;;
+  esac
+
+  # 2. Der Commit muss veroeffentlicht sein, sonst 404 fuer alle ausser dir.
+  if git rev-parse --verify -q origin/master >/dev/null 2>&1; then
+    git merge-base --is-ancestor "$sha" origin/master 2>/dev/null \
+      || emit "${RED}FAIL $path: $sha is not reachable from origin/master (unpublished pin)"
+  fi
+
+  # 3. Die Datei muss es an diesem Commit geben.
+  git cat-file -e "$sha:$path" 2>/dev/null \
+    || { emit "${RED}FAIL $path: does not exist at $sha"; continue; }
+
+  want=$(git show "$sha:$path" | shasum -a 256 | cut -d' ' -f1)
+  ALLWANT="$ALLWANT $want"
+  PINS="$PINS$sha/$path|$want"$'\n'
+done <<<"$pins"
+
+# --- Durchgang 2: die veroeffentlichten Digests pruefen ----------------------
+while IFS='|' read -r url want; do
+  [ -n "$url" ] || continue
+  path=${url#*/}
+  want_up=$(printf '%s' "$want" | tr 'a-f' 'A-F')
+
+  # (a) Eine Zeile, die den Pfad nennt UND einen Digest traegt, muss DIESEN tragen.
+  #     Das ist die Tabellenzeile.
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    got=$(printf '%s' "$line" | grep -oE '[0-9a-fA-F]{64}' | head -1 | tr 'A-F' 'a-f')
+    [ "$got" = "$want" ] || emit "${RED}FAIL $path: a line publishes SHA-256 $got, the pin has $want"
+  done < <(git grep -hE "$path" -- '*.md' | grep -E '[0-9a-fA-F]{64}' || true)
+
+  # (b) In den verify-then-run-Bloecken steht der Digest auf einer EIGENEN Zeile,
+  #     fuer PowerShell in Grossbuchstaben. Regel (a) sieht ihn dort nicht. Ein
+  #     Fenster von 8 Zeilen nach der URL ist, was so ein Block umspannt; erlaubt
+  #     ist jeder Digest einer gepinnten Datei, verboten jeder fremde.
+  while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    emit "${RED}FAIL a verify block near the pin publishes a foreign digest: $hit"
+  done < <(
+    git grep -l "$url" -- '*.md' 2>/dev/null | while IFS= read -r doc; do
+      [ -n "$doc" ] || continue
+      awk -v u="$url" -v ok="$ALLWANT" -v d="$doc" '
+        index($0, u) { win = 8; next }
+        win > 0 {
+          win--
+          if (match($0, /[0-9a-fA-F]{64}/)) {
+            h = tolower(substr($0, RSTART, RLENGTH))
+            if (index(ok, h) == 0) printf "%s:%d: %s\n", d, NR, h
+          }
+        }' "$doc"
+    done
+  )
+
+  # (c) Der echte Digest muss im pinnenden Dokument ueberhaupt vorkommen, sonst
+  #     kann ein Pin-Bump ohne Digest-Bump still durchgehen.
+  while IFS= read -r doc; do
+    [ -n "$doc" ] || continue
+    grep -qE "$want|$want_up" "$doc" \
+      || emit "${RED}FAIL $doc pins $path at ${url%%/*} but never publishes its digest $want"
+  done < <(git grep -l "$url" -- '*.md' 2>/dev/null || true)
+done <<<"$PINS"
+
+if [ "$fail" -ne 0 ]; then
+  printf '%scheck-install-pins: FAIL%s - a published install one-liner is broken\n' "$RED" "$NC" >&2
+  exit 1
+fi
+printf '%scheck-install-pins: %d pin(s) resolve, digests match%s\n' "$GREEN" "$n" "$NC"


### PR DESCRIPTION
Aus dem Feld gemeldet, Windows. **Jeder veröffentlichte Installer-Einzeiler lieferte 404.**

## Der Fehler

Die URLs waren auf `82c8328...` gepinnt. Das ist die Objekt-Id des **annotierten Tags** `skillctl/v0.4.0`, nicht die des Commits, auf den es zeigt. `git rev-parse <tag>` gibt das Tag-Objekt zurück; `raw.githubusercontent.com` serviert ausschließlich Commits.

```
.../82c8328.../tools/skillctl-install.ps1   404
.../f43eb49.../tools/skillctl-install.ps1   200
```

**13 Vorkommen** in README, Quickstart, Acceptance-Runbook und der Windows-Release-Doku, also Windows *und* Unix, im README *und* im Quickstart. Die veröffentlichten SHA-256-Digests waren für `f43eb49` bereits korrekt und bleiben unverändert; falsch war nur die Commit-Id.

## Nicht das Runbook ist schuld

`docs/releasing.md` sagt `git rev-parse origin/master` und liefert damit einen Commit. **Geprüft hat niemand, was tatsächlich eingetragen wurde** — das ist der eigentliche Defekt.

## Das Gate

`scripts/check-install-pins.sh`, offline aus den git-Objekten statt über das Netz, damit es in CI deterministisch ist und nicht grün wird, weil ein Proxy eine 200 gecacht hat:

1. der Pin muss ein **Commit** sein (das Tag-Objekt ist der Fehler, der ausgeliefert wurde)
2. er muss von `origin/master` erreichbar sein, sonst 404 für alle außer dir
3. die Datei muss an diesem Commit existieren
4. jeder in der Doku veröffentlichte SHA-256 dafür muss zu den Bytes am Pin passen

### Regel 4 brauchte drei Anläufe

Die erste Fassung prüfte nur die Tabellenzeile und ließ einen untergeschobenen falschen Digest **durch**. Die zweite ergänzte ein Fenster nach der URL und meldete daraufhin den *legitimen* Digest des Nachbar-Einzeilers, weil beide Blöcke direkt untereinander stehen. Jetzt werden erst alle gepinnten Digests gesammelt; ein **fremder** Digest im Verify-Block ist der Befund. Eine Zwischenfassung verlor zudem ihren Exit-Code an eine Subshell und meldete FAIL bei Exit 0.

### Von der Fehlerseite geprüft, alle vier blocken

| Eingeschleust | |
|---|---|
| der historische Tag-SHA | geblockt |
| falscher Digest in der Tabelle | geblockt |
| falscher Digest im PowerShell-Block | geblockt |
| falscher Digest im bash-Block | geblockt |

Verdrahtet im `boundary-gate` statt im Prosa-Gate, weil es die **volle Historie** braucht: ein Pin ist per Definition ein älterer Commit, und ein flacher Klon kann Commit und Tag-Objekt nicht unterscheiden.

## Verifikation

Beide URLs live **200** · `check-install-pins.sh` grün · `check-no-emdash` grün · `boundary-gate` clean · `id-xref-lint` clean · `check-docs.sh` PASS · `docaudit -cli all` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)