### PR TITLE
docs(prerequisites): git and Go on Windows, and the Git-for-Windows bash trap

### DIFF
--- a/demo/kup-training/TUTORIAL.md
+++ b/demo/kup-training/TUTORIAL.md
@@ -26,7 +26,7 @@ whether **you** can operate the thing. That is this ride.
 | You need | Why | Check |
 |---|---|---|
 | `git`, Go 1.25+ | the demo builds `skillctl` from this checkout | `go version` |
-| `bash`, `curl`, `tar`, `shasum` | the step scripts | present on macOS and Linux |
+| `bash`, `curl`, `tar`, `shasum` | the step scripts | present on macOS and Linux. On Windows they come with Git for Windows, see below |
 | about 200 MB free | build cache and artifacts | n/a |
 | **only for the online half** | an ER1 account, `ER1_API_KEY`, and a reachable aims-core | see [Part 3](#part-3-the-online-half-scan-use-decay) |
 
@@ -34,6 +34,18 @@ whether **you** can operate the thing. That is this ride.
 git clone https://github.com/kamir/m3c-tools.git
 cd m3c-tools/demo/kup-training
 ```
+
+**On Windows.** These are POSIX shell scripts and PowerShell does not run them. Git for
+Windows ships the bash you need, but its recommended install leaves `bash.exe` off your
+PATH, so call it by path:
+
+```powershell
+& "$env:ProgramFiles\Git\bin\bash.exe" run-all.sh --offline-only --no-pdf --no-release
+```
+
+or use the Start menu's **Git Bash** and run the commands below unchanged. Missing git or
+Go entirely: [docs/prerequisites.md](../../docs/prerequisites.md) has one `winget` line per
+tool, plus the no-admin path.
 
 Everything this ride writes lands under `demo/kup-training/artifacts/`, which is
 git-ignored. Your real `~/.claude/` is never touched: the demo gives "Eric" a fake home at

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,0 +1,153 @@
+---
+layout: default
+title: Prerequisites
+---
+
+# Prerequisites: what a machine needs before the first run
+
+Two tools, on every platform: **git** and **Go 1.25 or newer**. Everything else is
+optional and named as such below. If `git --version` and `go version` both answer, skip to
+[Quickstart: skillctl](quickstart-skillctl.md).
+
+---
+
+## Windows (PowerShell)
+
+### The two required tools
+
+Windows 10 (1809+) and Windows 11 ship `winget`. One line each, no manual download:
+
+```powershell
+winget install --id Git.Git    -e --source winget
+winget install --id GoLang.Go  -e --source winget
+```
+
+**Then reload your PATH.** A `winget` install writes the machine PATH, but your open
+PowerShell session still holds the old copy, so `git` will look missing until you either
+open a new window or run:
+
+```powershell
+$env:Path = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' +
+            [Environment]::GetEnvironmentVariable('Path','User')
+git --version
+go version
+```
+
+`go version` must print **1.25.0 or higher**; that is what `go.mod` requires.
+
+### If `winget` is not there
+
+`winget` comes with the **App Installer** package. Install it from the Microsoft Store, or
+use one of these instead:
+
+```powershell
+# Scoop: per-user, no admin rights at any point
+irm get.scoop.sh | iex
+scoop install git go
+
+# Chocolatey: machine-wide, needs an elevated shell
+choco install git golang -y
+```
+
+Or download the installers by hand: [git-scm.com/download/win](https://git-scm.com/download/win)
+and [go.dev/dl](https://go.dev/dl/). Both are signed MSI/EXE packages.
+
+### No admin rights on this machine?
+
+Use **Scoop** (above): it installs under `%USERPROFILE%\scoop` and never asks for
+elevation. Git for Windows also offers a per-user install, and `winget install Git.Git
+--scope user` selects it.
+
+### The bash question (this one surprises people)
+
+Parts of this repository are POSIX shell scripts: the demo chain in
+`demo/kup-training/`, and three of the gates in the stage 2 script. **Git for Windows
+already ships a bash**, so you do not install anything extra. But its recommended setup
+puts only `...\Git\cmd` on your PATH (that is `git.exe`), **not** `...\Git\bin` (that is
+`bash.exe`). So `bash` alone will usually fail in PowerShell on a machine that has a
+perfectly good bash.
+
+Three ways out, in order of preference:
+
+```powershell
+# 1. Call it by path (works everywhere, changes nothing):
+& "$env:ProgramFiles\Git\bin\bash.exe" run-all.sh --offline-only --no-pdf --no-release
+
+# 2. Add it to this session only:
+$env:Path += ";$env:ProgramFiles\Git\bin"
+bash --version
+
+# 3. Use the "Git Bash" entry in the Start menu and run the script there.
+```
+
+`scripts\skillctl-enterprise-test.ps1` finds Git's bash by itself, next to wherever
+`git.exe` lives, so you do not need any of this for the stage 2 gates.
+
+**A warning about `bash` on PATH.** If `bash` does resolve in PowerShell, it is often
+`C:\Windows\System32\bash.exe`, which is **WSL**, not Git. With a Linux distro installed it
+answers `--version` happily and then runs the script inside Linux, against `/mnt/c/...`
+paths and a different `git`. That is a different machine wearing your machine's name. Use
+Git's bash for these scripts.
+
+### Optional, and what you lose without each
+
+| Tool | Install | Without it |
+|---|---|---|
+| **gcc** (mingw-w64) | `winget install --id MSYS2.MSYS2` then `pacman -S mingw-w64-x86_64-gcc` | The Go race detector needs cgo and a C compiler. The tests still run; the stage 1 report shows `Race SKIP` instead of a pass |
+| **jq** | `winget install --id jqlang.jq -e` | The stage 2 `gosec` diff gate reports SKIP |
+| **gitleaks** | see the pinned install in `.github/workflows/ci.yml` | The stage 2 `gitleaks` gate reports SKIP. Deliberately not auto-installed: CI verifies its release tarball against a pinned SHA-256 first, and a convenience script must not fake that |
+
+`golangci-lint`, `gosec` and `go-test-coverage` are installed on demand by the stage 2
+script, at the versions CI pins, into `(go env GOPATH)\bin`. You do not install them by
+hand, and `-NoInstall` forbids it if you would rather not.
+
+### Windows-specific execution policy
+
+The one-liners start with:
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass -Force
+```
+
+`-Scope Process` applies to that one PowerShell window and dies with it. It changes nothing
+for your user or the machine.
+
+---
+
+## macOS
+
+```bash
+brew install git go        # git is also in the Xcode command line tools
+xcode-select --install     # optional: the C toolchain, which enables the race detector
+```
+
+`brew install portaudio pkg-config` only matters if you widen the stage 2 gates to `./...`
+with `--full`: the audio packages need it. Without it those gates report SKIP rather than a
+misleading red.
+
+## Linux
+
+```bash
+sudo apt install git golang-go build-essential   # Debian, Ubuntu
+sudo dnf install git golang gcc                   # Fedora, RHEL
+```
+
+If your distribution's Go is older than 1.25, take the tarball from
+[go.dev/dl](https://go.dev/dl/) instead; a package manager one minor version behind is the
+most common cause of a failed first build.
+
+---
+
+## Verify, then start
+
+```
+git --version      # any recent version
+go version         # must be 1.25.0 or newer
+```
+
+Then: [stage 1, the machine check](quickstart-skillctl.md#1b-optional-prove-it-on-your-own-machine-source-self-test),
+[stage 2, the CI gates](quickstart-skillctl.md#1c-stage-2-run-our-ci-on-your-own-machine-enterprise-gate),
+[stage 3, the Test Ride](quickstart-skillctl.md#1d-the-human-half-the-test-ride).
+
+Nothing above needs a server, an account or a network connection beyond the installs
+themselves. The ride is offline.

--- a/docs/quickstart-skillctl.md
+++ b/docs/quickstart-skillctl.md
@@ -94,8 +94,11 @@ irm https://raw.githubusercontent.com/kamir/m3c-tools/master/scripts/skillctl-te
 curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/master/scripts/skillctl-test.sh | bash
 ```
 
-Prerequisites: **git** and **Go 1.25+** on `PATH`. Nothing else. The scripts never touch your
-trust roots, never write outside the checkout, and exit non-zero if any step fails.
+Prerequisites: **git** and **Go 1.25+** on `PATH`. Nothing else. Missing either, or on a
+fresh Windows box, see [Prerequisites](prerequisites.md): one `winget` line per tool, the
+PATH reload that makes them visible in the session you already have open, and the
+no-admin-rights path. The scripts never touch your trust roots, never write outside the
+checkout, and exit non-zero if any step fails.
 
 Prefer to read before you run? The scripts are
 [`scripts/skillctl-test.ps1`](https://github.com/kamir/m3c-tools/blob/master/scripts/skillctl-test.ps1)
@@ -166,6 +169,11 @@ curl -fsSL https://raw.githubusercontent.com/kamir/m3c-tools/master/scripts/skil
 | `trust-surface` | the whole trust surface, whole-package, no allow-list | `windows-gate.yml` |
 | `lifecycle` | author, sign, verify, trust, and a tampered bundle **refused** | `skillctl-windows-smoke.yml` |
 
+On Windows, three gates (`pins`, `boundary`, `gosec`) need a POSIX shell. Git for Windows
+already ships one and this script finds it next to `git.exe`, even though the recommended
+install leaves `bash.exe` off your PATH; [Prerequisites](prerequisites.md) explains that
+trap, and why a `bash` that IS on your PATH is usually WSL and the wrong one.
+
 Flags: `--full` / `-Full` widens the Go gates from the skillctl trust surface to `./...`,
 `--no-install` / `-NoInstall` forbids installing a missing tool, `--strict` / `-Strict` makes a
 skipped gate fail the run, `--skip-stage1` / `-SkipStage1` skips the build-and-test stage.
@@ -207,6 +215,10 @@ as somebody else, and then break it four different ways and watch each attempt r
 git clone https://github.com/kamir/m3c-tools.git
 cd m3c-tools/demo/kup-training && ./run-all.sh --offline-only --no-pdf --no-release
 ```
+
+On Windows, run the demo scripts with Git's bash: `& "$env:ProgramFiles\Git\bin\bash.exe"
+run-all.sh --offline-only --no-pdf --no-release`, or from the Start menu's Git Bash. See
+[Prerequisites](prerequisites.md).
 
 The guide is [`demo/kup-training/TUTORIAL.md`](https://github.com/kamir/m3c-tools/blob/master/demo/kup-training/TUTORIAL.md):
 what each step proves, what the exit codes mean, and the one lesson people get wrong (a valid

--- a/scripts/skillctl-enterprise-test.ps1
+++ b/scripts/skillctl-enterprise-test.ps1
@@ -49,9 +49,10 @@
   SHA-256, and a convenience script should not fake that.
 
   POSIX GATES. prose, pins, boundary and the gosec diff gate are shell scripts.
-  prose is reimplemented here natively. The others run only if a working `bash`
-  is on PATH (Git for Windows provides one; the gosec diff gate also needs jq),
-  and report SKIP otherwise.
+  prose is reimplemented here natively. The others need a working `bash`: Git
+  for Windows ships one, and this script finds it next to git.exe even though
+  the recommended install leaves it off PATH. The gosec diff gate also needs jq.
+  Missing either, the gate reports SKIP. See docs/prerequisites.md.
 
 .PARAMETER RepoDir
   Where the checkout lives. Default: $HOME\m3c-tools.
@@ -195,18 +196,43 @@ function Test-Tool($command, $module) {
 # A usable POSIX shell? Git for Windows ships one. A WSL stub with no distro
 # installed answers `bash --version` with an error, which is why this probes
 # rather than testing for the file.
+#
+# Git for Windows SHIPS a bash, but its recommended install puts only
+# ...\Git\cmd on PATH (git.exe), not ...\Git\bin (bash.exe), so `Get-Command
+# bash` finds nothing on a perfectly well-equipped machine and three gates would
+# report SKIP for no reason. So look for Git's own bash FIRST, derived from
+# wherever git.exe actually is, then fall back to PATH.
+#
+# Order matters for a second reason: a PATH `bash` on Windows is usually WSL's
+# System32\bash.exe. With a distro installed it answers `--version` happily and
+# then runs our shell gates inside Linux, against /mnt/c paths and a different
+# git. Git for Windows' bash is the one that shares this filesystem view.
+$BashCandidates = @()
+$gitCmd = Get-Command git -ErrorAction SilentlyContinue
+if ($gitCmd) {
+  # ...\Git\cmd\git.exe  ->  ...\Git\bin\bash.exe   (also covers ...\Git\bin\git.exe)
+  $gitRoot = Split-Path -Parent (Split-Path -Parent $gitCmd.Source)
+  $BashCandidates += (Join-Path $gitRoot 'bin\bash.exe')
+  $BashCandidates += (Join-Path $gitRoot 'usr\bin\bash.exe')
+}
+foreach ($root in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, "$env:LOCALAPPDATA\Programs")) {
+  if ($root) { $BashCandidates += (Join-Path $root 'Git\bin\bash.exe') }
+}
+$pathBash = Get-Command bash -ErrorAction SilentlyContinue
+if ($pathBash) { $BashCandidates += $pathBash.Source }
+
 $Bash = $null
-$bashCmd = Get-Command bash -ErrorAction SilentlyContinue
-if ($bashCmd) {
-  & $bashCmd.Source -c 'exit 0' 2>&1 | Out-Null
-  if ($LASTEXITCODE -eq 0) { $Bash = $bashCmd.Source }
+foreach ($cand in $BashCandidates) {
+  if (-not $cand -or -not (Test-Path -LiteralPath $cand)) { continue }
+  & $cand -c 'exit 0' 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { $Bash = $cand; break }
 }
 
 $Scope = if ($Full) { @('./...') } else { @('./cmd/skillctl/...', './pkg/skillctl/...') }
 
 Write-Host "  repo   : $RepoDir"
 Write-Host "  scope  : $($Scope -join ' ')"
-Write-Host "  bash   : $(if ($Bash) { $Bash } else { 'not available (POSIX gates will be skipped)' })"
+Write-Host "  bash   : $(if ($Bash) { $Bash } else { 'not found (POSIX gates will be skipped; see docs/prerequisites.md)' })"
 
 # --- 1. stage 1 -------------------------------------------------------------
 if ($SkipStage1) {
@@ -280,8 +306,8 @@ if ($Bash) {
   Invoke-Gate 'pins'     { & $Bash ./scripts/check-install-pins.sh }
   Invoke-Gate 'boundary' { & $Bash ./tools/boundary-gate.sh }
 } else {
-  Skip-Gate 'pins'     'no working bash on PATH'
-  Skip-Gate 'boundary' 'no working bash on PATH'
+  Skip-Gate 'pins'     'no working bash found (Git for Windows ships one)'
+  Skip-Gate 'boundary' 'no working bash found (Git for Windows ships one)'
 }
 
 # --- 8. coverage ratchet ----------------------------------------------------
@@ -307,7 +333,7 @@ Invoke-Gate 'govulncheck' { & go run "golang.org/x/vuln/cmd/govulncheck@$Govulnc
 # findings (docs\security\gosec-baseline.md), so an absolute count says nothing.
 # What must never happen is a NEW finding.
 if (-not $Bash) {
-  Skip-Gate 'gosec' 'the diff gate is a POSIX shell script; no working bash on PATH'
+  Skip-Gate 'gosec' 'the diff gate is a POSIX shell script; no working bash found'
 } elseif (-not (Get-Command jq -ErrorAction SilentlyContinue)) {
   Skip-Gate 'gosec' 'jq is not installed (the diff gate needs it)'
 } elseif (Test-Tool 'gosec' "github.com/securego/gosec/v2/cmd/gosec@$GosecVersion") {


### PR DESCRIPTION
## Why

Reported from a real Windows box: `git` was missing, and nothing in the repo said how to get it there. Chasing that turned up a second problem that would have broken the Test Ride on every Windows machine.

## `docs/prerequisites.md`

One `winget` line per tool, then the step everybody misses: **reload PATH in the session you already have open.** `winget` writes the machine PATH; an open PowerShell still holds the old copy, so `git` looks missing until you reload or open a new window. Also Scoop (no admin rights at any point), Chocolatey, the signed installers, macOS/Linux equivalents, and what each optional tool buys:

| Tool | Without it |
|---|---|
| gcc (mingw-w64) | stage 1 reports `Race SKIP`, tests still run |
| jq | stage 2 `gosec` gate reports SKIP |
| gitleaks | stage 2 `gitleaks` gate reports SKIP. Deliberately not auto-installed: CI verifies its tarball against a pinned SHA-256 first |

## The bash trap (the actual finding)

Parts of this repo are POSIX shell: the whole `demo/kup-training/` chain and three stage-2 gates. **Git for Windows already ships a bash**, but its recommended install puts only `...\Git\cmd` on PATH (`git.exe`), **not** `...\Git\bin` (`bash.exe`). So `bash` fails in PowerShell on a machine that has a perfectly good bash, and the Test Ride instructions, which say `bash run-all.sh`, would have failed for that reason alone.

Two fixes:

- **`scripts/skillctl-enterprise-test.ps1` derives Git's bash from wherever `git.exe` is** (`...\Git\cmd\git.exe` -> `...\Git\bin\bash.exe`), checks the usual install roots, and only then falls back to a PATH bash. Three gates that would have reported SKIP now run.
  The order is deliberate for a second reason: a PATH `bash` on Windows is usually WSL's `System32\bash.exe`. With a distro installed it answers `--version` happily and then runs our shell gates inside Linux, against `/mnt/c/...` paths and a different `git`. That is a different machine wearing this machine's name.
- **`TUTORIAL.md` and quickstart §1d spell out the call-by-path form** rather than assuming `bash` resolves.

## Verification

`check-no-emdash.sh`, `check-docs.sh` (docaudit), `check-install-pins.sh` clean.

**Not verified on Windows**, and it cannot be from here: no PowerShell on this host. The bash-discovery paths are the documented Git for Windows layout (`Git\cmd\git.exe`, `Git\bin\bash.exe`, `Git\usr\bin\bash.exe`) plus the three standard install roots, and the probe still runs `bash -c 'exit 0'` before accepting a candidate, so a wrong guess degrades to the previous behaviour (SKIP) rather than a false pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)