### PR TITLE
feat(release): Post-Release-Trigger, der die Doku-Pins automatisch setzt

### DIFF
--- a/.github/workflows/pin-bump.yml
+++ b/.github/workflows/pin-bump.yml
@@ -1,0 +1,112 @@
+name: pin-bump
+
+# Post-release trigger: move the install one-liners in the docs to the commit of
+# the release that was just published, and recompute the SHA-256 digests beside
+# them.
+#
+# Why it exists (BUG-0215): this was a manual runbook step. The runbook said to
+# pin `git rev-parse origin/master`; somebody pinned a tag instead, and
+# `git rev-parse <annotated-tag>` returns the TAG OBJECT, which
+# raw.githubusercontent.com does not serve. Every published install one-liner
+# returned 404, on Windows and Unix, until a user reported it from the field.
+# scripts/bump-install-pins.sh resolves `<ref>^{commit}`, so the mistake is not
+# available any more.
+#
+# It fires on `published`, not on the tag push: skillctl-release.yml cuts a
+# DRAFT, and a pin must not move to a release nobody has released yet.
+#
+# It opens a PULL REQUEST rather than pushing to master. Two reasons, and the
+# second matters more: a bot pushing to master would bypass exactly the branch
+# protections that make a pinned commit worth trusting, and the bump edits the
+# repository's bootstrap-integrity claim, which is a thing a human should see.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "tag, branch or commit to pin (default: latest release tag)"
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    name: Pin the docs to the released commit
+    runs-on: ubuntu-latest
+    # Only skillctl releases carry the install scripts the one-liners fetch.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.release.tag_name, 'skillctl/v')
+    permissions:
+      contents: write        # push the bump branch
+      pull-requests: write   # open the PR
+    steps:
+      # A pin is by definition an older commit, and a shallow clone cannot tell
+      # a commit from a tag object. That distinction is the entire point here.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve the ref to pin
+        id: ref
+        env:
+          INPUT_REF: ${{ github.event.inputs.ref }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          ref="${INPUT_REF:-$TAG}"
+          [ -n "$ref" ] || { echo "no ref to pin" >&2; exit 1; }
+          git fetch --quiet --tags origin
+          commit=$(git rev-parse --verify "${ref}^{commit}")
+          echo "ref=$ref"       >> "$GITHUB_OUTPUT"
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+          echo "Pinning to $commit (from $ref)"
+
+      - name: Bump the pins and digests
+        run: ./scripts/bump-install-pins.sh "${{ steps.ref.outputs.commit }}"
+
+      # A bad bump must fail here, not become a pull request. The bumper only
+      # rewrites; this is what judges the result.
+      - name: Verify the result
+        run: ./scripts/check-install-pins.sh
+
+      - name: Open a pull request if anything changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ steps.ref.outputs.ref }}
+          COMMIT: ${{ steps.ref.outputs.commit }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "docs already pin ${COMMIT:0:12}; nothing to do"
+            exit 0
+          fi
+          branch="chore/pin-bump-${COMMIT:0:12}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git commit -qam "docs: pin the install one-liners to ${COMMIT:0:12} (${REF})
+
+          Post-release bump by .github/workflows/pin-bump.yml. The ref was
+          resolved with \`^{commit}\`, so an annotated tag cannot be pinned by
+          mistake; that mistake shipped once and 404'd every install one-liner
+          (BUG-0215). scripts/check-install-pins.sh passed before this branch
+          was pushed."
+          git push -q origin "$branch"
+          gh pr create --base master --head "$branch" \
+            --title "docs: pin the install one-liners to ${COMMIT:0:12} (${REF})" \
+            --body "Automatic post-release pin bump for \`${REF}\`.
+
+          The docs now pin commit \`${COMMIT}\` and publish the SHA-256 of the
+          install scripts at that commit.
+
+          Resolved with \`${REF}^{commit}\`: an annotated tag resolves to a tag
+          object, which raw.githubusercontent.com does not serve. That is the
+          bug this workflow exists to remove (BUG-0215).
+
+          \`scripts/check-install-pins.sh\` passed before this PR was opened:
+          the pin is a published commit, the files exist at it, and every
+          digest in the docs matches the bytes there."

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -156,14 +156,30 @@ slsa-verifier verify-artifact <asset> --provenance-path multiple.intoto.jsonl \
 The `README.md` and `docs/quickstart-skillctl*.md` one‑liners pin the bootstrap
 scripts to an **immutable commit hash** (not `master`), plus the expected SHA‑256
 of each script: a TOFU defence, since `master` could be rewritten to swap the
-script *and* its inner pins at once. On **each** signed release, bump the commit
-**and** both hashes together:
+script *and* its inner pins at once.
+
+**This is automated.** Publishing a `skillctl/v*` release fires
+[`.github/workflows/pin-bump.yml`](../.github/workflows/pin-bump.yml), which
+resolves the tag, rewrites the pin and both digests, verifies the result and
+opens a pull request. Your job is to review and merge that PR, not to edit the
+hashes by hand.
+
+> It fires on **published**, not on the tag push: the release workflow cuts a
+> *draft*, and a pin must not move to a release nobody has released yet.
+
+If you ever need it by hand, or want to check whether the docs are current:
 
 ```bash
-NEWPIN=$(git rev-parse origin/master)
-shasum -a 256 tools/skillctl-install.sh tools/skillctl-install.ps1
-# → update the pinned commit + both SHAs in README.md and docs/quickstart-skillctl.md
+./scripts/bump-install-pins.sh skillctl/vX.Y.Z --check   # exit 1 = stale
+./scripts/bump-install-pins.sh skillctl/vX.Y.Z           # rewrite
+./scripts/check-install-pins.sh                          # the gate
 ```
+
+**Never `git rev-parse <tag>` on its own.** An annotated tag resolves to a tag
+object, and `raw.githubusercontent.com` serves commits only. Pinning a tag
+object once put a 404 behind every published install one-liner, on Windows and
+Unix alike, until a user reported it from the field (BUG-0215). Both scripts
+above resolve `^{commit}`, which is why the mistake is no longer reachable.
 
 ---
 

--- a/scripts/bump-install-pins.sh
+++ b/scripts/bump-install-pins.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# bump-install-pins.sh: move the install one-liners to a new release commit and
+# recompute the SHA-256 digests published next to them.
+#
+# This automates the one manual step that broke the installers (BUG-0215). The
+# release runbook said to pin `git rev-parse origin/master`; somebody pinned a
+# tag instead, and `git rev-parse <annotated-tag>` returns the TAG OBJECT, which
+# raw.githubusercontent.com does not serve. Every published one-liner 404'd.
+#
+# So the first thing this script does, and the reason it exists, is
+# `<ref>^{commit}`. A tag, a branch or a commit all resolve to the commit.
+#
+# It only rewrites; it verifies nothing. scripts/check-install-pins.sh is the
+# gate, and the caller runs it afterwards: a bumper that also judged its own
+# work would be the same trust boundary problem as a self-signed attestation.
+#
+# Usage:
+#   scripts/bump-install-pins.sh <ref>            # rewrite in place
+#   scripts/bump-install-pins.sh <ref> --check    # report only, exit 1 if stale
+#
+# Exit: 0 nothing to do (or done) - 1 --check found drift - 2 usage/setup error
+#
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+ref=${1:-}
+mode=${2:-}
+[ -n "$ref" ] || { echo "usage: $0 <ref> [--check]" >&2; exit 2; }
+
+# THE line this whole script exists for.
+commit=$(git rev-parse --verify -q "${ref}^{commit}") \
+  || { echo "bump-install-pins: cannot resolve $ref to a commit" >&2; exit 2; }
+
+origin=$(git config --get remote.origin.url 2>/dev/null || true)
+origin=${origin%.git}; origin=${origin#git@github.com:}; origin=${origin#https://github.com/}
+[ -n "$origin" ] || { echo "bump-install-pins: no origin remote" >&2; exit 2; }
+
+# Current pins, as written in the docs.
+old_shas=$(git grep -hoE "raw\.githubusercontent\.com/$origin/[0-9a-f]{40}/" -- '*.md' \
+           | grep -oE '[0-9a-f]{40}' | sort -u || true)
+paths=$(git grep -hoE "raw\.githubusercontent\.com/$origin/[0-9a-f]{40}/[^ )\"'\`]+" -- '*.md' \
+        | sed -E 's#.*/[0-9a-f]{40}/##' | sort -u || true)
+[ -n "$paths" ] || { echo "bump-install-pins: no pinned URLs found"; exit 0; }
+
+changed=0
+tmp=$(mktemp); trap 'rm -f "$tmp"' EXIT
+
+apply() {                      # apply FROM TO  -- rewrite every tracked .md
+  local from=$1 to=$2 f
+  [ "$from" = "$to" ] && return 0
+  while IFS= read -r f; do
+    grep -q "$from" "$f" || continue
+    changed=1
+    if [ "$mode" = "--check" ]; then
+      printf '  %s: %s -> %s\n' "$f" "${from:0:12}" "${to:0:12}"
+    else
+      sed "s/$from/$to/g" "$f" > "$tmp" && mv "$tmp" "$f" && tmp=$(mktemp)
+    fi
+  done < <(git ls-files '*.md')
+}
+
+# 1. the pinned commit, long form and the short form used in prose
+while IFS= read -r old; do
+  [ -n "$old" ] || continue
+  apply "$old" "$commit"
+  apply "${old:0:7}" "${commit:0:7}"
+done <<<"$old_shas"
+
+# 2. the digests published beside them, in both cases (PowerShell uppercases)
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  git cat-file -e "$commit:$path" 2>/dev/null || {
+    echo "bump-install-pins: $path does not exist at ${commit:0:12}" >&2; exit 2; }
+  new=$(git show "$commit:$path" | shasum -a 256 | cut -d' ' -f1)
+  while IFS= read -r old; do
+    [ -n "$old" ] || continue
+    git cat-file -e "$old:$path" 2>/dev/null || continue
+    prev=$(git show "$old:$path" | shasum -a 256 | cut -d' ' -f1)
+    apply "$prev" "$new"
+    apply "$(printf '%s' "$prev" | tr 'a-f' 'A-F')" "$(printf '%s' "$new" | tr 'a-f' 'A-F')"
+  done <<<"$old_shas"
+done <<<"$paths"
+
+if [ "$mode" = "--check" ]; then
+  [ "$changed" -eq 0 ] && { echo "bump-install-pins: docs already pin ${commit:0:12}"; exit 0; }
+  echo "bump-install-pins: docs are stale for ${commit:0:12}" >&2
+  exit 1
+fi
+[ "$changed" -eq 0 ] && echo "bump-install-pins: docs already pin ${commit:0:12}" \
+                     || echo "bump-install-pins: pinned to ${commit:0:12}"


### PR DESCRIPTION
Der Pin-Bump war ein **manueller Runbook-Schritt** — und genau der Schritt, der die Installer zerlegt hat. Das Runbook sagt `git rev-parse origin/master` (liefert einen Commit); gepinnt wurde ein Tag, `git rev-parse` auf ein annotiertes Tag liefert das **Tag-Objekt**, und `raw.githubusercontent.com` serviert nur Commits. Ergebnis: 404 hinter jedem veröffentlichten Einzeiler, bis ein Nutzer es aus dem Feld meldete (BUG-0215).

## Zwei Teile

**`scripts/bump-install-pins.sh`** schreibt den gepinnten Commit und die daneben veröffentlichten SHA-256 um: in jeder getrackten Markdown-Datei, in Lang- und Kurzform, in Klein- und Großschreibung (PowerShell schreibt groß). Seine erste Arbeitszeile ist `<ref>^{commit}` — Tag, Branch und Commit lösen damit alle auf den Commit auf, **der ursprüngliche Fehler ist nicht mehr erreichbar**. `--check` meldet Drift ohne zu schreiben und endet mit 1.

Es schreibt und **beurteilt nichts**. `check-install-pins.sh` ist der Richter, und der Aufrufer lässt ihn danach laufen: ein Bumper, der seine eigene Arbeit benotet, wäre dasselbe Trust-Boundary-Problem wie eine selbstsignierte Attestierung.

**`.github/workflows/pin-bump.yml`** feuert auf `release: published`, **nicht** auf den Tag-Push — `skillctl-release.yml` schneidet einen *Draft*, und ein Pin darf nicht auf ein Release wandern, das niemand veröffentlicht hat.

Ablauf: Ref auflösen → bumpen → **Gate laufen lassen** → erst dann einen **Pull Request** öffnen.

## Warum PR und kein Push auf master

Zwei Gründe, der zweite wiegt schwerer:

1. Ein Bot, der auf master pusht, umgeht genau die Branch-Protections, die einen gepinnten Commit vertrauenswürdig machen.
2. Der Bump ändert die **Bootstrap-Integritätsaussage** des Repos. Das soll ein Mensch sehen.

`contents: read` oben, Schreibrechte nur im Job, der sie braucht.

## Bewiesen per Rundlauf, nicht per Behauptung

```
1. bump origin/master          -> Docs ändern sich, Gate grün
2. bump skillctl/v0.4.0        -> mit dem TAG-NAMEN
   Commit f43eb49 in den Docs: 13
   Tag-Objekt 82c8328:          0
   Gate grün, Baum identisch zum Ausgangszustand
```

## Runbook

`docs/releasing.md` sagt jetzt, dass der Bump automatisch läuft und die Aufgabe des Menschen der PR ist. Die manuellen Kommandos bleiben für den Bedarfsfall, mit der Warnung, warum `git rev-parse <tag>` allein nie benutzt werden darf.

## Verifikation

`check-install-pins.sh` grün · `bump-install-pins.sh --check` sauber · `check-no-emdash` grün · `boundary-gate` clean · `id-xref-lint` clean · `check-docs.sh` PASS · `docaudit -cli all` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)