### PR TITLE
feat(qa): stage 2, run the CI gates locally and get a trust report

### DIFF
--- a/docs/quickstart-skillctl.md
+++ b/docs/quickstart-skillctl.md
@@ -132,6 +132,71 @@ described in [Windows release verification](releasing-skillctl-windows.md).
 
 ---
 
+## 1c. Stage 2: run our CI on your own machine (enterprise gate)
+
+When stage 1 is green, the next question is not "does it build" but **"would this tree pass
+the gates we merge and release on?"** That is stage 2. It runs every CI gate that can honestly
+run on a laptop, never fails fast, and ends with a PASS / FAIL / SKIP **trust report**.
+
+**Windows (PowerShell):**
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass -Force
+irm https://raw.githubusercontent.com/kamir/m3c-tools/master/scripts/skillctl-enterprise-test.ps1 | iex
+```
+
+**macOS / Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/master/scripts/skillctl-enterprise-test.sh | bash
+```
+
+| Gate | What it proves | CI counterpart |
+|---|---|---|
+| `stage1` | builds, tests pass, CLI answers | the section above |
+| `vet` | no `go vet` finding | `ci.yml` Lint & Vet |
+| `lint` | golangci-lint clean (pinned v2.13.2) | `ci.yml` Lint & Vet |
+| `mod-tidy` | `go mod tidy` is a no-op | `ci.yml` CD-T4 |
+| `docaudit` | every real CLI flag documented, every documented flag real | `ci.yml` docs-gate |
+| `prose` | no U+2014 in the tracked tree | `ci.yml` prose-gate |
+| `pins` | every pinned install one-liner resolves, digests match | `pin-guard` and BUG-0215 |
+| `boundary` | the public/private plane boundary holds | `boundary-gate.yml` |
+| `coverage` | the `.testcoverage.yml` ratchet over the trust surface | `coverage-gate.yml` |
+| `govulncheck` | no CVE reachable from our code (pinned v1.7.0) | `ci.yml` govulncheck |
+| `gosec` | no **new** SAST finding against the committed baseline | `gosec-diff-gate.yml` |
+| `gitleaks` | no secret in the full history | `ci.yml` gitleaks |
+| `trust-surface` | the whole trust surface, whole-package, no allow-list | `windows-gate.yml` |
+| `lifecycle` | author, sign, verify, trust, and a tampered bundle **refused** | `skillctl-windows-smoke.yml` |
+
+Flags: `--full` / `-Full` widens the Go gates from the skillctl trust surface to `./...`,
+`--no-install` / `-NoInstall` forbids installing a missing tool, `--strict` / `-Strict` makes a
+skipped gate fail the run, `--skip-stage1` / `-SkipStage1` skips the build-and-test stage.
+
+**Three things this report deliberately does not do.**
+
+*It does not install tools behind your back without saying so.* golangci-lint, gosec and
+go-test-coverage are fetched at the versions CI pins, into `$(go env GOPATH)/bin`, and the run
+says so. gitleaks is never auto-installed: CI verifies its release tarball against a pinned
+SHA-256 before running it, and a convenience script should not fake that. Missing tool, `SKIP`.
+
+*It does not count a skip as a pass.* A gate that could not run says `SKIP` and the verdict
+line reads `PASS with N skipped`. Use `--strict` when you want the report to be evidence.
+
+*It is not the release.* SLSA provenance, cosign/OIDC signing, Code Scanning ingestion and the
+cross-compile matrix exist only server-side. A green report here is not a substitute for a
+green PR.
+
+**One Windows detail worth knowing.** A shipping Windows build ignores `$HOME` for the
+trust-root paths on purpose, because an environment variable is attacker-settable. The
+hermetic trust tests inject `$HOME`, so on Windows they only run for real under
+`-tags allow_home_override_test`. Stage 1 runs the untagged suite (shipping behaviour); the
+`trust-surface` gate here runs the tagged one, and the `lifecycle` gate builds its sandbox
+binary with that tag so the proof can never touch your real `%USERPROFILE%\.claude`. On macOS
+and Linux no tag is needed: `$HOME` is honored there, and the lifecycle proof is
+[`scripts/skillctl-quickstart-unix.sh`](https://github.com/kamir/m3c-tools/blob/master/scripts/skillctl-quickstart-unix.sh),
+the twin of the Windows
+[`scripts/skillctl-quickstart-windows.ps1`](https://github.com/kamir/m3c-tools/blob/master/scripts/skillctl-quickstart-windows.ps1).
+
+---
+
 ## 2. Create your author identity
 
 A skill is trusted because it's **signed**. Generate your ed25519 keypair once:
@@ -284,6 +349,7 @@ intents*, and it verifies offline, no authority in the path.
 
 - **Every command, flag and exit code:** [skillctl manual](manual-skillctl.md)
 - **Build it yourself and run the suite:** the [source self-test](#1b-optional-prove-it-on-your-own-machine-source-self-test) one-liners above
+- **Run our CI on your own machine:** the [enterprise gate](#1c-stage-2-run-our-ci-on-your-own-machine-enterprise-gate) and its trust report
 - **Capture the memory your agents reason over:** [Quickstart: m3c-tools](quickstart-m3c-tools.md)
 - **The full lifecycle & governance model** lives behind `skillctl help`: it groups commands
   by capability (signing, trust roots, install, agent identity, registry, transparency log,

--- a/scripts/skillctl-enterprise-test.ps1
+++ b/scripts/skillctl-enterprise-test.ps1
@@ -1,0 +1,390 @@
+<#
+.SYNOPSIS
+  The local, offline-capable twin of our CI for Windows. Stage 2 of the trust
+  check: runs the gates we merge and release on, then prints a trust report.
+
+.DESCRIPTION
+  Stage 1 (scripts\skillctl-test.ps1) answers "does it build and do the tests
+  pass here". This answers the harder question:
+
+    "Would this tree pass the gates we actually merge and release on?"
+
+  Every gate runs, none fails fast, each reports PASS / FAIL / SKIP. Exit 0 iff
+  no gate FAILED (with -Strict, iff none was skipped either).
+
+    stage1         build + tests + CLI smoke (scripts\skillctl-test.ps1)
+    vet            go vet
+    lint           golangci-lint (pinned v2.13.2, as in ci.yml)
+    mod-tidy       go mod tidy must be a no-op (go.mod/go.sum restored after)
+    docaudit       every real CLI flag documented, every documented flag real
+    prose          no U+2014 em dash in the tracked tree
+    pins           every pinned install one-liner resolves, digests match
+    boundary       the public/private plane boundary gate
+    coverage       the .testcoverage.yml ratchet over the skillctl trust surface
+    govulncheck    CVEs reachable from our code (pinned v1.7.0)
+    gosec          SAST, judged against docs\security\gosec-inci-baseline.txt
+    gitleaks       secret scan over the full history (config-aware)
+    trust-surface  the windows-gate.yml parity run, WITH the test tag (see below)
+    lifecycle      offline author/sign/verify/trust/tamper proof, fail-closed
+
+  THE TAG THAT MATTERS ON WINDOWS. A shipping Windows build deliberately
+  ignores $HOME for the trust-root and token-key paths, because an environment
+  variable is attacker-settable. The hermetic trust tests inject $HOME, so on
+  Windows they only run for real under `-tags allow_home_override_test`, which
+  is exactly what .github/workflows/windows-gate.yml does. Stage 1 runs the
+  untagged suite (shipping behaviour); the trust-surface gate here runs the
+  tagged one. A trust decision gated on a fetch or a registry that is never
+  exercised hermetically is how an over-broad fail-closed once survived local
+  runs and two adversarial reviews. That is why this gate exists separately.
+
+  WHAT IT IS NOT. Not the release: no tagging, no signing, no publish, no
+  provenance. SLSA provenance, cosign/OIDC signing, Code Scanning ingestion and
+  the cross-compile matrix live server-side. A green report here is not a
+  substitute for a green PR.
+
+  TOOLS. golangci-lint, gosec and go-test-coverage are installed on demand at
+  the versions CI pins, into (go env GOPATH)\bin. -NoInstall forbids that and a
+  missing tool reports SKIP. govulncheck runs via `go run ...@v1.7.0`. gitleaks
+  is never auto-installed: CI verifies its release tarball against a pinned
+  SHA-256, and a convenience script should not fake that.
+
+  POSIX GATES. prose, pins, boundary and the gosec diff gate are shell scripts.
+  prose is reimplemented here natively. The others run only if a working `bash`
+  is on PATH (Git for Windows provides one; the gosec diff gate also needs jq),
+  and report SKIP otherwise.
+
+.PARAMETER RepoDir
+  Where the checkout lives. Default: $HOME\m3c-tools.
+
+.PARAMETER Ref
+  Branch to test. Default: master.
+
+.PARAMETER Full
+  Widen the Go gates from the skillctl trust surface to ./...
+
+.PARAMETER NoInstall
+  Never install a missing tool; report SKIP instead.
+
+.PARAMETER Strict
+  A skipped gate also fails the run.
+
+.PARAMETER SkipStage1
+  Do not re-run scripts\skillctl-test.ps1 (build + tests + smoke).
+
+.EXAMPLE
+  powershell -ExecutionPolicy Bypass -File scripts\skillctl-enterprise-test.ps1
+
+.EXAMPLE
+  irm https://raw.githubusercontent.com/kamir/m3c-tools/master/scripts/skillctl-enterprise-test.ps1 | iex
+#>
+[CmdletBinding()]
+param(
+  [string] $RepoDir = (Join-Path $HOME 'm3c-tools'),
+  [string] $RepoUrl = 'https://github.com/kamir/m3c-tools.git',
+  [string] $Ref     = 'master',
+  [switch] $Full,
+  [switch] $NoInstall,
+  [switch] $Strict,
+  [switch] $SkipStage1,
+  [switch] $Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+# PowerShell 7.4+ turns a non-zero native exit code into a terminating error
+# under ErrorActionPreference Stop. Every gate here is judged by its exit code,
+# so turn that off and keep 5.1 and 7.x identical.
+if (Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue) {
+  $PSNativeCommandUseErrorActionPreference = $false
+}
+
+if ($Help) {
+  if ($PSCommandPath) { Get-Help -Detailed $PSCommandPath }
+  else { Write-Host 'Save the script to a file to see its help, or read scripts/skillctl-enterprise-test.ps1 in the repository.' }
+  exit 0
+}
+
+# Pinned exactly as .github/workflows/{ci,coverage-gate,gosec}.yml pin them.
+$GolangciVersion  = 'v2.13.2'
+$GovulncheckVersion = 'v1.7.0'
+$GosecVersion     = 'v2.29.0'
+$CoverageVersion  = 'v2.19.0'
+
+$Gates   = [System.Collections.ArrayList]::new()
+$NPass = 0; $NFail = 0; $NSkip = 0
+
+function Add-Gate($name, $state, $note) {
+  [void]$Gates.Add([pscustomobject]@{ Name = $name; State = $state; Note = $note })
+  switch ($state) {
+    'PASS' { $script:NPass++ }
+    'FAIL' { $script:NFail++ }
+    'SKIP' { $script:NSkip++ }
+  }
+}
+
+function Write-GateHead($name) {
+  Write-Host ''
+  Write-Host '----------------------------------------'
+  Write-Host ">>> $name" -ForegroundColor DarkGray
+}
+
+# Invoke-Gate: run a native command, stream its output, record the verdict.
+function Invoke-Gate {
+  param([string]$Name, [scriptblock]$Body)
+  Write-GateHead $Name
+  $global:LASTEXITCODE = 0
+  try { & $Body } catch {
+    Write-Host "  $($_.Exception.Message)"
+    $global:LASTEXITCODE = 1
+  }
+  if ($LASTEXITCODE -eq 0) {
+    Write-Host "  [PASS] $Name" -ForegroundColor Green
+    Add-Gate $Name 'PASS' ''
+  } else {
+    Write-Host "  [FAIL] $Name (exit $LASTEXITCODE)" -ForegroundColor Red
+    Add-Gate $Name 'FAIL' ''
+  }
+}
+
+function Skip-Gate($name, $reason) {
+  Write-GateHead $name
+  Write-Host "  [SKIP] $name ($reason)" -ForegroundColor Yellow
+  Add-Gate $name 'SKIP' $reason
+}
+
+function Stop-Setup($message) {
+  Write-Host ''
+  Write-Host "ERROR: $message" -ForegroundColor Red
+  exit 2
+}
+
+Write-Host ''
+Write-Host '========================================'
+Write-Host ' skillctl: enterprise gate (Windows)'
+Write-Host '========================================'
+Write-Host ''
+Write-Host '  This runs the CI gates locally and takes several minutes.'
+Write-Host ''
+
+# --- setup -----------------------------------------------------------------
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) { Stop-Setup 'Git is not installed or not on PATH.' }
+if (-not (Get-Command go  -ErrorAction SilentlyContinue)) { Stop-Setup 'Go is not installed or not on PATH. See https://go.dev/dl/' }
+
+if (Test-Path (Join-Path $RepoDir '.git')) {
+  Set-Location $RepoDir
+  if ((git status --porcelain) -join '') {
+    Stop-Setup "The checkout at $RepoDir has local changes. Commit, stash, or point -RepoDir somewhere else."
+  }
+} else {
+  git clone --branch $Ref $RepoUrl $RepoDir
+  if ($LASTEXITCODE -ne 0) { Stop-Setup 'git clone failed.' }
+  Set-Location $RepoDir
+}
+
+$GoBinDir = Join-Path (((go env GOPATH) -join '').Trim()) 'bin'
+$env:PATH = "$GoBinDir;$env:PATH"
+
+function Test-Tool($command, $module) {
+  if (Get-Command $command -ErrorAction SilentlyContinue) { return $true }
+  if ($NoInstall) { return $false }
+  Write-Host "  installing $module into $GoBinDir (needs the network) ..."
+  go install $module 2>&1 | Out-Null
+  return [bool](Get-Command $command -ErrorAction SilentlyContinue)
+}
+
+# A usable POSIX shell? Git for Windows ships one. A WSL stub with no distro
+# installed answers `bash --version` with an error, which is why this probes
+# rather than testing for the file.
+$Bash = $null
+$bashCmd = Get-Command bash -ErrorAction SilentlyContinue
+if ($bashCmd) {
+  & $bashCmd.Source -c 'exit 0' 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { $Bash = $bashCmd.Source }
+}
+
+$Scope = if ($Full) { @('./...') } else { @('./cmd/skillctl/...', './pkg/skillctl/...') }
+
+Write-Host "  repo   : $RepoDir"
+Write-Host "  scope  : $($Scope -join ' ')"
+Write-Host "  bash   : $(if ($Bash) { $Bash } else { 'not available (POSIX gates will be skipped)' })"
+
+# --- 1. stage 1 -------------------------------------------------------------
+if ($SkipStage1) {
+  Skip-Gate 'stage1' '-SkipStage1'
+} else {
+  Invoke-Gate 'stage1' {
+    & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $RepoDir 'scripts\skillctl-test.ps1') -RepoDir $RepoDir -Ref $Ref
+  }
+}
+
+# The gates below want a binary; stage 1 leaves one in build\, but not if it was
+# skipped or failed.
+$Binary = Join-Path $RepoDir 'build\skillctl.exe'
+if (-not (Test-Path $Binary)) { go build -o $Binary ./cmd/skillctl 2>&1 | Out-Null }
+
+# --- 2. vet -----------------------------------------------------------------
+Invoke-Gate 'vet' { & go vet @Scope }
+
+# --- 3. golangci-lint -------------------------------------------------------
+if (Test-Tool 'golangci-lint' "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$GolangciVersion") {
+  Invoke-Gate 'lint' { & golangci-lint run --timeout=5m @Scope }
+} else {
+  Skip-Gate 'lint' "golangci-lint $GolangciVersion not installed"
+}
+
+# --- 4. go mod tidy is a no-op ----------------------------------------------
+# CD-T4 in ci.yml. `go mod tidy` MUTATES go.mod/go.sum, so restore them either
+# way: a QA run must not leave the checkout rewritten.
+Invoke-Gate 'mod-tidy' {
+  & go mod tidy
+  if ($LASTEXITCODE -eq 0) { & git diff --exit-code go.mod go.sum }
+}
+& git checkout -- go.mod go.sum 2>&1 | Out-Null
+
+# --- 5. docaudit ------------------------------------------------------------
+Invoke-Gate 'docaudit' {
+  & go test -count=1 ./cmd/docaudit/ | Out-Null
+  if ($LASTEXITCODE -eq 0) { & go run ./cmd/docaudit -cli all }
+}
+
+# --- 6. prose (native: the shell gate needs POSIX tools) --------------------
+# scripts/check-no-emdash.sh is the canonical gate. This is the same rule over
+# the same file set: every tracked, non-exempt file, literal U+2014.
+Write-GateHead 'prose'
+$emdash = [char]0x2014
+$exempt = '^(pkg/skillctl/bodyscan/testdata/|demo/kup-training/artifacts/)'
+$hits = @()
+foreach ($f in (git ls-files)) {
+  if ($f -match $exempt) { continue }
+  $p = Join-Path $RepoDir $f
+  $item = Get-Item -LiteralPath $p -ErrorAction SilentlyContinue
+  # Skip directories, submodule entries and anything too big to be prose: the
+  # shell gate skips binaries via grep -I, this skips them by size.
+  if ($null -eq $item -or $item.PSIsContainer -or $item.Length -gt 2MB) { continue }
+  try {
+    $text = [System.IO.File]::ReadAllText($p)
+  } catch { continue }
+  if ($text.IndexOf($emdash) -ge 0) { $hits += $f }
+}
+if ($hits.Count -eq 0) {
+  Write-Host '  [PASS] prose (no U+2014 in the tracked tree)' -ForegroundColor Green
+  Add-Gate 'prose' 'PASS' ''
+} else {
+  Write-Host "  [FAIL] prose: $($hits.Count) file(s) contain an em dash" -ForegroundColor Red
+  $hits | Select-Object -First 20 | ForEach-Object { Write-Host "         $_" }
+  Add-Gate 'prose' 'FAIL' ''
+}
+
+# --- 7. the remaining POSIX shell gates -------------------------------------
+if ($Bash) {
+  Invoke-Gate 'pins'     { & $Bash ./scripts/check-install-pins.sh }
+  Invoke-Gate 'boundary' { & $Bash ./tools/boundary-gate.sh }
+} else {
+  Skip-Gate 'pins'     'no working bash on PATH'
+  Skip-Gate 'boundary' 'no working bash on PATH'
+}
+
+# --- 8. coverage ratchet ----------------------------------------------------
+# .testcoverage.yml reads `profile: cover.out` at the repo root. *.out is
+# git-ignored, and it is removed again below.
+if (Test-Tool 'go-test-coverage' "github.com/vladopajic/go-test-coverage/v2@$CoverageVersion") {
+  Invoke-Gate 'coverage' {
+    & go test ./pkg/skillctl/... ./cmd/skillctl/... -covermode=atomic -coverprofile=cover.out | Out-Null
+    if ($LASTEXITCODE -eq 0) { & go-test-coverage --config .testcoverage.yml }
+  }
+  Remove-Item -LiteralPath (Join-Path $RepoDir 'cover.out') -ErrorAction SilentlyContinue
+} else {
+  Skip-Gate 'coverage' "go-test-coverage $CoverageVersion not installed"
+}
+
+# --- 9. govulncheck ---------------------------------------------------------
+# Fails only on vulnerabilities REACHABLE from our code. Needs the network for
+# the vulnerability database (and for `go run` to fetch the tool).
+Invoke-Gate 'govulncheck' { & go run "golang.org/x/vuln/cmd/govulncheck@$GovulncheckVersion" @Scope }
+
+# --- 10. gosec against the committed baseline -------------------------------
+# The diff gate is the honest form: this tree has ~500 triaged pre-existing
+# findings (docs\security\gosec-baseline.md), so an absolute count says nothing.
+# What must never happen is a NEW finding.
+if (-not $Bash) {
+  Skip-Gate 'gosec' 'the diff gate is a POSIX shell script; no working bash on PATH'
+} elseif (-not (Get-Command jq -ErrorAction SilentlyContinue)) {
+  Skip-Gate 'gosec' 'jq is not installed (the diff gate needs it)'
+} elseif (Test-Tool 'gosec' "github.com/securego/gosec/v2/cmd/gosec@$GosecVersion") {
+  Invoke-Gate 'gosec' { & $Bash ./scripts/gosec-diff-gate.sh }
+} else {
+  Skip-Gate 'gosec' "gosec $GosecVersion not installed"
+}
+
+# --- 11. gitleaks -----------------------------------------------------------
+if (Get-Command gitleaks -ErrorAction SilentlyContinue) {
+  Invoke-Gate 'gitleaks' { & gitleaks git . --config .gitleaks.toml --no-banner --redact }
+} else {
+  Skip-Gate 'gitleaks' 'not on PATH; see the pinned install in .github/workflows/ci.yml'
+}
+
+# --- 12. trust surface, the windows-gate.yml parity run ---------------------
+# WITH -tags allow_home_override_test, and no -run allow-list: both are
+# deliberate in CI. Without the tag the hermetic trust tests cannot inject
+# $HOME on Windows, and a suite that skips them is not evidence.
+Invoke-Gate 'trust-surface' {
+  & go test -tags allow_home_override_test -count=1 -timeout=300s ./pkg/skillctl/... ./cmd/skillctl/... ./evaluation/...
+}
+
+# --- 13. lifecycle smoke (offline, sandboxed) -------------------------------
+# The quickstart proof sandboxes its trust-root writes through $HOME, which a
+# SHIPPING Windows build ignores on purpose. Build the sandbox binary with the
+# tag, exactly as skillctl-windows-smoke.yml does, so the proof cannot touch the
+# real %USERPROFILE%\.claude.
+$SandboxBin = Join-Path $RepoDir 'build\skillctl-sandbox.exe'
+go build -tags allow_home_override_test -o $SandboxBin ./cmd/skillctl 2>&1 | Out-Null
+if (Test-Path $SandboxBin) {
+  $env:SKILLCTL = $SandboxBin
+  Invoke-Gate 'lifecycle' {
+    & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $RepoDir 'scripts\skillctl-quickstart-windows.ps1')
+  }
+  Remove-Item Env:\SKILLCTL -ErrorAction SilentlyContinue
+} else {
+  Skip-Gate 'lifecycle' 'could not build the sandbox binary (-tags allow_home_override_test)'
+}
+
+# --- trust report -----------------------------------------------------------
+Write-Host ''
+Write-Host '========================================'
+if ($NFail -gt 0) {
+  Write-Host ' TRUST REPORT: FAIL' -ForegroundColor Red
+} elseif ($NSkip -gt 0 -and $Strict) {
+  Write-Host ' TRUST REPORT: FAIL (strict: a gate was skipped)' -ForegroundColor Red
+} elseif ($NSkip -gt 0) {
+  Write-Host " TRUST REPORT: PASS with $NSkip skipped" -ForegroundColor Yellow
+} else {
+  Write-Host ' TRUST REPORT: PASS' -ForegroundColor Green
+}
+Write-Host '========================================'
+Write-Host ''
+Write-Host "Platform   : Windows $([System.Environment]::OSVersion.Version) ($env:PROCESSOR_ARCHITECTURE)"
+Write-Host "PowerShell : $($PSVersionTable.PSVersion)"
+Write-Host "Repository : $RepoDir"
+Write-Host "Commit     : $((git rev-parse HEAD) -join '')"
+Write-Host "Scope      : $($Scope -join ' ')"
+Write-Host "Go         : $(((go version) -join '') -replace '^go version ', '')"
+Write-Host ''
+foreach ($g in $Gates) {
+  $color = switch ($g.State) { 'PASS' { 'Green' } 'FAIL' { 'Red' } default { 'Yellow' } }
+  Write-Host ("  {0,-14} {1,-4}  {2}" -f $g.Name, $g.State, $g.Note) -ForegroundColor $color
+}
+Write-Host ''
+Write-Host ("  {0} passed, {1} failed, {2} skipped" -f $NPass, $NFail, $NSkip)
+Write-Host ''
+if ($NSkip -gt 0) {
+  Write-Host 'A skipped gate is not a passed gate. Each one is listed above with its'
+  Write-Host 'reason, so a missing local tool is never read as evidence.'
+  Write-Host ''
+}
+Write-Host 'Server-side only, never covered here: SLSA provenance, cosign/OIDC signing,'
+Write-Host 'Code Scanning ingestion, and the cross-compile matrix. Read the PR.'
+Write-Host ''
+
+if ($NFail -gt 0) { exit 1 }
+if ($Strict -and $NSkip -gt 0) { exit 1 }
+exit 0

--- a/scripts/skillctl-enterprise-test.sh
+++ b/scripts/skillctl-enterprise-test.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+#
+# skillctl-enterprise-test.sh: the local, offline-capable twin of our CI, for
+# macOS and Linux. Stage 2 of the trust check. Stage 1
+# (scripts/skillctl-test.sh) answers "does it build and do the tests pass here";
+# this answers the harder question:
+#
+#   "Would this tree pass the gates we actually merge and release on?"
+#
+# It runs every gate CI runs that can honestly run on a laptop, one after the
+# other, never fail-fast, and prints a PASS / FAIL / SKIP trust report at the
+# end. Exit 0 iff no gate FAILED (with --strict, iff none was skipped either).
+#
+#   stage1        build + tests + CLI smoke (scripts/skillctl-test.sh)
+#   vet           go vet
+#   lint          golangci-lint (pinned v2.13.2, as in ci.yml)
+#   mod-tidy      go mod tidy must be a no-op (go.mod/go.sum restored after)
+#   docaudit      every real CLI flag documented, every documented flag real
+#   prose         no U+2014 em dash in the tracked tree
+#   pins          every pinned install one-liner resolves, digests match
+#   boundary      the public/private plane boundary gate
+#   coverage      the .testcoverage.yml ratchet over the skillctl trust surface
+#   govulncheck   CVEs reachable from our code (pinned v1.7.0)
+#   gosec         SAST, judged against docs/security/gosec-inci-baseline.txt
+#   gitleaks      secret scan over the full history (config-aware)
+#   trust-surface the windows-gate.yml parity run, whole-package, no allow-list
+#   lifecycle     offline author/sign/verify/trust/tamper proof, fail-closed
+#
+# WHAT IT IS NOT. It is not the release: no tagging, no signing, no publish, no
+# provenance. Some gates only exist server-side (SLSA provenance, cosign/OIDC,
+# Code Scanning ingestion, the Windows matrix); those stay in CI, and a green
+# report here is not a substitute for a green PR.
+#
+# TOOLS. golangci-lint, gosec and go-test-coverage are installed on demand at
+# the versions CI pins, into $(go env GOPATH)/bin. Pass --no-install to forbid
+# that: a missing tool then reports SKIP instead. govulncheck is run via
+# `go run …@v1.7.0` and needs no install. gitleaks is never auto-installed (its
+# release tarball is hash-verified in CI, which a convenience script should not
+# fake); if it is not on PATH the gate reports SKIP. Anything that installs or
+# downloads needs the network; the rest is offline.
+#
+# SCOPE. The Go gates default to the skillctl trust surface
+# (./cmd/skillctl/... ./pkg/skillctl/...), the same scope the coverage gate
+# uses. --full widens them to ./..., which on macOS also needs PortAudio
+# (brew install portaudio pkg-config) for the cgo audio packages; without it
+# those gates report SKIP rather than a misleading red.
+#
+# Usage:
+#   ./scripts/skillctl-enterprise-test.sh [--repo-dir DIR] [--ref BRANCH]
+#                                         [--full] [--no-install] [--strict]
+#                                         [--skip-stage1]
+#   curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/master/scripts/skillctl-enterprise-test.sh | bash
+#
+# Exit: 0 no gate failed - 1 a gate failed (or, with --strict, was skipped)
+#       2 the setup is unusable (no git, no Go, dirty checkout)
+#
+set -uo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/kamir/m3c-tools.git}"
+REPO_DIR="${REPO_DIR:-$HOME/m3c-tools}"
+REF="${REF:-master}"
+FULL=0; NO_INSTALL=0; STRICT=0; SKIP_STAGE1=0
+
+# Pinned exactly as .github/workflows/{ci,coverage-gate,gosec}.yml pin them.
+GOLANGCI_VERSION="v2.13.2"
+GOVULNCHECK_VERSION="v1.7.0"
+GOSEC_VERSION="v2.29.0"
+COVERAGE_VERSION="v2.19.0"
+
+usage() {
+  cat <<'USAGE'
+skillctl-enterprise-test.sh: the local twin of our CI (stage 2).
+
+  --repo-dir DIR   where the checkout lives (default: $HOME/m3c-tools)
+  --repo-url URL   clone URL (default: the public GitHub repository)
+  --ref BRANCH     branch to test (default: master)
+  --full           widen the Go gates from the skillctl trust surface to ./...
+  --no-install     never install a missing tool; report SKIP instead
+  --strict         a SKIPPED gate also fails the run
+  --skip-stage1    do not re-run scripts/skillctl-test.sh (build + tests)
+  -h, --help       this text
+
+Exit 0 iff no gate failed (with --strict, iff none was skipped either).
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-dir) REPO_DIR="${2:?--repo-dir needs a path}"; shift 2 ;;
+    --repo-url) REPO_URL="${2:?--repo-url needs a URL}";  shift 2 ;;
+    --ref)      REF="${2:?--ref needs a branch}";         shift 2 ;;
+    --full)         FULL=1;        shift ;;
+    --no-install)   NO_INSTALL=1;  shift ;;
+    --strict)       STRICT=1;      shift ;;
+    --skip-stage1)  SKIP_STAGE1=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; DIM=$'\033[2m'; NC=$'\033[0m'
+[ -t 1 ] || { RED=""; GREEN=""; YELLOW=""; DIM=""; NC=""; }
+
+NAMES=(); STATES=(); NOTES=()
+N_FAIL=0; N_SKIP=0; N_PASS=0
+
+record() {                      # record <name> <PASS|FAIL|SKIP> [note]
+  NAMES+=("$1"); STATES+=("$2"); NOTES+=("${3:-}")
+  case "$2" in
+    PASS) N_PASS=$((N_PASS + 1)) ;;
+    FAIL) N_FAIL=$((N_FAIL + 1)) ;;
+    SKIP) N_SKIP=$((N_SKIP + 1)) ;;
+  esac
+  return 0
+}
+
+gate_head() { printf '\n%s\n%s>>> %s%s\n' "----------------------------------------" "$DIM" "$1" "$NC"; }
+
+# run_gate <name> <command...>: run it, stream its output, record the verdict.
+run_gate() {
+  local name="$1"; shift
+  gate_head "$name"
+  if "$@"; then
+    printf '  %s[PASS]%s %s\n' "$GREEN" "$NC" "$name"
+    record "$name" PASS
+  else
+    printf '  %s[FAIL]%s %s (exit %d)\n' "$RED" "$NC" "$name" "$?"
+    record "$name" FAIL
+  fi
+}
+
+skip_gate() {                   # skip_gate <name> <reason>
+  gate_head "$1"
+  printf '  %s[SKIP]%s %s (%s)\n' "$YELLOW" "$NC" "$1" "$2"
+  record "$1" SKIP "$2"
+}
+
+die() { printf '\n%sERROR: %s%s\n' "$RED" "$1" "$NC" >&2; exit 2; }
+
+echo ""
+echo "========================================"
+echo " skillctl: enterprise gate ($(uname -s))"
+echo "========================================"
+echo ""
+echo "  This runs the CI gates locally and takes several minutes."
+echo ""
+
+# --- setup ------------------------------------------------------------------
+command -v git >/dev/null 2>&1 || die "git is not installed or not on PATH."
+command -v go  >/dev/null 2>&1 || die "Go is not installed or not on PATH. See https://go.dev/dl/"
+
+if [ -d "$REPO_DIR/.git" ]; then
+  cd "$REPO_DIR" || die "cannot enter $REPO_DIR"
+  [ -z "$(git status --porcelain)" ] \
+    || die "the checkout at $REPO_DIR has local changes. Commit, stash, or pass --repo-dir."
+else
+  git clone --branch "$REF" "$REPO_URL" "$REPO_DIR" || die "git clone failed."
+  cd "$REPO_DIR" || die "cannot enter $REPO_DIR"
+fi
+
+GOBIN_DIR="$(go env GOPATH)/bin"
+export PATH="$GOBIN_DIR:$PATH"
+
+# ensure_tool <command> <module@version>: 0 if usable, 1 if not.
+ensure_tool() {
+  command -v "$1" >/dev/null 2>&1 && return 0
+  [ "$NO_INSTALL" -eq 1 ] && return 1
+  echo "  installing $2 into $GOBIN_DIR (needs the network) ..."
+  go install "$2" >/dev/null 2>&1 || return 1
+  command -v "$1" >/dev/null 2>&1
+}
+
+if [ "$FULL" -eq 1 ]; then SCOPE=("./...")
+else SCOPE=("./cmd/skillctl/..." "./pkg/skillctl/..."); fi
+
+# Do the cgo audio packages typecheck here? On macOS they need PortAudio, and
+# without it every ./... gate would go red for a reason that has nothing to do
+# with the code under test. Probe once, report SKIP where it matters.
+CGO_FULL_OK=1
+if ! go build -o /dev/null ./pkg/recorder/ >/dev/null 2>&1; then
+  CGO_FULL_OK=0
+  echo "  note: the cgo audio packages do not build here"
+  [ "$(uname -s)" = "Darwin" ] && echo "        (brew install portaudio pkg-config enables the ./... gates)"
+fi
+if [ "$FULL" -eq 1 ] && [ "$CGO_FULL_OK" -eq 0 ]; then
+  echo "  note: --full requested but ./... does not build; falling back to the trust surface"
+  SCOPE=("./cmd/skillctl/..." "./pkg/skillctl/...")
+fi
+
+echo "  repo   : $REPO_DIR"
+echo "  scope  : ${SCOPE[*]}"
+
+# --- 1. stage 1: build + tests + smoke --------------------------------------
+if [ "$SKIP_STAGE1" -eq 1 ]; then
+  skip_gate "stage1" "--skip-stage1"
+else
+  run_gate "stage1" bash ./scripts/skillctl-test.sh --repo-dir "$REPO_DIR" --ref "$REF"
+fi
+
+# The gates below want a binary; stage 1 leaves one in build/, but not if it was
+# skipped or failed.
+[ -x "$REPO_DIR/build/skillctl" ] || go build -o "$REPO_DIR/build/skillctl" ./cmd/skillctl >/dev/null 2>&1
+
+# --- 2. vet -----------------------------------------------------------------
+run_gate "vet" go vet "${SCOPE[@]}"
+
+# --- 3. golangci-lint -------------------------------------------------------
+if ensure_tool golangci-lint "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$GOLANGCI_VERSION"; then
+  run_gate "lint" golangci-lint run --timeout=5m "${SCOPE[@]}"
+else
+  skip_gate "lint" "golangci-lint $GOLANGCI_VERSION not installed"
+fi
+
+# --- 4. go mod tidy is a no-op ----------------------------------------------
+# CD-T4 in ci.yml. `go mod tidy` MUTATES go.mod/go.sum, so restore them
+# afterwards either way: a QA run must not leave the checkout rewritten.
+gate_head "mod-tidy"
+if go mod tidy >/dev/null 2>&1 && git diff --exit-code go.mod go.sum >/dev/null 2>&1; then
+  printf '  %s[PASS]%s mod-tidy\n' "$GREEN" "$NC"; record "mod-tidy" PASS
+else
+  printf '  %s[FAIL]%s mod-tidy (go mod tidy changed go.mod/go.sum)\n' "$RED" "$NC"
+  git diff --stat go.mod go.sum
+  record "mod-tidy" FAIL
+fi
+git checkout -- go.mod go.sum 2>/dev/null || true
+
+# --- 5. docaudit ------------------------------------------------------------
+gate_head "docaudit"
+if go test -count=1 ./cmd/docaudit/ >/dev/null 2>&1 && go run ./cmd/docaudit -cli all; then
+  printf '  %s[PASS]%s docaudit\n' "$GREEN" "$NC"; record "docaudit" PASS
+else
+  printf '  %s[FAIL]%s docaudit\n' "$RED" "$NC"; record "docaudit" FAIL
+fi
+
+# --- 6-8. the shell gates ---------------------------------------------------
+run_gate "prose"    ./scripts/check-no-emdash.sh
+run_gate "pins"     ./scripts/check-install-pins.sh
+run_gate "boundary" ./tools/boundary-gate.sh
+
+# --- 9. coverage ratchet ----------------------------------------------------
+# .testcoverage.yml reads `profile: cover.out` at the repo root. *.out is
+# git-ignored, and it is removed again below.
+if ensure_tool go-test-coverage "github.com/vladopajic/go-test-coverage/v2@$COVERAGE_VERSION"; then
+  gate_head "coverage"
+  if go test ./pkg/skillctl/... ./cmd/skillctl/... -covermode=atomic -coverprofile=cover.out >/dev/null \
+     && go-test-coverage --config .testcoverage.yml; then
+    printf '  %s[PASS]%s coverage\n' "$GREEN" "$NC"; record "coverage" PASS
+  else
+    printf '  %s[FAIL]%s coverage (a package fell below its ratchet floor)\n' "$RED" "$NC"
+    record "coverage" FAIL
+  fi
+  rm -f cover.out
+else
+  skip_gate "coverage" "go-test-coverage $COVERAGE_VERSION not installed"
+fi
+
+# --- 10. govulncheck --------------------------------------------------------
+# Fails only on vulnerabilities REACHABLE from our code. Needs the network for
+# the vulnerability database (and for `go run` to fetch the tool).
+run_gate "govulncheck" go run "golang.org/x/vuln/cmd/govulncheck@$GOVULNCHECK_VERSION" "${SCOPE[@]}"
+
+# --- 11. gosec, judged against the committed baseline -----------------------
+# The diff gate is the honest form: this tree has ~500 triaged pre-existing
+# findings (docs/security/gosec-baseline.md), so an absolute count says nothing.
+# What must never happen is a NEW finding.
+if [ "$CGO_FULL_OK" -eq 0 ]; then
+  skip_gate "gosec" "gosec type-checks ./..., and the cgo packages do not build here"
+elif ! command -v jq >/dev/null 2>&1; then
+  skip_gate "gosec" "jq is not installed (the diff gate needs it)"
+elif ensure_tool gosec "github.com/securego/gosec/v2/cmd/gosec@$GOSEC_VERSION"; then
+  run_gate "gosec" ./scripts/gosec-diff-gate.sh
+else
+  skip_gate "gosec" "gosec $GOSEC_VERSION not installed"
+fi
+
+# --- 12. gitleaks -----------------------------------------------------------
+# Deliberately never auto-installed: CI verifies the release tarball against a
+# pinned SHA-256 before it runs it, and a convenience script should not pretend
+# to do that.
+if command -v gitleaks >/dev/null 2>&1; then
+  run_gate "gitleaks" gitleaks git . --config .gitleaks.toml --no-banner --redact
+else
+  skip_gate "gitleaks" "not on PATH; see the pinned install in .github/workflows/ci.yml"
+fi
+
+# --- 13. trust surface, the windows-gate.yml parity run ---------------------
+# The same package set the Windows gate runs, whole-package, no -run allow-list
+# (both are deliberate in CI), and including ./evaluation/... which stage 1 does
+# not cover. On Windows this run needs -tags allow_home_override_test, because a
+# shipping Windows build ignores $HOME for the trust-root paths and the hermetic
+# trust tests inject it; outside Windows $HOME is always honored, so no tag.
+run_gate "trust-surface" go test -count=1 -timeout=300s ./pkg/skillctl/... ./cmd/skillctl/... ./evaluation/...
+
+# --- 14. lifecycle smoke (offline, sandboxed) -------------------------------
+run_gate "lifecycle" ./scripts/skillctl-quickstart-unix.sh --bin "$REPO_DIR/build/skillctl"
+
+# --- trust report -----------------------------------------------------------
+echo ""
+echo "========================================"
+if [ "$N_FAIL" -gt 0 ]; then
+  printf ' %sTRUST REPORT: FAIL%s\n' "$RED" "$NC"
+elif [ "$N_SKIP" -gt 0 ] && [ "$STRICT" -eq 1 ]; then
+  printf ' %sTRUST REPORT: FAIL (strict: a gate was skipped)%s\n' "$RED" "$NC"
+elif [ "$N_SKIP" -gt 0 ]; then
+  printf ' %sTRUST REPORT: PASS with %d skipped%s\n' "$YELLOW" "$N_SKIP" "$NC"
+else
+  printf ' %sTRUST REPORT: PASS%s\n' "$GREEN" "$NC"
+fi
+echo "========================================"
+echo ""
+echo "Platform   : $(uname -s) $(uname -m)"
+echo "Repository : $REPO_DIR"
+echo "Commit     : $(git rev-parse HEAD)"
+echo "Scope      : ${SCOPE[*]}"
+echo "Go         : $(go version | sed -E 's/^go version //')"
+echo ""
+for i in "${!NAMES[@]}"; do
+  case "${STATES[$i]}" in
+    PASS) c="$GREEN" ;; FAIL) c="$RED" ;; *) c="$YELLOW" ;;
+  esac
+  printf '  %s%-14s %-4s%s %s\n' "$c" "${NAMES[$i]}" "${STATES[$i]}" "$NC" "${NOTES[$i]}"
+done
+echo ""
+printf '  %d passed, %d failed, %d skipped\n' "$N_PASS" "$N_FAIL" "$N_SKIP"
+echo ""
+if [ "$N_SKIP" -gt 0 ]; then
+  echo "A skipped gate is not a passed gate. Each one is listed above with its"
+  echo "reason, so a missing local tool is never read as evidence."
+  echo ""
+fi
+echo "Server-side only, never covered here: SLSA provenance, cosign/OIDC signing,"
+echo "Code Scanning ingestion, and the Windows/cross-compile matrix. Read the PR."
+echo ""
+
+[ "$N_FAIL" -eq 0 ] || exit 1
+[ "$STRICT" -eq 1 ] && [ "$N_SKIP" -gt 0 ] && exit 1
+exit 0

