### PR TITLE
docs(security): das gemessene Ergebnis eintragen, nicht die Vorhersage

### DIFF
--- a/docs/security/codeql-backlog.md
+++ b/docs/security/codeql-backlog.md
@@ -96,16 +96,33 @@ modelling the guard above it.
 | `go/zipslip` | `pkg/skillbundle/unpack.go` | **False positive.** `sanitizeArchivePath` rejects NUL bytes, backslashes, colons (the NTFS ADS and drive separator), absolute paths, `..` traversal and Windows volume prefixes, and the extraction joins under a resolved destination root. CodeQL does not model the custom sanitizer, so it sees an unsanitized `tar.Header.Name` reaching a file operation. Rewriting working, well-reasoned traversal defence to satisfy a query that cannot see it would trade real safety for a green tick. |
 | `go/weak-sensitive-data-hashing` | `pkg/pocket/syncapi.go` | **Misclassification, and changing it would cost data.** `DeriveAccountID` derives a stable identifier from a high-entropy `pk_` API key with SHA-256. It is not password storage, so "not computationally expensive" does not apply; brute-forcing a `pk_` key through the hash is not a practical attack. More importantly the derived id is **persisted in existing sync ledgers**, so switching to HMAC or a slow KDF would orphan every already-synced account. The alert is accepted, not fixed. |
 
-Both are now **dismissed** in Code Scanning with those reasons recorded on the
+Both are **dismissed** in Code Scanning with those reasons recorded on the
 alert (`go/zipslip` as "false positive", `go/weak-sensitive-data-hashing` as
 "won't fix"). Dismissal is an account action, not a code change: no commit
-removes an alert that CodeQL believes in. If either is ever reopened, this
-section is the reason it was closed.
+removes an alert that CodeQL believes in.
 
-A third alert, `go/disabled-certificate-check` on `cmd/skillctl/replay_cmds.go`,
-is dismissed once the restructure above is on the default branch: the loopback
-property is checked at runtime on the URL being requested, and CodeQL flags the
-`InsecureSkipVerify` literal without seeing the guard.
+### What the fixes actually cleared, measured afterwards
+
+The prediction was that the six alerts fixed in code would close on their own
+once the fixes were on the default branch. **One did.** The measured outcome:
+
+| Alert | Outcome after the fix landed |
+|---|---|
+| `go/clear-text-logging` (`pkg/er1/config.go`) | **Closed as fixed by itself.** CodeQL recognised `config.MaskAPIKey` as a barrier. |
+| `go/path-injection` x4 (`pkg/config/profile.go`) | Still reported, at shifted line numbers. CodeQL does not model `ValidateProfileName` / `profilePath` as a sanitizer. |
+| `go/request-forgery` (`pkg/setup/pocket_validate.go`) | Still reported. CodeQL does not model the `checkPocketBaseURL` allow-list. |
+| `go/disabled-certificate-check` (`cmd/skillctl/replay_cmds.go`) | The old alert closed as fixed, and an identical new one was raised at the new line. |
+
+So five of the six are the same situation as `go/zipslip`: the guard exists, is
+tested, and is invisible to the query. They are dismissed as false positives,
+each with the guard and its test named on the alert.
+
+**The regression guard is the test suite, not the alert.** A dismissed alert
+stays dismissed, so it will not warn if someone deletes a validator later. What
+does warn is the Go test for each guard, and each of those has a **negative
+control**: with the guard removed the test fails. Those tests run in CI on every
+pull request. If a validator is ever removed, delete the dismissal too, and say
+so here.
 
 ---
 
@@ -169,18 +186,24 @@ Two lessons, both now enforced rather than remembered:
 Two facts worth stating plainly, because they change what "the gate is green"
 is worth:
 
-**`master` has no branch protection and no rulesets.** Verified with:
+**`master` is covered by a ruleset named `base`, and it requires no status
+checks.** Measured with:
 
 ```bash
-gh api repos/<owner>/<repo>/branches/master/protection   # 404 Branch not protected
-gh api repos/<owner>/<repo>/rulesets                     # empty
+gh api repos/<owner>/<repo>/branches/master/protection   # 404: classic protection is not used
+gh api repos/<owner>/<repo>/rulesets                     # the `base` ruleset, active
+gh api repos/<owner>/<repo>/rulesets/<id> --jq '[.rules[].type]'
 ```
 
