### PR TITLE
feat(skillctl): FR-0110b — required-mode audit fail-close mechanism (SPEC-0403 §6b, 2-lens gated)

### DIFF
--- a/cmd/skillctl/enforce_cmds.go
+++ b/cmd/skillctl/enforce_cmds.go
@@ -102,6 +102,14 @@ func runEnforce(stdin io.Reader, stdout, stderr io.Writer) int {
 	// is preserved byte-for-byte. An allow emits nothing to stdout, so writing the
 	// deny now is clean.
 	//
+	// SPEC-0403 §6b RECONCILIATION (FR-0110b): this block IS the LIVE gate-path
+	// instantiation of the §6b positive-list entry `policy.allow` under `required`.
+	// The mapping (policy.allow ↔ escalated allow, spool = fulfillment, denial
+	// exemption ↔ a deny is never re-escalated, the separate skillctlRequireLocalAudit
+	// flag ↔ REQ-6.10a confirmation) is documented in required_audit.go. FR-0110b
+	// deliberately adds NO second policy.allow fail-close here; it adds the general
+	// §6b mechanism in pkg/skillctl/auditevent for the other REQ-6.9 types.
+	//
 	// SCOPE (breadth): "a skill ALLOW" means EVERY audited Skill decision the gate
 	// allowed: managed, UNMANAGED (default-allow plugins / namespaced skills), AND
 	// allowlisted. audActive is set before those branches, so all reach the sink.

--- a/cmd/skillctl/required_audit.go
+++ b/cmd/skillctl/required_audit.go
@@ -1,0 +1,81 @@
+package main
+
+// required_audit.go: the FR-0110b reconciliation surface (SPEC-0403 §6b).
+//
+// WHY THIS FILE EXISTS. §6b's `required` fail-close for policy.allow ALREADY runs
+// LIVE in the gate hot path as SPEC-0317 R-8.2 `require_local_audit`
+// (enforce_cmds.go): a skill ALLOW whose evidence cannot be DURABLY recorded
+// (outbox row AND spool line both failed) is escalated to a fail-closed deny
+// (exit 26). That path is the concrete instantiation of the §6b positive-list
+// entry `policy.allow`:
+//
+//	§6b / this package                    SPEC-0317 R-8.2 enforce path
+//	----------------------------------    -----------------------------------------
+//	policy.allow on the positive list  ↔  a gated skill ALLOW is escalated
+//	spool acceptance = fulfillment     ↔  durable = outbox row OR spool line (no net)
+//	denial types exempt (REQ-6.7)      ↔  a DENY is never re-escalated (kept as-is)
+//	separate confirmation (REQ-6.10a)  ↔  skillctlRequireLocalAudit, a flag DISTINCT
+//	                                       from skillctlEnterprise
+//	default byte-identical (REQ-6.4)   ↔  flag unset → decision returned unchanged
+//
+// FR-0110b therefore does NOT wire a SECOND policy.allow fail-close into the gate
+// (that would double-enforce). It adds the GENERAL, reusable §6b mechanism in
+// pkg/skillctl/auditevent (for the other REQ-6.9 types: skill.execute,
+// capability.grant, trustroot.change, config.change, whose producers arrive with
+// FR-0111), and it makes the ONE managed toggle wired today readable as the §6b
+// vocabulary via effectiveRequiredAuditConfig, so the two layers share ONE
+// interpretation instead of drifting.
+//
+// O3 / SPEC-0247 P1.3 HONESTY. `required` is only a *policy* (not merely a
+// *request*) when its source is a tier a same-uid user cannot rewrite. The source
+// here is the ROOT-OWNED managed-settings file (pin.RequireLocalAuditFromBytes,
+// enterprise-gated), which is the correct tier (REQ-11.2). But P1.3 (the pinning
+// runbook) is NOT yet in force, and skillctl at same-uid cannot PROVE the file is
+// root-owned, so we do not claim unbypassability: `session baseline` prints the
+// RED "advisory-only until SPEC-0247 P1.3 pinned" banner whenever the gate is not
+// pinned (AUD-07), and this file's summary defers to that banner.
+
+import (
+	"fmt"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/auditevent"
+)
+
+// effectiveRequiredAuditConfig maps the ONE §6b toggle wired today, the SPEC-0317
+// R-8.2 require_local_audit managed flag, onto the auditevent.RequiredConfig
+// vocabulary. require_local_audit == the positive-list entry policy.allow WITH its
+// REQ-6.10a separate confirmation (the flag is itself a distinct managed key from
+// skillctlEnterprise), fulfilled at the local spool (REQ-6.10b).
+//
+// When the flag is off it returns the zero config (mode ""), which BuildPolicy
+// maps to "no required policy" (best-effort/durable default, REQ-6.4). The other
+// four REQ-6.9 types have no managed toggle yet (their producers are FR-0111), so
+// they are deliberately NOT asserted here: claiming them active would overclaim.
+func effectiveRequiredAuditConfig(requireLocalAudit bool) auditevent.RequiredConfig {
+	if !requireLocalAudit {
+		return auditevent.RequiredConfig{} // mode "" → no policy.
+	}
+	return auditevent.RequiredConfig{
+		Mode:               string(auditevent.ModeRequired),
+		AllowList:          []string{string(auditevent.EventPolicyAllow)},
+		ConfirmPolicyAllow: true, // the managed flag IS the REQ-6.10a separate confirmation.
+	}
+}
+
+// describeRequiredAudit returns a one-line operator summary of the effective §6b
+// required-audit policy, VALIDATED through the same BuildPolicy the library uses
+// (so a future mis-map surfaces here rather than silently). It never fails the
+// caller: a validation error is surfaced as text, because this is an
+// informational surface (session baseline), never a gate.
+func describeRequiredAudit(requireLocalAudit bool) string {
+	rc := effectiveRequiredAuditConfig(requireLocalAudit)
+	pol, err := rc.BuildPolicy()
+	if err != nil {
+		return fmt.Sprintf("misconfigured (%v)", err)
+	}
+	if pol == nil {
+		return "off (best-effort/durable default: a lost audit event never changes a decision)"
+	}
+	// policy.allow is the only type wired live; name it and its fulfillment rule.
+	return "required for policy.allow (SPEC-0403 §6b, fulfilled at the local spool, REQ-6.10b; enforced in the gate by R-8.2 require_local_audit)"
+}

--- a/cmd/skillctl/session_baseline_cmds.go
+++ b/cmd/skillctl/session_baseline_cmds.go
@@ -107,12 +107,14 @@ func runSessionBaseline(args []string, stdout, stderr io.Writer) int {
 			AdvisoryBanner  string   `json:"advisory_banner,omitempty"`
 			Notes           []string `json:"notes,omitempty"`
 			RequireLocalAud bool     `json:"require_local_audit"`
+			RequiredAudit   string   `json:"required_audit_policy"`
 			StateGateFallbk bool     `json:"state_gate_fallback"`
 		}{
 			StateDecision:   dec,
 			PinLevel:        pinStatus.Level.String(),
 			Pinned:          pinStatus.Pinned(),
 			RequireLocalAud: pol.RequireLocalAudit,
+			RequiredAudit:   describeRequiredAudit(gateRequireLocalAudit()),
 			StateGateFallbk: stateGateFallback,
 		}
 		if !pinStatus.Pinned() {
@@ -138,6 +140,7 @@ func runSessionBaseline(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "  translog anchor:      %s\n", yesNo(dec.AnchorPresent))
 	fmt.Fprintf(stdout, "  enterprise profile:   %s\n", yesNo(dec.Enterprise))
 	fmt.Fprintf(stdout, "  require local audit:  %s  [ENFORCED (R-8.2) by enforce: an allow that can't be durably recorded fails closed, exit 26]\n", yesNo(gateRequireLocalAudit()))
+	fmt.Fprintf(stdout, "  required-audit policy:%s\n", describeRequiredAudit(gateRequireLocalAudit()))
 	fmt.Fprintf(stdout, "  online fallback:      %s  [%s]\n", allowedBlocked(dec.AllowOnlineFallback), onlineFallbackNote(stateGateFallback))
 	fmt.Fprintf(stdout, "  high-risk fail-closed:%s\n", yesNoPad(dec.HighRiskFailsClosed))
 	fmt.Fprintf(stdout, "  deny all managed:     %s  [ENFORCED (R-7.2) by verify-hook/enforce when the gate is pinned: a locked host denies non-allowlisted managed skills, exit 28]\n", yesNo(dec.DenyAllManaged))

--- a/pkg/skillctl/auditevent/delivery.go
+++ b/pkg/skillctl/auditevent/delivery.go
@@ -1,23 +1,47 @@
 package auditevent
 
-// delivery.go: the FR-0110a delivery semantics (SPEC-0403 §6). Stiller Verlust
-// darf nicht das Standardverhalten sein (REQ-6.1): the delivery MODE is an
-// explicit, selectable Dispatcher property, NOT a Sink concern (a Sink only
-// reports whether its Write succeeded; the Dispatcher decides what a failure
-// means, sink.go).
+// delivery.go: the FR-0110a delivery semantics (SPEC-0403 §6) PLUS the FR-0110b
+// `required` fail-close (§6b). Stiller Verlust darf nicht das Standardverhalten
+// sein (REQ-6.1): the delivery MODE is an explicit, selectable Dispatcher
+// property, NOT a Sink concern (a Sink only reports whether its Write succeeded;
+// the Dispatcher decides what a failure means, sink.go).
 //
-// SCOPE (FR-0110a). This file implements `best-effort` and `durable`. `required`
-// (REQ-6.1 / §6b, the hot-path fail-close for the positive-list event types) is
-// MODELED here so a producer can already name it, but its ENFORCEMENT is
-// explicitly OUT OF SCOPE: it is FR-0110b, a separate challenge-gated PR. See
-// writeToSinks: `required` currently behaves like `durable` and NEVER fails the
-// caller, so the SPEC-0255 / REQ-6.4 decision-invariance default is untouched by
-// this PR.
+// SCOPE. This file implements `best-effort`, `durable`, and now the `required`
+// ENFORCEMENT: for an event whose type is on an explicitly configured positive
+// list (REQ-6.6/6.9) and is NOT a denial type (REQ-6.7), a delivery that was not
+// durably accepted returns the load-bearing sentinel ErrRequiredNotDurable, and
+// a caller that opted in (IsFailClosed) fails its consequential operation closed.
+// The positive-list policy + its validation live in required.go. Every OTHER
+// path (any non-required mode, a required Dispatcher with no policy, an event not
+// on the list, a denial type, or a durable success) returns only an ADVISORY
+// error, so the SPEC-0255 / REQ-6.4 decision-invariance default is byte-identical
+// to FR-0110a on every path a required policy does not explicitly cover.
 
 import (
 	"errors"
 	"fmt"
 )
+
+// ErrRequiredNotDurable is the sentinel a Dispatch returns when a MANDATORY audit
+// event (an allow-listed, non-denial type under an active RequiredPolicy, §6b)
+// could not be durably accepted. It is the ONLY error class the Dispatcher marks
+// load-bearing: a caller on a consequential path MUST fail its operation closed
+// when IsFailClosed reports true (REQ-6.6, AUD-01). Every other delivery error
+// stays advisory, so a caller that never checks IsFailClosed (the gate hot path)
+// keeps its byte-identical default decision (REQ-6.4).
+var ErrRequiredNotDurable = errors.New("auditevent: required audit event not durably accepted")
+
+// IsFailClosed reports whether err carries the required-mode fail-close signal
+// (ErrRequiredNotDurable). It is the caller's opt-in: a caller that ignores
+// Dispatch's error entirely (as the gate hot path does today) sees no behavior
+// change from FR-0110b, which is exactly what REQ-6.4 requires. A required-mode
+// caller wraps its consequential step so that IsFailClosed(err) == fail closed.
+//
+// NOTE ON SCOPE: this is the DURABILITY fail-close only (REQ-6.6/6.10b, "not
+// durably accepted"). A validation error (ErrInvalidEvent) is a producer bug, not
+// a durability failure, and is returned distinctly; a mandatory-event producer
+// should treat that as its own hard stop, but it is not this contract.
+func IsFailClosed(err error) bool { return errors.Is(err, ErrRequiredNotDurable) }
 
 // Mode is the SPEC-0403 §6 delivery semantics selector (REQ-6.1).
 type Mode string
@@ -33,13 +57,15 @@ const (
 	// ModeRequired: a consequential operation MUST fail if its mandatory audit
 	// event was not durably accepted (REQ-6.1, high-security policy).
 	//
-	// TODO(FR-0110b): ENFORCEMENT (hot-path fail-close for the §6b/REQ-6.9
-	// positive list: policy.allow, skill.execute, capability.grant,
-	// trustroot.change, config.change, with deny-class events exempt per REQ-6.7,
-	// and the getrennte Bestaetigung for policy.allow per REQ-6.10) is a SEPARATE,
-	// challenge-gated PR. It is NOT implemented here: this PR must not fail-close
-	// anywhere. Until FR-0110b lands, ModeRequired is accepted by Valid() and
-	// behaves exactly like ModeDurable (never fails the caller).
+	// FR-0110b ENFORCEMENT: a required Dispatcher fail-closes ONLY for the event
+	// types on an explicitly configured positive list (REQ-6.6/6.9: policy.allow,
+	// skill.execute, capability.grant, trustroot.change, config.change), with
+	// denial types exempt even if listed (REQ-6.7) and policy.allow requiring a
+	// separate confirmation (REQ-6.10a). Build a required Dispatcher via
+	// NewDispatcherRequired with a policy from RequiredConfig.BuildPolicy
+	// (required.go); a required Dispatcher built WITHOUT a policy (via
+	// NewDispatcherMode) never fail-closes and behaves like ModeDurable, so no
+	// path silently gains fail-close.
 	ModeRequired Mode = "required"
 )
 
@@ -91,10 +117,25 @@ func (d *Dispatcher) WithDurableRetries(n int) *Dispatcher {
 }
 
 // deliver fans e out to every sink and joins the per-sink errors. It is the
-// single fan-out point Dispatch calls after redaction and validation. The
-// returned error is advisory in best-effort/durable; a caller on the decision hot
-// path (the gate) ignores it (REQ-6.4). It NEVER panics and NEVER fails-closed
-// here: required-mode enforcement is FR-0110b (see writeToSinks).
+// single fan-out point Dispatch calls after redaction and validation. It NEVER
+// panics.
+//
+// FR-0110b fail-close: under ModeRequired with an active RequiredPolicy, if the
+// event type is fail-closeable (on the positive list, not a denial type, and, for
+// policy.allow, confirmed) AND delivery did not durably succeed (any configured
+// sink failed to accept the write), the joined error is wrapped in
+// ErrRequiredNotDurable so IsFailClosed reports true and the caller fails closed.
+//
+// "Durably accepted" is defined as EVERY configured sink accepting the write. The
+// recommended required wiring is a SINGLE durable sink (OutboxSink), for which
+// that is exactly spool acceptance (REQ-6.10b), never a network ack: the OutboxSink
+// reaches no broker, so a required policy can never hang a load path on a remote
+// promise. Adding a flaky best-effort sink alongside the durable one is a
+// mis-config that fails SAFE (closed), not open.
+//
+// On every OTHER path (any non-required mode, no policy, a non-listed type, a
+// denial type, or a durable success) deliver returns only the advisory joined
+// error, which a gate-hot-path caller ignores (REQ-6.4).
 func (d *Dispatcher) deliver(e *Event) error {
 	var errs []error
 	for _, s := range d.sinks {
@@ -102,19 +143,24 @@ func (d *Dispatcher) deliver(e *Event) error {
 			errs = append(errs, fmt.Errorf("sink %q: %w", s.Name(), err))
 		}
 	}
-	return errors.Join(errs...)
+	joined := errors.Join(errs...)
+	if joined != nil && d.mode == ModeRequired && d.required.failCloseable(e.EventType) {
+		return fmt.Errorf("%w (event_type=%s, spool acceptance is the fulfillment point, REQ-6.10b): %v",
+			ErrRequiredNotDurable, e.EventType, joined)
+	}
+	return joined
 }
 
 // writeToSinks performs one sink Write under the Dispatcher's mode.
 //
 //   - best-effort: exactly one Write attempt; the error (if any) is returned
 //     advisory (byte-for-byte the FR-0109 landed behavior).
-//   - durable: up to durableRetries in-process attempts to ride out a transient
-//     failure; the durable sink (OutboxSink) additionally spools so the row
-//     survives restart and is deduped on event_id (REQ-6.2).
-//   - required: TODO(FR-0110b). The hot-path fail-close is a separate PR. Until
-//     then this behaves EXACTLY like durable and never fails the caller, so
-//     decision-invariance (REQ-6.4 / SPEC-0255) is preserved by this PR.
+//   - durable / required: up to durableRetries in-process attempts to ride out a
+//     transient failure; the durable sink (OutboxSink) additionally spools so the
+//     row survives restart and is deduped on event_id (REQ-6.2). writeToSinks
+//     itself is identical for durable and required: the FR-0110b fail-close
+//     decision (whether a residual failure is load-bearing) is made ONCE in
+//     deliver, from the event type and the policy, not per sink here.
 func (d *Dispatcher) writeToSinks(s Sink, e *Event) error {
 	switch d.mode {
 	case ModeDurable, ModeRequired:

--- a/pkg/skillctl/auditevent/required.go
+++ b/pkg/skillctl/auditevent/required.go
@@ -1,0 +1,216 @@
+package auditevent
+
+// required.go: the FR-0110b `required` positive-list policy and its config
+// validation (SPEC-0403 §6b). This is the ONLY fail-closed path in the audit
+// layer, and it runs in a skill load path, so the rules are deliberately narrow:
+//
+//   - REQ-6.6: `required` fail-closes ONLY for an explicitly configured positive
+//     list of event types. A `required` with NO list is a config error and is
+//     rejected (BuildPolicy).
+//   - REQ-6.7: DENIAL events (policy.deny, signature.reject, revocation.detect)
+//     are exempt EVEN IF listed. You never fail an already-failed operation a
+//     second time; that reopens the DoS the list just bounded. The exemption is
+//     enforced in failCloseable, in CODE, not only in docs.
+//   - REQ-6.9: the eligible types are exactly policy.allow, skill.execute,
+//     capability.grant, trustroot.change, config.change. Anything else on a
+//     configured list is a config error (bounding the DoS surface, REQ-6.8).
+//   - REQ-6.10a: policy.allow is in EVERY skill's load path, so listing it needs a
+//     SEPARATE confirmation (ConfirmPolicyAllow), distinct from enabling required.
+//   - REQ-6.10b: "durably accepted" for policy.allow is spool acceptance, never a
+//     network/broker ack; the enforcement in deliver reaches only local sinks.
+//
+// O3 / SPEC-0247 P1.3 HONESTY (AUD-07). This policy makes `required` a fail-close
+// for the LISTED types. Whether that is a *policy* or merely *a request* depends
+// on WHERE its config was read from. A `required` config MUST be sourced from the
+// highest-precedence, root-owned tier (managed settings, REQ-11.2). SPEC-0247
+// P1.3 (managed-settings pinning) is NOT yet marked in force: without it a
+// same-uid user can rewrite the source and flip `required` off, so on such a host
+// this is advisory (AUD-07). This package does NOT claim it read a pinned tier: it
+// validates a config it is handed. The caller that sources the bytes owns the
+// pinning check and the operator warning (cmd/skillctl surfaces it in
+// `session baseline`: the RED "advisory-only until SPEC-0247 P1.3 pinned" banner).
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// RequiredPolicy is the validated §6b positive list. It is the DoS boundary of
+// ModeRequired (REQ-6.8): only a type on the list, that is not a denial type, and
+// (for policy.allow) confirmed, can ever fail a caller's operation closed. Build
+// one with RequiredConfig.BuildPolicy; a zero/nil RequiredPolicy fail-closes
+// nothing.
+type RequiredPolicy struct {
+	allow         map[EventType]struct{} // configured, validated subset of the REQ-6.9 five.
+	policyAllowOK bool                   // the getrennte Bestaetigung for policy.allow (REQ-6.10a).
+}
+
+// denialEventTypes are the DENIAL events (REQ-6.7): a denial logs an operation
+// that ALREADY failed, so failing it a second time protects no one and reopens
+// the DoS the positive list just bounded. They are exempt from required
+// fail-close EVEN IF an operator lists them; the exemption is NOT configurable.
+var denialEventTypes = map[EventType]struct{}{
+	EventPolicyDeny:       {},
+	EventSignatureReject:  {},
+	EventRevocationDetect: {},
+}
+
+// canonicalRequiredTypes is the REQ-6.9 decided positive list: the ONLY event
+// types an operator may make fail-closeable under required. Anything outside it
+// on a configured list is a config error (bounding the DoS surface, REQ-6.8).
+var canonicalRequiredTypes = map[EventType]struct{}{
+	EventPolicyAllow:     {},
+	EventSkillExecute:    {},
+	EventCapabilityGrant: {},
+	EventTrustrootChange: {},
+	EventConfigChange:    {},
+}
+
+// IsDenialEventType reports whether t is a non-configurable denial-exempt type
+// (REQ-6.7): a required policy can never fail-close on it, whatever the config says.
+func IsDenialEventType(t EventType) bool {
+	_, ok := denialEventTypes[t]
+	return ok
+}
+
+// CanonicalRequiredTypes returns the REQ-6.9 eligible positive list, sorted. The
+// returned slice is a copy the caller may mutate.
+func CanonicalRequiredTypes() []EventType {
+	out := make([]EventType, 0, len(canonicalRequiredTypes))
+	for t := range canonicalRequiredTypes {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// failCloseable reports whether an event of type t must fail the caller's
+// operation closed when it was not durably accepted. ALL of the following gate it,
+// and each is a distinct code check, not a comment:
+//
+//	(1) t is on the operator's configured positive list;
+//	(2) t is NOT a denial type (REQ-6.7, the non-configurable exemption);
+//	(3) if t is policy.allow, the separate confirmation was given (REQ-6.10a).
+//
+// A nil receiver (no policy) returns false, so a required Dispatcher built without
+// a policy, and every non-required Dispatcher, fail-closes nothing.
+func (p *RequiredPolicy) failCloseable(t EventType) bool {
+	if p == nil {
+		return false
+	}
+	if IsDenialEventType(t) { // (2) checked first, so a listed denial is still exempt.
+		return false
+	}
+	if _, ok := p.allow[t]; !ok { // (1)
+		return false
+	}
+	if t == EventPolicyAllow && !p.policyAllowOK { // (3)
+		return false
+	}
+	return true
+}
+
+// RequiredConfig is the raw, operator-facing shape of the required-mode policy as
+// read from a config surface. It is validated by BuildPolicy. A required policy
+// MUST be sourced from the highest-precedence, root-owned tier (managed settings,
+// REQ-11.2 / the O3 note in the file header); this type does not itself enforce
+// that, it only validates the parsed values.
+type RequiredConfig struct {
+	// Mode is the §6 delivery mode name. Only "required" builds a policy; any
+	// other value (including "", "best-effort", "durable") builds no policy and is
+	// not an error (BuildPolicy returns nil, nil).
+	Mode string
+	// AllowList is the operator's positive list of event-type names that fail-close
+	// under required (REQ-6.6). Empty under required is a config error.
+	AllowList []string
+	// ConfirmPolicyAllow is the SEPARATE REQ-6.10a switch. It MUST be a different
+	// toggle from whatever enables required, so an operator turning on required does
+	// not accidentally couple skill execution to a file write. policy.allow on the
+	// list without this is a config error.
+	ConfirmPolicyAllow bool
+}
+
+// ErrRequiredConfig is the sentinel wrapped by every BuildPolicy rejection, so a
+// caller can errors.Is it without matching on message text.
+var ErrRequiredConfig = errors.New("auditevent: invalid required-mode config")
+
+// BuildPolicy validates c into a RequiredPolicy (SPEC-0403 §6b).
+//
+//	Mode != "required"                         : (nil, nil) no policy, not an error.
+//	required + EMPTY allow-list                : ErrRequiredConfig (REQ-6.6).
+//	required + a type outside the REQ-6.9 five : ErrRequiredConfig (REQ-6.9/6.8);
+//	                                             a denial type is TOLERATED but inert (REQ-6.7).
+//	required + only inert (denial) entries     : ErrRequiredConfig (nothing to enforce).
+//	policy.allow listed without confirmation   : ErrRequiredConfig (REQ-6.10a).
+//
+// A rejected config MUST be treated by the caller as fatal to activating required
+// (fail-closed on config), never silently downgraded to advisory: a malformed
+// high-security policy that silently becomes best-effort is exactly the false
+// assurance §6b forbids.
+func (c RequiredConfig) BuildPolicy() (*RequiredPolicy, error) {
+	if Mode(strings.TrimSpace(c.Mode)) != ModeRequired {
+		return nil, nil
+	}
+
+	// REQ-6.6: required WITHOUT a positive list is a config error.
+	hasEntry := false
+	for _, s := range c.AllowList {
+		if strings.TrimSpace(s) != "" {
+			hasEntry = true
+			break
+		}
+	}
+	if !hasEntry {
+		return nil, fmt.Errorf("%w: mode=required needs a non-empty allow-list (REQ-6.6): a required with no positive list is the unbounded DoS surface the list exists to bound",
+			ErrRequiredConfig)
+	}
+
+	allow := make(map[EventType]struct{}, len(c.AllowList))
+	for _, raw := range c.AllowList {
+		name := EventType(strings.TrimSpace(raw))
+		if name == "" {
+			continue
+		}
+		if IsDenialEventType(name) {
+			// REQ-6.7: tolerated on the list, but never enforceable. Keep it OUT of
+			// the fail-close set rather than error, so a copy-paste of the full
+			// taxonomy is not rejected; the exemption is what matters.
+			continue
+		}
+		if _, ok := canonicalRequiredTypes[name]; !ok {
+			return nil, fmt.Errorf("%w: %q is not a required-eligible event type (REQ-6.9: only policy.allow, skill.execute, capability.grant, trustroot.change, config.change)",
+				ErrRequiredConfig, name)
+		}
+		allow[name] = struct{}{}
+	}
+	if len(allow) == 0 {
+		// The list held only denial-exempt entries: `required` is on, but nothing
+		// can ever fail-close. That is a mis-config (the list is BOTH the DoS bound
+		// AND the reason to fail-close). Reject rather than silently degrade.
+		return nil, fmt.Errorf("%w: the allow-list has no enforceable type (only denial-exempt entries, REQ-6.6/6.7)",
+			ErrRequiredConfig)
+	}
+	if _, wantsPolicyAllow := allow[EventPolicyAllow]; wantsPolicyAllow && !c.ConfirmPolicyAllow {
+		return nil, fmt.Errorf("%w: policy.allow needs the separate confirmation (REQ-6.10a): it sits in EVERY skill's load path, so listing it couples skill execution to a spool write and must be an explicit, distinct opt-in",
+			ErrRequiredConfig)
+	}
+
+	return &RequiredPolicy{allow: allow, policyAllowOK: c.ConfirmPolicyAllow}, nil
+}
+
+// NewDispatcherRequired builds a ModeRequired Dispatcher that ENFORCES fail-close
+// for the event types on policy (SPEC-0403 §6b). Obtain policy from
+// RequiredConfig.BuildPolicy (which rejects an empty allow-list, REQ-6.6). A nil
+// policy is accepted but fail-closes NOTHING (it degrades to durable-equivalent):
+// pass a validated, non-nil policy for real enforcement.
+//
+// sinks SHOULD be a SINGLE durable sink (OutboxSink). Under required, "durably
+// accepted" is every configured sink accepting the write, which for the OutboxSink
+// is spool acceptance (REQ-6.10b), never a network ack.
+func NewDispatcherRequired(policy *RequiredPolicy, r Redactor, sinks ...Sink) *Dispatcher {
+	d := NewDispatcherMode(ModeRequired, r, sinks...)
+	d.required = policy
+	return d
+}

--- a/pkg/skillctl/auditevent/required_test.go
+++ b/pkg/skillctl/auditevent/required_test.go
@@ -1,0 +1,232 @@
+package auditevent
+
+// required_test.go: the FR-0110b bite tests (SPEC-0403 §6b). Each test is written
+// so that REMOVING the specific guard it targets makes it FAIL (bite-proof); the
+// comment on each names the guard and the removal that breaks it. These are
+// hermetic: no env, no network, no ambient managed-settings file. The library
+// fail-close signal is IsFailClosed(err); the exit-code (load-path) form of the
+// policy.allow case lives in cmd/skillctl/enforce_require_audit_test.go (the
+// SPEC-0317 R-8.2 require_local_audit path, the live instantiation of this policy
+// in the gate hot path, which FR-0110b reconciles with rather than duplicates).
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// policyAllowConfirmed is the validated policy the enforce path's require_local_audit
+// mirrors: policy.allow, fail-closeable, with the REQ-6.10a confirmation.
+func policyAllowConfirmed(t *testing.T) *RequiredPolicy {
+	t.Helper()
+	p, err := RequiredConfig{Mode: "required", AllowList: []string{"policy.allow"}, ConfirmPolicyAllow: true}.BuildPolicy()
+	if err != nil || p == nil {
+		t.Fatalf("expected a valid policy.allow required policy, got p=%v err=%v", p, err)
+	}
+	return p
+}
+
+// (1) required + allow-listed policy.allow + a spool write that FAILS → the
+// operation fails closed (IsFailClosed true, with a clear reason).
+// BITE: delete the `d.required.failCloseable(...)` branch in deliver (making every
+// residual error advisory) and IsFailClosed goes false → this fails.
+func TestRequired_PolicyAllow_SpoolFails_FailsClosed(t *testing.T) {
+	d := NewDispatcherRequired(policyAllowConfirmed(t), Redactor{}, &failingSink{}) // failingSink models a full-disk/unwritable spool.
+	err := d.Dispatch(New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x"))
+	if !IsFailClosed(err) {
+		t.Fatalf("policy.allow that could not be durably accepted must fail closed; got err=%v (IsFailClosed=false)", err)
+	}
+	if !strings.Contains(err.Error(), "policy.allow") || !strings.Contains(err.Error(), "REQ-6.10b") {
+		t.Fatalf("fail-close reason must name the event type and the spool fulfillment rule; got %q", err.Error())
+	}
+}
+
+// (2) spool write SUCCEEDS → the operation proceeds. The sink is the REAL
+// spool-only OutboxSink (no broker reachable), so this also proves the fulfillment
+// point is local spool acceptance, never a network ack (REQ-6.10b).
+// BITE: if a durable success wrongly wrapped ErrRequiredNotDurable, err != nil here.
+func TestRequired_PolicyAllow_SpoolSucceeds_Proceeds(t *testing.T) {
+	home := t.TempDir()
+	sink := NewOutboxSinkWithStore(nil, home) // nil store → spool-only, no db, no network.
+	d := NewDispatcherRequired(policyAllowConfirmed(t), Redactor{}, sink)
+
+	e := New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	e.EventID = "aud-required-ok-1"
+	if err := d.Dispatch(e); err != nil {
+		t.Fatalf("a spool-accepted policy.allow must proceed (spool is the fulfillment point); got err=%v", err)
+	}
+	spool := filepath.Join(home, ".claude", "skillctl", "spool.jsonl")
+	if b, err := os.ReadFile(spool); err != nil || len(b) == 0 {
+		t.Fatalf("expected the line durably accepted by the local spool (no network); read err=%v len=%d", err, len(b))
+	}
+}
+
+// (3) a DENIAL event under required is NEVER failed a second time, EVEN when it is
+// on the allow-list (REQ-6.7, the non-configurable exemption). Constructed by hand
+// (BuildPolicy would skip a denial type) to prove the RUNTIME guard.
+// BITE: delete the `IsDenialEventType(t)` check in failCloseable and every one of
+// these becomes fail-closed → this fails.
+func TestRequired_DenialEvents_NeverFailClosed(t *testing.T) {
+	for _, dt := range []EventType{EventPolicyDeny, EventSignatureReject, EventRevocationDetect} {
+		// Denial type PLUS a real enforceable type on the list, all confirmed, so the
+		// only reason the denial does not fail-close is the exemption.
+		pol := &RequiredPolicy{
+			allow:         map[EventType]struct{}{dt: {}, EventSkillExecute: {}},
+			policyAllowOK: true,
+		}
+		if pol.failCloseable(dt) {
+			t.Fatalf("denial type %q must be exempt from required fail-close even when listed (REQ-6.7)", dt)
+		}
+		d := NewDispatcherRequired(pol, Redactor{}, &failingSink{})
+		// A denial event carries a deny/failure outcome; use one the taxonomy accepts.
+		out := OutcomeDeny
+		if dt == EventSignatureReject {
+			out = OutcomeFailure
+		}
+		err := d.Dispatch(New(dt, out, SeverityWarning, "skillctl/x"))
+		if IsFailClosed(err) {
+			t.Fatalf("dispatching denial %q under required must not fail closed (already-failed op); got fail-close", dt)
+		}
+	}
+}
+
+// (4) required with an EMPTY allow-list is a config error (REQ-6.6): the policy is
+// rejected, never silently downgraded to advisory.
+// BITE: delete the REQ-6.6 empty-list check and an empty list falls through to the
+// "no enforceable type" branch, whose message does NOT contain "non-empty
+// allow-list" → this fails on the message assertion.
+func TestRequired_EmptyAllowList_RejectedAsConfigError(t *testing.T) {
+	for _, empty := range [][]string{nil, {}, {""}, {"  "}} {
+		_, err := RequiredConfig{Mode: "required", AllowList: empty}.BuildPolicy()
+		if !errors.Is(err, ErrRequiredConfig) {
+			t.Fatalf("required with empty allow-list %v must be a config error; got %v", empty, err)
+		}
+		if !strings.Contains(err.Error(), "non-empty allow-list") {
+			t.Fatalf("empty-list rejection must cite REQ-6.6 (non-empty allow-list); got %q", err.Error())
+		}
+	}
+	// A well-formed required config (a non-policy.allow type) builds cleanly, proving
+	// the rejection is specific to the empty list, not a blanket refusal.
+	if p, err := (RequiredConfig{Mode: "required", AllowList: []string{"skill.execute"}}).BuildPolicy(); err != nil || p == nil {
+		t.Fatalf("a well-formed required config must build; got p=%v err=%v", p, err)
+	}
+}
+
+// (5) the DEFAULT / unconfigured path is decision-invariant: a failing sink never
+// produces a load-bearing (fail-close) error. Two shapes: (a) the best-effort
+// default, and (b) a required Dispatcher with NO policy (the FR-0110a shape).
+// BITE: if a required Dispatcher fail-closed without an explicit policy (REQ-6.4
+// violation), case (b) trips IsFailClosed → this fails.
+func TestRequired_DefaultPath_DecisionInvariant(t *testing.T) {
+	// (a) best-effort default: the sink error is surfaced ADVISORY, never fail-close.
+	dBE := NewDispatcher(Redactor{}, &failingSink{})
+	errBE := dBE.Dispatch(New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x"))
+	if errBE == nil {
+		t.Fatal("best-effort must still surface the sink error (advisory)")
+	}
+	if IsFailClosed(errBE) {
+		t.Fatal("best-effort must NEVER fail closed (REQ-6.4)")
+	}
+	// (b) required MODE but no configured policy: durable-equivalent, never fail-close.
+	dNoPol := NewDispatcherMode(ModeRequired, Redactor{}, &failingSink{})
+	errNoPol := dNoPol.Dispatch(New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x"))
+	if IsFailClosed(errNoPol) {
+		t.Fatal("required mode with NO explicit policy must not fail closed (REQ-6.4: no path silently gains fail-close)")
+	}
+}
+
+// (6) policy.allow requires the SEPARATE confirmation (REQ-6.10a). Proven three
+// ways: BuildPolicy rejects an unconfirmed config; the runtime guard refuses an
+// unconfirmed policy; and the confirmed policy DOES fail-close.
+// BITE: delete the `t == EventPolicyAllow && !p.policyAllowOK` check and the
+// unconfirmed policy becomes fail-closeable → the middle assertion fails; delete
+// the BuildPolicy REQ-6.10a check and the first assertion fails.
+func TestRequired_PolicyAllow_NeedsSeparateConfirmation(t *testing.T) {
+	// Config-time: policy.allow without the separate confirmation is rejected.
+	if _, err := (RequiredConfig{Mode: "required", AllowList: []string{"policy.allow"}, ConfirmPolicyAllow: false}).BuildPolicy(); !errors.Is(err, ErrRequiredConfig) {
+		t.Fatalf("policy.allow without the separate confirmation must be a config error (REQ-6.10a); got %v", err)
+	}
+	// Runtime guard: an unconfirmed policy.allow is not fail-closeable even if listed.
+	unconf := &RequiredPolicy{allow: map[EventType]struct{}{EventPolicyAllow: {}}, policyAllowOK: false}
+	if unconf.failCloseable(EventPolicyAllow) {
+		t.Fatal("unconfirmed policy.allow must not be fail-closeable (REQ-6.10a)")
+	}
+	if IsFailClosed(NewDispatcherRequired(unconf, Redactor{}, &failingSink{}).Dispatch(New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x"))) {
+		t.Fatal("dispatching policy.allow under an unconfirmed policy must not fail closed")
+	}
+	// Confirmed: it IS fail-closeable and DOES fail-close on a failing sink.
+	conf := policyAllowConfirmed(t)
+	if !conf.failCloseable(EventPolicyAllow) {
+		t.Fatal("confirmed policy.allow must be fail-closeable")
+	}
+	if !IsFailClosed(NewDispatcherRequired(conf, Redactor{}, &failingSink{}).Dispatch(New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x"))) {
+		t.Fatal("confirmed policy.allow with a failing spool must fail closed")
+	}
+}
+
+// A non-policy.allow eligible type (skill.execute) needs NO separate confirmation
+// and fail-closes on a failing sink but proceeds on a spool success: the general
+// mechanism for the REQ-6.9 "granted effect" types.
+// BITE: this covers the four non-policy.allow types; if failCloseable wrongly gated
+// them behind policyAllowOK, the fail-close assertion trips.
+func TestRequired_SkillExecute_FailClosesWithoutExtraConfirm(t *testing.T) {
+	p, err := RequiredConfig{Mode: "required", AllowList: []string{"skill.execute"}}.BuildPolicy()
+	if err != nil || p == nil {
+		t.Fatalf("skill.execute required config must build without a policy.allow confirmation; got p=%v err=%v", p, err)
+	}
+	if !IsFailClosed(NewDispatcherRequired(p, Redactor{}, &failingSink{}).Dispatch(New(EventSkillExecute, OutcomeSuccess, SeverityInfo, "skillctl/x"))) {
+		t.Fatal("skill.execute that could not be durably accepted must fail closed")
+	}
+	// Spool success → proceeds.
+	home := t.TempDir()
+	d := NewDispatcherRequired(p, Redactor{}, NewOutboxSinkWithStore(nil, home))
+	e := New(EventSkillExecute, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	e.EventID = "aud-skexec-ok-1"
+	if err := d.Dispatch(e); err != nil {
+		t.Fatalf("a spool-accepted skill.execute must proceed; got %v", err)
+	}
+}
+
+// A type outside the REQ-6.9 five is a config error (REQ-6.9/6.8: the list is the
+// DoS bound; arbitrary types would widen it).
+// BITE: drop the canonicalRequiredTypes membership check and this builds instead.
+func TestRequired_NonEligibleType_RejectedAsConfigError(t *testing.T) {
+	for _, bad := range []string{"invocation.complete", "skill.verify", "audit.sink.fail", "not.a.type"} {
+		if _, err := (RequiredConfig{Mode: "required", AllowList: []string{bad}}).BuildPolicy(); !errors.Is(err, ErrRequiredConfig) {
+			t.Fatalf("required-ineligible type %q must be a config error (REQ-6.9); got %v", bad, err)
+		}
+	}
+}
+
+// A denial type is TOLERATED on the list (not a config error) but inert: it does
+// not by itself satisfy the non-empty requirement.
+// BITE: if a lone denial type built a non-nil enforcing policy, the first case fails.
+func TestRequired_DenialOnlyList_RejectedButDenialTolerated(t *testing.T) {
+	// Only a denial type → nothing enforceable → config error.
+	if _, err := (RequiredConfig{Mode: "required", AllowList: []string{"policy.deny"}}).BuildPolicy(); !errors.Is(err, ErrRequiredConfig) {
+		t.Fatalf("a required list of only denial types must be rejected (REQ-6.6/6.7); got %v", err)
+	}
+	// A denial type ALONGSIDE an enforceable type is tolerated; the denial stays inert.
+	p, err := RequiredConfig{Mode: "required", AllowList: []string{"policy.deny", "config.change"}}.BuildPolicy()
+	if err != nil || p == nil {
+		t.Fatalf("a denial type alongside an enforceable type must build; got p=%v err=%v", p, err)
+	}
+	if p.failCloseable(EventPolicyDeny) {
+		t.Fatal("a tolerated denial type must remain inert (REQ-6.7)")
+	}
+	if !p.failCloseable(EventConfigChange) {
+		t.Fatal("the enforceable type alongside it must still fail-close")
+	}
+}
+
+// Non-required modes never build a policy and never fail-close (sanity for REQ-6.4).
+func TestRequired_NonRequiredModes_NoPolicy(t *testing.T) {
+	for _, m := range []string{"", "best-effort", "durable", "teleport"} {
+		p, err := RequiredConfig{Mode: m, AllowList: []string{"policy.allow"}, ConfirmPolicyAllow: true}.BuildPolicy()
+		if err != nil || p != nil {
+			t.Fatalf("mode %q must yield no policy and no error; got p=%v err=%v", m, p, err)
+		}
+	}
+}

--- a/pkg/skillctl/auditevent/sink.go
+++ b/pkg/skillctl/auditevent/sink.go
@@ -45,6 +45,13 @@ type Dispatcher struct {
 	sinks          []Sink
 	mode           Mode // §6 delivery semantics; best-effort unless set (delivery.go).
 	durableRetries int  // in-process retry budget for a durable/required sink Write (>=1).
+	// required is the FR-0110b §6b positive-list policy. It is nil for every
+	// non-required Dispatcher AND for a required Dispatcher built without a
+	// validated policy: in both cases deliver never fail-closes, so the
+	// SPEC-0255 / REQ-6.4 default holds. It is set ONLY by NewDispatcherRequired,
+	// whose policy comes from RequiredConfig.BuildPolicy (which rejects an empty
+	// allow-list, REQ-6.6). See required.go.
+	required *RequiredPolicy
 }
 
 // NewDispatcher builds a best-effort Dispatcher applying r to every event before

--- a/pkg/skillctl/pin/pin.go
+++ b/pkg/skillctl/pin/pin.go
@@ -83,6 +83,18 @@ type GenerateOptions struct {
 	// On a host with an unrecordable outbox it therefore denies the plugin ecosystem
 	// and the operator's allowlisted escapes too; that is the intended "no un-audited
 	// allow" posture, not a bug. Enable it deliberately.
+	//
+	// SPEC-0403 §6b / REQ-6.10c OPERATIONAL DUTY. This flag is the separate,
+	// explicit confirmation (REQ-6.10a) that puts `policy.allow` on the `required`
+	// positive list: it couples SKILL EXECUTION to a durable audit write. Whoever
+	// sets it takes on a SPOOL-PATH AVAILABILITY duty (disk space, permissions,
+	// inode reserve): a FULL DISK becomes a SKILL-EXECUTION FAILURE (the allow can
+	// no longer be spooled, so it fails closed, exit 26). That is the deliberate
+	// trade for "no un-audited allow"; it is fulfilled at the LOCAL SPOOL, never a
+	// broker (REQ-6.10b), so a skill start never hangs on a remote promise. Setting
+	// it is only an unbypassable POLICY (not merely a request) when the
+	// managed-settings file is pinned root-owned per SPEC-0247 P1.3; until then a
+	// same-uid user can flip it and it is advisory (AUD-07).
 	RequireLocalAudit bool
 	// StateGateFallback emits `skillctlStateGateFallback: true`: the SPEC-0317
 	// R-1.4 P2 opt-in that state-gates the verify-hook's ONLINE fallback (the §7


### PR DESCRIPTION
## FR-0110b — SPEC-0403 §6b `required` audit fail-close mechanism (2-lens challenge-gated)

The fail-closed half of §6 delivery. **Additive**: a reusable library mechanism in `pkg/skillctl/auditevent` + config validation + a reconciliation with the pre-existing live fail-close. **No new live decision path** — the library's producers arrive with FR-0111.

### What it does
- **`required` mode** (`delivery.go` / `required.go`): under `ModeRequired`, a mandatory event that is not durably accepted returns the sentinel `ErrRequiredNotDurable`; `IsFailClosed(err)` is the caller opt-in. Every other path stays advisory, so best-effort/durable callers (FR-0109/0110a) are byte-unchanged (REQ-6.4).
- **DoS-bound in code** (REQ-6.6..6.10): allow-list restricted to the five REQ-6.9 types; **denial events (`policy.deny`/`signature.reject`/`revocation.detect`) are exempt non-configurably** (checked before list membership, defense-in-depth at both `BuildPolicy` and `failCloseable`); empty allow-list rejected; **`policy.allow` requires a separate `ConfirmPolicyAllow`** (REQ-6.10a); "durably accepted" = local spool acceptance, never a broker ack (REQ-6.10b).
- **Reconciliation, not duplication**: the live gate-path `policy.allow` fail-close stays the pre-existing SPEC-0317 R-8.2 `require_local_audit` (exit 26, unchanged — the `enforce_cmds.go` diff is comment-only). `required_audit.go` maps that one live toggle onto the §6b vocabulary as a validated **display-only** string in `session baseline`. No second fail-close, no path where both fire.
- **O3/P1.3 honesty**: no unbypassability overclaim — the "advisory-only until SPEC-0247 P1.3 pinned" caveat is in the file headers and surfaced as a RED banner in `session baseline`.

### Challenge gate (2 lenses, both CLEARED, hermetic, commit 854c192)
- **infosec-pentest**: could not refute "additive / no live decision change / mechanism correct"; decision-invariance CONFIRMED; DoS-bound correct + bite-proven; no overclaim; no test-theater.
- **security-reviewer**: REQ-6.6..6.10 all **Compliant** (file:line table); reconciliation clean; every bite test independently reproduced (revert→FAIL); full regression 0 failures; gosec 0 new.

### Carried to FR-0111 (the wiring PR — non-blocking, both lenses agree)
1. A mandatory-event producer must hard-stop on `ErrInvalidEvent`/any non-nil Dispatch error (a shared `DispatchRequired` helper + bite test), so a malformed mandatory event can't proceed un-audited.
2. `NewDispatcherRequired` should reject non-local sinks so REQ-6.10b (spool-only) is enforced in code, not just by the caller contract.
3. Cosmetic: `session baseline` "required-audit policy:" column spacing.

### Verified
`env -u ER1_* go test -race -count=1 ./cmd/skillctl/... ./pkg/skillctl/...` 0 failures; SPEC-0255 decision-invariance + kill-switch tests green; `go build`/`vet`/gofmt clean; `gosec-diff-gate` 0 new; gitleaks clean; no em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
