### PR TITLE
feat(skillctl): FR-0111 — auditlog observability CLI + 3 gate follow-ups (SPEC-0403 §8)

### DIFF
--- a/cmd/skillctl/auditlog_cmds.go
+++ b/cmd/skillctl/auditlog_cmds.go
@@ -1,0 +1,457 @@
+package main
+
+// auditlog_cmds.go: FR-0111, the SPEC-0403 §8 observability CLI for the audit
+// event layer: `skillctl auditlog status | test | flush`.
+//
+// VERB CHOICE + EXIT SPACE (REQ-8.5 / REQ-8.6). The subsystem verbs live under
+// their OWN stem `auditlog`, NOT under `audit`. `skillctl audit` already exists
+// (SPEC-0189 §14): it computes per-skill posture verdicts with its OWN exit codes
+// 0/2/3. A `skillctl audit status` next to it would be ambiguous and its exit
+// codes would collide (a health finding read as a posture finding). `auditlog`
+// therefore has a DISJOINT exit space: 0 = healthy / accepted / drained, 1 =
+// unhealthy / not accepted / drain error. 2 is reserved for a usage/flag error, the
+// universal skillctl meaning; it is orthogonal to the 0/1 health verdict and, being
+// on a DIFFERENT verb, never collides with `skillctl audit`'s posture 2.
+//
+//	skillctl audit               posture verdicts        0/2/3   (SPEC-0189 §14)
+//	skillctl auditlog status     subsystem health        0/1     (this file)
+//	skillctl auditlog test        "
+//	skillctl auditlog flush       "
+//
+// FR-0113 VERB REGISTER (REQ-8.7). `auditlog` is meant to be the FIRST entry in the
+// SPEC-0404 §7-K3 verb register: a verb is REGISTERED before it is implemented, so
+// the register catches a future collision. That register is NOT built yet (no
+// register mechanism exists in cmd/skillctl today: verbs are a hand-rolled switch
+// in main.go). This file therefore registers `auditlog` the SAME way every existing
+// verb is registered (a case in main.go's dispatch) and records the dependency:
+// when FR-0113's register lands, `auditlog` should be its first migrated entry. We
+// deliberately do NOT build the register here (out of scope for FR-0111).
+//
+// REQ-8.1 / REQ-8.2 (observability without recursion). A transport failure is
+// surfaced as an observable audit.sink.* / audit.queue.* event on a SEPARATE, safe
+// channel (a stderr WriterSink built fresh in emitAuditlogObservability), NEVER back
+// through the sink that just failed. That separation is the no-recursion guard in
+// CODE: a failure reporting a sink failure cannot re-enter the failed sink.
+//
+// NO KAFKA (REQ-8.3 shape, but only true fields). `status` reports the fields that
+// are real today: the default file sink and the local SPEC-0317 outbox/spool. It
+// does NOT fabricate a broker endpoint/topic/connection: a direct Kafka sink is
+// FR-0112 and EC-blocked (§7.2).
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/auditevent"
+	"github.com/kamir/m3c-tools/pkg/skillctl/outbox"
+)
+
+const (
+	auditlogExitOK        = 0 // healthy / sink accepted / queue drained
+	auditlogExitUnhealthy = 1 // unhealthy / sink refused / drain error
+	auditlogExitUsage     = 2 // usage / flag error (orthogonal to the 0/1 health verdict)
+)
+
+// runAuditlog is the `skillctl auditlog <status|test|flush>` dispatcher.
+func runAuditlog(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		printAuditlogUsage(stderr)
+		return auditlogExitUsage
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "status":
+		return runAuditlogStatus(rest, stdout, stderr)
+	case "test":
+		return runAuditlogTest(rest, stdout, stderr)
+	case "flush":
+		return runAuditlogFlush(rest, stdout, stderr)
+	case "help", "-h", "--help":
+		printAuditlogUsage(stdout)
+		return auditlogExitOK
+	default:
+		fmt.Fprintf(stderr, "skillctl auditlog: unknown subcommand %q\n\n", sub)
+		printAuditlogUsage(stderr)
+		return auditlogExitUsage
+	}
+}
+
+func printAuditlogUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage: skillctl auditlog <status|test|flush> [--json]")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "  status   Report audit-subsystem health (enabled, mode, sink, outbox/spool pending, last event). Exit 0 healthy / 1 unhealthy.")
+	fmt.Fprintln(w, "  test     Emit one synthetic skillctl.audit.v1 event and confirm the sink accepted it. Exit 0 accepted / 1 refused.")
+	fmt.Fprintln(w, "  flush    Reconcile the local spool queue into the durable outbox (the local half of `skillctl sync`; no broker egress). Exit 0 / 1.")
+}
+
+// --- status -------------------------------------------------------------------
+
+// auditlogStatus is the REQ-8.3-shaped health report, restricted to the fields
+// that are TRUE today: there is no Kafka endpoint/topic/connection (FR-0112,
+// EC-blocked), so none is reported.
+type auditlogStatus struct {
+	Enabled       bool   `json:"enabled"`
+	Mode          string `json:"mode"`
+	Sink          string `json:"sink"`
+	SinkPath      string `json:"sink_path"`
+	OutboxPending int    `json:"outbox_pending"`
+	SpoolPending  int    `json:"spool_pending"`
+	LastEvent     string `json:"last_event,omitempty"`
+	Healthy       bool   `json:"healthy"`
+	Detail        string `json:"detail,omitempty"`
+}
+
+func runAuditlogStatus(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("auditlog status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	jsonOut := fs.Bool("json", false, "Emit the status as stable JSON.")
+	if err := fs.Parse(args); err != nil {
+		return auditlogExitUsage
+	}
+	home, err := userHome()
+	if err != nil || home == "" {
+		fmt.Fprintln(stderr, "skillctl auditlog status: cannot resolve home dir")
+		return auditlogExitUnhealthy
+	}
+	st := gatherAuditlogStatus(home)
+	if *jsonOut {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(st)
+	} else {
+		printAuditlogStatusHuman(stdout, st)
+	}
+	if st.Healthy {
+		return auditlogExitOK
+	}
+	return auditlogExitUnhealthy
+}
+
+// gatherAuditlogStatus reads the REAL subsystem state: the gate's default file
+// sink plus the SPEC-0317 outbox/spool. It performs a no-network writability probe
+// on the audit directory as the health signal.
+func gatherAuditlogStatus(home string) auditlogStatus {
+	st := auditlogStatus{
+		Enabled:  true, // REQ-5.1: audit logging is on by default, no infrastructure required.
+		Sink:     "file",
+		SinkPath: gateAuditPath(home),
+	}
+	// Mode: the gate default is best-effort (REQ-6.4 decision-invariance). The one
+	// live `required` escalation is require_local_audit (SPEC-0317 R-8.2), which makes
+	// policy.allow fail-closed at the local spool (SPEC-0403 §6b, REQ-6.10b).
+	if gateRequireLocalAudit() {
+		st.Mode = "required (policy.allow, fulfilled at the local spool; SPEC-0403 §6b / SPEC-0317 R-8.2)"
+	} else {
+		st.Mode = "best-effort (gate default, decision-invariant; durable outbox available)"
+	}
+
+	// Health probe: is the audit trail directory writable? Pure local, no network.
+	dir := verdictDir(home)
+	if mkErr := os.MkdirAll(dir, 0o700); mkErr != nil {
+		st.Healthy = false
+		st.Detail = fmt.Sprintf("audit directory not writable: %v", mkErr)
+		return st
+	}
+
+	// Outbox pending (durable rows awaiting the SEPARATE `skillctl sync` egress) and
+	// spool pending (un-reconciled hot-path fallback lines). If the db cannot be
+	// opened, the spool-only fallback still records, so this is DEGRADED, not
+	// unhealthy: report the spool count and note the db is unavailable.
+	if store, oErr := outbox.Open(home); oErr == nil {
+		if n, cErr := store.PendingCount(); cErr == nil {
+			st.OutboxPending = n
+		}
+		st.SpoolPending = countSpoolLines(store.SpoolPath())
+		_ = store.Close()
+	} else {
+		st.SpoolPending = countSpoolLines(filepath.Join(dir, "spool.jsonl"))
+		st.Detail = fmt.Sprintf("outbox db unavailable, spool-only fallback in force: %v", oErr)
+	}
+
+	st.LastEvent = lastAuditEventTimestamp(home)
+	st.Healthy = true // the trail directory is writable: the subsystem can record.
+	return st
+}
+
+func printAuditlogStatusHuman(w io.Writer, st auditlogStatus) {
+	fmt.Fprintln(w, "skillctl auditlog status")
+	fmt.Fprintf(w, "  Audit:        %s\n", enabledWord(st.Enabled))
+	fmt.Fprintf(w, "  Mode:         %s\n", st.Mode)
+	fmt.Fprintf(w, "  Sink:         %s\n", st.Sink)
+	fmt.Fprintf(w, "  Sink path:    %s\n", st.SinkPath)
+	fmt.Fprintf(w, "  Outbox:       %d pending (awaiting `skillctl sync` egress, default-OFF)\n", st.OutboxPending)
+	fmt.Fprintf(w, "  Spool:        %d pending (un-reconciled; drain with `skillctl auditlog flush`)\n", st.SpoolPending)
+	if st.LastEvent != "" {
+		fmt.Fprintf(w, "  Last event:   %s\n", st.LastEvent)
+	} else {
+		fmt.Fprintf(w, "  Last event:   (none recorded)\n")
+	}
+	fmt.Fprintf(w, "  Health:       %s\n", healthWord(st.Healthy))
+	if st.Detail != "" {
+		fmt.Fprintf(w, "  Detail:       %s\n", st.Detail)
+	}
+	// No broker line: a Kafka sink is FR-0112 and EC-blocked (§7.2); status does not
+	// fabricate an endpoint that does not exist.
+}
+
+func enabledWord(b bool) string {
+	if b {
+		return "ENABLED"
+	}
+	return "DISABLED"
+}
+
+func healthWord(b bool) string {
+	if b {
+		return "HEALTHY"
+	}
+	return "UNHEALTHY"
+}
+
+// --- test ---------------------------------------------------------------------
+
+// auditlogTestResult is the JSON shape of `auditlog test`.
+type auditlogTestResult struct {
+	Accepted bool   `json:"accepted"`
+	Sink     string `json:"sink"`
+	Marker   string `json:"marker"`
+	EventID  string `json:"event_id"`
+	Error    string `json:"error,omitempty"`
+}
+
+func runAuditlogTest(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("auditlog test", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	jsonOut := fs.Bool("json", false, "Emit the result as stable JSON.")
+	if err := fs.Parse(args); err != nil {
+		return auditlogExitUsage
+	}
+	home, err := userHome()
+	if err != nil || home == "" {
+		fmt.Fprintln(stderr, "skillctl auditlog test: cannot resolve home dir")
+		return auditlogExitUnhealthy
+	}
+
+	marker := fmt.Sprintf("auditlog-test-%d", time.Now().UnixNano())
+	ev := auditevent.New(auditevent.EventAuditSinkConnect, auditevent.OutcomeSuccess,
+		auditevent.SeverityNotice, auditevent.ProducerString(version))
+	ev.Message = "synthetic auditlog test event (skillctl auditlog test); NOT a real audit record"
+	_ = ev.SetExt("synthetic", true)
+	_ = ev.SetExt("test_marker", marker)
+
+	// Emit through the REAL default file sink (the gate audit path) so the test
+	// exercises the sink the subsystem actually uses. Best-effort dispatcher: a
+	// write failure is surfaced here, never re-reported through the same sink.
+	sink, sErr := auditevent.NewFileSink(gateAuditPath(home), 0)
+	if sErr != nil {
+		emitAuditlogObservability(stderr, auditevent.EventAuditSinkFail, auditevent.OutcomeError,
+			fmt.Sprintf("could not build the audit file sink: %v", sErr), marker)
+		reportAuditlogTest(stdout, *jsonOut, auditlogTestResult{Accepted: false, Marker: marker, EventID: ev.EventID, Error: sErr.Error()})
+		return auditlogExitUnhealthy
+	}
+	d := auditevent.NewDispatcher(auditevent.DefaultRedactor(), sink)
+	wErr := d.Dispatch(ev)
+	_ = d.Close()
+
+	res := auditlogTestResult{Accepted: wErr == nil, Sink: sink.Name(), Marker: marker, EventID: ev.EventID}
+	if wErr != nil {
+		res.Error = wErr.Error()
+		// REQ-8.1: surface the transport error as an observable audit.sink.fail event
+		// on a SEPARATE channel (stderr), never back through the file sink that just
+		// failed (REQ-8.2: no recursion).
+		emitAuditlogObservability(stderr, auditevent.EventAuditSinkFail, auditevent.OutcomeError,
+			fmt.Sprintf("synthetic test event was NOT accepted by sink %q: %v", sink.Name(), wErr), marker)
+		reportAuditlogTest(stdout, *jsonOut, res)
+		return auditlogExitUnhealthy
+	}
+	reportAuditlogTest(stdout, *jsonOut, res)
+	return auditlogExitOK
+}
+
+func reportAuditlogTest(w io.Writer, jsonOut bool, res auditlogTestResult) {
+	if jsonOut {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(res)
+		return
+	}
+	if res.Accepted {
+		fmt.Fprintf(w, "skillctl auditlog test: sink %s ACCEPTED the synthetic event (marker %s, event_id %s)\n",
+			res.Sink, res.Marker, res.EventID)
+		return
+	}
+	fmt.Fprintf(w, "skillctl auditlog test: sink did NOT accept the synthetic event (marker %s): %s\n",
+		res.Marker, res.Error)
+}
+
+// --- flush --------------------------------------------------------------------
+
+// auditlogFlushResult is the JSON shape of `auditlog flush`. SpoolBefore/After are
+// the queue this command actually drains (the un-reconciled hot-path spool);
+// PendingBefore/After are the durable rows still awaiting the SEPARATE network sync.
+type auditlogFlushResult struct {
+	SpoolBefore   int    `json:"spool_before"`
+	Drained       int    `json:"drained"`
+	SpoolAfter    int    `json:"spool_after"`
+	PendingBefore int    `json:"outbox_pending_before"`
+	PendingAfter  int    `json:"outbox_pending_after"`
+	Error         string `json:"error,omitempty"`
+}
+
+// runAuditlogFlush reconciles the local spool queue into the durable outbox. It is
+// the LOCAL half of `skillctl sync`: sync calls store.Reconcile() first and THEN
+// does the EC-gated network egress; flush does ONLY the reconcile and stops there
+// (REQ-6.10b: fulfillment is the local spool, never a broker ack). It reports
+// pending-before/after and never reaches the network.
+func runAuditlogFlush(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("auditlog flush", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	jsonOut := fs.Bool("json", false, "Emit the result as stable JSON.")
+	if err := fs.Parse(args); err != nil {
+		return auditlogExitUsage
+	}
+	home, err := userHome()
+	if err != nil || home == "" {
+		fmt.Fprintln(stderr, "skillctl auditlog flush: cannot resolve home dir")
+		return auditlogExitUnhealthy
+	}
+
+	store, oErr := outbox.Open(home)
+	if oErr != nil {
+		fmt.Fprintf(stderr, "skillctl auditlog flush: cannot open outbox: %v\n", oErr)
+		emitAuditlogObservability(stderr, auditevent.EventAuditQueueFlush, auditevent.OutcomeError,
+			fmt.Sprintf("flush could not open the outbox: %v", oErr), "")
+		return auditlogExitUnhealthy
+	}
+	defer store.Close()
+
+	res := auditlogFlushResult{
+		SpoolBefore: countSpoolLines(store.SpoolPath()),
+	}
+	res.PendingBefore, _ = store.PendingCount()
+
+	drained, rErr := store.Reconcile()
+	res.Drained = drained
+	res.SpoolAfter = countSpoolLines(store.SpoolPath())
+	res.PendingAfter, _ = store.PendingCount()
+
+	if rErr != nil {
+		res.Error = rErr.Error()
+		reportAuditlogFlush(stdout, *jsonOut, res)
+		// REQ-8.1: the queue-flush transport error becomes observable state on a
+		// separate channel (stderr), never recursed through the outbox/spool it drained.
+		emitAuditlogObservability(stderr, auditevent.EventAuditQueueFlush, auditevent.OutcomeError,
+			fmt.Sprintf("spool reconcile failed after draining %d row(s): %v", drained, rErr), "")
+		return auditlogExitUnhealthy
+	}
+	reportAuditlogFlush(stdout, *jsonOut, res)
+	// REQ-8.1: a normal flush also produces the observable audit.queue.flush state.
+	emitAuditlogObservability(stderr, auditevent.EventAuditQueueFlush, auditevent.OutcomeSuccess,
+		fmt.Sprintf("reconciled %d spooled row(s) into the durable outbox", drained), "")
+	return auditlogExitOK
+}
+
+func reportAuditlogFlush(w io.Writer, jsonOut bool, res auditlogFlushResult) {
+	if jsonOut {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(res)
+		return
+	}
+	fmt.Fprintln(w, "skillctl auditlog flush")
+	fmt.Fprintf(w, "  spool queue before:   %d line(s)\n", res.SpoolBefore)
+	fmt.Fprintf(w, "  reconciled:           %d row(s) into the durable outbox\n", res.Drained)
+	fmt.Fprintf(w, "  spool queue after:    %d line(s)\n", res.SpoolAfter)
+	fmt.Fprintf(w, "  outbox pending sync:  %d -> %d  [egress is `skillctl sync`, default-OFF; a broker sink is FR-0112, EC-gated]\n",
+		res.PendingBefore, res.PendingAfter)
+	if res.Error != "" {
+		fmt.Fprintf(w, "  error:                %s\n", res.Error)
+	}
+}
+
+// --- shared helpers -----------------------------------------------------------
+
+// emitAuditlogObservability writes one audit.sink.* / audit.queue.* observability
+// event to a DEDICATED stderr WriterSink (REQ-8.1). The sink is built FRESH here and
+// is a WriterSink, never the file/outbox sink under inspection, so a failure while
+// reporting a sink failure cannot recurse through the failed sink (REQ-8.2, the
+// no-recursion guard in code). Best-effort: its own error is dropped, never
+// re-emitted.
+func emitAuditlogObservability(w io.Writer, et auditevent.EventType, outcome auditevent.Outcome, msg, marker string) {
+	sev := auditevent.SeverityInfo
+	if outcome == auditevent.OutcomeError {
+		sev = auditevent.SeverityError
+	}
+	ev := auditevent.New(et, outcome, sev, auditevent.ProducerString(version))
+	ev.Message = msg
+	_ = ev.SetExt("observability", true)
+	if marker != "" {
+		_ = ev.SetExt("test_marker", marker)
+	}
+	d := auditevent.NewDispatcher(auditevent.DefaultRedactor(), auditevent.NewWriterSink("stderr", w))
+	_ = d.Dispatch(ev) // best-effort; a failure here is intentionally NOT re-reported.
+	_ = d.Close()
+}
+
+// countSpoolLines counts the non-empty lines in the spool file. A missing file is
+// zero (nothing spooled), never an error.
+func countSpoolLines(path string) int {
+	f, err := os.Open(path) // #nosec G304 -- path is the operator's own outbox spool, not attacker input.
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	n := 0
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
+	for sc.Scan() {
+		if len(trimSpace(sc.Bytes())) > 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// trimSpace trims ASCII whitespace from both ends of b without allocating a string.
+func trimSpace(b []byte) []byte {
+	i := 0
+	for i < len(b) && (b[i] == ' ' || b[i] == '\t' || b[i] == '\r' || b[i] == '\n') {
+		i++
+	}
+	j := len(b)
+	for j > i && (b[j-1] == ' ' || b[j-1] == '\t' || b[j-1] == '\r' || b[j-1] == '\n') {
+		j--
+	}
+	return b[i:j]
+}
+
+// lastAuditEventTimestamp returns the timestamp of the most recent well-formed
+// audit event in the gate audit log (the default file sink), or "" if none. It
+// reads the live generation only (the newest events); a torn/malformed line is
+// skipped, never fatal.
+func lastAuditEventTimestamp(home string) string {
+	f, err := os.Open(gateAuditPath(home)) // #nosec G304 -- operator's own audit log path.
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	last := ""
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		var e auditevent.Event
+		if jErr := json.Unmarshal(sc.Bytes(), &e); jErr != nil {
+			continue
+		}
+		if e.Timestamp != "" {
+			last = e.Timestamp
+		}
+	}
+	return last
+}

--- a/cmd/skillctl/auditlog_cmds_test.go
+++ b/cmd/skillctl/auditlog_cmds_test.go
@@ -1,0 +1,215 @@
+package main
+
+// auditlog_cmds_test.go: FR-0111 tests for `skillctl auditlog status|test|flush`.
+// Hermetic: a temp $HOME, no network, no ambient managed-settings. Each verb is
+// exercised on its happy path and on an unhealthy path (an audit directory that
+// cannot be written, forced by making <home>/.claude a regular FILE, so every
+// downstream MkdirAll fails deterministically).
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/outbox"
+	"github.com/kamir/m3c-tools/pkg/skillgate"
+)
+
+// wedgeAuditHome makes <home>/.claude a regular file, so any attempt to create
+// <home>/.claude/skillctl (the audit dir) fails. Returns the home.
+func wedgeAuditHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".claude"), []byte("not a dir"), 0o600); err != nil {
+		t.Fatalf("wedge home: %v", err)
+	}
+	return home
+}
+
+func TestAuditlogStatus_Healthy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	var out, errb bytes.Buffer
+	code := runAuditlog([]string{"status"}, &out, &errb)
+	if code != auditlogExitOK {
+		t.Fatalf("healthy status must exit 0; got %d (stderr=%q)", code, errb.String())
+	}
+	s := out.String()
+	for _, want := range []string{"ENABLED", "HEALTHY", "Sink:", "best-effort"} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("status output missing %q; got:\n%s", want, s)
+		}
+	}
+}
+
+func TestAuditlogStatus_JSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	var out, errb bytes.Buffer
+	if code := runAuditlog([]string{"status", "--json"}, &out, &errb); code != auditlogExitOK {
+		t.Fatalf("healthy status --json must exit 0; got %d", code)
+	}
+	var st auditlogStatus
+	if err := json.Unmarshal(out.Bytes(), &st); err != nil {
+		t.Fatalf("status --json must emit valid JSON; got %v\n%s", err, out.String())
+	}
+	if !st.Enabled || !st.Healthy {
+		t.Fatalf("healthy JSON status must have enabled+healthy true; got %+v", st)
+	}
+	// REQ-8.3 shape but no Kafka: there must be no fabricated broker fields.
+	if strings.Contains(out.String(), "kafka") || strings.Contains(out.String(), "endpoint") || strings.Contains(out.String(), "topic") {
+		t.Fatalf("status must NOT fabricate a broker endpoint/topic (FR-0112, EC-blocked); got:\n%s", out.String())
+	}
+}
+
+func TestAuditlogStatus_Unhealthy(t *testing.T) {
+	home := wedgeAuditHome(t)
+	t.Setenv("HOME", home)
+	var out, errb bytes.Buffer
+	code := runAuditlog([]string{"status"}, &out, &errb)
+	if code != auditlogExitUnhealthy {
+		t.Fatalf("an unwritable audit dir must exit 1; got %d\nstdout=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "UNHEALTHY") || !strings.Contains(out.String(), "not writable") {
+		t.Fatalf("unhealthy status must say UNHEALTHY and name the writability failure; got:\n%s", out.String())
+	}
+}
+
+func TestAuditlogTest_Happy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	var out, errb bytes.Buffer
+	code := runAuditlog([]string{"test"}, &out, &errb)
+	if code != auditlogExitOK {
+		t.Fatalf("test on a writable home must exit 0; got %d (stderr=%q)", code, errb.String())
+	}
+	if !strings.Contains(out.String(), "ACCEPTED") {
+		t.Fatalf("test happy path must report ACCEPTED; got:\n%s", out.String())
+	}
+	// The synthetic event must have landed in the real default sink, clearly marked.
+	logPath := filepath.Join(home, ".claude", "skillctl", "gate-audit.jsonl")
+	b, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("expected the synthetic event written to %s; read err=%v", logPath, err)
+	}
+	if !strings.Contains(string(b), "auditlog-test-") || !strings.Contains(string(b), "audit.sink.connect") {
+		t.Fatalf("the written event must be the clearly-synthetic audit.sink.connect with the test marker; got:\n%s", string(b))
+	}
+	if !strings.Contains(string(b), "\"synthetic\":true") {
+		t.Fatalf("the written event must carry the synthetic marker field; got:\n%s", string(b))
+	}
+}
+
+func TestAuditlogTest_Unhealthy(t *testing.T) {
+	home := wedgeAuditHome(t)
+	t.Setenv("HOME", home)
+	var out, errb bytes.Buffer
+	code := runAuditlog([]string{"test"}, &out, &errb)
+	if code != auditlogExitUnhealthy {
+		t.Fatalf("test with an unwritable sink must exit 1; got %d", code)
+	}
+	// REQ-8.1: the transport failure is surfaced as an observable audit.sink.fail
+	// event, and (REQ-8.2) on stderr, NOT back through the file sink that failed.
+	if !strings.Contains(errb.String(), "audit.sink.fail") {
+		t.Fatalf("a sink write failure must surface an observable audit.sink.fail on stderr (REQ-8.1); got stderr:\n%s", errb.String())
+	}
+	// REQ-8.2 no-recursion: nothing must have been written to the (broken) file sink
+	// (the path is unwritable, so the file must not exist at all).
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skillctl", "gate-audit.jsonl")); err == nil {
+		t.Fatal("no audit line must reach the failed file sink (no recursion), but the log file exists")
+	}
+}
+
+// spoolOne appends one row to the home's spool.jsonl (the hot-path fallback queue).
+func spoolOne(t *testing.T, home, eventID, occurredAt string) {
+	t.Helper()
+	rec := skillgate.InvocationRecord{
+		Schema:     skillgate.InvocationSchema,
+		EventID:    eventID,
+		EventType:  "policy.allow",
+		OccurredAt: occurredAt,
+		Tool:       "audit",
+		Action:     "audit",
+	}
+	pj, ph, err := outbox.RecordPayload(rec)
+	if err != nil {
+		t.Fatalf("RecordPayload: %v", err)
+	}
+	if err := outbox.SpoolTo(home, rec, pj, ph); err != nil {
+		t.Fatalf("SpoolTo: %v", err)
+	}
+}
+
+func TestAuditlogFlush_Happy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	spoolOne(t, home, "flush-a", "2026-09-04T10:00:00Z")
+	spoolOne(t, home, "flush-b", "2026-09-04T10:00:01Z")
+
+	var out, errb bytes.Buffer
+	code := runAuditlog([]string{"flush", "--json"}, &out, &errb)
+	if code != auditlogExitOK {
+		t.Fatalf("flush of a writable spool must exit 0; got %d (stderr=%q)", code, errb.String())
+	}
+	var res auditlogFlushResult
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatalf("flush --json must emit valid JSON; got %v\n%s", err, out.String())
+	}
+	if res.SpoolBefore != 2 || res.Drained != 2 || res.SpoolAfter != 0 {
+		t.Fatalf("flush must drain both spooled rows and empty the spool; got %+v", res)
+	}
+	if res.PendingAfter < 2 {
+		t.Fatalf("the reconciled rows must be durable (unsynced) in the outbox after flush; got pending_after=%d", res.PendingAfter)
+	}
+	// REQ-8.1: a normal flush produces the observable audit.queue.flush state.
+	if !strings.Contains(errb.String(), "audit.queue.flush") {
+		t.Fatalf("flush must surface an observable audit.queue.flush event (REQ-8.1); got stderr:\n%s", errb.String())
+	}
+}
+
+func TestAuditlogFlush_EmptyIsHealthy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	var out, errb bytes.Buffer
+	if code := runAuditlog([]string{"flush"}, &out, &errb); code != auditlogExitOK {
+		t.Fatalf("flush with an empty spool must still be healthy (exit 0); got %d", code)
+	}
+	if !strings.Contains(out.String(), "reconciled:           0 row(s)") {
+		t.Fatalf("empty flush must report 0 reconciled; got:\n%s", out.String())
+	}
+}
+
+func TestAuditlogFlush_Unhealthy(t *testing.T) {
+	home := wedgeAuditHome(t)
+	t.Setenv("HOME", home)
+	var out, errb bytes.Buffer
+	code := runAuditlog([]string{"flush"}, &out, &errb)
+	if code != auditlogExitUnhealthy {
+		t.Fatalf("flush against an unopenable outbox must exit 1; got %d", code)
+	}
+	if !strings.Contains(errb.String(), "audit.queue.flush") {
+		t.Fatalf("a flush transport error must surface an observable audit.queue.flush event (REQ-8.1); got stderr:\n%s", errb.String())
+	}
+}
+
+func TestAuditlog_UsageErrors(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := runAuditlog(nil, &out, &errb); code != auditlogExitUsage {
+		t.Fatalf("no subcommand must be a usage error (2); got %d", code)
+	}
+	if code := runAuditlog([]string{"bogus"}, &out, &errb); code != auditlogExitUsage {
+		t.Fatalf("an unknown subcommand must be a usage error (2); got %d", code)
+	}
+}
+
+// The auditlog verb must NOT collide with `skillctl audit`'s 0/2/3 posture space:
+// its own exit space is 0/1 for the health verdict (REQ-8.5/8.6). This asserts the
+// constants are the disjoint values the SPEC decided.
+func TestAuditlog_ExitSpaceIsOwnAndDisjoint(t *testing.T) {
+	if auditlogExitOK != 0 || auditlogExitUnhealthy != 1 {
+		t.Fatalf("auditlog health verdict must be 0/1 (REQ-8.6); got ok=%d unhealthy=%d", auditlogExitOK, auditlogExitUnhealthy)
+	}
+}

