### PR TITLE
feat(skillctl): FR-0113 — CLI verb register + CI checker (SPEC-0404 §7-K3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,12 @@ jobs:
       - name: Every real flag documented, every documented flag real
         run: go run ./cmd/docaudit -cli all
 
+      - name: verbaudit unit tests
+        run: go test -count=1 ./cmd/verbaudit/
+
+      - name: Every dispatched verb registered (FR-0113)
+        run: go run ./cmd/verbaudit
+
   test:
     name: Unit Tests
     runs-on: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Every real flag documented, every documented flag real
         run: go run ./cmd/docaudit -cli all
 
+      - name: verbaudit unit tests
+        run: go test -count=1 ./cmd/verbaudit/
+
+      - name: Every dispatched verb registered (FR-0113)
+        run: go run ./cmd/verbaudit
+
       - name: No U+2014 EM DASH in the tracked tree (CODESTYLE.md)
         run: ./scripts/check-no-emdash.sh
 

--- a/.github/workflows/skillctl-release.yml
+++ b/.github/workflows/skillctl-release.yml
@@ -78,6 +78,12 @@ jobs:
       - name: Every real skillctl flag documented, every documented flag real
         run: go run ./cmd/docaudit -cli skillctl
 
+      - name: verbaudit unit tests
+        run: go test -count=1 ./cmd/verbaudit/
+
+      - name: Every dispatched verb registered (FR-0113)
+        run: go run ./cmd/verbaudit
+
       - name: No U+2014 EM DASH in the tracked tree (CODESTYLE.md)
         run: ./scripts/check-no-emdash.sh
 

--- a/cmd/verbaudit/main.go
+++ b/cmd/verbaudit/main.go
@@ -1,0 +1,388 @@
+// Command verbaudit is the dispatch-to-register consistency gate for the
+// skillctl top-level verb surface (FR-0113, SPEC-0404 §7-K3, REQ-7.8 .. 7.10).
+//
+// It answers one release-gate question: is every DISPATCHED verb registered?
+//
+//   - A `case "<verb>":` in the top-level dispatch switch with no row in
+//     docs/CLI-VERBS.md is UNREGISTERED and turns CI red (REQ-7.10). Allocation
+//     of a verb is thereby a WRITE (add the row first), not a READ of main.go.
+//   - A main-table row whose Verb appears nowhere in the dispatch is a STALE row
+//     (the code moved on): a warning, not a failure.
+//   - A main-table row with an empty Exit-Code cell fails the mandatory-column
+//     rule (REQ-7.9): the exit-code space is what both known verb collisions
+//     turned on, so it may not be left blank.
+//
+// The DISPATCHED surface is read mechanism-independently by AST, the same
+// discipline cmd/docaudit uses for the flag surface: verbaudit parses
+// cmd/skillctl/main.go, finds the `switch os.Args[1]` statement, and collects
+// the string literals of its case clauses (aliases included, e.g. "--version").
+// A verb the switch never names cannot be dispatched at runtime, so the set of
+// case literals IS the dispatch surface.
+//
+// The REGISTERED surface is docs/CLI-VERBS.md. Its "Verb register" table lists
+// dispatched verbs (canonical name plus any aliases, each in a backtick span in
+// the Verb cell); its "Reserved (registered before implemented)" table lists
+// names allocated before their case lands. A dispatched literal is registered if
+// it matches a canonical name OR an alias in either table. Reserved rows with no
+// dispatch are allowed (that is the point of reserving); a MAIN-table row with no
+// dispatch warns.
+//
+// Exit codes: 0 = consistent; 1 = a violation found (the gate blocks); 2 = a
+// usage/IO/parse error. Pure Go stdlib, portable (runs on the cheap CI runner).
+//
+// Usage:
+//
+//	verbaudit [-main <path>] [-register <path>] [-json]
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultMain     = "cmd/skillctl/main.go"
+	defaultRegister = "docs/CLI-VERBS.md"
+)
+
+// backtickRe captures the content of one inline backtick span (never spanning a
+// line break). The Verb cell of a register row leads with the canonical name in
+// a span, followed by any aliases each in their own span.
+var backtickRe = regexp.MustCompile("`([^`\n]+)`")
+
+// sepCellRe matches a markdown table separator cell (---, :--, --:, :--:).
+var sepCellRe = regexp.MustCompile(`^:?-{2,}:?$`)
+
+// row is one parsed register row.
+type row struct {
+	Canonical string   `json:"canonical"`
+	Aliases   []string `json:"aliases,omitempty"`
+	Spec      string   `json:"spec"`
+	ExitSpace string   `json:"exit_space"`
+	Reserved  bool     `json:"reserved"`
+}
+
+// tokens returns the canonical name plus every alias: the full set of literals
+// that route to this row.
+func (r row) tokens() []string { return append([]string{r.Canonical}, r.Aliases...) }
+
+type report struct {
+	MainFile     string   `json:"main_file"`
+	RegisterFile string   `json:"register_file"`
+	Dispatched   int      `json:"dispatched"`
+	MainRows     int      `json:"main_rows"`
+	ReservedRows int      `json:"reserved_rows"`
+	Unregistered []string `json:"unregistered"` // dispatched, no register row (FAIL)
+	MissingExit  []string `json:"missing_exit"` // main row, empty Exit-Code cell (FAIL)
+	Stale        []string `json:"stale"`        // main row, no dispatch (WARN)
+}
+
+func (r report) ok() bool { return len(r.Unregistered) == 0 && len(r.MissingExit) == 0 }
+
+func main() { os.Exit(run(os.Args[1:])) }
+
+func run(argv []string) int {
+	mainPath := defaultMain
+	regPath := defaultRegister
+	asJSON := false
+	// Minimal flag parsing, no external deps: matches cmd/docaudit's idiom.
+	for i := 0; i < len(argv); i++ {
+		switch argv[i] {
+		case "-main":
+			i++
+			if i < len(argv) {
+				mainPath = argv[i]
+			}
+		case "-register":
+			i++
+			if i < len(argv) {
+				regPath = argv[i]
+			}
+		case "-json":
+			asJSON = true
+		case "-h", "--help":
+			fmt.Fprint(os.Stdout, "usage: verbaudit [-main <path>] [-register <path>] [-json]\n")
+			return 0
+		default:
+			fmt.Fprintf(os.Stderr, "verbaudit: unknown argument %q\n", argv[i])
+			return 2
+		}
+	}
+
+	dispatched, err := dispatchVerbs(mainPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "verbaudit: %v\n", err)
+		return 2
+	}
+	rows, err := registerRows(regPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "verbaudit: %v\n", err)
+		return 2
+	}
+
+	rep := reconcile(mainPath, regPath, dispatched, rows)
+
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rep); err != nil {
+			return 2
+		}
+	} else {
+		printHuman(rep)
+	}
+	if !rep.ok() {
+		return 1
+	}
+	return 0
+}
+
+// reconcile computes the drift between the dispatch surface and the register.
+func reconcile(mainPath, regPath string, dispatched map[string]bool, rows []row) report {
+	rep := report{MainFile: mainPath, RegisterFile: regPath, Dispatched: len(dispatched)}
+
+	// registered token -> is it a reserved-only token.
+	registered := map[string]bool{}
+	for _, r := range rows {
+		if r.Reserved {
+			rep.ReservedRows++
+		} else {
+			rep.MainRows++
+		}
+		for _, t := range r.tokens() {
+			registered[t] = true
+		}
+	}
+
+	// REQ-7.10: any dispatched verb with no register row (main OR reserved).
+	for v := range dispatched {
+		if !registered[v] {
+			rep.Unregistered = append(rep.Unregistered, v)
+		}
+	}
+	sort.Strings(rep.Unregistered)
+
+	for _, r := range rows {
+		if r.Reserved {
+			continue
+		}
+		// REQ-7.9: the Exit-Code column is mandatory on every main-table row.
+		if strings.TrimSpace(r.ExitSpace) == "" {
+			rep.MissingExit = append(rep.MissingExit, r.Canonical)
+		}
+		// A main-table row none of whose tokens are dispatched is stale.
+		dispatchedRow := false
+		for _, t := range r.tokens() {
+			if dispatched[t] {
+				dispatchedRow = true
+				break
+			}
+		}
+		if !dispatchedRow {
+			rep.Stale = append(rep.Stale, r.Canonical)
+		}
+	}
+	sort.Strings(rep.MissingExit)
+	sort.Strings(rep.Stale)
+	return rep
+}
+
+// dispatchVerbs AST-parses main.go and returns the string literals of every case
+// clause in the top-level `switch os.Args[1]` dispatch (aliases included).
+func dispatchVerbs(path string) (map[string]bool, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	var sw *ast.SwitchStmt
+	ast.Inspect(f, func(n ast.Node) bool {
+		if sw != nil {
+			return false
+		}
+		s, ok := n.(*ast.SwitchStmt)
+		if ok && isOsArgsIndex(s.Tag) {
+			sw = s
+			return false
+		}
+		return true
+	})
+	if sw == nil {
+		return nil, fmt.Errorf("%s: no `switch os.Args[1]` dispatch found", path)
+	}
+	out := map[string]bool{}
+	for _, stmt := range sw.Body.List {
+		cc, ok := stmt.(*ast.CaseClause)
+		if !ok {
+			continue // default clause has no List
+		}
+		for _, e := range cc.List {
+			lit, ok := e.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				continue
+			}
+			v, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				continue
+			}
+			if v != "" {
+				out[v] = true
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("%s: dispatch switch has no string-literal cases", path)
+	}
+	return out, nil
+}
+
+// isOsArgsIndex reports whether expr is the index expression `os.Args[1]`.
+func isOsArgsIndex(expr ast.Expr) bool {
+	idx, ok := expr.(*ast.IndexExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := idx.X.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Args" {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "os" {
+		return false
+	}
+	lit, ok := idx.Index.(*ast.BasicLit)
+	return ok && lit.Kind == token.INT && lit.Value == "1"
+}
+
+// registerRows parses docs/CLI-VERBS.md into the main and reserved verb rows.
+// A table row is a line whose trimmed form starts with "|". The Verb cell (first
+// data cell) contributes the canonical name (its first backtick span) and any
+// aliases (further spans). Rows after a heading matching /reserved/i are marked
+// reserved.
+func registerRows(path string) ([]row, error) {
+	b, err := os.ReadFile(path) // #nosec G304 G703 -- path is a trusted CLI argument (the register markdown, default docs/CLI-VERBS.md), not attacker input: same trust model as cmd/docaudit's manual read.
+	if err != nil {
+		return nil, fmt.Errorf("read register: %w", err)
+	}
+	var rows []row
+	inReserved := false
+	for _, line := range strings.Split(string(b), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			if strings.Contains(strings.ToLower(trimmed), "reserved") {
+				inReserved = true
+			}
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "|") {
+			continue
+		}
+		cells := splitRow(trimmed)
+		if len(cells) < 3 {
+			continue
+		}
+		verbCell, specCell, exitCell := cells[0], cells[1], cells[2]
+		// Skip the header row and the separator row.
+		if strings.EqualFold(verbCell, "Verb") {
+			continue
+		}
+		if isSeparatorRow(cells) {
+			continue
+		}
+		spans := backtickRe.FindAllStringSubmatch(verbCell, -1)
+		if len(spans) == 0 {
+			continue // not a verb row (no backtick-quoted verb)
+		}
+		tokens := make([]string, 0, len(spans))
+		for _, m := range spans {
+			tokens = append(tokens, strings.TrimSpace(m[1]))
+		}
+		rows = append(rows, row{
+			Canonical: tokens[0],
+			Aliases:   tokens[1:],
+			Spec:      specCell,
+			ExitSpace: exitCell,
+			Reserved:  inReserved,
+		})
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("%s: no verb rows parsed (is the register table present?)", path)
+	}
+	return rows, nil
+}
+
+// splitRow splits a markdown table row into its trimmed cells, dropping the
+// empty fields produced by the leading and trailing pipe.
+func splitRow(line string) []string {
+	parts := strings.Split(line, "|")
+	var cells []string
+	for _, p := range parts {
+		cells = append(cells, strings.TrimSpace(p))
+	}
+	// Drop a leading and/or trailing empty cell from the border pipes.
+	if len(cells) > 0 && cells[0] == "" {
+		cells = cells[1:]
+	}
+	if len(cells) > 0 && cells[len(cells)-1] == "" {
+		cells = cells[:len(cells)-1]
+	}
+	return cells
+}
+
+// isSeparatorRow reports whether every cell is a markdown separator (---).
+func isSeparatorRow(cells []string) bool {
+	for _, c := range cells {
+		if !sepCellRe.MatchString(c) {
+			return false
+		}
+	}
+	return len(cells) > 0
+}
+
+func printHuman(r report) {
+	const (
+		green  = "\033[0;32m"
+		red    = "\033[0;31m"
+		yellow = "\033[0;33m"
+		bold   = "\033[1m"
+		dim    = "\033[2m"
+		nc     = "\033[0m"
+	)
+	fmt.Println("=== skillctl verb register consistency (verbaudit) ===")
+	fmt.Printf("\n%sdispatch%s %s(%d verbs in %s)%s vs %sregister%s %s(%d main + %d reserved rows in %s)%s\n",
+		bold, nc, dim, r.Dispatched, r.MainFile, nc, bold, nc, dim, r.MainRows, r.ReservedRows, r.RegisterFile, nc)
+
+	if len(r.Unregistered) > 0 {
+		fmt.Printf("  %s✗ UNREGISTERED%s (dispatched in main.go, no row in the register: add a row first):\n", red, nc)
+		for _, v := range r.Unregistered {
+			fmt.Printf("      %s\n", v)
+		}
+	}
+	if len(r.MissingExit) > 0 {
+		fmt.Printf("  %s✗ MISSING EXIT-CODE%s (main-table row with an empty Exit-Code cell: mandatory per REQ-7.9):\n", red, nc)
+		for _, v := range r.MissingExit {
+			fmt.Printf("      %s\n", v)
+		}
+	}
+	if len(r.Stale) > 0 {
+		fmt.Printf("  %s! STALE ROW%s (registered in the main table, not dispatched: the code may have moved on):\n", yellow, nc)
+		for _, v := range r.Stale {
+			fmt.Printf("      %s\n", v)
+		}
+	}
+
+	fmt.Println("\n─────────────────────────────")
+	if r.ok() {
+		fmt.Printf("%sPASS%s: every dispatched verb is registered and every main row carries an exit-code space.\n", green, nc)
+	} else {
+		fmt.Printf("%sFAIL%s: the dispatch and the register disagree (release gate blocks). See docs/CLI-VERBS.md.\n", red, nc)
+	}
+}