-So there are **zero required status checks**. Every gate this repository builds,
-`prose-gate`, the docaudit CLI/manual gate, the gosec no-new-findings diff gate,
-`boundary-gate`, the race suites, is advisory in the only sense that matters:
-nothing prevents a merge while one of them is red. The gates still do their job
-for anyone who reads them; they simply do not block.
+What `base` enforces today: a pull request is required (with zero required
+approvals), the branch cannot be deleted, and non-fast-forward pushes are
+refused. There are **no bypass actors**, so the rules apply to the owner too.
+
+What it does not enforce: there is **no `required_status_checks` rule**, so
+every gate this repository builds, `prose-gate`, the docaudit CLI/manual gate,
+the gosec no-new-findings diff gate, `boundary-gate`, the race suites, still
+does not block a merge. Requiring a pull request without requiring its checks
+means the checks are seen, not obeyed. Closing that gap is step 1 below.
 
 **Secret-scanning push protection is off** (secret scanning itself and
 Dependabot security updates are on).
@@ -189,8 +212,9 @@ Dependabot security updates are on).
 
 These need repository-admin rights and cannot be done from a pull request.
 
-1. **Protect `master`** (Settings, Branches, or a ruleset) and require these
-   checks, which are the names CI reports today:
+1. **Add a `required_status_checks` rule to the `base` ruleset** (Settings,
+   Rules). The ruleset already requires a pull request; this is the part that
+   makes its checks binding. The names CI reports today:
 
    ```
    Lint & Vet
@@ -213,9 +237,10 @@ These need repository-admin rights and cannot be done from a pull request.
    CodeQL"; and the `gosec` check run reports **skipped** on most runs, so it is
    deliberately not in the list.
 
-   `CodeQL` only belongs in that list **after** the accepted alerts are
-   dismissed, otherwise it blocks every pull request on findings this file
-   documents as accepted.
+   `CodeQL` is safe to require now: as of this file, **zero alerts are open**
+   on the default branch. Requiring it before the accepted alerts were dismissed
+   would have blocked every pull request on findings documented here as
+   accepted.
 
    Verify with:
 


### PR DESCRIPTION
Nachtrag zu #181. Zwei Stellen in `docs/security/codeql-backlog.md` standen als **Erwartung** drin und wurden nie nachgemessen. Beide sind jetzt durch das ersetzt, was tatsaechlich passiert ist.

## 1. "Die sechs im Code gefixten Alerts schliessen sich von selbst"

**Einer hat das getan.** Gemessen nach dem Merge von #181:

| Alert | Ergebnis |
|---|---|
| `go/clear-text-logging` (`pkg/er1/config.go`) | **Von selbst geschlossen.** CodeQL erkennt `config.MaskAPIKey` als Barriere. |
| `go/path-injection` ×4 (`pkg/config/profile.go`) | Weiter gemeldet, an verschobenen Zeilen. `ValidateProfileName` / `profilePath` werden nicht als Sanitizer modelliert. |
| `go/request-forgery` (`pkg/setup/pocket_validate.go`) | Weiter gemeldet. Die `checkPocketBaseURL`-Allow-Liste wird nicht modelliert. |
| `go/disabled-certificate-check` (`cmd/skillctl/replay_cmds.go`) | Alter Alert als fixed geschlossen, identischer neuer an der neuen Zeile aufgegangen. |

Fuenf davon sind damit derselbe Fall wie `go/zipslip`: **der Guard existiert, ist getestet, und ist fuer die Query unsichtbar.** Alle fuenf als false positive dismissed, mit Guard **und** zugehoerigem Test am Alert benannt. Offen auf master: **0**.

Mit dem ehrlichen Nachsatz, der vorher fehlte: ein dismisster Alert warnt nicht mehr, wenn spaeter jemand einen Validator entfernt. **Der eigentliche Regressionswaechter ist der Test je Guard**, jeder mit Negativkontrolle, und der laeuft in CI auf jedem PR.

## 2. "master hat weder Branch-Protection noch Rulesets"

Inzwischen gibt es das Ruleset `base`. Gemessen:

- Pull Request erforderlich (null erforderliche Freigaben)
- kein Loeschen, kein Non-Fast-Forward
- **keine Bypass-Actors**, die Regeln gelten also auch fuer den Owner

Was fehlt: die **`required_status_checks`-Regel**. Einen PR zu verlangen, ohne seine Checks zu verlangen, heisst: die Gates werden gesehen, nicht befolgt. `prose-gate`, docaudit, gosec-diff-gate, `boundary-gate` und die Race-Suiten blockieren weiterhin keinen Merge.

Schritt 1 der Admin-Liste ist entsprechend umgeschrieben (Regel zum bestehenden Ruleset hinzufuegen, nicht "master schuetzen"), und `CodeQL` darf jetzt in die Liste, weil null Alerts offen sind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)