--- a/cmd/skillctl/main.go
+++ b/cmd/skillctl/main.go
@@ -142,6 +142,15 @@ func main() {
 	case "gate-stats":
 		os.Exit(runGateStats(os.Args[2:], os.Stdout, os.Stderr))
 	// === END SPEC-0255 ===
+	// === SPEC-0403 §8 (FR-0111): audit-subsystem observability CLI. ===
+	// OWN verb stem with its OWN exit space 0/1 (REQ-8.6): distinct from `audit`
+	// (SPEC-0189 §14 posture verdicts, 0/2/3, above) so a health finding is never
+	// read as a posture finding. `auditlog` is intended to be the first entry in the
+	// FR-0113 verb register (REQ-8.7); that register is not built yet, so it is
+	// registered here the same hand-rolled way as every other verb.
+	case "auditlog":
+		os.Exit(runAuditlog(os.Args[2:], os.Stdout, os.Stderr))
+	// === END SPEC-0403 §8 ===
 	// === SPEC-0247 §7.3 P1.3: managed-settings pinning (make the gate un-deletable). ===
 	case "pin":
 		os.Exit(runPin(os.Args[2:], os.Stdout, os.Stderr))
@@ -269,6 +278,8 @@ func printUsage(w *os.File) {
 	fmt.Fprintln(w, "               write-once outbox for durable, drainable audit (SPEC-0317). Fail-closed.")
 	fmt.Fprintln(w, "  gate-stats   Summarise the gate-audit.jsonl (decisions, top blocks, cache-hit rate).")
 	fmt.Fprintln(w, "               Flags: --since <168h|YYYY-MM-DD>, --json.")
+	fmt.Fprintln(w, "  auditlog     Audit-subsystem observability (SPEC-0403 §8). OWN exit space 0/1,")
+	fmt.Fprintln(w, "               distinct from `audit` above. Subcommands: status | test | flush [--json].")
 	fmt.Fprintln(w, "  pin          Pin the trust gate into Claude Code managed settings so a")
 	fmt.Fprintln(w, "               non-privileged user cannot delete it (SPEC-0247 §7.3).")
 	fmt.Fprintln(w, "               Subcommands: generate | status | install. --strict for CISO lockdown.")

--- a/cmd/skillctl/session_baseline_cmds.go
+++ b/cmd/skillctl/session_baseline_cmds.go
@@ -140,7 +140,7 @@ func runSessionBaseline(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "  translog anchor:      %s\n", yesNo(dec.AnchorPresent))
 	fmt.Fprintf(stdout, "  enterprise profile:   %s\n", yesNo(dec.Enterprise))
 	fmt.Fprintf(stdout, "  require local audit:  %s  [ENFORCED (R-8.2) by enforce: an allow that can't be durably recorded fails closed, exit 26]\n", yesNo(gateRequireLocalAudit()))
-	fmt.Fprintf(stdout, "  required-audit policy:%s\n", describeRequiredAudit(gateRequireLocalAudit()))
+	fmt.Fprintf(stdout, "  required-audit policy: %s\n", describeRequiredAudit(gateRequireLocalAudit()))
 	fmt.Fprintf(stdout, "  online fallback:      %s  [%s]\n", allowedBlocked(dec.AllowOnlineFallback), onlineFallbackNote(stateGateFallback))
 	fmt.Fprintf(stdout, "  high-risk fail-closed:%s\n", yesNoPad(dec.HighRiskFailsClosed))
 	fmt.Fprintf(stdout, "  deny all managed:     %s  [ENFORCED (R-7.2) by verify-hook/enforce when the gate is pinned: a locked host denies non-allowlisted managed skills, exit 28]\n", yesNo(dec.DenyAllManaged))

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -111,6 +111,7 @@ Additional codes surface in specific commands:
 
 | Code | Command(s) | Meaning |
 |-----:|------------|---------|
+| `1` | `auditlog status`, `auditlog test`, `auditlog flush` | subsystem unhealthy / sink refused / drain error (own `0/1` health space, SPEC-0403 §8; distinct from `audit`'s `0/2/3`). |
 | `3` | `audit` | at least one skill is `BROKEN`. |
 | `4` | `import-public` | pin required (input validation). |
 | `5` | `import-public` | scanner refuse (scanner / policy hit). |
@@ -721,6 +722,44 @@ Summarises `gate-audit.jsonl`: decisions, top blocks, cache-hit rate.
 ```bash
 skillctl gate-stats --since 168h
 skillctl gate-stats --since 2026-06-01 --json
+```
+
+---
+
+### `auditlog`: audit-subsystem observability (SPEC-0403 §8)
+
+```bash
+skillctl auditlog <status|test|flush> [--json]
+```
+
+The observability CLI for the audit event layer. It has its **own verb stem** and its
+**own exit space `0/1`** (`0` healthy/accepted/drained, `1` unhealthy/refused/drain error;
+`2` is a usage error). This is deliberate: `skillctl audit` (above) is the antivirus-style
+**posture** verb with exit codes `0/2/3`, and a health finding must never be read as a
+posture finding. `auditlog` is intended to be the first entry in the FR-0113 verb register.
+
+| Subcommand | Purpose |
+|------------|---------|
+| `status` | Report subsystem health: enabled, mode, sink type + path, outbox pending, spool pending, last event. Exit `0` healthy / `1` unhealthy. |
+| `test` | Emit ONE clearly-synthetic `skillctl.audit.v1` event through the real default sink and confirm it was accepted. Exit `0` accepted / `1` refused. |
+| `flush` | Reconcile the local spool queue into the durable outbox (the local half of `sync`, no broker egress) and report pending before/after. Exit `0` / `1`. |
+
+| Flag | Purpose |
+|------|---------|
+| `-json` | Emit the result as stable JSON. |
+
+There is **no Kafka**: a direct broker sink is FR-0112 and EC-blocked (§7.2), so `status`
+reports only the sink and outbox/spool that exist today and never fabricates a broker
+endpoint. `flush` reaches only the local spool (REQ-6.10b); network egress is `skillctl sync`
+(default-OFF). A transport failure is surfaced as an observable `audit.sink.fail` /
+`audit.queue.flush` event on stderr, never re-reported through the sink that failed (no
+recursive error loop, REQ-8.2).
+
+```bash
+skillctl auditlog status
+skillctl auditlog status --json
+skillctl auditlog test
+skillctl auditlog flush
 ```
 
 ---

--- a/pkg/skillctl/auditevent/delivery.go
+++ b/pkg/skillctl/auditevent/delivery.go
@@ -43,6 +43,68 @@ var ErrRequiredNotDurable = errors.New("auditevent: required audit event not dur
 // should treat that as its own hard stop, but it is not this contract.
 func IsFailClosed(err error) bool { return errors.Is(err, ErrRequiredNotDurable) }
 
+// DispatchRequired dispatches e and, for a MANDATORY event, fail-closes on ANY
+// non-nil Dispatch error, not only ErrRequiredNotDurable (SPEC-0403 §6b, AUD-01).
+//
+// WHY THIS EXISTS. IsFailClosed reports ONLY the durability fail-close
+// (ErrRequiredNotDurable). But a mandatory event can fail Dispatch for a SECOND
+// reason: it is MALFORMED (ErrInvalidEvent from Validate), in which case Dispatch
+// returns before any sink is written and the event is never recorded. A required
+// caller that gates solely on IsFailClosed would then let a malformed mandatory
+// event proceed UN-AUDITED, which is exactly the false assurance §6b/AUD-01 forbid
+// (a consequential operation reported successful while its mandatory audit event
+// was silently dropped). DispatchRequired closes that gap: for a mandatory event,
+// a validation error is as fail-closing as a durability error.
+//
+// It changes NOTHING for a non-mandatory event: a denial type (REQ-6.7, exempt), a
+// type not on the positive list, an unconfirmed policy.allow, a nil/absent policy,
+// or any non-required mode all return Dispatch's error verbatim, so the SPEC-0255 /
+// REQ-6.4 decision-invariance default is untouched. Use plain Dispatch on the gate
+// hot path; use DispatchRequired at a consequential producer that has opted into
+// required for e's type.
+func (d *Dispatcher) DispatchRequired(e *Event) error {
+	err := d.Dispatch(e)
+	if err == nil || IsFailClosed(err) {
+		return err // success, or already load-bearing (durability fail-close).
+	}
+	if d.isMandatory(e) {
+		// A mandatory event that did not go through (a malformed ErrInvalidEvent, or
+		// any other non-durability delivery error) MUST fail the caller closed: the
+		// operation cannot be reported audited when its required event was not
+		// recorded (AUD-01). Wrap in the load-bearing sentinel so IsFailClosed==true.
+		// Two %w: the result satisfies IsFailClosed (ErrRequiredNotDurable) AND still
+		// carries the underlying cause (e.g. ErrInvalidEvent) for an operator.
+		return fmt.Errorf("%w: a MANDATORY audit event was not recorded (event_type=%s): %w",
+			ErrRequiredNotDurable, mandatoryTypeOf(e), err)
+	}
+	return err // not a mandatory event: advisory, decision-invariant (REQ-6.4).
+}
+
+// isMandatory reports whether e is an event this Dispatcher's required policy would
+// fail-close on: required mode, a non-nil policy, and (for a non-nil event) a
+// fail-closeable type (on the positive list, not a denial type, and, for
+// policy.allow, confirmed). A NIL event under an active required policy is treated
+// as mandatory: the caller invoked the required variant, so a nil event is the
+// worst un-audited case and must not slip through as merely advisory.
+func (d *Dispatcher) isMandatory(e *Event) bool {
+	if d.mode != ModeRequired || d.required == nil {
+		return false
+	}
+	if e == nil {
+		return true
+	}
+	return d.required.failCloseable(e.EventType)
+}
+
+// mandatoryTypeOf renders the event type for a fail-close message, tolerating a
+// nil event.
+func mandatoryTypeOf(e *Event) EventType {
+	if e == nil {
+		return "<nil>"
+	}
+	return e.EventType
+}
+
 // Mode is the SPEC-0403 §6 delivery semantics selector (REQ-6.1).
 type Mode string
 

--- a/pkg/skillctl/auditevent/dispatchrequired_test.go
+++ b/pkg/skillctl/auditevent/dispatchrequired_test.go
@@ -1,0 +1,120 @@
+package auditevent
+
+// dispatchrequired_test.go: the FR-0110b challenge-gate follow-up (1) bite test.
+//
+// The gate found that IsFailClosed reports ONLY the durability fail-close
+// (ErrRequiredNotDurable). A MALFORMED mandatory event fails Dispatch with
+// ErrInvalidEvent (Validate rejects it before any sink is written), for which
+// IsFailClosed is false, so a required caller gating solely on IsFailClosed would
+// let a malformed mandatory event proceed UN-AUDITED (AUD-01). DispatchRequired
+// closes that: for a mandatory event, ANY non-nil Dispatch error fail-closes.
+//
+// Each test is bite-proof: the comment names the guard whose removal makes it fail.
+
+import (
+	"errors"
+	"testing"
+)
+
+// malformedPolicyAllow builds a policy.allow event (a MANDATORY type under the
+// confirmed policy) that is MALFORMED: its outcome is not in the vocabulary, so
+// Validate rejects it with ErrInvalidEvent before any sink is written.
+func malformedPolicyAllow() *Event {
+	e := New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	e.EventID = "aud-malformed-1"
+	e.Outcome = "bogus-outcome" // not a known Outcome → Validate fails (ErrInvalidEvent).
+	return e
+}
+
+// (1) THE BITE. A malformed MANDATORY event: plain Dispatch returns a non-fail-close
+// error (the gap), DispatchRequired fail-closes (the fix).
+// BITE: delete the `d.isMandatory(e)` branch in DispatchRequired (return err
+// verbatim) and the malformed policy.allow returns bare ErrInvalidEvent →
+// IsFailClosed goes false → this test fails on the second assertion.
+func TestDispatchRequired_MalformedMandatory_FailsClosed(t *testing.T) {
+	home := t.TempDir()
+	// A real, spool-only, LOCAL fulfillment sink (so construction is accepted and a
+	// WELL-FORMED event would be durably accepted; the malformation is the only fault).
+	d := mustRequired(t, policyAllowConfirmed(t), NewOutboxSinkWithStore(nil, home))
+
+	// Control: plain Dispatch surfaces the malformation as ErrInvalidEvent, which is
+	// NOT load-bearing. This is exactly the gap the helper exists to close: a caller
+	// gating only on IsFailClosed would proceed here, un-audited.
+	plain := d.Dispatch(malformedPolicyAllow())
+	if !errors.Is(plain, ErrInvalidEvent) {
+		t.Fatalf("a malformed event must fail Dispatch validation (ErrInvalidEvent); got %v", plain)
+	}
+	if IsFailClosed(plain) {
+		t.Fatalf("plain Dispatch must NOT report a validation error as fail-closed (that is the gap); got IsFailClosed=true")
+	}
+
+	// The fix: DispatchRequired fail-closes the SAME malformed mandatory event.
+	got := d.DispatchRequired(malformedPolicyAllow())
+	if !IsFailClosed(got) {
+		t.Fatalf("DispatchRequired must fail closed on a malformed MANDATORY event (AUD-01); got err=%v (IsFailClosed=false)", got)
+	}
+	// The load-bearing wrapper must still carry the underlying validation cause, so an
+	// operator can see WHY it failed closed, not merely THAT it did.
+	if !errors.Is(got, ErrRequiredNotDurable) || !errors.Is(got, ErrInvalidEvent) {
+		t.Fatalf("the fail-close error must wrap BOTH ErrRequiredNotDurable and the underlying ErrInvalidEvent; got %v", got)
+	}
+}
+
+// (2) A well-formed mandatory event whose LOCAL spool accepts it proceeds through
+// DispatchRequired exactly as through Dispatch (no false fail-close).
+func TestDispatchRequired_WellFormedMandatory_Proceeds(t *testing.T) {
+	home := t.TempDir()
+	d := mustRequired(t, policyAllowConfirmed(t), NewOutboxSinkWithStore(nil, home))
+	e := New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	e.EventID = "aud-req-ok-1"
+	if err := d.DispatchRequired(e); err != nil {
+		t.Fatalf("a spool-accepted mandatory event must proceed through DispatchRequired; got %v", err)
+	}
+}
+
+// (3) A well-formed mandatory event whose spool FAILS fail-closes through
+// DispatchRequired too (the durability path, unchanged from Dispatch).
+func TestDispatchRequired_DurabilityFailure_FailsClosed(t *testing.T) {
+	d := mustRequired(t, policyAllowConfirmed(t), &failingSink{})
+	got := d.DispatchRequired(New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x"))
+	if !IsFailClosed(got) {
+		t.Fatalf("a mandatory event whose durable sink failed must fail closed; got %v", got)
+	}
+}
+
+// (4) A DENIAL type stays exempt EVEN through DispatchRequired and EVEN when
+// malformed (REQ-6.7): an already-failed operation is never failed a second time.
+// BITE: if isMandatory ignored the denial exemption, a malformed policy.deny would
+// fail-close here.
+func TestDispatchRequired_MalformedDenial_NotFailClosed(t *testing.T) {
+	// A policy that lists a denial type alongside an enforceable one, all confirmed:
+	// the only reason the denial does not fail-close is the REQ-6.7 exemption.
+	pol := &RequiredPolicy{
+		allow:         map[EventType]struct{}{EventPolicyDeny: {}, EventSkillExecute: {}},
+		policyAllowOK: true,
+	}
+	d := mustRequired(t, pol, &failingSink{})
+	e := New(EventPolicyDeny, OutcomeDeny, SeverityWarning, "skillctl/x")
+	e.Severity = "bogus-severity" // malform it too.
+	got := d.DispatchRequired(e)
+	if IsFailClosed(got) {
+		t.Fatalf("a denial event must never fail closed through DispatchRequired, even malformed (REQ-6.7); got fail-close")
+	}
+}
+
+// (5) A non-listed type is not mandatory: DispatchRequired returns Dispatch's error
+// verbatim (decision-invariant, REQ-6.4). A malformed non-mandatory event stays
+// advisory.
+func TestDispatchRequired_NonMandatory_Advisory(t *testing.T) {
+	// policy.allow confirmed, but the event is skill.verify (NOT on the list).
+	d := mustRequired(t, policyAllowConfirmed(t), &failingSink{})
+	e := New(EventSkillVerify, OutcomeSuccess, SeverityInfo, "skillctl/x")
+	e.Outcome = "bogus" // malform: ErrInvalidEvent.
+	got := d.DispatchRequired(e)
+	if IsFailClosed(got) {
+		t.Fatalf("a non-listed (non-mandatory) event must not fail closed through DispatchRequired (REQ-6.4); got fail-close")
+	}
+	if !errors.Is(got, ErrInvalidEvent) {
+		t.Fatalf("a non-mandatory malformed event must surface the advisory validation error verbatim; got %v", got)
+	}
+}

--- a/pkg/skillctl/auditevent/filesink.go
+++ b/pkg/skillctl/auditevent/filesink.go
@@ -90,6 +90,11 @@ func (f *FileSink) Write(e *Event) error {
 // Write so a rotation or external truncation is always observed).
 func (f *FileSink) Close() error { return nil }
 
+// localSink marks FileSink as a LocalSink (REQ-6.10b): it writes only to a local
+// file, no network. It is therefore an acceptable fulfillment sink under
+// ModeRequired.
+func (f *FileSink) localSink() {}
+
 // WriterSink emits redacted audit events as JSON Lines to any io.Writer; the
 // stderr / stdout targets of REQ-5.2. It never closes the underlying writer
 // (stderr/stdout are process-owned). Safe for concurrent Write via a mutex.
@@ -127,3 +132,7 @@ func (s *WriterSink) Write(e *Event) error {
 
 // Close is a no-op: the underlying writer is process-owned and not closed here.
 func (s *WriterSink) Close() error { return nil }
+
+// localSink marks WriterSink as a LocalSink (REQ-6.10b): it writes to a
+// process-owned stream (stderr/stdout), no network. Acceptable under ModeRequired.
+func (s *WriterSink) localSink() {}

--- a/pkg/skillctl/auditevent/localsink_test.go
+++ b/pkg/skillctl/auditevent/localsink_test.go
@@ -1,0 +1,84 @@
+package auditevent
+
+// localsink_test.go: the FR-0110b challenge-gate follow-up (2) test.
+//
+// REQ-6.10b requires a required-mode Dispatcher to be fulfilled at the LOCAL spool,
+// never a broker ack, so a covered skill load path can never hang on a remote
+// promise (the DoS the positive list bounds). NewDispatcherRequired now enforces
+// this in CODE: it rejects any sink that is not a LocalSink. This test proves the
+// rejection, and that the in-package local sinks are accepted.
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+// networkSink is a Sink that models a NETWORK-egress destination (a would-be Kafka
+// sink, FR-0112). It deliberately does NOT implement the unexported localSink()
+// marker, so it is not a LocalSink and must be rejected under required.
+type networkSink struct{}
+
+func (networkSink) Write(*Event) error { return nil }
+func (networkSink) Name() string       { return "kafka://broker.example:9092" }
+func (networkSink) Close() error       { return nil }
+
+func TestNewDispatcherRequired_RejectsNonLocalSink(t *testing.T) {
+	_, err := NewDispatcherRequired(policyAllowConfirmed(t), Redactor{}, networkSink{})
+	if !errors.Is(err, ErrNonLocalSink) {
+		t.Fatalf("a required-mode dispatcher must reject a non-local (network) sink with ErrNonLocalSink; got %v", err)
+	}
+}
+
+func TestNewDispatcherRequired_RejectsMixedLocalAndNonLocal(t *testing.T) {
+	// One good local sink and one network sink: the presence of ANY non-local sink
+	// must fail construction (fail SAFE, closed), never silently drop the bad one.
+	local := NewOutboxSinkWithStore(nil, t.TempDir())
+	_, err := NewDispatcherRequired(policyAllowConfirmed(t), Redactor{}, local, networkSink{})
+	if !errors.Is(err, ErrNonLocalSink) {
+		t.Fatalf("a required-mode dispatcher must reject a batch containing any non-local sink; got %v", err)
+	}
+}
+
+func TestNewDispatcherRequired_RejectsNoSink(t *testing.T) {
+	_, err := NewDispatcherRequired(policyAllowConfirmed(t), Redactor{})
+	if !errors.Is(err, ErrNonLocalSink) {
+		t.Fatalf("a required-mode dispatcher with no sink can never be durably accepted; must be rejected; got %v", err)
+	}
+}
+
+func TestNewDispatcherRequired_AcceptsLocalSinks(t *testing.T) {
+	fs, err := NewFileSink(t.TempDir()+"/audit.jsonl", 0)
+	if err != nil {
+		t.Fatalf("NewFileSink: %v", err)
+	}
+	local := []Sink{
+		fs,
+		NewWriterSink("stderr", io.Discard),
+		NewOutboxSinkWithStore(nil, t.TempDir()),
+		&failingSink{}, // a LOCAL sink that fails writes is still local (no network).
+	}
+	for _, s := range local {
+		d, err := NewDispatcherRequired(policyAllowConfirmed(t), Redactor{}, s)
+		if err != nil {
+			t.Fatalf("local sink %q must be accepted under required; got %v", s.Name(), err)
+		}
+		if d == nil || d.Mode() != ModeRequired {
+			t.Fatalf("expected a required-mode dispatcher for local sink %q", s.Name())
+		}
+	}
+}
+
+// isLocalSink correctly classifies the in-package sinks and rejects a foreign one.
+func TestIsLocalSink_Classification(t *testing.T) {
+	fs, _ := NewFileSink(t.TempDir()+"/a.jsonl", 0)
+	locals := []Sink{fs, NewWriterSink("x", io.Discard), NewOutboxSinkWithStore(nil, t.TempDir())}
+	for _, s := range locals {
+		if !isLocalSink(s) {
+			t.Fatalf("%q must classify as a LocalSink", s.Name())
+		}
+	}
+	if isLocalSink(networkSink{}) {
+		t.Fatal("a network sink must NOT classify as a LocalSink")
+	}
+}

--- a/pkg/skillctl/auditevent/outboxsink.go
+++ b/pkg/skillctl/auditevent/outboxsink.go
@@ -70,6 +70,13 @@ func NewOutboxSinkWithStore(st *outbox.Store, home string) *OutboxSink {
 // Name identifies the sink for observability (FR-0111).
 func (o *OutboxSink) Name() string { return "outbox" }
 
+// localSink marks OutboxSink as a LocalSink (REQ-6.10b): it persists to the local
+// SPEC-0317 outbox (SQLite + spool.jsonl) and reaches NO broker; the network drain
+// is the SEPARATE `skillctl sync` process. It is therefore the recommended
+// fulfillment sink under ModeRequired, where "durably accepted" is exactly spool
+// acceptance, never a remote ack.
+func (o *OutboxSink) localSink() {}
+
 // Close closes the underlying store (if this sink opened one). A spool-only sink
 // holds nothing to close.
 func (o *OutboxSink) Close() error {

--- a/pkg/skillctl/auditevent/required.go
+++ b/pkg/skillctl/auditevent/required.go
@@ -200,17 +200,42 @@ func (c RequiredConfig) BuildPolicy() (*RequiredPolicy, error) {
 	return &RequiredPolicy{allow: allow, policyAllowOK: c.ConfirmPolicyAllow}, nil
 }
 
+// ErrNonLocalSink is the sentinel NewDispatcherRequired returns when it is handed
+// a sink that is not a LocalSink. It exists so a caller can errors.Is it rather
+// than match on message text.
+var ErrNonLocalSink = errors.New("auditevent: required-mode dispatcher rejects a non-local sink")
+
 // NewDispatcherRequired builds a ModeRequired Dispatcher that ENFORCES fail-close
 // for the event types on policy (SPEC-0403 §6b). Obtain policy from
 // RequiredConfig.BuildPolicy (which rejects an empty allow-list, REQ-6.6). A nil
 // policy is accepted but fail-closes NOTHING (it degrades to durable-equivalent):
 // pass a validated, non-nil policy for real enforcement.
 //
-// sinks SHOULD be a SINGLE durable sink (OutboxSink). Under required, "durably
-// accepted" is every configured sink accepting the write, which for the OutboxSink
-// is spool acceptance (REQ-6.10b), never a network ack.
-func NewDispatcherRequired(policy *RequiredPolicy, r Redactor, sinks ...Sink) *Dispatcher {
+// REQ-6.10b ENFORCED IN CODE. Under required, "durably accepted" is every
+// configured sink accepting the write, and for a required Dispatcher the
+// fulfillment point MUST be the local spool, NEVER a broker ack: otherwise every
+// covered skill load path would hang on a remote promise, the DoS the positive
+// list exists to bound. This is no longer only a caller contract: every sink MUST
+// be a LocalSink (FileSink / WriterSink / OutboxSink, or another in-package
+// no-network sink). A sink that is not local, a network-egress sink such as a
+// future Kafka sink (FR-0112), is REJECTED here with ErrNonLocalSink. At least one
+// sink is required (a required Dispatcher with no sink can never be durably
+// accepted, so it would fail-close every covered event, which is a mis-config, not
+// a policy).
+func NewDispatcherRequired(policy *RequiredPolicy, r Redactor, sinks ...Sink) (*Dispatcher, error) {
+	if len(sinks) == 0 {
+		return nil, fmt.Errorf("%w: a required-mode dispatcher needs at least one local sink (spool acceptance is the fulfillment point, REQ-6.10b)", ErrNonLocalSink)
+	}
+	for _, s := range sinks {
+		if !isLocalSink(s) {
+			name := "<nil>"
+			if s != nil {
+				name = s.Name()
+			}
+			return nil, fmt.Errorf("%w: sink %q does network I/O; under required, fulfillment MUST be the local spool, never a broker ack (REQ-6.10b)", ErrNonLocalSink, name)
+		}
+	}
 	d := NewDispatcherMode(ModeRequired, r, sinks...)
 	d.required = policy
-	return d
+	return d, nil
 }

--- a/pkg/skillctl/auditevent/required_test.go
+++ b/pkg/skillctl/auditevent/required_test.go
@@ -28,12 +28,25 @@ func policyAllowConfirmed(t *testing.T) *RequiredPolicy {
 	return p
 }
 
+// mustRequired builds a required-mode Dispatcher and fails the test if construction
+// is rejected. NewDispatcherRequired now returns an error (it rejects a non-local
+// sink, REQ-6.10b); these tests all pass a local sink (failingSink or a spool-only
+// OutboxSink), so construction must succeed.
+func mustRequired(t *testing.T, policy *RequiredPolicy, sinks ...Sink) *Dispatcher {
+	t.Helper()
+	d, err := NewDispatcherRequired(policy, Redactor{}, sinks...)
+	if err != nil {
+		t.Fatalf("NewDispatcherRequired: unexpected construction error: %v", err)
+	}
+	return d
+}
+
 // (1) required + allow-listed policy.allow + a spool write that FAILS → the
 // operation fails closed (IsFailClosed true, with a clear reason).
 // BITE: delete the `d.required.failCloseable(...)` branch in deliver (making every
 // residual error advisory) and IsFailClosed goes false → this fails.
 func TestRequired_PolicyAllow_SpoolFails_FailsClosed(t *testing.T) {
-	d := NewDispatcherRequired(policyAllowConfirmed(t), Redactor{}, &failingSink{}) // failingSink models a full-disk/unwritable spool.
+	d := mustRequired(t, policyAllowConfirmed(t), &failingSink{}) // failingSink models a full-disk/unwritable spool.
 	err := d.Dispatch(New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x"))
 	if !IsFailClosed(err) {
 		t.Fatalf("policy.allow that could not be durably accepted must fail closed; got err=%v (IsFailClosed=false)", err)
@@ -50,7 +63,7 @@ func TestRequired_PolicyAllow_SpoolFails_FailsClosed(t *testing.T) {
 func TestRequired_PolicyAllow_SpoolSucceeds_Proceeds(t *testing.T) {
 	home := t.TempDir()
 	sink := NewOutboxSinkWithStore(nil, home) // nil store → spool-only, no db, no network.
-	d := NewDispatcherRequired(policyAllowConfirmed(t), Redactor{}, sink)
+	d := mustRequired(t, policyAllowConfirmed(t), sink)
 
 	e := New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x")
 	e.EventID = "aud-required-ok-1"
@@ -79,7 +92,7 @@ func TestRequired_DenialEvents_NeverFailClosed(t *testing.T) {
 		if pol.failCloseable(dt) {
 			t.Fatalf("denial type %q must be exempt from required fail-close even when listed (REQ-6.7)", dt)
 		}
-		d := NewDispatcherRequired(pol, Redactor{}, &failingSink{})
+		d := mustRequired(t, pol, &failingSink{})
 		// A denial event carries a deny/failure outcome; use one the taxonomy accepts.
 		out := OutcomeDeny
 		if dt == EventSignatureReject {
@@ -153,7 +166,7 @@ func TestRequired_PolicyAllow_NeedsSeparateConfirmation(t *testing.T) {
 	if unconf.failCloseable(EventPolicyAllow) {
 		t.Fatal("unconfirmed policy.allow must not be fail-closeable (REQ-6.10a)")
 	}
-	if IsFailClosed(NewDispatcherRequired(unconf, Redactor{}, &failingSink{}).Dispatch(New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x"))) {
+	if IsFailClosed(mustRequired(t, unconf, &failingSink{}).Dispatch(New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x"))) {
 		t.Fatal("dispatching policy.allow under an unconfirmed policy must not fail closed")
 	}
 	// Confirmed: it IS fail-closeable and DOES fail-close on a failing sink.
@@ -161,7 +174,7 @@ func TestRequired_PolicyAllow_NeedsSeparateConfirmation(t *testing.T) {
 	if !conf.failCloseable(EventPolicyAllow) {
 		t.Fatal("confirmed policy.allow must be fail-closeable")
 	}
-	if !IsFailClosed(NewDispatcherRequired(conf, Redactor{}, &failingSink{}).Dispatch(New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x"))) {
+	if !IsFailClosed(mustRequired(t, conf, &failingSink{}).Dispatch(New(EventPolicyAllow, OutcomeSuccess, SeverityInfo, "skillctl/x"))) {
 		t.Fatal("confirmed policy.allow with a failing spool must fail closed")
 	}
 }
@@ -176,12 +189,12 @@ func TestRequired_SkillExecute_FailClosesWithoutExtraConfirm(t *testing.T) {
 	if err != nil || p == nil {
 		t.Fatalf("skill.execute required config must build without a policy.allow confirmation; got p=%v err=%v", p, err)
 	}
-	if !IsFailClosed(NewDispatcherRequired(p, Redactor{}, &failingSink{}).Dispatch(New(EventSkillExecute, OutcomeSuccess, SeverityInfo, "skillctl/x"))) {
+	if !IsFailClosed(mustRequired(t, p, &failingSink{}).Dispatch(New(EventSkillExecute, OutcomeSuccess, SeverityInfo, "skillctl/x"))) {
 		t.Fatal("skill.execute that could not be durably accepted must fail closed")
 	}
 	// Spool success → proceeds.
 	home := t.TempDir()
-	d := NewDispatcherRequired(p, Redactor{}, NewOutboxSinkWithStore(nil, home))
+	d := mustRequired(t, p, NewOutboxSinkWithStore(nil, home))
 	e := New(EventSkillExecute, OutcomeSuccess, SeverityInfo, "skillctl/x")
 	e.EventID = "aud-skexec-ok-1"
 	if err := d.Dispatch(e); err != nil {

--- a/pkg/skillctl/auditevent/sink.go
+++ b/pkg/skillctl/auditevent/sink.go
@@ -34,6 +34,29 @@ type Sink interface {
 	Close() error
 }
 
+// LocalSink marks a Sink that performs NO network I/O: its Write reaches only the
+// local machine (a file, a process stream, or the local outbox/spool). It exists
+// to enforce REQ-6.10b in CODE: under ModeRequired, "durably accepted" is spool
+// acceptance, NEVER a broker ack, so NewDispatcherRequired refuses any sink that is
+// not a LocalSink. A required policy can then never hang a skill load path on a
+// remote promise (the DoS the positive list exists to bound, §6b).
+//
+// The marker method is UNEXPORTED on purpose: only a Sink defined in THIS package
+// can claim localness. A network-egress sink in another package (a future Kafka
+// sink, FR-0112, or any HTTP poster) physically cannot implement it, so it is
+// rejected at construction rather than trusted by a caller-side contract.
+type LocalSink interface {
+	Sink
+	localSink()
+}
+
+// isLocalSink reports whether s satisfies the LocalSink marker (a no-network,
+// spool-only fulfillment sink, REQ-6.10b).
+func isLocalSink(s Sink) bool {
+	_, ok := s.(LocalSink)
+	return ok
+}
+
 // Dispatcher redacts an event, validates it, and fans it out to every configured
 // sink. Its delivery MODE (best-effort / durable / required, §6) decides what a
 // sink failure means (delivery.go). It never panics and never blocks, which

--- a/pkg/skillctl/auditevent/sink_test.go
+++ b/pkg/skillctl/auditevent/sink_test.go
@@ -34,6 +34,11 @@ func (f *failingSink) Write(*Event) error {
 }
 func (f *failingSink) Close() error { f.closed = true; return nil }
 
+// failingSink models a full-disk / unwritable LOCAL spool: it is a LocalSink (no
+// network) whose Write fails, so it is an accepted sink under NewDispatcherRequired
+// (the fail-close comes from the WRITE failing, not from the sink being non-local).
+func (f *failingSink) localSink() {}
+
 // TestDispatchFanOutAndErrorCollection proves an event reaches every sink and a
 // single sink failure is collected (not swallowed, not fatal to the others).
 func TestDispatchFanOutAndErrorCollection(t *testing.T) {


### PR DESCRIPTION
## FR-0111 — `skillctl auditlog` observability CLI + 3 FR-0110b gate follow-ups (SPEC-0403 §8)

The final SPEC-0403 chunk: the audit subsystem's observability CLI, plus the three non-blocking follow-ups the FR-0110b challenge gate flagged. Completes SPEC-0403 (FR-0109/0110a/0110b/0111); only FR-0112 Kafka stays out (EC-blocked).

### `skillctl auditlog status|test|flush` (§8)
- **Own verb stem, own exit space 0/1** (REQ-8.5/8.6), distinct from `skillctl audit`'s 0/2/3 posture space (no collision). Registered in `main.go` like every other verb; FR-0113 verb register is not built yet, so the dependency is noted (REQ-8.7).
- **status**: real subsystem state (enabled, mode, file sink + path, outbox/spool pending, last event) via a no-network writability probe. Does NOT fabricate a Kafka broker (FR-0112 EC-blocked).
- **test**: emits one clearly-synthetic `skillctl.audit.v1` event through the real default `FileSink` and confirms acceptance.
- **flush**: reconciles the local spool into the durable outbox (the local half of `skillctl sync`, `store.Reconcile()`), stops before any broker egress (REQ-6.10b), reports pending before/after.
- **REQ-8.1/8.2**: transport failures surface as `audit.sink.fail`/`audit.queue.flush` events on a SEPARATE stderr sink, never recursed through the failed sink.

### The 3 carried gate follow-ups
1. **`DispatchRequired`** (`delivery.go`): fail-closes on ANY non-nil Dispatch error for a mandatory event, including a malformed one (`ErrInvalidEvent`) — closing the gap where a required caller gating only on `IsFailClosed` would let a malformed mandatory event proceed un-audited (AUD-01). Bite test included (`dispatchrequired_test.go`).
2. **`NewDispatcherRequired` rejects non-local sinks** (`required.go` + `sink.go`): enforces REQ-6.10b spool-only fulfillment IN CODE via an unexported `LocalSink` marker interface (FileSink/WriterSink/OutboxSink implement it; a network-egress sink in another package physically cannot claim it). Test in `localsink_test.go`.
3. **Cosmetic**: aligned the `required-audit policy:` line in `session baseline`.

### Verified
`go build`/`go vet`/gofmt clean; `env -u ER1_* go test -race -count=1 ./cmd/skillctl/... ./pkg/skillctl/...` 0 failures (decision-invariance / gate / required / session-baseline stay green); **`gosec-diff-gate` 0 new** (against the current 460 master baseline); gitleaks clean; em-dash gate exit 0; **docaudit PASS** (manual updated with the `auditlog` reference + exit-code row). Does not touch the gate decision path or `skillctl audit`'s exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