--- a/cmd/verbaudit/main_test.go
+++ b/cmd/verbaudit/main_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// sampleMain is a minimal main.go carrying a top-level `switch os.Args[1]`
+// dispatch with a canonical verb, an aliased verb, and a default clause. A
+// second, unrelated switch (over a different tag) is present to prove the AST
+// walk locks onto the os.Args[1] one and ignores the decoy.
+const sampleMain = `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	switch flavour := "x"; flavour {
+	case "decoy":
+		fmt.Println("not a verb")
+	}
+	switch os.Args[1] {
+	case "login":
+		os.Exit(0)
+	case "version", "--version", "-v":
+		fmt.Println("dev")
+	case "audit":
+		os.Exit(0)
+	default:
+		os.Exit(2)
+	}
+}
+`
+
+// sampleRegister is a well-formed register: a main table (login/version/audit)
+// plus a reserved section (capability). It deliberately does NOT register the
+// prose bullets that also contain backticks, to prove only pipe-rows are read.
+const sampleRegister = "# skillctl CLI verb register\n" +
+	"\n" +
+	"- **Verb** `not-a-row` should be ignored (not a table row).\n" +
+	"\n" +
+	"## Verb register\n" +
+	"\n" +
+	"| Verb | Owning SPEC | Exit-Code space |\n" +
+	"| --- | --- | --- |\n" +
+	"| `login` | FR-0043 | 0/1/2 |\n" +
+	"| `version` (`--version`, `-v`) | built-in | 0 |\n" +
+	"| `audit` | SPEC-0189 §14 | 0/2/3 |\n" +
+	"\n" +
+	"## Reserved (registered before implemented)\n" +
+	"\n" +
+	"| Verb | Owning SPEC | Exit-Code space |\n" +
+	"| --- | --- | --- |\n" +
+	"| `capability` | SPEC-0378 | 0/1 |\n"
+
+func writeTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+func TestDispatchVerbs_ExtractsCasesIncludingAliases(t *testing.T) {
+	p := writeTemp(t, "main.go", sampleMain)
+	got, err := dispatchVerbs(p)
+	if err != nil {
+		t.Fatalf("dispatchVerbs: %v", err)
+	}
+	want := []string{"login", "version", "--version", "-v", "audit"}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("dispatch missing %q; got %v", w, got)
+		}
+	}
+	if got["decoy"] {
+		t.Error("decoy case from the non-os.Args switch leaked into the dispatch set")
+	}
+	if len(got) != len(want) {
+		t.Errorf("dispatch size = %d, want %d (%v)", len(got), len(want), got)
+	}
+}
+
+func TestRegisterRows_MainAndReserved(t *testing.T) {
+	p := writeTemp(t, "CLI-VERBS.md", sampleRegister)
+	rows, err := registerRows(p)
+	if err != nil {
+		t.Fatalf("registerRows: %v", err)
+	}
+	byName := map[string]row{}
+	for _, r := range rows {
+		byName[r.Canonical] = r
+	}
+	if _, ok := byName["not-a-row"]; ok {
+		t.Error("a prose backtick span was parsed as a verb row")
+	}
+	ver, ok := byName["version"]
+	if !ok {
+		t.Fatal("version row not parsed")
+	}
+	if len(ver.Aliases) != 2 || ver.Aliases[0] != "--version" || ver.Aliases[1] != "-v" {
+		t.Errorf("version aliases = %v, want [--version -v]", ver.Aliases)
+	}
+	if ver.ExitSpace != "0" {
+		t.Errorf("version exit space = %q, want 0", ver.ExitSpace)
+	}
+	cap, ok := byName["capability"]
+	if !ok {
+		t.Fatal("capability row not parsed")
+	}
+	if !cap.Reserved {
+		t.Error("capability should be a reserved row")
+	}
+	if ver.Reserved {
+		t.Error("version should NOT be a reserved row")
+	}
+}
+
+func TestReconcile_CleanTree(t *testing.T) {
+	mp := writeTemp(t, "main.go", sampleMain)
+	rp := writeTemp(t, "CLI-VERBS.md", sampleRegister)
+	disp, err := dispatchVerbs(mp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := registerRows(rp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep := reconcile(mp, rp, disp, rows)
+	if !rep.ok() {
+		t.Errorf("expected clean, got unregistered=%v missingExit=%v", rep.Unregistered, rep.MissingExit)
+	}
+	if len(rep.Stale) != 0 {
+		t.Errorf("expected no stale rows, got %v", rep.Stale)
+	}
+	if rep.ReservedRows != 1 {
+		t.Errorf("reserved rows = %d, want 1", rep.ReservedRows)
+	}
+}
+
+func TestReconcile_UnregisteredDispatchFails(t *testing.T) {
+	// main.go dispatches an extra verb the register does not carry.
+	extra := sampleMain[:len(sampleMain)-len("	default:\n\t\tos.Exit(2)\n\t}\n}\n")] +
+		"	case \"zzztest\":\n\t\tos.Exit(0)\n" +
+		"	default:\n\t\tos.Exit(2)\n\t}\n}\n"
+	mp := writeTemp(t, "main.go", extra)
+	rp := writeTemp(t, "CLI-VERBS.md", sampleRegister)
+	disp, err := dispatchVerbs(mp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := registerRows(rp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep := reconcile(mp, rp, disp, rows)
+	if rep.ok() {
+		t.Fatal("expected FAIL for an unregistered dispatched verb")
+	}
+	found := false
+	for _, u := range rep.Unregistered {
+		if u == "zzztest" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("unregistered set %v does not name zzztest", rep.Unregistered)
+	}
+}
+
+func TestReconcile_MissingExitFails(t *testing.T) {
+	reg := "## Verb register\n\n" +
+		"| Verb | Owning SPEC | Exit-Code space |\n" +
+		"| --- | --- | --- |\n" +
+		"| `login` | FR-0043 |  |\n"
+	mp := writeTemp(t, "main.go", sampleMain)
+	rp := writeTemp(t, "CLI-VERBS.md", reg)
+	disp, err := dispatchVerbs(mp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := registerRows(rp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep := reconcile(mp, rp, disp, rows)
+	if rep.ok() {
+		t.Fatal("expected FAIL for a main-table row with an empty Exit-Code cell")
+	}
+	if len(rep.MissingExit) != 1 || rep.MissingExit[0] != "login" {
+		t.Errorf("missingExit = %v, want [login]", rep.MissingExit)
+	}
+}
+
+func TestReconcile_StaleRowWarnsButPasses(t *testing.T) {
+	// A registered main-table verb the dispatch does not carry: warn, not fail.
+	reg := "## Verb register\n\n" +
+		"| Verb | Owning SPEC | Exit-Code space |\n" +
+		"| --- | --- | --- |\n" +
+		"| `login` | FR-0043 | 0/1/2 |\n" +
+		"| `version` (`--version`, `-v`) | built-in | 0 |\n" +
+		"| `audit` | SPEC-0189 §14 | 0/2/3 |\n" +
+		"| `ghostverb` | SPEC-9999 | 0/1 |\n"
+	mp := writeTemp(t, "main.go", sampleMain)
+	rp := writeTemp(t, "CLI-VERBS.md", reg)
+	disp, err := dispatchVerbs(mp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := registerRows(rp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep := reconcile(mp, rp, disp, rows)
+	if !rep.ok() {
+		t.Errorf("a stale row must NOT fail the gate; got unregistered=%v missingExit=%v", rep.Unregistered, rep.MissingExit)
+	}
+	if len(rep.Stale) != 1 || rep.Stale[0] != "ghostverb" {
+		t.Errorf("stale = %v, want [ghostverb]", rep.Stale)
+	}
+}
+
+// TestRun_RealTree pins the checker green against the actual repository tree, so
+// this test regresses if a future verb lands in main.go without a register row.
+func TestRun_RealTree(t *testing.T) {
+	code := run([]string{"-main", "../skillctl/main.go", "-register", "../../docs/CLI-VERBS.md"})
+	if code != 0 {
+		t.Fatalf("verbaudit on the real tree returned %d, want 0 (register out of sync with dispatch)", code)
+	}
+}

--- a/docs/CLI-VERBS.md
+++ b/docs/CLI-VERBS.md
@@ -1,0 +1,132 @@
+# skillctl CLI verb register
+
+This file is the allocation table for the top-level `skillctl` verbs, analogous
+to the SPEC slot table that FR-0104 introduced for SPEC numbers. Its purpose is
+to turn verb allocation from a **read** into a **write**: before FR-0113 the only
+way to find out whether a verb name was taken was to read `cmd/skillctl/main.go`
+and see what looked free, so two people reading at different times got the same
+answer and two collisions landed in two days (`audit` vs `auditlog`, and
+`capability` vs the SPEC-0401 reference bindings). Recording the allocation here
+makes the second reader see that the name is already spoken for.
+
+Source: SPEC-0404 §7-K3 (REQ-7.8 .. REQ-7.10), decided 2026-09-04.
+
+## Columns
+
+- **Verb** the canonical dispatched verb. Aliases that route to the same handler
+  are listed in parentheses after it, e.g. `version` (`--version`, `-v`).
+- **Owning SPEC** the specification (and section, where the code names one) that
+  owns the verb's semantics. `built-in` marks a verb with no owning SPEC (usage
+  and version printing). A trailing `(?)` marks a value the code does not pin
+  precisely; it is a best-supported guess, not an invented fact.
+- **Exit-Code space** the set of process exit codes the verb's handler can
+  produce. This column is **mandatory** (REQ-7.9): both known collisions turned
+  on it. `skillctl audit` owns `0/2/3` (SPEC-0189 §14 posture verdicts), so a
+  script that branches on exit `2` must never be handed a `2` that means
+  something else. The trust chain owns `0` plus `10..17` (SPEC-0188 §11). A
+  register that carried only names would have caught the ambiguity at
+  `audit status` but not the real risk, that a script branching on `2` today
+  gets a wrong answer tomorrow.
+
+Notation: `0/1/2` is the shared base space (`exitOK`=0, `exitGeneric`=1,
+`exitUsage`=2 from `cmd/skillctl/signing_cmds.go`). `10..17` is an inclusive
+numeric range from the `pkg/skillctl/exitcode` registry. A code shown as
+`(NN in refusal_code)` rides the signed decision JSON while the PROCESS still
+exits `2` to block the PreToolUse call (verify-hook / enforce / guard-path
+convention); it is not a distinct process exit.
+
+## How to add a verb
+
+1. **Register first.** Add a row to the main table below with the canonical
+   name, its owning SPEC, and its exit-code space. Pick a name not already in
+   this table. If the verb is agreed but not yet implemented, add it to the
+   **Reserved** section instead.
+2. **Then implement.** Add the `case "<verb>":` to the top-level dispatch switch
+   in `cmd/skillctl/main.go` and the handler.
+
+A dispatched verb with **no** register row turns CI **red** (REQ-7.10): this is
+enforcement, not convention. The checker is `cmd/verbaudit`; it AST-parses the
+`switch os.Args[1]` dispatch, parses this file, and fails on any dispatched verb
+that is not registered, plus any main-table row with an empty Exit-Code cell. It
+is wired blocking into `scripts/check-docs.sh` and the `docs-gate` CI job, the
+same way `cmd/docaudit` gates the flag surface.
+
+## Verb register
+
+| Verb | Owning SPEC | Exit-Code space |
+| --- | --- | --- |
+| `login` | FR-0043 | 0/1/2 |
+| `version` (`--version`, `-v`) | built-in | 0 |
+| `pack` | SPEC-0188 (Phase 1 PoC) | 0/1/2, 18 |
+| `keygen` | SPEC-0188 §11 | 0/1/2 |
+| `sign` | SPEC-0188 §11 | 0/1/2 |
+| `verify-sig` | SPEC-0188 §11 | 0/1/2, 11 |
+| `trust` | SPEC-0188 (S7) | 0/1/2 |
+| `peer` | SPEC-0359 (D2) | 0/1/2 |
+| `cross-sign` | SPEC-0359 (D3) | 0/1/2 |
+| `attest` | SPEC-0188 (S9) | 0/1/2 |
+| `revoke` | SPEC-0188 §4.5 | 0/1/2 |
+| `audit` | SPEC-0189 §14 | 0/2/3 |
+| `propose` | SPEC-0194 | 0/1/2 |
+| `install` | SPEC-0188 §11 (S8) | 0/1/2, 10..16 |
+| `verify` | SPEC-0188 §11 (S8) | 0/1/2, 10..17 |
+| `export-verification-kit` | SPEC-0276 R4.3 | 0/1/2, 10..19 |
+| `compliance` | SPEC-0276 R5 | 0/1/2 |
+| `verify-hook` | SPEC-0247 P0.1 | 0/2 (25/26/28 in refusal_code) |
+| `enforce` | SPEC-0317 P0 | 0/2 (26 in refusal_code) |
+| `guard-path` | SPEC-0317 R-6 | 0/2 (27 in refusal_code) |
+| `agentid` | SPEC-0277 P0+P1 | 0/1/2, 11/12/17/20/21 |
+| `gate-stats` | SPEC-0255 | 0/1/2 |
+| `auditlog` | SPEC-0403 §8 | 0/1 |
+| `pin` | SPEC-0247 §7.3 | 0/1/2 |
+| `session-baseline` | SPEC-0317 R-7 | 0/1/2 |
+| `scan` | SPEC-0189 (S0a) | 0/1 |
+| `report` | SPEC-0189 (S0a) | 0/1 |
+| `diff` | SPEC-0189 (S0a) | 0/1 |
+| `seal` | SPEC-0189 (S0a) | 0/1 |
+| `import` | SPEC-0189 (S0a) | 0/1 |
+| `menubar` | SPEC-0189 (S0a) | 0/1 |
+| `review` | SPEC-0189 (S0a) (?) | 0/1 |
+| `browse` | SPEC-0189 (S0a) (?) | 0/1 |
+| `consolidate` | SPEC-0189 (S0a) (?) | 0/1 |
+| `sync-usage` | SPEC-0189 (S0a) | 0/1 |
+| `sync` | SPEC-0317 R-5 | 0/1/2, 29 |
+| `awareness` | SPEC-0195 (S2 M1) | 0/1/2, 18/19 |
+| `intent` | SPEC-0195 (S2 M2) | 0/1/2, 18/19 |
+| `translog` | SPEC-0278 P5 | 0/1/2 |
+| `project` | SPEC-0214 | 0/1/2 |
+| `session` | SPEC-0213 | 0/1/2 |
+| `publish` | SPEC-0225 P1 | 0/1/2 |
+| `pull` | SPEC-0225 P2 | 0/1/2 |
+| `registry` | SPEC-0225 P2 | 0/1/2 |
+| `runbook` | SPEC-0272 | 0/1/2 |
+| `room` | SPEC-0246 §7 | 0/1/2 |
+| `help` (`--help`, `-h`) | built-in | 0 |
+
+Notes on sourcing:
+
+- `review`, `browse`, `consolidate` predate SPEC-0189 and were baselined into
+  its S0a scanner family when the branch merged (`cmd/skillctl/scanner_cmds.go`
+  header: "pre-SPEC-0189 behaviour preserved"), so their owning SPEC is marked
+  `(?)`: S0a is where they are dispatched and documented, not necessarily where
+  they were born.
+- `revoke` (the author-side verb) exits `0/1/2`. The verifier's
+  `identity_revoked` exit `17` (`pkg/skillctl/exitcode` Tier 4) is surfaced by
+  `verify` / `install`, not by `revoke` itself.
+- `import` here is the SPEC-0189 S0a scanner import, exit `0/1`. It is distinct
+  from the `import-public` surface (exit `4/5/17/18/19`), which is not a
+  top-level verb in the current dispatch.
+
+## Reserved (registered before implemented)
+
+These names are allocated but not yet dispatched in `main.go`. The checker does
+NOT fail on a reserved entry that has no dispatch (that is the whole point of
+reserving). Move a row up to the main table when the `case` lands.
+
+| Verb | Owning SPEC | Exit-Code space |
+| --- | --- | --- |
+| `capability` | SPEC-0378 | 0/1 |
+
+`capability` is the second known collision. SPEC-0378 owns capability binding
+(normative P0); SPEC-0401 §3 describes reference bindings under the same word.
+Reserving the stem here settles the ownership before either lands a `case`.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -82,6 +82,24 @@ else
     echo "      go run ./cmd/docaudit -cli <m3c-tools|skillctl> -scaffold"
 fi
 
+# ─── 5. skillctl verb register (BLOCKING) ───
+#
+# FR-0113 / SPEC-0404 §7-K3: verbaudit AST-reads the `switch os.Args[1]` dispatch
+# in cmd/skillctl/main.go and reconciles it against docs/CLI-VERBS.md. A
+# dispatched verb with no register row turns this red (REQ-7.10), and a
+# main-table row must carry an exit-code space (REQ-7.9). It blocks for the same
+# reason the flag gate does: verb allocation must be a WRITE, so two collisions
+# in two days cannot recur.
+echo "5. skillctl verb register (verbaudit)"
+if ! command -v go >/dev/null 2>&1; then
+    fail "go toolchain not found - cannot run the verb-register gate"
+elif go run ./cmd/verbaudit; then
+    pass "every dispatched verb is registered in docs/CLI-VERBS.md"
+else
+    fail "a dispatched verb is not registered (see the report above)"
+    echo "    Register the verb first (add a row to docs/CLI-VERBS.md), then implement its case."
+fi
+
 # ─── Summary ───
 echo ""
 echo "─────────────────────────────"


### PR DESCRIPTION
## FR-0113 — skillctl CLI verb register + CI checker (SPEC-0404 §7-K3)

Closes the last SPEC-0403/0404 loose end: the CLI-verb equivalent of the SPEC-slot table. Two verb collisions surfaced in two days (`audit` vs the proposed `audit status`; `capability bind` in SPEC-0378 vs reference bindings in SPEC-0401) because verb allocation was a **read** (grep `main.go`, take what looks free), not a **write**. This makes it a write, enforced in CI (REQ-7.8..7.10).

### What's in it
- **`docs/CLI-VERBS.md`** — the register: `| Verb | Owning SPEC | Exit-Code space |` for all **47 dispatched verbs**, plus a "Reserved (registered before implemented)" section for `capability` (SPEC-0378). Exit-code space is a mandatory column (REQ-7.9) because both known collisions turn on it. Owning-SPEC + exit codes sourced from the code (dispatch comments, `pkg/skillctl/exitcode/registry.go`, the per-command exit consts); three pre-SPEC-0189 scanner verbs (`review`/`browse`/`consolidate`) carry a `(?)` on the owning-SPEC rather than invented precision. The two anchor collisions are exact: `audit → SPEC-0189 §14, 0/2/3` and `auditlog → SPEC-0403 §8, 0/1`.
- **`cmd/verbaudit/`** — the checker, modeled on `cmd/docaudit`: pure stdlib `go/ast`, locks onto the `switch os.Args[1]` in `main.go`, collects every case literal (aliases included), reconciles against the register, and **fails (exit 1)** on any dispatched verb with no register row (REQ-7.10) or any main row with an empty exit-code cell (REQ-7.9). Reserved-but-undispatched rows are allowed; stale main rows warn. 7 unit tests + a real-tree pin.
- **CI wiring (blocking)** — `scripts/check-docs.sh` section 5 + a step in the `docs-gate` job of ci.yml / release.yml / skillctl-release.yml (mirrors how docaudit is gated). SHA-pinned actions, read-only token.

### Verified (independently)
`go build`/`vet`/gofmt clean; **verbaudit PASS on the real tree** (51 dispatched literals, all registered); **bite-tested** (injected an unregistered `zzzbite` case → `✗ UNREGISTERED` + exit 1; reverted); `env -u ER1_* go test -race ./cmd/... ./pkg/skillctl/...` not regressed (the only failure is the pre-existing environmental `cmd/thinking-engine` health test that needs a prebuilt binary, untouched here); `gosec-diff-gate` 0 new; gitleaks clean; em-dash gate exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