--- a/scripts/skillctl-quickstart-unix.sh
+++ b/scripts/skillctl-quickstart-unix.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+#
+# skillctl-quickstart-unix.sh: offline lifecycle SMOKE TEST for skillctl on
+# macOS and Linux. The POSIX twin of scripts/skillctl-quickstart-windows.ps1:
+# same seven steps, same PASS/FAIL/SKIP vocabulary, same fail-closed assertion
+# at the end, so a Windows run and a Unix run can be compared line by line.
+#
+# Each lifecycle step is EXECUTED and ASSERTED (exit code plus the load-bearing
+# artifact it must have written). Exit 0 iff every required step passed, so it
+# is safe to wire into a gate.
+#
+#   1. version     prints a non-empty version string
+#   2. keygen      writes <work>/author.priv + author.pub
+#   3. pack        packs a throwaway skill dir into <work>/demo.skb
+#   4. sign        writes the detached <bundle>.<digest>.author.sig
+#   5. verify-sig  accepts the genuine bundle (exit 0)
+#   6. trust add   pins the author pubkey in the SANDBOXED trust-roots.yaml
+#   7. tamper      flips a byte in a COPY, re-points the signature at the new
+#                  digest, and asserts verify-sig REFUSES it (ideal exit 11,
+#                  author signature invalid; any non-zero is fail-closed)
+#
+# Why it cannot touch your real trust roots: `skillctl trust add` writes
+# $HOME/.claude/skill-trust-roots.yaml, and skillctl resolves that home from
+# $HOME (pkg/skillctl/verify/home.go), so the run happens with $HOME pointed at
+# a fresh temp dir. (The Windows twin needs a binary built with
+# `-tags allow_home_override_test` for the same sandbox, because a shipping
+# Windows build deliberately ignores the attacker-settable $HOME. On Unix a
+# plain `go build` is enough.)
+#
+# Everything is OFFLINE. The registry URL pinned in step 6 is a `.invalid`
+# host that is never contacted: `trust add` only writes local YAML.
+#
+# It never prints a private key or signature bytes. Only paths, digests and
+# exit codes.
+#
+# Usage:
+#   ./scripts/skillctl-quickstart-unix.sh [--bin PATH] [--keep-work]
+#   SKILLCTL=/path/to/skillctl ./scripts/skillctl-quickstart-unix.sh
+#
+# Binary resolution, in order: --bin, $SKILLCTL, ./build/skillctl, PATH.
+#
+# Exit: 0 every required step passed - 1 a step failed - 2 no binary found.
+#
+set -uo pipefail
+
+BIN="${SKILLCTL:-}"
+KEEP_WORK=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --bin)       BIN="${2:?--bin needs a path}"; shift 2 ;;
+    --keep-work) KEEP_WORK=1; shift ;;
+    -h|--help)   sed -n '3,40p' "$0" | sed 's/^#\{1,\} \{0,1\}//'; exit 0 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; NC=$'\033[0m'
+[ -t 1 ] || { RED=""; GREEN=""; YELLOW=""; NC=""; }
+
+PASS_N=0; FAIL_N=0; SKIP_N=0
+_pass() { printf '  %s[PASS]%s %s\n' "$GREEN" "$NC" "$1"; PASS_N=$((PASS_N + 1)); }
+_fail() { printf '  %s[FAIL]%s %s\n' "$RED" "$NC" "$1"; [ $# -gt 1 ] && printf '         hint: %s\n' "$2"; FAIL_N=$((FAIL_N + 1)); return 0; }
+_skip() { printf '  %s[SKIP]%s %s (%s)\n' "$YELLOW" "$NC" "$1" "${2:-}"; SKIP_N=$((SKIP_N + 1)); }
+_stage() { printf '\n%s\n' "$1"; }
+
+# --- locate the binary ------------------------------------------------------
+if [ -z "$BIN" ]; then
+  REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+  if [ -x "$REPO_ROOT/build/skillctl" ]; then BIN="$REPO_ROOT/build/skillctl"
+  elif command -v skillctl >/dev/null 2>&1; then BIN="$(command -v skillctl)"
+  fi
+fi
+if [ -z "$BIN" ] || [ ! -x "$BIN" ]; then
+  echo "ERROR: no skillctl binary. Build one (go build -o build/skillctl ./cmd/skillctl)," >&2
+  echo "       pass --bin PATH, or set \$SKILLCTL." >&2
+  exit 2
+fi
+
+# --- sandbox ----------------------------------------------------------------
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/skillctl-quickstart.XXXXXX")" || exit 2
+ORIG_HOME="$HOME"
+cleanup() {
+  HOME="$ORIG_HOME"
+  if [ "$KEEP_WORK" -eq 1 ]; then echo ""; echo "work dir kept: $WORK"
+  else rm -rf "$WORK"; fi
+}
+trap cleanup EXIT
+export HOME="$WORK"     # sandboxes every trust-roots write for this run only
+
+echo ""
+echo "========================================"
+echo " skillctl lifecycle smoke ($(uname -s))"
+echo "========================================"
+echo "  binary : $BIN"
+echo "  work   : $WORK"
+
+# --- 1. version -------------------------------------------------------------
+_stage "Step 1: version"
+VER="$("$BIN" version 2>/dev/null | head -1)"
+if [ -n "$VER" ]; then _pass "version prints '$VER'"
+else _fail "version printed nothing" "wrong or broken binary"; fi
+
+# --- 2. keygen --------------------------------------------------------------
+_stage "Step 2: keygen"
+STEM="$WORK/author"; PRIV="$STEM.priv"; PUB="$STEM.pub"
+KEYGEN_OK=0
+if "$BIN" keygen --out "$STEM" >/dev/null 2>&1 && [ -f "$PRIV" ] && [ -f "$PUB" ]; then
+  _pass "keygen wrote author.priv + author.pub"      # contents deliberately not echoed
+  KEYGEN_OK=1
+else
+  _fail "keygen did not produce both key files" "skillctl keygen --out <stem> writes <stem>.priv and <stem>.pub"
+fi
+
+# --- 3. pack ----------------------------------------------------------------
+_stage "Step 3: pack"
+SKILL_DIR="$WORK/skill"; BUNDLE="$WORK/demo.skb"; PACK_OK=0
+mkdir -p "$SKILL_DIR"
+cat > "$SKILL_DIR/SKILL.md" <<'SKILLMD'
+---
+name: skillctl-quickstart-smoke
+version: 0.0.1
+governance_level: green
+---
+
+# skillctl-quickstart-smoke
+
+Throwaway skill packed by scripts/skillctl-quickstart-unix.sh to prove the
+author, sign, verify, trust lifecycle runs here. Not for install.
+SKILLMD
+if [ "$KEYGEN_OK" -eq 1 ]; then
+  if "$BIN" pack --skill "$SKILL_DIR" -o "$BUNDLE" --name skillctl-quickstart-smoke --version 0.0.1 >/dev/null 2>&1 \
+     && [ -f "$BUNDLE" ] && [ "$(wc -c < "$BUNDLE" | tr -d ' ')" -ge 128 ]; then
+    _pass "pack wrote demo.skb ($(wc -c < "$BUNDLE" | tr -d ' ') bytes)"
+    PACK_OK=1
+  else
+    _fail "pack did not produce a non-trivial demo.skb" "pack needs --skill, -o, --name, --version and a SKILL.md"
+  fi
+else
+  _skip "pack" "keygen failed, nothing to sign afterwards"
+fi
+
+# --- 4. sign ----------------------------------------------------------------
+_stage "Step 4: sign"
+SIGN_OK=0; SIG=""
+if [ "$PACK_OK" -eq 1 ]; then
+  # Flags BEFORE the positional bundle: Go's flag package stops at the first non-flag.
+  if "$BIN" sign --key "$PRIV" "$BUNDLE" >/dev/null 2>&1; then
+    SIG="$(find "$WORK" -maxdepth 1 -name 'demo.skb.*.author.sig' | head -1)"
+  fi
+  if [ -n "$SIG" ]; then
+    _pass "sign wrote detached signature ($(basename "$SIG"))"
+    SIGN_OK=1
+  else
+    _fail "sign did not produce a signature" "skillctl sign --key <priv> <bundle>, flag before the bundle"
+  fi
+else
+  _skip "sign" "pack did not produce a bundle"
+fi
+
+# --- 5. verify-sig ----------------------------------------------------------
+_stage "Step 5: verify-sig"
+VERIFY_OK=0
+if [ "$SIGN_OK" -eq 1 ]; then
+  if "$BIN" verify-sig --pubkey "$PUB" "$BUNDLE" >/dev/null 2>&1; then
+    _pass "verify-sig accepts the genuine bundle (exit 0)"
+    VERIFY_OK=1
+  else
+    _fail "verify-sig rejected a genuine bundle" "sign/verify key mismatch, or sidecar signature name drift"
+  fi
+else
+  _skip "verify-sig" "no signature to verify"
+fi
+
+# --- 6. trust add -----------------------------------------------------------
+_stage "Step 6: trust add"
+if [ "$KEYGEN_OK" -eq 1 ]; then
+  # `--registry self` is invalid (the URL validator requires https:// or a
+  # loopback http://). This host is never contacted: trust add writes YAML.
+  REGISTRY="https://skillctl-quickstart.invalid/api/skills"
+  TRUST_FILE="$WORK/.claude/skill-trust-roots.yaml"
+  if "$BIN" trust add --registry "$REGISTRY" --pubkey "$PUB" >/dev/null 2>&1 \
+     && [ -f "$TRUST_FILE" ] && grep -qF "$REGISTRY" "$TRUST_FILE"; then
+    _pass "trust add pinned the author pubkey (sandboxed trust-roots.yaml)"
+  else
+    _fail "trust add did not pin the registry" "skillctl trust add --registry <https-url> --pubkey <pub>"
+  fi
+else
+  _skip "trust add" "no pubkey to pin"
+fi
+
+# --- 7. tamper check (fail-closed) ------------------------------------------
+_stage "Step 7: tamper check (fail-closed)"
+if [ "$VERIFY_OK" -eq 1 ]; then
+  TDIR="$WORK/tamper"; mkdir -p "$TDIR"
+  TAMPERED="$TDIR/tampered.skb"
+  cp "$BUNDLE" "$TAMPERED"
+
+  # Flip one byte in the COPY. dd writes a single byte at the midpoint; the
+  # replacement is chosen to differ from whatever was there.
+  SIZE=$(wc -c < "$TAMPERED" | tr -d ' ')
+  OFF=$((SIZE / 2))
+  ORIG_BYTE="$(dd if="$TAMPERED" bs=1 skip="$OFF" count=1 2>/dev/null | od -An -tu1 | tr -d ' ')"
+  NEW_BYTE=$(( (ORIG_BYTE + 1) % 256 ))
+  printf "$(printf '\\%03o' "$NEW_BYTE")" | dd of="$TAMPERED" bs=1 seek="$OFF" count=1 conv=notrunc 2>/dev/null
+
+  # verify-sig recomputes the digest and looks for <bundle>.<newdigest>.author.sig.
+  # Re-point the ORIGINAL signature at the tampered digest, so the refusal comes
+  # from the crypto path (exit 11) and not from a missing sidecar file (exit 1).
+  # Both are fail-closed; 11 is the real proof.
+  if command -v shasum >/dev/null 2>&1; then
+    NEW_HASH="$(shasum -a 256 "$TAMPERED" | cut -d' ' -f1)"
+  else
+    NEW_HASH="$(sha256sum "$TAMPERED" | cut -d' ' -f1)"
+  fi
+  [ -n "$SIG" ] && cp "$SIG" "$TDIR/tampered.skb.$NEW_HASH.author.sig"
+
+  "$BIN" verify-sig --pubkey "$PUB" "$TAMPERED" >/dev/null 2>&1
+  CODE=$?
+  if [ "$CODE" -eq 11 ]; then
+    _pass "tamper REFUSED with exit 11 (author signature invalid), fail-closed proven"
+  elif [ "$CODE" -ne 0 ]; then
+    _pass "tamper REFUSED with exit $CODE (non-zero, fail-closed; ideal is 11)"
+  else
+    _fail "CRITICAL: verify-sig ACCEPTED a tampered bundle (fail-OPEN)" "a modified .skb must never verify, this is a trust-chain breach"
+  fi
+else
+  _skip "tamper check" "the genuine verify-sig did not pass, so a tamper delta proves nothing"
+fi
+
+# --- summary ----------------------------------------------------------------
+echo ""
+echo "========================================"
+if [ "$FAIL_N" -eq 0 ]; then
+  printf ' %sPASS%s  %d checks, %d skipped\n' "$GREEN" "$NC" "$PASS_N" "$SKIP_N"
+else
+  printf ' %sFAIL%s  %d passed, %d failed, %d skipped\n' "$RED" "$NC" "$PASS_N" "$FAIL_N" "$SKIP_N"
+fi
+echo "========================================"
+echo ""
+[ "$FAIL_N" -eq 0 ] || exit 1
+exit 0

--- a/scripts/skillctl-test.ps1
+++ b/scripts/skillctl-test.ps1
@@ -276,6 +276,6 @@ Set-Result 'CLI smoke' 'PASS'
 Write-Summary
 if ($script:Failed) { exit 1 }
 Write-Host 'skillctl builds and tests clean on this machine.'
-Write-Host 'Next: the stage 2 enterprise gate (lint, govulncheck, gosec, coverage, e2e).'
+Write-Host 'Next: stage 2, the local CI gate: scripts\skillctl-enterprise-test.ps1'
 Write-Host ''
 exit 0

--- a/scripts/skillctl-test.sh
+++ b/scripts/skillctl-test.sh
@@ -251,6 +251,6 @@ set_result "CLI smoke" "PASS"
 summary
 [ "$FAILED" -eq 0 ] || exit 1
 echo "skillctl builds and tests clean on this machine."
-echo "Next: the stage 2 enterprise gate (lint, govulncheck, gosec, coverage, e2e)."
+echo "Next: stage 2, the local CI gate: ./scripts/skillctl-enterprise-test.sh"
 echo ""
 exit 0


### PR DESCRIPTION
## What

Stage 2 of the local verification one-liners. **Stage 1 shipped in #190** (merged); this is the half that was still on the branch when #190 was merged, rebased onto current master.

Local verification one-liners per platform, in two stages, for someone who wants to build the current `master` themselves before trusting a binary we built (Eric on Windows is the immediate case).

**Stage 1: does it build and do the tests pass here?**

| | |
|---|---|
| `scripts/skillctl-test.ps1` | Windows, PowerShell 5.1 and 7.x |
| `scripts/skillctl-test.sh` | macOS and Linux |

Six steps, each PASS/FAIL, summary table, exit 0 only if every required step passed: prerequisites, repository (clone or fast-forward), `go mod download` + `verify`, build `skillctl`, `go test [-race]`, CLI smoke.

**Stage 2: would this tree pass the gates we merge and release on?**

| | |
|---|---|
| `scripts/skillctl-enterprise-test.ps1` | Windows |
| `scripts/skillctl-enterprise-test.sh` | macOS and Linux |
| `scripts/skillctl-quickstart-unix.sh` | the POSIX twin of the Windows lifecycle proof, which had none |

Fourteen gates, none fail-fast, each mirroring its CI counterpart at the version CI pins, ending in a PASS/FAIL/SKIP trust report: `stage1`, `vet`, `lint` (golangci-lint v2.13.2), `mod-tidy`, `docaudit`, `prose`, `pins`, `boundary`, `coverage` (`.testcoverage.yml` ratchet), `govulncheck` v1.7.0, `gosec` v2.29.0 against the committed baseline, `gitleaks`, `trust-surface`, `lifecycle`.

Documented as quickstart section **1c** (section 1b came with #190) with the gate-to-CI mapping table.

```powershell
Set-ExecutionPolicy -Scope Process Bypass -Force
irm https://raw.githubusercontent.com/kamir/m3c-tools/master/scripts/skillctl-test.ps1 | iex             # stage 1
irm https://raw.githubusercontent.com/kamir/m3c-tools/master/scripts/skillctl-enterprise-test.ps1 | iex  # stage 2
```
```bash
curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/master/scripts/skillctl-test.sh | bash             # stage 1
curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/master/scripts/skillctl-enterprise-test.sh | bash  # stage 2
```

## Decisions worth reviewing

- **A SKIP is never a PASS.** A gate whose tool is missing reports `SKIP`, the verdict reads `PASS with N skipped`, and `--strict` turns that into exit 1. Quietly not running a gate and printing green is the failure mode the hermetic-trust-test lesson (H-F1) was about.
- **gosec is judged by the diff gate**, not by an absolute count: this tree carries ~500 triaged pre-existing findings, so a count proves nothing and a *new* finding proves a lot. **gitleaks is never auto-installed**, because CI verifies its tarball against a pinned SHA-256 first and a convenience script must not fake that.
- **On Windows the trust surface runs WITH `-tags allow_home_override_test`**, as `windows-gate.yml` does, and the lifecycle proof gets a sandbox binary built with the same tag. A shipping Windows build ignores `$HOME` for the trust-root paths on purpose; without the tag the hermetic trust tests cannot inject `$HOME`, and a suite that skips them is not evidence. It also means the proof can never write into the operator's real `%USERPROFILE%\.claude`.
- **Nothing mutates the checkout.** `go mod tidy` is run and restored either way, `cover.out` is removed, the lifecycle proofs work in a temp dir with `$HOME` redirected, and a dirty checkout is refused up front.
- **Test scope defaults to the release gate's package set** (`./cmd/skillctl/... ./pkg/skillctl/...`). A bare `./...` here also builds packages needing network, ER1, whisper or a microphone (and PortAudio on macOS); those failures say nothing about skillctl. `--full` opts in, and falls back with a note if the cgo packages do not build.
- **The Unix lifecycle proof is new** because the existing POSIX chain (`demo/kup-training`) hardcodes personal paths, reads the macOS keychain and rewrites tracked demo artifacts. The Windows quickstart proof was ported instead: same seven steps, same fail-closed tamper assertion (exit 11).

## Not in scope

SLSA provenance, cosign/OIDC signing, Code Scanning ingestion and the cross-compile matrix exist only server-side. Both scripts say so in their report.

## Verification (macOS arm64)

- Stage 1 end to end three ways: fresh clone, existing checkout, `--no-race`. All PASS; race `PASS` with the Xcode CLT, `SKIP` under `--no-race`.
- Stage 2 end to end twice: **14 gates, 14 PASS, 0 skipped** (gosec ran over `./...`, coverage reported 58.5% against the ratchet, govulncheck found nothing, the lifecycle proof refused the tampered bundle with exit 11).
- Adversarial runs: `--skip-stage1 --no-install --strict` produced the correct `FAIL (strict: a gate was skipped)` and exit 1. **That run also found a real bug**: `skip_gate` referenced `$name` instead of `$1`, so under `set -u` the first skipped gate aborted the whole script with no report. Fixed, then re-verified.
- A deliberately injected em dash made `prose` the only red gate, the other thirteen still ran, and the verdict line read `TRUST REPORT: FAIL` (12 passed, 1 failed, 1 skipped).
- Repository gates clean on this branch: `check-no-emdash.sh`, `check-install-pins.sh` (3 pins resolve), `check-docs.sh` (docaudit 62 + 200 flags), `boundary-gate.sh`, `id-xref-lint.sh`.
- **The two `.ps1` files could not be executed here (no PowerShell on this host).** They were written against the `.sh` twins and reviewed line by line, including the PowerShell 7.4 `PSNativeCommandUseErrorActionPreference` behaviour. Their first real run is the review run on a Windows machine.

## Note

The documented one-liners point at `master/scripts/...`, so they go live when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
