### PR TITLE
docs: die beiden User-Szenarien der Publisher-Kette, als nachspielbare Tutorials

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,9 @@ agent skills that act on it (sign, admit, verify, revoke: offline-verifiable).
 - [Bug & feature tracking](bug-tracking): the private analysis file, the public issue, and the guards between them
 - [Acceptance & Handover: skill lifecycle](acceptance-skillctl-lifecycle): the two-person (Mirko → Eric) procedure over ER1, with success criteria
 - [Runbook: two-person ER1 exchange](runbook-two-person-er1-exchange): copy-paste prod runbook (Mirko + Eric lanes) for the live exercise
+- [Tutorial, Szenario 01 (Deutsch)](tutorial-szenario-01-eigene-skills-mehrere-maschinen.de): eigene Skills auf mehreren Maschinen, plus fremde signierte Skills
+- [Tutorial, Szenario 02 (Deutsch)](tutorial-szenario-02-erster-signierter-skill.de): der erste signierte Skill, mit Prüfung durch einen Zweiten
+- [Tutorial, Katas und Test Ride (Deutsch)](tutorial-katas-und-test-ride.de): üben statt zusehen, jeder Beat ein echter Exit-Code
 - [CISO onboarding deck](skillctl-ciso-deck.html): sharp, honest arguments to defend skillctl to a security expert + a CTO (infographic)
 - [CISO-Onboarding-Deck (Deutsch)](skillctl-ciso-deck.de.html): dieselben Argumente auf Deutsch
 - [Menu Bar App](menubar-app): channels, Observation Window, menu items

--- a/docs/tutorial-katas-und-test-ride.de.md
+++ b/docs/tutorial-katas-und-test-ride.de.md
@@ -1,0 +1,244 @@
+---
+layout: default
+title: "Tutorial: Katas und Test Ride, üben statt zusehen"
+---
+
+# Tutorial: Katas und Test Ride
+
+**Für wen:** Sie haben `skillctl` installiert und wollen es **können**, nicht nur darüber
+gelesen haben. Oder Sie geben eine Schulung und brauchen einen Ablauf, der am Ende einen
+Beleg produziert.
+
+**Was Sie am Ende haben:** einen geführten Durchlauf, in dem Sie einen Skill versiegeln, einen
+fremden Schlüssel pinnen, als jemand anderes installieren und den Skill dann auf vier
+verschiedene Arten kaputt machen, wobei jeder Versuch verweigert wird. Danach fünf Übungen,
+die Sie so lange wiederholen, bis der Griff sitzt.
+
+**Der eine Satz, um den es geht:** in beiden Formaten ist ein „bestanden" **ein echter
+Exit-Code**, nie eine Selbstauskunft.
+
+---
+
+## Die Landkarte: vier Stufen, zwei Beweise
+
+Es gibt zwei verschiedene Fragen, und sie werden dauernd verwechselt.
+
+| Stufe | Frage | Artefakt | Beweist |
+|---|---|---|---|
+| 1 | Baut es und laufen die Tests? | `scripts/skillctl-test.sh` bzw. `.ps1` | die Maschine |
+| 2 | Würde dieser Stand unsere CI-Tore bestehen? | `scripts/skillctl-enterprise-test.sh` bzw. `.ps1` | die Maschine |
+| 3 | Kann **ich** das Werkzeug bedienen? | `demo/kup-training/`, der **Test Ride** | den Menschen, einmal |
+| 4 | Sitzt der Griff auch nächste Woche noch? | `skillctl-demo --mode kata`, die **Katas** | den Menschen, dauerhaft |
+
+Stufen 1 und 2 stehen im [Quickstart](quickstart-skillctl.md#1b-optional-prove-it-on-your-own-machine-source-self-test).
+Dieses Tutorial behandelt 3 und 4. Die Reihenfolge ist keine Empfehlung, sondern eine
+Abhängigkeit: der Ride reitet auf dem, was Stufe 1 gebaut hat.
+
+---
+
+## Teil 1: der Test Ride (etwa 20 Minuten, offline)
+
+### 1.1 Holen und starten
+
+```bash
+git clone https://github.com/kamir/m3c-tools.git
+cd m3c-tools/demo/kup-training
+./run-all.sh --offline-only --no-pdf --no-release
+```
+
+Die drei Flags sagen: kein Server, kein PDF-Satz, kein plattformübergreifender Release-Bau.
+Übrig bleibt der Teil, der die Vertrauenskette beweist, und der läuft ohne Netz.
+
+**Alles bleibt in diesem Verzeichnis.** Der Ride schreibt ausschließlich unter
+`demo/kup-training/artifacts/` und benutzt `artifacts/eric-home/` als künstliches `$HOME`.
+Ihr echtes `~/.claude/` wird nicht angefasst. Aufräumen ist ein `rm -rf artifacts/`.
+
+### 1.2 Was dabei passiert
+
+Zehn Schritte, in dieser Reihenfolge:
+
+| Schritt | Rolle | Was er zeigt | Erwartetes Ergebnis |
+|---|---|---|---|
+| `00` | Werkzeug | baut `skillctl` aus der Quelle, prüft die Umgebung | Binary vorhanden |
+| `01` | Mirko (Autor) | `keygen`, `pack`, `sign`, `verify-sig`; zweimal packen ist byteidentisch | Exit `0`, Determinismus belegt |
+| `02` | Mirko | Identität und Bundle ins Registry (nur online) | offline sauber übersprungen |
+| `03` | Reviewer | Attestierung `green` auf den Digest | Urteil liegt vor |
+| `04` | Eric | pinnt Mirkos Schlüssel in seine Trust-Roots | Schlüssel steht in der Datei |
+| `05` | Eric | prüft, installiert, **führt den Skill aus** | `output/hello.txt` entsteht |
+| `06` | Angreifer | ein Byte im Bundle geändert, Signatur passend umbenannt | Exit **`11`**, Signatur ungültig |
+| `07` | Angreifer | fremder Schlüssel, fremde Signatur, Mirkos Identität behauptet | Exit **`11`** gegen Mirkos Pin, `0` gegen den eigenen |
+| `08` | Angreifer | Bundle ganz ohne Signatur | Verweigerung, kein Durchrutschen |
+| `09` | Angreifer | installierte Datei nachträglich editiert | Abweichung erkannt, Reparatur aus dem Bundle |
+
+Schritt `07` ist der lehrreichste: dasselbe Bundle wird gegen zwei verschiedene Schlüssel
+geprüft und liefert zwei verschiedene Urteile. Nicht das Artefakt entscheidet, sondern **wessen
+Schlüssel Sie gepinnt haben**.
+
+### 1.3 Die Lektion, die die meisten falsch mitnehmen
+
+Eine gültige Signatur sagt: **„das ist, was dieser Schlüssel versiegelt hat".** Sie sagt
+niemals: „das ist ungefährlich". Schritt `07` beweist genau das: die Signatur des Angreifers
+ist mathematisch einwandfrei, sie ist nur nicht von dem, dem Sie vertrauen.
+
+### 1.4 Mit Beleg abschließen
+
+```bash
+./run-and-prove.sh --skip-online --chain-only --json ride-report.json
+```
+
+Das ist die Zwillingsvariante von `run-all.sh`: sie prüft nicht nur die Exit-Codes, sondern
+auch, ob jeder Schritt sein tragendes Artefakt tatsächlich erzeugt hat, und schreibt eine
+Zusammenfassung. `--chain-only` lässt die beiden Tore weg, die eine Handbuch-Quelle bzw. einen
+Release-Bau brauchen; ohne das bricht der Lauf ab, nachdem alle Vertrauensprüfungen bereits
+grün waren.
+
+`ride-report.json` ist Ihr Nachweis. Heben Sie ihn zusammen mit `skillctl version` auf.
+
+### 1.5 Die Online-Hälfte (optional)
+
+Drei weitere Schritte schließen den Kreis zur Nutzungsseite. Sie werden von `run-all.sh`
+**nicht** ausgeführt und brauchen ein erreichbares aims-core plus `ER1_API_KEY`:
+
+```bash
+./10-scan-and-sync.sh     # SCAN:  was ist installiert, ins Profil spiegeln
+./11-use-skill.sh         # USE:   Nutzungsereignisse, Reifegrad steigt
+./12-decay.sh             # DECAY: ungeübtes verfällt wieder
+```
+
+Jeder prüft zuerst die Erreichbarkeit und überspringt sich mit einer Warnung, wenn Server oder
+Schlüssel fehlen. `10-scan-and-sync.sh --operator` liest das **echte** `~/.claude/skills/` des
+Trainers statt des Demo-Homes; benutzen Sie das nur bewusst.
+
+### 1.6 Wenn etwas klemmt
+
+| Symptom | Ursache | Abhilfe |
+|---|---|---|
+| Schritt `01` bricht bei `sign` ab, „insecure mode 0644" | ein privater Schlüssel mit zu offenem Modus | `chmod 600 artifacts/keys/*.priv`, dann neu starten. Seit 2026-09-04 erzwingt `00-preflight.sh` das selbst |
+| Der Lauf endet rot, obwohl alle Vertrauensprüfungen grün waren | ein Tor braucht eine Quelle, die nur auf der Wartungsebene liegt | `run-and-prove.sh --skip-online --chain-only` |
+| Schritt `02`, `03` melden „skipped" | kein Registry erreichbar | erwartet und in Ordnung: der kryptografische Beweis ist offline derselbe |
+
+---
+
+## Teil 2: die Katas (fünf Übungen, dauerhaft)
+
+Der Ride beweist einmal, dass Sie es können. Die Katas halten es. Sie sind bewusstes Üben mit
+einem Coach, und der Coach ist das Werkzeug selbst.
+
+### 2.1 Starten
+
+```bash
+# aus dem Repository, baut skillctl gleich mit:
+make build-skillctl-demo
+
+./build/skillctl-demo --kata-list        # das Brett anzeigen und beenden
+./build/skillctl-demo --mode kata        # die Coach-Schleife starten
+./build/skillctl-demo --kata K3          # direkt in eine Übung springen
+```
+
+Beim Start baut das Werkzeug einen abgeschotteten Sandkasten (eigenes `HOME`, eigene
+Schlüssel, eigenes dateibasiertes Registry, eigene Trust-Roots), findet das echte `skillctl`,
+öffnet einen Spiegel im Browser auf `127.0.0.1` und zeigt das Kata-Brett. Es ist offline, ohne
+Installation, ohne Adminrechte.
+
+### 2.2 Die fünf Übungen
+
+| Kata | Sie können danach | Geübt mit | Grün, wenn |
+|---|---|---|---|
+| **K1 Seal & prove** | einen Skill versiegeln und die Urheberschaft offline beweisen | `keygen`, `pack`, `sign`, `verify --bundle` | 3 saubere Durchgänge mit Exit `0` |
+| **K2 Detect tamper** | eine Manipulation erkennen, **bevor** der Skill geladen wird | Datei auf der Platte ändern, `verify --all --quarantine` | 3 Durchgänge mit Urteil `10` |
+| **K3 Govern reversibly** | eine löschende Operation fahren, die sich nicht erzwingen lässt | `audit --cleanup --dry-run-cleanup`, dann Bestätigung auf einem veränderten Zustand | 3 Durchgänge mit Exit `2` |
+| **K4 Trust roots & install** | ein Registry pinnen und nur Zugelassenes installieren | `trust add`, `verify --bundle` | 3 Durchgänge mit Exit `0` |
+| **K5 Revoke & fail-closed** | einen widerrufenen Skill offline abweisen | `verify --bundle … --revocations <signierte Liste>` | 1 Durchgang mit Exit `17` |
+
+K3 ist die Übung, die man unterschätzt: es gibt **kein** `--force`. Der Plan bekommt ein Token
+mit fünf Minuten Gültigkeit, und die Bestätigung prüft den Zustand **erneut**. Hat er sich
+zwischenzeitlich verändert, verweigert sie. Das ist kein Schutz gegen Angreifer, es ist
+Schutz gegen Sie selbst um 23 Uhr.
+
+### 2.3 Wie eine Runde abläuft
+
+Fünf Fragen, jede Runde dieselben:
+
+1. **Ziel.** Was sollen Sie zeigen können?
+2. **Ist-Stand.** Wo stehen Sie? Führen Sie es aus und schauen Sie hin.
+3. **Hindernis.** Was hat blockiert? Das Werkzeug übersetzt den echten Exit-Code (`10`, `2`,
+   `17`) in ein Hindernis in Klartext.
+4. **Nächstes Experiment und Erwartung.** **Sie sagen den Exit-Code voraus**, bevor Sie
+   drücken.
+5. **Hingehen und sehen.** Ausführen, das echte Ergebnis vergleichen, ein Beat wird gezählt.
+
+Schritt 4 ist der Kern. Wer den Exit-Code vorhersagt, hat ein Modell; wer nur ausführt, sammelt
+Anekdoten.
+
+### 2.4 Reifegrad und Verfall
+
+Drei Zustände, wie im CEW-Modell: **rot** (neu), **gelb** (in Übung), **grün** (sitzt). Ein
+sauberer, eigenständiger Durchgang ist ein Beat, `N/3` führt zu grün. Wird eine Kata länger
+nicht geübt, **rostet** sie zurück; das Fenster steuert `KATA_STALL_DAYS` (Standard `5`).
+
+Der Fortschritt liegt lokal unter `~/.skillctl-demo/kata-progress.json`, der Browser zeigt
+dasselbe als Brett, eine Karte je Kata, live.
+
+Das heißt auch: fünf Katas an einem Nachmittag durchzuklicken ergibt **nicht** grün, sondern
+`1/3` fünfmal. Das ist Absicht.
+
+### 2.5 Für die CI, und für die Frage „läuft das überhaupt ehrlich?"
+
+```bash
+./build/skillctl-demo --selftest
+```
+
+Fährt die Live-Szenarien ohne Interaktion, vergleicht jeden beobachteten Exit-Code mit seiner
+Erwartung, druckt eine PASS/FAIL-Tabelle und endet ungleich null, wenn eine Behauptung nicht
+hält.
+
+Dazu die Hausregel, die das Werkzeug an sich selbst anlegt: Szenarien, die **nichts
+ausführen**, sind als `ROADMAP` oder `PARTIAL` gekennzeichnet und werden nie als echtes Urteil
+ausgegeben. Bei K5 ist der Offline-Widerruf (Exit `17`) echt; was Konzept bleibt, ist die
+flottenweite Ausbreitung, weil dieser Aufbau kein Registry hochfährt.
+
+---
+
+## Teil 3: für Trainerinnen und Trainer
+
+Ein Kohorten-Nachmittag, der etwas hinterlässt:
+
+1. **Vorher, allein, 30 Minuten.** Alle laufen Stufe 1 und 2
+   ([Quickstart §1b/§1c](quickstart-skillctl.md#1b-optional-prove-it-on-your-own-machine-source-self-test)).
+   Wer hier hängt, hängt an der Werkzeugkette, nicht am Stoff.
+2. **Gemeinsam, 30 Minuten.** Der Test Ride bis Schritt `05`. Halten Sie bei `05` an und
+   lassen Sie zeigen, dass die Datei entstanden ist.
+3. **Gemeinsam, 30 Minuten.** Die Schritte `06` bis `09`, einer nach dem anderen, jeweils mit
+   der Frage vorweg: „welchen Exit-Code erwarten Sie?"
+4. **Abschluss, 10 Minuten.** `run-and-prove.sh --skip-online --chain-only --json` bei allen,
+   die Berichte einsammeln.
+5. **Danach, über zwei Wochen.** Die Katas, dreimal je Kata, verteilt über Tage. Das Brett ist
+   der Fortschrittsbericht.
+
+Für den Vorführmodus ohne Publikumsbeteiligung gibt es `--mode kiosk --kiosk-delay 5s`, eine
+Endlosschleife für Messestand oder geteilten Bildschirm.
+
+Ein Hinweis zu den Unterlagen: `make-pdf.sh` setzt drei PDFs, greift dafür aber auf eine
+Quelle auf der privaten Wartungsebene zu. Wer die nicht hat, lässt `--no-pdf` stehen; am
+Ride ändert das nichts.
+
+---
+
+## Welches Format wann
+
+| Situation | Nehmen Sie |
+|---|---|
+| Neu im Werkzeug, will einmal alles gesehen haben | Test Ride, offline |
+| Soll es morgen bei einem Kunden bedienen | Test Ride, dann K1 und K4 |
+| Hat es vor zwei Monaten gemacht | `--kata-list`, was rot geworden ist, das üben |
+| Muss belegen, dass die Kette hält | `run-and-prove.sh … --json` plus `skillctl-demo --selftest` |
+| Will einem Entscheider fünf Minuten zeigen | `skillctl-demo` im Standardmodus, Szenarien S1 und S5 |
+
+---
+
+## Wie es weitergeht
+
+- Eigene Skills auf mehreren Maschinen: [Szenario 01](tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md)
+- Der erste signierte Skill mit Prüfung durch einen Zweiten: [Szenario 02](tutorial-szenario-02-erster-signierter-skill.de.md)
+- Alle Modi, Flags und Szenarien des Demo-Werkzeugs: [Quickstart skillctl-demo](quickstart-skillctl-demo.md)
+- Jedes Kommando, jedes Flag, jeder Exit-Code: [Manual](manual-skillctl.md)

--- a/docs/tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md
+++ b/docs/tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md
@@ -1,0 +1,574 @@
+---
+layout: default
+title: "Tutorial, Szenario 01: eigene Skills auf mehreren Maschinen"
+---
+
+# Tutorial, Szenario 01: eigene Skills auf mehreren Maschinen
+
+**Für wen:** Sie nutzen Ihre eigenen Skills auf mehr als einem Rechner (Laptop, Desktop,
+Windows-Maschine) und wollen zusätzlich fremde, bereits signierte Skills einsetzen.
+Sie sind der einzige Autor Ihrer eigenen Skills.
+
+**Was Sie am Ende haben:** einen Signierschlüssel, der genau eine Maschine nie verlässt,
+Ihre eigenen Skills auf allen anderen Maschinen **verwaltet installiert** (also dauerhaft
+nachprüfbar), einen fremden Schlüssel korrekt gepinnt, und ein Gate, das einen manipulierten
+Skill blockiert, bevor der Agent ihn lädt.
+
+**Dauer:** etwa 45 Minuten für den ersten Durchlauf, danach Minuten pro Skill.
+
+**Verwandte Dokumente:** [Quickstart skillctl](quickstart-skillctl.md) (Installation und
+Grundbegriffe), [Manual](manual-skillctl.md) (jedes Kommando, jedes Flag),
+[Szenario 02](tutorial-szenario-02-erster-signierter-skill.de.md) (zwei Personen, eine
+Freigabe).
+
+---
+
+## Das Modell in vier Sätzen
+
+Ein Skill ist vertrauenswürdig, weil er **signiert** ist, nicht weil er von einem bestimmten
+Server kam. Deshalb ist es auch zweitrangig, ob Ihr Registry ein Git-Repository oder ein ER1-
+Kontext ist: produktiv nehmen wir **Git** (intern GitLab, beim Kunden dessen eigene Instanz),
+ER1 ist der Testpfad, und die Kommandos unterscheiden sich nur im `--registry`-Wert. Das Registry ist Transport und Audit-Fläche, es steht **nicht** im
+kryptografischen Prüfpfad. Sie vertrauen genau den öffentlichen Schlüsseln, die Sie selbst
+gepinnt haben. Und eine gültige Signatur sagt „das hat dieser Schlüssel versiegelt", sie sagt
+niemals „das ist ungefährlich".
+
+---
+
+## Teil 0: die Entscheidung vor dem ersten Kommando
+
+**Legen Sie eine Signierstation fest.** Genau eine Maschine hält Ihren privaten Schlüssel.
+Alle anderen Maschinen sind reine Konsumenten. Der Grund ist unromantisch: jede weitere Kopie
+eines `.priv` vervielfacht die Angriffsfläche, und der Dateimodus `0600`, auf den `skillctl
+sign` fail-closed besteht, überlebt weder Git noch die meisten Sync-Dienste. Ein Schlüssel,
+der über einen Sync-Ordner reist, kommt irgendwann als `0644` an, und dann verweigert `sign`
+den Dienst, zu Recht.
+
+Prüfen Sie zuerst, dass überall dasselbe, echte Release läuft:
+
+```bash
+skillctl version        # muss skillctl/vX.Y.Z zeigen, nicht "dev"
+```
+
+Zeigt das `dev`, haben Sie einen Build aus dem Quellbaum vor sich und keinen signierten
+Release. Installation: siehe [Quickstart §1](quickstart-skillctl.md#1-install).
+
+---
+
+## Teil A: die Signierstation einrichten (einmalig)
+
+### A1. Schlüsselpaar erzeugen
+
+```bash
+mkdir -p ~/.config/m3c/skill-keys
+skillctl keygen --out ~/.config/m3c/skill-keys/eric
+```
+
+Erwartete Ausgabe:
+
+```
+wrote ~/.config/m3c/skill-keys/eric.priv (mode 0600)
+wrote ~/.config/m3c/skill-keys/eric.pub  (mode 0644)
+```
+
+`eric.priv` bleibt auf dieser Maschine. `eric.pub` darf überall hin.
+
+### A2. Den eigenen Fingerprint festhalten
+
+Sie brauchen ihn auf jeder weiteren Maschine, und Sie brauchen ihn in einer Form, die Sie
+vorlesen können:
+
+```bash
+openssl pkey -pubin -in ~/.config/m3c/skill-keys/eric.pub -outform DER | tail -c 32 | base64
+openssl pkey -pubin -in ~/.config/m3c/skill-keys/eric.pub -outform DER | tail -c 32 | shasum -a 256
+```
+
+Die erste Zeile ist der rohe Schlüssel in Base64 (der Wert `pubkey_b64`), die zweite der
+Fingerprint. Notieren Sie beide.
+
+### A3. Einen Skill packen und signieren
+
+Nehmen wir einen Skill, den Sie lokal gebaut haben, unter `~/.claude/skills/mein-skill`.
+Er braucht mindestens eine `SKILL.md`.
+
+```bash
+cd ~/skills-workbench                       # ein Arbeitsverzeichnis, egal welches
+
+skillctl pack \
+  --skill ~/.claude/skills/mein-skill \
+  -o mein-skill@1.0.0.skb \
+  --name mein-skill \
+  --version 1.0.0 \
+  --summary "was der Skill tut" \
+  --author-intent green \
+  --author-intent-rationale "kein Netzwerk; schreibt nur ./out"
+
+SIGN_OUT=$(skillctl sign \
+  --key ~/.config/m3c/skill-keys/eric.priv \
+  --identity-id id:eric@kup \
+  mein-skill@1.0.0.skb)
+echo "$SIGN_OUT"
+
+DIGEST="sha256:$(echo "$SIGN_OUT" | awk '/^digest:/ {print $2}')"
+echo "$DIGEST"
+```
+
+> **Falle, die Sie einmal erleben und nie vergessen.** `pack` gibt eine Zeile
+> `bundle_digest: sha256:…` aus, `sign` gibt eine Zeile `digest: …` aus, und **das sind zwei
+> verschiedene Werte**. Der Digest, den Sie ab jetzt brauchen (Signaturdateiname,
+> `--digest` bei `publish` und `revoke`, das Argument von `attest`), ist **der von `sign`**.
+> Der von `pack` ist der Manifest-Digest.
+
+Die Variable `$DIGEST` oben hält genau diesen Wert fest, und `sign` ist idempotent: ein
+zweiter Lauf über dieselben Bytes schreibt dieselbe Signatur, Sie können den Block also
+gefahrlos wiederholen.
+
+### A4. Sofort selbst gegenprüfen
+
+```bash
+skillctl verify-sig --pubkey ~/.config/m3c/skill-keys/eric.pub mein-skill@1.0.0.skb
+echo "rc=$?"          # 0 = OK: signature verified
+```
+
+Exit `0` heißt: diese Bytes wurden von diesem Schlüssel versiegelt. Exit `11` heißt: die
+Signatur passt nicht zu den Bytes. Exit `1` mit „signature file not found" heißt: zu diesen
+Bytes existiert überhaupt keine Signatur, meist weil die Datei nach dem Signieren verändert
+wurde (der Signaturdateiname enthält den Digest).
+
+### A5. Publizieren und attestieren
+
+Ab hier brauchen Sie eine ER1-Anmeldung. Der Skill wandert in Ihr persönliches
+`self`-Registry, aus dem Ihre anderen Maschinen ziehen.
+
+```bash
+skillctl login --base-url https://onboarding.guide
+skillctl login --status
+
+skillctl publish mein-skill@1.0.0 \
+  --bundle mein-skill@1.0.0.skb \
+  --registry self --er1-target prod --er1-context skills \
+  --key ~/.config/m3c/skill-keys/eric.priv \
+  --identity id:eric@kup \
+  --yes
+```
+
+Jetzt der Schritt, den fast jeder beim ersten Mal auslässt und dann eine Stunde sucht:
+**ohne eine grüne Attestierung schlägt Ihr eigener Pull auf der zweiten Maschine mit
+Exit `13` (`governance_below_min`) fehl.** Die Governance-Schwelle ist Teil der Kette, und
+`--author-intent green` aus A3 ist ausdrücklich **nur ein Hinweis**, den der Verifier
+ignoriert. Bindend ist eine signierte Attestierung.
+
+Für eigene Skills auf eigenen Maschinen erzeugen Sie dafür einen zweiten Schlüssel, den
+Reviewer-Schlüssel:
+
+```bash
+skillctl keygen --out ~/.config/m3c/skill-keys/eric-reviewer
+
+skillctl publish --attest mein-skill@1.0.0 \
+  --level green \
+  --rationale "eigener Skill; kein Netzwerk; Datenpfade geprüft" \
+  --registry self --er1-target prod --er1-context skills \
+  --identity id:eric-reviewer@kup \
+  --key ~/.config/m3c/skill-keys/eric-reviewer.priv \
+  --yes
+```
+
+> **Was das ist und was es nicht ist.** Zwei Schlüssel einer Person sind eine
+> **Schlüsseltrennung**, keine Gewaltenteilung. Für Ihre eigenen Skills auf Ihren eigenen
+> Maschinen ist das angemessen: es gibt niemanden, den Sie täuschen könnten außer sich
+> selbst. Sobald ein Skill an Dritte geht, ist es das nicht mehr, und dann gilt
+> [Szenario 02](tutorial-szenario-02-erster-signierter-skill.de.md).
+
+---
+
+## Teil A6: Variante für den Produktivbetrieb, ein Git-Registry statt ER1
+
+Alles aus A1 bis A4 bleibt unverändert. Es ändern sich nur die beiden Kommandos aus A5 und
+später der Pull, und zwar ausschliesslich im `--registry`-Wert.
+
+Einmalig: ein leeres, **privates** Repository anlegen (es wird das Audit-Log) und ein Token
+mit Schreibrecht erzeugen.
+
+```bash
+export M3C_GITHUB_TOKEN="<personal access token>"
+export REG="github://<owner>/<repo>"                # gitlab://<host>/<gruppe>/<projekt>, sobald der Sync steht
+
+skillctl publish mein-skill@1.0.0 --bundle mein-skill@1.0.0.skb --version 1.0.0 \
+  --registry "$REG" --key ~/.config/m3c/skill-keys/eric.priv --identity id:eric@kup --yes
+
+skillctl publish --attest mein-skill@1.0.0 --digest "$DIGEST" --level green \
+  --rationale "eigener Skill; kein Netzwerk; Datenpfade geprüft" \
+  --registry "$REG" --identity id:eric-reviewer@kup \
+  --key ~/.config/m3c/skill-keys/eric-reviewer.priv --yes
+
+skillctl registry ls --registry "$REG"      # muss gov=green status=ok zeigen
+```
+
+Auf den Konsumentenmaschinen steht dann im `trust-roots.yaml` aus B2 statt `registry: self`
+der Locator (`registry: gitlab://…`), und der Pull heisst
+`skillctl pull --registry "$REG" --skill mein-skill --install --trust-mode …`, sonst identisch.
+Dort genügt ein **Lesetoken** (`M3C_GITHUB_RO_TOKEN`, für GitLab `M3C_GITLAB_RO_TOKEN`), der
+Schreibtoken bleibt auf der Signierstation.
+
+Zwei Vorzüge gegenüber ER1, die den Aufwand rechtfertigen: das Repository ist lesbar
+(`skills/<name>/<version>/bundle.json` liest sich im Browser, jedes Urteil ist ein Commit),
+und die zweite Maschine braucht keine ER1-Anmeldung, nur einen Lesetoken.
+
+Und ein Weg, der ganz ohne Server auskommt: `skillctl registry init --registry
+local://$HOME/skill-registry.git` legt ein bares Repo auf der Platte an, in das Sie genauso
+publizieren; `git -C ~/skill-registry.git push --mirror https://github.com/<owner>/<repo>.git` schiebt es
+später hoch.
+
+---
+
+## Teil B: die zweite (und dritte) Maschine
+
+Auf jeder weiteren Maschine, **ohne** privaten Schlüssel.
+
+### B1. Anmelden
+
+```bash
+skillctl login --base-url https://onboarding.guide
+skillctl login --status
+```
+
+### B2. Den eigenen Schlüssel pinnen
+
+Für den ER1-`self`-Weg wird die Trust-Roots-Datei **von Hand** geschrieben. Das ist Absicht:
+der Pin ist der Moment, in dem Sie Vertrauen aussprechen, und der soll nicht nebenbei
+passieren.
+
+```bash
+cat > ~/.claude/trust-roots.yaml <<'YAML'
+registry: self
+pubkey_b64: <der Base64-Wert aus Schritt A2, Ihr Signierschlüssel>
+fingerprint: sha256:<der Fingerprint aus Schritt A2>
+governance_minimum: green
+governance_quorum: 1
+signers:
+  - reviewer_id: id:eric-reviewer@kup
+    pubkey_b64: <der Base64-Wert Ihres REVIEWER-Schlüssels aus A5>
+YAML
+```
+
+Der Block `signers:` ist nicht optional, wenn Sie in A5 mit einem **zweiten** Schlüssel
+attestiert haben: die Attestierung wird gegen die gepinnten Signer geprüft, und ohne diesen
+Eintrag gilt implizit nur der Signierschlüssel als zulässiger Attestierer. Der Pull würde
+sonst mit Exit `13` abbrechen, obwohl die Attestierung existiert. Wer beide Rollen mit
+demselben Schlüssel fährt, lässt `governance_quorum` und `signers` weg.
+
+> **Die zwei Dateien, die man verwechselt.** `~/.claude/trust-roots.yaml` (flach, von Hand)
+> gilt für den ER1-`self`-Weg und wird von `pull` gelesen.
+> `~/.claude/skill-trust-roots.yaml` gilt für HTTP-Registries, wird von
+> `skillctl trust add --registry <URL> --pubkey <datei>` geschrieben und von `install`,
+> `verify` und `audit` gelesen. Die falsche Datei zu füllen ist der häufigste
+> Einrichtungsfehler und äußert sich als Exit `12` (`registry_not_trusted`).
+
+### B3. Ziehen und installieren (zweistufig)
+
+Das Installieren ist ein G-23-Zweischritt: erst ein Plan mit einem kurzlebigen Token, dann
+die Bestätigung, die den Plan gegen den **aktuellen** Zustand neu prüft.
+
+```bash
+skillctl pull --registry self --er1-target prod --er1-context skills \
+  --skill mein-skill --install --trust-mode --dry-run-install --no-checkpoint
+```
+
+Die Ausgabe zeigt, was angelegt und was überschrieben würde, und endet mit
+`dry-run-install token (5-minute TTL): <TOK>`. Lesen Sie den Plan. Dann:
+
+```bash
+skillctl pull --registry self --er1-target prod --er1-context skills \
+  --skill mein-skill --install --trust-mode \
+  --confirm-install --dry-run-install-token <TOK> --no-checkpoint
+```
+
+Dabei laufen fünf Tore: Envelope-Signatur, nicht widerrufen, Governance-Schwelle, Digest,
+Bundle-Signaturen. Der Skill landet unter `~/.claude/skills/mein-skill/` mit einer
+Provenienz-Datei `.m3c-provenance.json` daneben.
+
+### B4. Nachprüfen
+
+```bash
+skillctl verify mein-skill
+echo "rc=$?"        # 0
+skillctl verify --all
+```
+
+> **Warum nicht einfach entpacken?** Ein `.skb` ist ein tar.gz, und `tar -xzf` funktioniert.
+> Aber ein von Hand entpackter Skill ist danach **stumm**: `skillctl verify <name>` antwortet
+> „no .skb found … (was this skill installed by skillctl install?)", und auch
+> `verify --offline <name>` findet keine hinterlegten Metadaten. Damit fällt er aus dem
+> Sweep `verify --all` und aus dem Gate heraus. Von Hand entpacken ist ein Notweg für den
+> Fall ohne Registry (Teil C2), kein Installationsweg.
+
+---
+
+## Teil C: fremde, bereits signierte Skills einsetzen
+
+Jetzt kommen Skills ins Spiel, die jemand anderes signiert hat, im Folgenden „Mirko".
+
+**Die Regel vorweg, sie spart Ihnen später Ärger.** Pinnen Sie nicht mehrere Registries
+nebeneinander. Ein fremder Skill wird geprüft und **in Ihr eigenes Registry aufgenommen**
+(Re-Admit), genau wie ein Artefakt-Mirror im Unternehmen. Dann pinnt jede Ihrer Maschinen
+weiterhin genau einen Schlüssel, einen Locator und eine Schwelle. Der Grund ist nicht
+Ordnungsliebe: `trust-roots.yaml` trägt genau einen Registry-Eintrag, und die Alternative
+(eine Datei je Herkunft, beim Pull mit `--trust-roots` mitgegeben) verlagert eine
+Sicherheitsentscheidung in die Kommandozeile, wo sie irgendwann falsch getippt wird.
+
+### C0. Zuerst der Pin, dann das Artefakt
+
+Ein öffentlicher Schlüssel, der **zusammen mit dem Bundle** ankommt, beweist nichts: er kam
+über denselben ungeprüften Weg wie das Bundle selbst. Lassen Sie sich den Fingerprint über
+einen **zweiten Kanal** vorlesen (Telefon, Videocall, persönlich) und vergleichen Sie ihn
+Zeichen für Zeichen. Erst danach stimmt der Satz „ich muss dem Transportweg nicht vertrauen".
+
+### C1. Weg 1: Re-Admit in Ihr eigenes Registry (Regelweg)
+
+Sie sind hier in genau der Rolle, die in [Szenario 02](tutorial-szenario-02-erster-signierter-skill.de.md)
+Eric hat: Sie sind Freigeber für einen Skill, den jemand anderes geschrieben hat.
+
+```bash
+# 1. Mirkos Bundle und seine .author.sig entgegennehmen, Fingerprint vorher
+#    über den zweiten Kanal bestätigt haben (C0).
+skillctl verify-sig --pubkey ./mirko.pub mirko-skill@1.0.0.skb
+echo "rc=$?"        # 0, sonst hier abbrechen
+
+# 2. Ansehen, worüber Sie urteilen.
+mkdir -p /tmp/review-mirko && tar -xzf mirko-skill@1.0.0.skb -C /tmp/review-mirko
+cat /tmp/review-mirko/SKILL.md && ls -R /tmp/review-mirko
+
+# 3. In Ihr Registry aufnehmen und attestieren.
+skillctl publish mirko-skill@1.0.0 --bundle mirko-skill@1.0.0.skb --version 1.0.0 \
+  --registry "$REG" --key ~/.config/m3c/skill-keys/eric.priv --identity id:eric@kup --yes
+
+skillctl publish --attest mirko-skill@1.0.0 --digest "<Digest aus Mirkos sign-Ausgabe>" \
+  --level green --rationale "Upstream id:mirko@m3c; Signatur verifiziert; Inhalt geprüft am <datum>" \
+  --registry "$REG" --identity id:eric-reviewer@kup \
+  --key ~/.config/m3c/skill-keys/eric-reviewer.priv --yes
+```
+
+Danach zieht **jede** Ihrer Maschinen den Skill mit demselben Kommando und demselben Pin wie
+Ihre eigenen Skills:
+
+```bash
+skillctl pull --registry "$REG" --skill mirko-skill --install --trust-mode \
+  --dry-run-install --no-checkpoint
+```
+
+Was Sie damit gewonnen haben: eine Quelle, ein Pin, und in `registry show mirko-skill` steht,
+**wer** wann geurteilt hat, nämlich Sie. Mirkos Autorenschaft bleibt im Bundle sichtbar, aber
+die Verantwortung für „das läuft bei uns" liegt sichtbar dort, wo sie hingehört.
+
+> **Ausnahme, kein Regelweg.** Auf einer einzelnen Maschine, für einen einmaligen Versuch,
+> können Sie ein fremdes Registry auch direkt pinnen: eine zweite Trust-Roots-Datei anlegen und
+> beim Pull `--trust-roots <datei>` mitgeben. Machen Sie das nicht auf mehreren Maschinen und
+> nicht dauerhaft.
+
+### C2. Weg 2: über einen ER1-Raum (Testpfad)
+
+Mirko publiziert in **seinen** Kontext und teilt den Skill in einen gemeinsamen Raum. Sie
+werden serverseitig Mitglied dieses Raums (dafür gibt es kein `skillctl`-Verb, das passiert
+in der onboarding.guide-Konsole). Dann ziehen Sie aus **seinem** Kontext:
+
+```bash
+# Trust-Roots-Datei für Mirkos Schlüssel, gleiche Form wie in B2
+skillctl pull --registry self --er1-target prod --er1-context <mirko-sub>___skills \
+  --skill mirko-skill --install --trust-mode --dry-run-install --no-checkpoint
+# ... Plan lesen, dann mit --confirm-install und dem Token bestätigen
+```
+
+Wichtig: **kein** `--key` und **kein** `--emit-installed`. Sie sind hier reiner Konsument,
+und nichts von Ihnen soll in Mirkos Registry zurückgeschrieben werden.
+
+Der ausführliche Zwei-Personen-Ablauf mit allen Feldern steht im
+[Runbook Zwei-Personen-Austausch](runbook-two-person-er1-exchange.md).
+
+### C3. Weg 3: über ein HTTP-Registry (heute nur gegen eine Instanz ohne Client-Auth)
+
+> **Vorher lesen.** `/api/skills` ist das aims-core-Modul `skill_registry`, dieselbe Maschine
+> wie ER1, andere API. Es läuft in Produktion (`GET /api/skills/health` antwortet `healthy`),
+> aber `skillctl` sendet an diese API **keinen Auth-Header**, und die Produktivinstanz
+> verlangt einen: `/api/skills/bundles` antwortet mit `401 AUTH_REQUIRED`. Dieser Weg
+> funktioniert deshalb heute gegen eine Instanz, die die Endpunkte ohne Client-Auth bedient
+> (etwa die lokale Docker-Instanz aus `demo/kup-training/`), nicht gegen prod. Für den
+> Produktivbetrieb nehmen Sie Weg 2.
+
+```bash
+skillctl trust add \
+  --registry https://<registry-host>/api/skills \
+  --pubkey ./mirko.pub \
+  --id mirko-2026
+
+skillctl trust list
+```
+
+`trust list` gibt den gepinnten Schlüssel als Base64 aus. Vergleichen Sie ihn mit dem, was
+Mirko Ihnen am Telefon vorgelesen hat. Dann:
+
+```bash
+skillctl install mirko-skill@1.0.0
+echo "rc=$?"                     # 0 = installiert
+skillctl verify mirko-skill
+```
+
+Schlägt es fehl, sagt der Exit-Code, woran:
+
+| Code | Bedeutung | Was zu tun ist |
+|---|---|---|
+| `10` | Digest passt nicht | Bundle neu beziehen, nicht weitermachen |
+| `11` | Autorensignatur ungültig | Bundle neu beziehen, nicht weitermachen |
+| `12` | Registry nicht in den Trust-Roots | falsche Datei oder falscher Schlüssel gepinnt (siehe B2) |
+| `13` | Governance unter der Schwelle | es fehlt eine grüne Attestierung; beim Herausgeber nachfragen |
+| `14` | `depends_on` nicht erfüllt | die deklarierte Abhängigkeit bereitstellen |
+| `17` | widerrufen | der Skill wurde zurückgezogen; nicht installieren |
+
+### C4. Weg 4: ohne Registry, per Datei
+
+Wenn Sie nur ein `.skb` und die Signaturdatei bekommen, ist die einzige Aussage, die Sie
+offline prüfen können, die **Autorensignatur**:
+
+```bash
+skillctl verify-sig --pubkey ./mirko.pub mirko-skill@1.0.0.skb
+echo "rc=$?"        # 0 = von diesem Schlüssel versiegelt
+```
+
+Erst wenn das `0` ist, entpacken Sie:
+
+```bash
+mkdir -p ~/.claude/skills/mirko-skill
+tar -xzf mirko-skill@1.0.0.skb -C ~/.claude/skills/mirko-skill
+```
+
+Seien Sie ehrlich darüber, was Sie damit **nicht** haben: kein Governance-Level, keine
+Widerrufsprüfung, keinen Tenant-Scope, und keine spätere Nachprüfbarkeit (siehe B4).
+Das ist ein Notweg, kein Regelweg. Der dafür vorgesehene portable Weg,
+`skillctl verify --bundle` mit einer `BundleMeta`-Hülle, setzt voraus, dass das Bundle einmal
+durch ein Registry gelaufen ist: die Hülle `<name>.skbmeta.json` entsteht beim Admit, und
+`export-verification-kit` kann sie heute nicht aus einem frisch signierten Bundle erzeugen.
+
+---
+
+## Teil D: das Gate scharfschalten (auf jeder Maschine)
+
+Bis hierhin haben Sie geprüft, wenn Sie daran gedacht haben. Das Gate prüft, wenn Sie es
+vergessen. Es hängt als `PreToolUse(Skill)`-Hook in Claude Code, verifiziert die Kette,
+**bevor** ein Skill geladen wird, und verweigert im Zweifel (fail-closed).
+
+In der Claude-Code-Konfiguration (`settings.json`):
+
+```json
+{ "hooks": { "PreToolUse": [ { "matcher": "Skill", "hooks": [ { "type": "command", "command": "skillctl verify-hook" } ] } ] } }
+```
+
+`verify-hook` wird **nicht von Hand aufgerufen**. Es liest das Hook-Ereignis von der
+Standardeingabe; ruft man es interaktiv auf, gibt es folgerichtig eine Ablehnung aus
+(„unreadable hook event on stdin (fail-closed)") und endet mit `2`. Das ist kein Fehler,
+das ist das Verhalten im Zweifel.
+
+Danach kann ein Agent einen Skill, der die Kette nicht besteht, nicht mehr laden, auch dann
+nicht, wenn er es versucht. Was das Tor entschieden hat, sehen Sie hier:
+
+```bash
+skillctl gate-stats --since 168h     # Entscheidungen der letzten Woche
+```
+
+Regelmäßig, und nach jedem Verdacht:
+
+```bash
+skillctl verify --all
+skillctl audit --source all --minimum-governance green
+```
+
+> **Zwei Grenzen, gemessen, bevor Sie das in einen Cronjob schreiben.** Erstens antwortet
+> `skillctl verify <name>` nach einer Installation aus einem Git- oder ER1-Registry mit
+> „trust roots not configured; run `skillctl trust add …`" und zeigt auf
+> `~/.claude/skill-trust-roots.yaml`, die Datei des HTTP-Modells: das Nachprüfen eines
+> einzelnen installierten Skills ist an dieses Modell gebunden. Der belastbare Nachweis ist
+> vorerst der Pull selbst plus `skillctl registry show`. Zweitens fällt `verify --all` unter
+> verwalteten Trust-Roots **fail-closed**, wenn keine Widerrufsquelle erreichbar ist, und
+> würde mit `--quarantine` frisch installierte Skills verschieben. Lassen Sie den Sweep
+> deshalb erst ohne `--quarantine` laufen und lesen Sie die Ausgabe, bis der Widerrufskanal
+> steht.
+
+`audit` hat eine eigene Skala: `0` alles in Ordnung, `2` mindestens ein Skill unbestätigt
+oder unter der Schwelle, `3` mindestens ein Skill defekt.
+
+---
+
+## Teil E: Widerruf
+
+Wenn ein eigener Skill zurückgezogen werden muss:
+
+```bash
+skillctl publish --revoke mein-skill \
+  --digest "$DIGEST" \
+  --reason superseded \
+  --registry self --er1-target prod --er1-context skills \
+  --key ~/.config/m3c/skill-keys/eric.priv --identity id:eric@kup --yes
+```
+
+Gegen ein Git-Registry heisst dasselbe Kommando `--registry "$REG"` statt
+`--registry self --er1-target …`; der Widerruf wird als weiteres signiertes Ereignis unter
+`events/<digesthex>/` abgelegt und beim nächsten Pull als `gate 5: revoked` wirksam.
+
+Auf den anderen Maschinen greift der Widerruf beim nächsten `verify --all` (Exit `17`).
+Der Widerruf ist signiert und offline prüfbar, und eine veraltete oder zurückgedrehte
+Widerrufsliste wird zurückgewiesen statt stillschweigend geglaubt (Exit `22`).
+
+---
+
+## Abschluss: die Evidenz, die Sie aufheben
+
+Nicht „hat funktioniert", sondern Zahlen:
+
+```bash
+{
+  echo "Datum:        $(date -u +%FT%TZ)"
+  echo "Host:         $(hostname)"
+  skillctl version
+  echo "Fingerprint:  $(openssl pkey -pubin -in ~/.config/m3c/skill-keys/eric.pub \
+                        -outform DER | tail -c 32 | shasum -a 256 | awk '{print $1}')"
+  echo "Digest:       $DIGEST"
+  skillctl trust list
+  skillctl verify --all
+  echo "verify --all rc=$?"
+} | tee ~/szenario-01-evidenz.txt
+```
+
+Diese Datei beantwortet in sechs Monaten die Frage, was an diesem Tag tatsächlich galt.
+
+---
+
+## Windows
+
+Alles oben gilt, mit drei Unterschieden:
+
+- Pfade: `%USERPROFILE%\.claude\trust-roots.yaml` und
+  `%USERPROFILE%\.claude\skill-trust-roots.yaml`.
+- Ein ausgelieferter Windows-Build ignoriert `$HOME` für alle sicherheitsrelevanten Pfade
+  absichtlich, weil eine Umgebungsvariable von einem Angreifer setzbar ist. Er liest
+  `%USERPROFILE%`. Sandkasten-Tricks über `$HOME` funktionieren dort also nicht.
+- Installation über die PowerShell-Einzeile aus [Quickstart §1](quickstart-skillctl.md#1-install),
+  und entweder diese **oder** den maschinenweiten Installer, nicht beide.
+
+---
+
+## Wenn etwas klemmt
+
+| Symptom | Bedeutung | Abhilfe |
+|---|---|---|
+| `sign`: „insecure mode 0644" | der private Schlüssel ist zu offen | `chmod 600 <key>.priv`; wenn er über einen Sync-Ordner kam, ist die Signierstation aus Teil 0 die eigentliche Antwort |
+| `pull` Exit `12` | falsche Trust-Roots-Datei oder falscher Schlüssel | B2 lesen: `trust-roots.yaml` für `self`, `skill-trust-roots.yaml` für HTTP |
+| `pull` Exit `13` | keine grüne Attestierung | A5 zweiter Block |
+| `publish` HTTP 403 | Publish in einen fremden Kontext | nur in den **eigenen** `--er1-context skills` publizieren |
+| `verify <name>`: „no .skb found" | der Skill wurde von Hand entpackt | über `pull --install` oder `install` neu installieren |
+| `verify-sig` Exit `1`, „signature file not found" | die Bytes wurden nach dem Signieren verändert | Bundle neu beziehen |
+
+---
+
+## Wie es weitergeht
+
+- Zwei Personen, eine Freigabe: [Szenario 02](tutorial-szenario-02-erster-signierter-skill.de.md)
+- Üben, bis es sitzt: [Katas und Test Ride](tutorial-katas-und-test-ride.de.md)
+- Jedes Kommando, jedes Flag: [Manual](manual-skillctl.md)

--- a/docs/tutorial-szenario-02-erster-signierter-skill.de.md
+++ b/docs/tutorial-szenario-02-erster-signierter-skill.de.md
@@ -1,0 +1,738 @@
+---
+layout: default
+title: "Tutorial, Szenario 02: der erste signierte Skill, mit Prüfung durch einen Zweiten"
+---
+
+# Tutorial, Szenario 02: der erste signierte Skill
+
+**Für wen:** Sie haben mit Claude Code lokal einen Skill gebaut und wollen ihn erstmals
+signieren und veröffentlichen. Ihr Vorgesetzter oder eine Kollegin prüft ihn vorher.
+In diesem Text heißen die drei Rollen **Mitarbeiter** (Autor), **Eric** (Reviewer und
+Herausgeber) und **Konsument** (jemand, der den Skill danach installiert).
+
+**Was Sie am Ende haben:** einen signierten Skill mit einer Attestierung, die **eine andere
+Person** unterschrieben hat, und einen Konsumenten, der ihn installieren kann, weil die
+Prüfung stattgefunden hat, nicht weil ihm jemand gesagt hat, sie habe stattgefunden.
+
+**Dauer:** Teil 1 (Trockenlauf, offline, ohne Server) etwa 15 Minuten. Teil 2 (der echte
+Vorgang) etwa eine Stunde beim ersten Mal, danach Minuten.
+
+**Verwandte Dokumente:** [Szenario 01](tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md)
+(eine Person, mehrere Maschinen), [Runbook Zwei-Personen-Austausch](runbook-two-person-er1-exchange.md)
+(derselbe Vorgang als Abnahmeprozedur), [Manual](manual-skillctl.md).
+
+---
+
+## Die Regel, aus der alles Weitere folgt
+
+**Niemand darf seinen eigenen Skill freigeben.** Der Autor versiegelt, ein Zweiter
+bescheinigt. Deshalb hat der Vorgang zwei Schlüssel in zwei Händen und nicht einen in einer.
+Alles Umständliche an diesem Tutorial kommt aus dieser einen Regel, und sie ist der Grund,
+warum das Ergebnis etwas wert ist.
+
+Zwei Begriffe, die man nicht verwechseln darf:
+
+- **Autorenabsicht** (`--author-intent green`) ist ein Hinweis des Autors. Der Verifier
+  **ignoriert** sie. Sie kostet nichts und beweist nichts.
+- **Attestierung** (`skillctl publish --attest` über ER1, `skillctl attest` gegen ein
+  HTTP-Registry) ist ein signiertes Urteil eines Prüfers über einen bestimmten Digest. Sie ist
+  bindend. Fehlt sie, scheitert jede Installation mit Exit `13`.
+
+---
+
+## Teil 0: was VOR dem ersten Signieren erledigt sein muss
+
+Sieben Punkte. Die ersten drei sind offensichtlich, die anderen vier sind der Grund, warum
+der erste Versuch sonst an einer unverständlichen Fehlermeldung endet.
+
+| # | Punkt | Prüfen mit | Wer |
+|---|---|---|---|
+| 1 | `skillctl` aus einem **signierten Release**, nicht aus einem Quellbaum-Build, und auf allen beteiligten Maschinen **dieselbe** Version | `skillctl version` zeigt `skillctl/vX.Y.Z`, nicht `dev` | alle |
+| 2 | Ein eigenes Schlüsselpaar, privater Teil mit Modus `0600` | `skillctl keygen --out <pfad>` | Mitarbeiter, Eric |
+| 3 | Eine Identitäts-ID der Form `id:<name>@<org>`, die in jede Signatur eingestempelt wird und später nicht folgenlos wechselt | Absprache | Mitarbeiter, Eric |
+| 4 | Ein **Registry, in das geschrieben werden darf**: bei Git ein leeres Repository plus ein Project Access Token für den Herausgeber (kein Deploy Token), beim HTTP-Registry zusätzlich eine serverseitig registrierte Identität, sonst `19 identity_mismatch` | `skillctl registry ls --registry <locator>` antwortet | Registry-Betreiber |
+| 5 | Der Reviewer ist **nicht** der Autor und hat einen **eigenen** Schlüssel | Absprache, siehe die Regel oben | Eric |
+| 6 | Beim Git-Weg: der Locator und die Token-Variablen sind gesetzt. Beim ER1-Weg: Anmeldung und eine serverseitig eingerichtete Raum-Mitgliedschaft (dafür gibt es **kein** `skillctl`-Verb) | `echo $REG`, `skillctl login --status` | alle |
+| 7 | Jede Seite hat den Fingerprint der anderen über einen **zweiten Kanal** bestätigt | Telefon, Videocall, persönlich | Mitarbeiter, Eric, Konsument |
+
+Zu Punkt 7, weil er der am leichtesten übersprungene ist: ein öffentlicher Schlüssel, der
+zusammen mit dem Bundle ankommt, beweist nichts. Er kam über denselben ungeprüften Weg wie
+das Bundle. Erst der vorherige, über einen zweiten Kanal bestätigte Pin macht den Satz „ich
+muss dem Transportweg nicht vertrauen" wahr. Ein Pin ohne Kanalwechsel ist kein Pin.
+
+Und ein Punkt, der **nicht** in der Liste steht: Ihr Skill muss nicht perfekt sein. Er muss
+prüfbar sein.
+
+---
+
+## Teil 1: der Trockenlauf (offline, ohne Server, 15 Minuten)
+
+Dieser Teil braucht kein Registry, keine Anmeldung, kein Netz. Er spielt die Mechanik einmal
+durch, damit Sie im echten Vorgang wissen, wie eine Ablehnung aussieht. Alles passiert in
+einem Arbeitsverzeichnis; Ihr echtes `~/.claude/` wird nicht angefasst.
+
+### 1.1 Arbeitsverzeichnis und ein winziger Skill
+
+```bash
+export WS="$HOME/skillctl-uebung"
+rm -rf "$WS" && mkdir -p "$WS"/{keys,src/hello-kup/scripts} && cd "$WS"
+
+cat > src/hello-kup/SKILL.md <<'MD'
+---
+name: hello-kup
+version: 0.1.0
+description: Minimaler Uebungsskill fuer die Publisher-Kette, schreibt eine Datei nach ./out.
+---
+
+# hello-kup
+
+Schreibt einen Gruss nach ./out/hello.txt. Kein Netzwerk, keine Secrets.
+MD
+
+cat > src/hello-kup/scripts/hello.sh <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p ./out
+echo "hello from hello-kup" > ./out/hello.txt
+cat ./out/hello.txt
+SH
+chmod +x src/hello-kup/scripts/hello.sh
+```
+
+### 1.2 Zwei Schlüssel, zwei Rollen
+
+```bash
+skillctl keygen --out "$WS/keys/mitarbeiter"
+skillctl keygen --out "$WS/keys/eric-reviewer"
+ls -l "$WS/keys"
+```
+
+Erwartet: vier Dateien, die `.priv` mit Modus `-rw-------`. Ist ein `.priv` offener, verweigert
+`sign` später den Dienst, absichtlich.
+
+> Geben Sie absolute Pfade an. Bei einem relativen Pfad warnt `keygen` („relative path;
+> resolving against CWD"), und Sie finden den Schlüssel später an einer anderen Stelle, als
+> Sie denken.
+
+### 1.3 Packen und signieren
+
+```bash
+skillctl pack \
+  --skill ./src/hello-kup \
+  -o hello-kup@0.1.0.skb \
+  --name hello-kup \
+  --version 0.1.0 \
+  --summary "Uebungsskill" \
+  --author-intent green \
+  --author-intent-rationale "kein Netzwerk; schreibt nur ./out"
+
+SIGN_OUT=$(skillctl sign \
+  --key "$WS/keys/mitarbeiter.priv" \
+  --identity-id id:mitarbeiter@kup \
+  hello-kup@0.1.0.skb)
+echo "$SIGN_OUT"
+
+DIGEST="sha256:$(echo "$SIGN_OUT" | awk '/^digest:/ {print $2}')"
+echo "DIGEST=$DIGEST"
+```
+
+> **Die Falle, die jeder einmal erlebt.** `pack` gibt `bundle_digest: sha256:…` aus, `sign`
+> gibt `digest: …` aus, und **die beiden Werte sind verschieden**. Der Wert, den Sie ab jetzt
+> überall brauchen (Signaturdateiname, das Argument von `attest`, `--digest` bei `publish`
+> und `revoke`), ist **der von `sign`**. Der von `pack` ist der Manifest-Digest, nicht der
+> Digest der Bundle-Bytes.
+
+### 1.4 Der Autor prüft sich selbst
+
+```bash
+skillctl verify-sig --pubkey "$WS/keys/mitarbeiter.pub" hello-kup@0.1.0.skb
+echo "rc=$?"
+```
+
+Erwartet: `OK: signature verified`, `rc=0`.
+
+### 1.5 Die Reproduzierbarkeitsprobe
+
+Zweimal packen muss byteidentisch sein. Ist es das nicht, enthält Ihr Skill etwas
+Zeitabhängiges, und dann ist keine Signatur der Welt eine Aussage über den Inhalt.
+
+```bash
+skillctl pack --skill ./src/hello-kup -o probe.skb --name hello-kup --version 0.1.0 \
+  --summary "Uebungsskill" --author-intent green \
+  --author-intent-rationale "kein Netzwerk; schreibt nur ./out" >/dev/null
+shasum -a 256 hello-kup@0.1.0.skb probe.skb
+rm -f probe.skb
+```
+
+Erwartet: zweimal derselbe Hash.
+
+### 1.6 Das Freigabe-Tor des Autors
+
+Bevor Sie jemandem etwas vorlegen, lassen Sie die Selbstprüfung laufen. Sie braucht den Skill
+an seinem normalen Ort:
+
+```bash
+mkdir -p "$WS/home/.claude/skills/hello-kup"
+tar -xzf hello-kup@0.1.0.skb -C "$WS/home/.claude/skills/hello-kup"
+HOME="$WS/home" skillctl propose hello-kup --dry-run --intent green
+```
+
+Ausgabe: eine Tabelle mit elf Prüfungen. In diesem Übungsskill schlägt `#9 smoke-test marker`
+fehl, weil es kein `tests/smoke.sh` gibt. Das ist der beabsichtigte Anblick: das Tor sagt
+Ihnen, was fehlt, bevor ein Mensch seine Zeit darauf verwendet.
+
+> Zwei Dinge dazu. Mit `--dry-run` ist der Prozess-Exit **immer** `0`, lesen Sie die Tabelle,
+> nicht den Exit-Code; ohne `--dry-run` bedeutet `2`, dass das Tor gehalten hat.
+> Und `tar -xzf` ist hier nur ein Übungsgriff: ein von Hand entpackter Skill ist danach für
+> `skillctl verify` unsichtbar (siehe Teil 3.3).
+
+### 1.7 Die beiden Ablehnungen, die Sie kennen müssen
+
+Zuerst der Unfall: jemand ändert das Bundle nach dem Signieren.
+
+```bash
+cp hello-kup@0.1.0.skb kaputt.skb
+printf '\xff' | dd of=kaputt.skb bs=1 seek=200 count=1 conv=notrunc 2>/dev/null
+skillctl verify-sig --pubkey "$WS/keys/mitarbeiter.pub" kaputt.skb
+echo "rc=$?"
+```
+
+Erwartet: `signature file not found …`, `rc=1`. Die Begründung ist wörtlich zu nehmen: der
+Name der Signaturdatei enthält den Digest, und zu diesen neuen Bytes existiert schlicht keine
+Signatur.
+
+Jetzt der Angriff: derselbe Byte-Tausch, aber der Angreifer benennt die Originalsignatur so
+um, dass sie zu den neuen Bytes zu gehören scheint.
+
+```bash
+cp hello-kup@0.1.0.skb boese.skb
+SIZE=$(wc -c < boese.skb | tr -d ' ')
+printf '\xff' | dd of=boese.skb bs=1 seek=$((SIZE / 2)) count=1 conv=notrunc 2>/dev/null
+BOESE_DIGEST=$(shasum -a 256 boese.skb | awk '{print $1}')
+cp "hello-kup@0.1.0.skb.${DIGEST#sha256:}.author.sig" "boese.skb.${BOESE_DIGEST}.author.sig"
+
+skillctl verify-sig --pubkey "$WS/keys/mitarbeiter.pub" boese.skb
+echo "rc=$?"
+```
+
+Erwartet: `signature is invalid …`, `rc=11`. Das ist der Fall, für den die Kryptografie da
+ist: eine Signatur, die behauptet, zu diesen Bytes zu gehören, und es nicht tut.
+
+**Der Unterschied ist wichtig.** `1` heißt „zu diesen Bytes gibt es keine Signatur", `11`
+heißt „die vorgelegte Signatur ist falsch". Beide sind korrekte Verweigerungen, sie begründen
+nur Verschiedenes. Wer für einen Nachweis nur `verify-sig` gegen ein verändertes Bundle
+laufen lässt, bekommt in der Regel `1` und dokumentiert damit etwas anderes, als er glaubt.
+
+### 1.9 Kür: die ganze Kette offline, mit echtem Registry
+
+Der Trockenlauf oben endet bei der Signatur. Wenn Sie zehn Minuten mehr haben, bauen Sie das
+komplette Registry auf der Platte: **derselbe Code-Pfad wie GitLab**, nur ohne Remote. Damit
+haben Sie den Produktivablauf einmal ganz gesehen, bevor Sie ihn gegen einen Server fahren.
+
+```bash
+cd "$WS"
+skillctl keygen --out "$WS/keys/eric-herausgeber"
+skillctl registry init --registry "local://$WS/registry.git"
+
+# Eric nimmt das Bundle des Mitarbeiters auf:
+skillctl publish hello-kup@0.1.0 --bundle hello-kup@0.1.0.skb --version 0.1.0 \
+  --registry "local://$WS/registry.git" \
+  --key "$WS/keys/eric-herausgeber.priv" --identity id:eric@kup --yes
+
+# Eric attestiert, mit dem ANDEREN Schlüssel:
+skillctl publish --attest hello-kup@0.1.0 --digest "$DIGEST" --level green \
+  --rationale "geprueft im Trockenlauf" \
+  --registry "local://$WS/registry.git" \
+  --identity id:eric-reviewer@kup --key "$WS/keys/eric-reviewer.priv" --yes
+
+skillctl registry ls --registry "local://$WS/registry.git"
+```
+
+Erwartet: eine Zeile `hello-kup  0.1.0  sha256:…  green  ok`.
+
+Jetzt die Konsumentenseite, in einem eigenen Zuhause:
+
+```bash
+mkdir -p "$WS/kunde/.claude"
+cat > "$WS/kunde/.claude/trust-roots.yaml" <<YAML
+registry: local://$WS/registry.git
+pubkey_b64: $(openssl pkey -pubin -in "$WS/keys/eric-herausgeber.pub" -outform DER | tail -c 32 | base64)
+fingerprint: sha256:$(openssl pkey -pubin -in "$WS/keys/eric-herausgeber.pub" -outform DER | tail -c 32 | shasum -a 256 | awk '{print $1}')
+governance_minimum: green
+governance_quorum: 1
+signers:
+  - reviewer_id: id:eric-reviewer@kup
+    pubkey_b64: $(openssl pkey -pubin -in "$WS/keys/eric-reviewer.pub" -outform DER | tail -c 32 | base64)
+YAML
+
+HOME="$WS/kunde" skillctl pull --registry "local://$WS/registry.git" --skill hello-kup \
+  --install --trust-mode --dry-run-install --no-checkpoint
+```
+
+Erwartet: `✅ hello-kup@0.1.0 … gov=green` und ein Token mit fünf Minuten Gültigkeit.
+Mit `--confirm-install --dry-run-install-token <TOK>` landet der Skill unter
+`$WS/kunde/.claude/skills/hello-kup/`, mit `.m3c-provenance.json` und `.skillctl-attest.json`.
+
+**Und jetzt die lehrreiche Variante.** Löschen Sie den `signers:`-Block aus der
+`trust-roots.yaml` und wiederholen Sie den Pull:
+
+```
+❌ hello-kup@0.1.0  [gate 4: no attestation at or above the trust-roots governance_minimum]
+```
+
+Die Attestierung liegt im Repository, sie ist gültig, und sie zählt trotzdem nicht: der
+Konsument hat diesen Reviewer nicht gepinnt. Das ist keine Panne, das ist die Aussage des
+Systems. Vertrauen entsteht beim Empfänger, nicht beim Sender.
+
+### 1.8 Aufräumen
+
+```bash
+cd ~ && rm -rf "$WS"
+```
+
+(Damit ist auch das Übungs-Registry weg. Es lag ausschliesslich unter `$WS`.)
+
+Damit ist der Trockenlauf abgeschlossen. Sie haben eine Versiegelung erzeugt, sie geprüft,
+und zwei Arten von Ablehnung mit echten Exit-Codes gesehen.
+
+---
+
+## Teil 2: der echte Vorgang (Produktion: das Git-Registry)
+
+Drei Bahnen: Mitarbeiter, Eric, Konsument. **Produktiv ist das Registry ein Git-Repository.**
+Die Kommandos unten benutzen `github://<owner>/<repo>`, weil das der Locator ist, der heute
+belastbar läuft. Die interne GitLab-Instanz (`gitlab://<host>/<gruppe>/<projekt>`) ist
+dieselbe Mechanik und derselbe Backend-Kern; sobald deren Sync steht, ändert sich genau zwei
+Dinge: der `--registry`-Wert und der Name der Token-Variable. Der ER1-Weg steht in Anhang A
+und ist der **Testpfad**.
+
+Warum ein Git-Repository ein gutes Registry ist: das Layout ist lesbar und reviewbar, jede
+Aufnahme und jedes Urteil ist ein Commit, und die Historie ist genau das Audit-Log, das
+sonst gebaut werden müsste.
+
+```
+skills/<name>/<version>/bundle.skb     das versiegelte Bundle (sha256 == Digest)
+skills/<name>/<version>/bundle.json    das entpackte Manifest, zum Nachlesen im Merge Request
+events/<digesthex>/<seq>-<kind>.json   die signierten Ereignisse: admit, attest, revoke
+```
+
+Die Rollenteilung ist die, die auch organisatorisch gilt:
+
+| Rolle | Wer | Was er tut | Sein Schlüssel |
+|---|---|---|---|
+| **Autor** | der Mitarbeiter | packt und versiegelt | eigener Autorenschlüssel |
+| **Freigeber und Herausgeber** | Eric | prüft, nimmt auf, attestiert | Herausgeberschlüssel und Reviewer-Schlüssel |
+| **Konsument** | Dritte | zieht und installiert | kein Schlüssel, nur ein Pin auf das Registry |
+
+Der Mitarbeiter publiziert **nicht selbst**, und er braucht keinen Schreibzugriff auf das
+Repository. Das ist keine Einschränkung, sondern der Punkt.
+
+### Vorbereitung: das Registry und der Token
+
+Das Repository legt ein Mensch an: leer, **privat** (es wird das Audit-Log), Default-Branch
+geschützt. Schreibrecht auf den Default-Branch hat nur der Herausgeber.
+
+```bash
+# Schreibtoken, nur der Herausgeber braucht ihn (GitHub: PAT mit repo-Schreibrecht):
+export M3C_GITHUB_TOKEN="<personal access token>"
+
+# Optional, empfohlen: ein getrennter Lesetoken für Konsumenten,
+# damit ein Pull nie den Schreibtoken überträgt.
+export M3C_GITHUB_RO_TOKEN="<read token>"
+
+export REG="github://<owner>/<repo>"
+```
+
+Auf macOS gehen beide auch in die Keychain, unter den Dienstnamen `m3c-skillctl-github` und
+`m3c-skillctl-github-ro`; `skillctl` liest die Umgebungsvariable zuerst, dann die Keychain.
+
+> **Für die interne GitLab-Instanz**, sobald deren Sync steht: `export
+> REG="gitlab://<host>/<gruppe>/<projekt>"` und die Variablen heissen `M3C_GITLAB_TOKEN` /
+> `M3C_GITLAB_RO_TOKEN` (Keychain: `m3c-skillctl-gitlab[-ro]`). Dort braucht der Schreibpfad
+> ein **Project Access Token** oder einen PAT, **kein Deploy Token**: GitLab kennt
+> `write_repository` als Deploy-Token-Scope nicht. Eine selbstgehostete Instanz ohne TLS im
+> LAN erreichen Sie mit `M3C_GIT_HTTP=1`. Alles andere in diesem Tutorial bleibt Wort für
+> Wort gleich.
+
+### Bahn 1: der Mitarbeiter (Autor)
+
+```bash
+# M1. Einmalig: Schlüssel. Der private Teil verlässt diese Maschine nie.
+mkdir -p ~/.config/m3c/skill-keys
+skillctl keygen --out ~/.config/m3c/skill-keys/mitarbeiter
+
+# M2. Fingerprint und Rohschlüssel, für Punkt 7 aus Teil 0.
+openssl pkey -pubin -in ~/.config/m3c/skill-keys/mitarbeiter.pub -outform DER \
+  | tail -c 32 | base64
+openssl pkey -pubin -in ~/.config/m3c/skill-keys/mitarbeiter.pub -outform DER \
+  | tail -c 32 | shasum -a 256
+
+# M3. Selbstprüfung, bevor Eric Zeit investiert.
+skillctl propose <skill-name> --intent green
+#   Exit 0: das Tor hält. Exit 2: es hat gegriffen, die FAIL-Zeilen abarbeiten.
+
+# M4. Packen und signieren.
+skillctl pack --skill ~/.claude/skills/<skill-name> \
+  -o <skill-name>@<version>.skb \
+  --name <skill-name> --version <version> \
+  --summary "<ein Satz>" \
+  --author-intent green --author-intent-rationale "<warum harmlos>"
+
+SIGN_OUT=$(skillctl sign --key ~/.config/m3c/skill-keys/mitarbeiter.priv \
+  --identity-id id:mitarbeiter@kup <skill-name>@<version>.skb)
+DIGEST="sha256:$(echo "$SIGN_OUT" | awk '/^digest:/ {print $2}')"
+echo "$DIGEST"
+
+# M5. Selbst gegenprüfen.
+skillctl verify-sig --pubkey ~/.config/m3c/skill-keys/mitarbeiter.pub \
+  <skill-name>@<version>.skb        # -> 0
+```
+
+**Was Sie Eric übergeben, und auf welchem Weg:**
+
+| Was | Weg | Warum |
+|---|---|---|
+| `<skill-name>@<version>.skb` **und** die `.author.sig` daneben | beliebig (Mail, Freigabe, Ticket, Merge Request) | der Transportweg muss nicht vertrauenswürdig sein, beide Dateien werden gebraucht |
+| Der Digest aus M4 | derselbe Weg, aber **zusätzlich vorgelesen** | Eric muss prüfen, worüber er urteilt |
+| Ihr Fingerprint aus M2 | **anderer Kanal**, einmalig | siehe Teil 0, Punkt 7 |
+| Was der Skill tut, welche Daten er anfasst, was er ins Netz schickt | Text, Ticket, Merge Request | das ist der Gegenstand der Prüfung, nicht die Signatur |
+
+### Bahn 2: Eric (Freigeber und Herausgeber)
+
+```bash
+# E1. Einmalig: zwei Schlüssel mit zwei Aufgaben.
+skillctl keygen --out ~/.config/m3c/skill-keys/eric-herausgeber
+skillctl keygen --out ~/.config/m3c/skill-keys/eric-reviewer
+
+# E2. Die Autorensignatur des Mitarbeiters prüfen. Vorher muss der Fingerprint
+#     aus M2 über den zweiten Kanal bestätigt sein.
+skillctl verify-sig --pubkey ./mitarbeiter.pub <skill-name>@<version>.skb
+echo "rc=$?"        # 0, sonst hier abbrechen und nichts aufnehmen
+
+# E3. Über denselben Digest urteilen, den der Mitarbeiter genannt hat.
+shasum -a 256 <skill-name>@<version>.skb
+```
+
+**E4, die eigentliche Prüfung.** Nicht automatisierbar, und der Punkt der Übung:
+
+```bash
+mkdir -p /tmp/review-<skill-name>
+tar -xzf <skill-name>@<version>.skb -C /tmp/review-<skill-name>
+ls -R /tmp/review-<skill-name>
+cat /tmp/review-<skill-name>/SKILL.md
+```
+
+Worauf zu achten ist: Was liest der Skill, was schreibt er, wohin schickt er etwas? Steht in
+`SKILL.md` etwas anderes, als die Skripte tun? Enthält das Bundle Zugangsdaten, Tokens,
+Kundendaten? Passen die deklarierten Abhängigkeiten zu dem, was aufgerufen wird? Und die
+Frage, die keine Signatur beantwortet: **wollen wir, dass dieser Skill im Unternehmen läuft?**
+
+**E5. Aufnehmen (Admit).** Erst jetzt, und nur wenn E2 und E4 sauber waren:
+
+```bash
+skillctl publish <skill-name>@<version> \
+  --bundle <skill-name>@<version>.skb \
+  --version <version> \
+  --registry "$REG" \
+  --key ~/.config/m3c/skill-keys/eric-herausgeber.priv \
+  --identity id:eric@kup \
+  --yes
+```
+
+Erwartete Ausgabe: `==> admitted: <name>/v<version>  transport=git  registry=<REG>`. Im
+Repository stehen danach ein Commit mit dem Bundle und einer unter `events/<digesthex>/`.
+
+**E6. Attestieren, mit dem Reviewer-Schlüssel:**
+
+```bash
+skillctl publish --attest <skill-name>@<version> \
+  --digest "$DIGEST" \
+  --level green \
+  --rationale "geprüft am <datum>; Autorensignatur id:mitarbeiter@kup verifiziert; kein Netzwerkzugriff; schreibt nur unter ./out" \
+  --registry "$REG" \
+  --identity id:eric-reviewer@kup \
+  --key ~/.config/m3c/skill-keys/eric-reviewer.priv \
+  --yes
+```
+
+**E7. Kontrollieren, was im Registry steht:**
+
+```bash
+skillctl registry ls --registry "$REG"
+skillctl registry show <skill-name> --registry "$REG"
+```
+
+`registry ls` muss den Skill mit `gov=green` und `status=ok` zeigen. Steht dort `gov=` leer
+oder `status` anders, fehlt die Attestierung, und kein Konsument wird installieren können.
+
+Die drei Stufen bedeuten: **green** freigegeben, **yellow** mit Auflagen, **red** abgelehnt.
+Ein `red` ist kein Scheitern des Vorgangs, es ist sein Funktionieren.
+
+### Bahn 3: der Konsument
+
+Der Konsument pinnt **das Registry**, und zwar von Hand, in `~/.claude/trust-roots.yaml`:
+
+```yaml
+registry: github://<owner>/<repo>
+pubkey_b64: <Erics Herausgeberschlüssel, roh, base64>
+fingerprint: sha256:<über den zweiten Kanal bestätigt>
+governance_minimum: green
+governance_quorum: 1
+signers:
+  - reviewer_id: id:eric-reviewer@kup
+    pubkey_b64: <Erics Reviewer-Schlüssel, roh, base64>
+```
+
+> **Warum von Hand und nicht mit `skillctl peer add`.** `peer add` erzwingt den
+> Out-of-Band-Pin (es verweigert, wenn `--pin` nicht zum `--pubkey` passt) und wäre die
+> schönere Form. Es kann heute aber **keinen Reviewer-Schlüssel ausdrücken**: ein gepinnter
+> Peer trägt genau einen Schlüssel, und der Pull weist die Attestierung dann mit
+> `gate 4: no attestation at or above the trust-roots governance_minimum` ab, obwohl sie im
+> Repository liegt (nachgemessen, Prozess-Exit `1`). Solange das so ist, ist die
+> handgeschriebene Datei der Weg, und der Fingerprint-Vergleich ist Ihre Aufgabe, nicht die
+> des Werkzeugs. Wer Herausgeber und Reviewer bewusst mit **einem** Schlüssel fährt, kann
+> `peer add` benutzen und `signers` weglassen.
+
+```bash
+# K1. Nur Lesetoken setzen. Ein Konsument braucht keinen Schreibzugriff.
+export M3C_GITHUB_RO_TOKEN="<read token>"
+export REG="github://<owner>/<repo>"
+
+# K2. Plan ansehen (G-23, Schritt 1).
+skillctl pull --registry "$REG" --skill <skill-name> \
+  --install --trust-mode --dry-run-install --no-checkpoint
+#   -> "✅ <name>@<version> … gov=green" und
+#      "dry-run-install token (5-minute TTL): <TOK>"
+
+# K3. Bestätigen (G-23, Schritt 2). Kein --key, kein --emit-installed.
+skillctl pull --registry "$REG" --skill <skill-name> \
+  --install --trust-mode \
+  --confirm-install --dry-run-install-token <TOK> --no-checkpoint
+```
+
+Installiert wird unter `~/.claude/skills/<name>/`, mit `.m3c-provenance.json` und
+`.skillctl-attest.json` daneben: die signierten Ereignisse werden mitgelegt, damit das
+Laufzeit-Tor später auch offline gegen den gepinnten Schlüssel nachrechnen kann.
+
+Dabei laufen fünf Tore: Envelope-Signatur, nicht widerrufen, Governance-Schwelle, Digest,
+Bundle-Signaturen. Was eine Ablehnung bedeutet:
+
+| Zeile bzw. Code | Bedeutung | Wer ist am Zug |
+|---|---|---|
+| `✅ … gov=green` | alle Tore bestanden | n/a |
+| `gate 1: envelope` | Ereignis nicht vom gepinnten Schlüssel signiert | falscher Pin, oder das Repository ist nicht das, für das Sie es halten |
+| `gate 4: no attestation …` | keine gültige Attestierung ≥ Schwelle | E6 fehlt, oder der Reviewer-Schlüssel steht nicht unter `signers:` |
+| `gate 5: revoked` | widerrufen | nicht installieren |
+| `gate 2/3: digest` bzw. `bundle sigs` | Bytes oder Signatur passen nicht | Bundle neu beziehen, nicht weitermachen |
+
+**Achtung beim Skripten:** ein Pull, der alle Bundles verwirft, endet mit Prozess-Exit `1`
+und der Zeile `NOT installing: N bundle(s) were skipped`. Ein Pull, der **nichts** zu tun
+findet, endet mit `0`. Prüfen Sie in Automatisierungen die `✅`-Zeilen, nicht nur den Code.
+
+### Der Weg ohne Netz: erst lokal, dann hochschieben
+
+Sie können das gesamte Registry offline aufbauen und später nach GitLab spiegeln. Der
+Code-Pfad ist derselbe, nur der Locator ändert sich:
+
+```bash
+skillctl registry init --registry local://$HOME/skill-registry.git
+skillctl publish <name>@<ver> --bundle <name>@<ver>.skb --version <ver> \
+  --registry local://$HOME/skill-registry.git --key <herausgeber.priv> --identity id:eric@kup --yes
+# ... admit + attest wie oben ...
+
+git -C "$HOME/skill-registry.git" push --mirror https://github.com/<owner>/<repo>.git
+```
+
+Für eine Übergabe ohne jeden Server gibt es zusätzlich
+`skillctl registry export --registry local://<pfad> --out <datei.bundle>`: eine einzige
+Datei, aus der ein Empfänger mit `pull --registry local://<datei.bundle>` zieht, mit
+demselben Torlauf.
+
+### Was der Konsument dabei prüft, und was nicht
+
+Sagen Sie es genau, sonst verspricht die Kette mehr, als sie hält:
+
+- **Geprüft:** dass Eric dieses Bundle aufgenommen hat (Herausgebersignatur über den Digest),
+  dass ein gepinnter Reviewer-Schlüssel grün attestiert hat, dass die Bytes unverändert sind,
+  dass zu diesem Digest kein Widerruf im Repository liegt.
+- **Nicht geprüft:** die Autorensignatur des **Mitarbeiters**. Der Herausgeber signiert beide
+  Rollen (Autor und Registry) mit seinem Schlüssel, und die losgelöste `.author.sig` des
+  Mitarbeiters reist nicht mit ins Repository. Die Urheberangabe steht im Bundle und ist
+  durch Erics Signatur gegen Veränderung geschützt, aber **wer den Skill wirklich geschrieben
+  hat, hat Eric in E2 geprüft, nicht der Konsument.**
+
+Genau deshalb ist E2 kein Formalismus. Der Konsument vertraut Eric; Eric vertraut niemandem,
+sondern rechnet nach.
+
+### Nach der Installation, heute noch eine Baustelle
+
+Zwei Dinge, die Sie wissen müssen, bevor Sie den Betrieb darauf aufsetzen:
+
+- `skillctl verify <name>` und `verify --offline <name>` antworten nach einer Installation aus
+  einem Git-Registry mit „trust roots not configured; run `skillctl trust add …`" und zeigen
+  auf `~/.claude/skill-trust-roots.yaml`, also auf die Datei des HTTP-Modells. Das Nachprüfen
+  eines installierten Skills ist an dieses Modell gebunden und für Peer- und Git-Registries
+  noch nicht verdrahtet. Der belastbare Nachweis bleibt vorerst der Pull selbst (die
+  `✅`-Zeilen) plus `skillctl registry show`.
+- `skillctl verify --all` fällt unter verwalteten Trust-Roots ohne erreichbare
+  Revocation-Quelle **fail-closed** und würde installierte Skills quarantänisieren. Bevor der
+  Sweep in den Alltag geht, muss der Widerrufskanal stehen; bis dahin ohne `--quarantine`
+  laufen lassen und die Ausgabe lesen.
+
+## Teil 3: drei Dinge, die dieses Tutorial nicht verschweigt
+
+### 3.1 Eine Signatur ist keine Unbedenklichkeitsbescheinigung
+
+Sie sagt: „diese Bytes hat dieser Schlüssel versiegelt". Sie sagt nicht, dass der Inhalt
+harmlos ist. Ein perfekt signierter Skill kann Daten abziehen. Genau deshalb steht in Bahn 2
+ein Mensch mit einer Attestierung, und deshalb ist E5 der Teil, den man nicht abkürzen darf.
+
+### 3.2 Der Weg „signiertes .skb per Mail" ist ein Notweg
+
+Die vollständige Kette prüft mehr als die Autorensignatur: Registry-Signatur, Bundle-Status,
+Governance-Level, Tenant-Scope. Offline und ohne Registry können Sie davon nur die
+Autorensignatur prüfen. Der dafür vorgesehene portable Weg (`skillctl verify --bundle` mit
+einer `BundleMeta`-Hülle, oder ein `export-verification-kit`) setzt voraus, dass das Bundle
+einmal durch ein Registry gelaufen ist: die Hülle `<name>.skbmeta.json` entsteht beim Admit.
+Ein frisch gepacktes, sauber signiertes Bundle lässt sich heute nicht in ein solches Kit
+verwandeln.
+
+### 3.3 Von Hand entpackte Skills sind stumm
+
+`tar -xzf` funktioniert, aber danach antwortet `skillctl verify <name>` mit „no .skb found …
+(was this skill installed by skillctl install?)", und `verify --offline <name>` findet keine
+hinterlegten Metadaten. Damit fällt der Skill aus dem Sweep `verify --all` und aus dem Gate
+heraus. Für die Prüfung in E5 ist Entpacken richtig, für eine Installation nicht.
+
+---
+
+## Teil 4: die Abnahme
+
+Der Vorgang gilt als bestanden, wenn diese vier Punkte belegt sind, jeder mit einer Ausgabe,
+nicht mit einer Einschätzung:
+
+| # | Kriterium | Beleg |
+|---|---|---|
+| 1 | Der Mitarbeiter hat authentisch versiegelt | M5 und E2 `verify-sig` rc=0, und der Digest aus M4 ist derselbe, über den Eric in E6 geurteilt hat |
+| 2 | Ein Zweiter hat geprüft | E2 rc=0 (Eric hat die Autorensignatur selbst verifiziert), E6 angenommen mit einer `--identity` ungleich der aus M4, und E7 zeigt `gov=green status=ok` |
+| 3 | Ein Dritter kann installieren | K2 zeigt `✅ … gov=green`, K3 installiert mit Provenienz-Datei |
+| 4 | Ein manipuliertes Bundle wird abgelehnt | Trockenlauf 1.7, rc=11 mit umbenannter Signatur |
+
+Die Evidenz in eine Datei, die man in sechs Monaten noch lesen kann:
+
+```bash
+{
+  echo "Datum:      $(date -u +%FT%TZ)"
+  echo "Host:       $(hostname)"
+  skillctl version
+  echo "Autor:      id:mitarbeiter@kup"
+  echo "Registry:   $REG"
+  echo "Herausgeber: id:eric@kup"
+  echo "Reviewer:   id:eric-reviewer@kup"
+  echo "Digest:     $DIGEST"
+  echo "Fingerprint bestätigt über: <Telefon / Videocall / persönlich>, am <datum>"
+  skillctl trust list
+} | tee ~/szenario-02-evidenz.txt
+```
+
+Der Fingerprint-Kanal gehört ins Protokoll. Ein Pin, bei dem nicht steht, **wie** er bestätigt
+wurde, ist kein Pin, sondern Vertrauen beim ersten Anblick mit besserer Presse.
+
+---
+
+## Anhang A: derselbe Vorgang über ER1 `self` (der Testpfad)
+
+ER1 `self` ist der Weg zum **Testen** und für Einzelnutzer ohne Git-Registry. Die Rollen, die
+Prüfung und die Trust-Roots-Datei bleiben identisch; es ändern sich nur drei Kommandos und
+die Adressierung des Registry.
+
+```bash
+# Einmalig auf jeder beteiligten Maschine:
+skillctl login --base-url https://onboarding.guide
+skillctl login --status
+
+# E5 (Admit) und E6 (Attest) laufen gegen den eigenen ER1-Kontext:
+skillctl publish <skill-name>@<version> --bundle <skill-name>@<version>.skb \
+  --registry self --er1-target prod --er1-context skills \
+  --key ~/.config/m3c/skill-keys/eric-herausgeber.priv --identity id:eric@kup --yes
+
+skillctl publish --attest <skill-name>@<version> --digest "$DIGEST" --level green \
+  --rationale "geprüft am <datum>" \
+  --registry self --er1-target prod --er1-context skills \
+  --identity id:eric-reviewer@kup --key ~/.config/m3c/skill-keys/eric-reviewer.priv --yes
+
+# Sichtbar machen, damit der Konsument es findet:
+skillctl room share <skill-name> --room <raum-label> --yes
+
+# K2/K3 beim Konsumenten, aus ERICS Kontext:
+skillctl pull --registry self --er1-target prod --er1-context <eric-sub>___skills \
+  --skill <skill-name> --install --trust-mode --dry-run-install --no-checkpoint
+```
+
+In der `trust-roots.yaml` steht dann `registry: self` statt des Git-Locators; der
+`signers:`-Block bleibt unverändert nötig, wenn Herausgeber und Reviewer verschiedene
+Schlüssel benutzen.
+
+Drei Eigenheiten dieses Pfades, die auf Git nicht existieren: `publish` schreibt **immer** in
+den eigenen Kontext (ein Publish in einen fremden endet mit `403`), die Raum-Mitgliedschaft
+wird serverseitig in der Konsole eingerichtet (es gibt kein `skillctl`-Verb dafür), und der
+Kontextname des Herausgebers muss dem Konsumenten exakt bekannt sein. Der ausführliche
+Zwei-Personen-Ablauf steht im
+[Runbook Zwei-Personen-Austausch](runbook-two-person-er1-exchange.md).
+
+## Anhang B: das HTTP-Registry `/api/skills`, und warum es hier nicht der Hauptweg ist
+
+Neben dem ER1-`self`-Registry (Memory-Layer, `publish` / `pull`) hat aims-core ein zweites
+Registry-Gesicht: das Modul `skill_registry` unter `<base>/api/skills`. Das ist **kein
+zweiter Server**, es ist eine zweite API auf demselben Dienst, und sie läuft in Produktion:
+`GET https://onboarding.guide/api/skills/health` antwortet mit
+`{"module":"skill_registry","status":"healthy"}`. Für dieses Gesicht gelten die Kommandos
+`skillctl trust add`, `install`, `attest` und die Datei `~/.claude/skill-trust-roots.yaml`.
+
+Trotzdem steht in Teil 2 der ER1-Weg, und zwar aus einem messbaren Grund: **`skillctl` kann
+sich an `/api/skills` heute nicht anmelden.** Die Produktivinstanz antwortet auf
+`/api/skills/bundles`, `/identities` und `/attestations` mit `401 AUTH_REQUIRED`, während der
+Registry-Client (`pkg/skillctl/registry/client.go`) und `skillctl attest`
+(`cmd/skillctl/attest_cmds.go`) ausschließlich `Content-Type`, `Accept` und `User-Agent`
+senden. Es gibt keinen Header und keine Umgebungsvariable für ein Token. Der Weg funktioniert
+deshalb heute nur gegen eine Instanz, die diese Endpunkte ohne Client-Auth bedient, etwa die
+lokale Docker-Instanz aus `demo/kup-training/`.
+
+Wo dieser Weg läuft, ist er die sauberere Form von Teil 2, weil der Reviewer dort **selbst**
+postet und der Umweg über Eric als Herausgeber entfällt:
+
+```bash
+# Reviewer, gegen eine Instanz, die den Endpunkt ohne Client-Auth bedient:
+skillctl attest "$DIGEST" --level green \
+  --rationale "geprüft am <datum>" \
+  --reviewer-id id:eric@kup --author-id id:mitarbeiter@kup \
+  --key ~/.config/m3c/skill-keys/eric-reviewer.priv \
+  --registry https://<host>/api/skills
+
+# Konsument:
+skillctl trust add --registry https://<host>/api/skills --pubkey ./registry.pub
+skillctl install <skill-name>@<version>
+```
+
+`--author-id` ist dabei nicht Kosmetik: damit greift die Prüfung „Reviewer ist nicht Autor"
+auch dann, wenn der Admit-Datensatz gerade nicht erreichbar ist. Antwortet das Registry mit
+`19 identity_mismatch`, ist Punkt 4 aus Teil 0 offen: die Reviewer-Identität ist dort noch
+nicht registriert (`POST /api/skills/identities`, Vorlage
+`demo/kup-training/register-identity.sh`).
+
+## Anhang C: Windows
+
+- Pfade: `%USERPROFILE%\.claude\skill-trust-roots.yaml` statt `~/.claude/…`.
+- Ein ausgelieferter Windows-Build ignoriert `$HOME` für sicherheitsrelevante Pfade
+  absichtlich und liest `%USERPROFILE%`. Der Sandkasten aus Teil 1 muss dort über
+  `$env:USERPROFILE` gebaut werden.
+- Statt `shasum -a 256` nehmen Sie `Get-FileHash -Algorithm SHA256`.
+- Installation über die PowerShell-Einzeile aus [Quickstart §1](quickstart-skillctl.md#1-install).
+
+---
+
+## Wie es weitergeht
+
+- Eigene Skills auf mehreren Maschinen: [Szenario 01](tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md)
+- Üben, bis es sitzt: [Katas und Test Ride](tutorial-katas-und-test-ride.de.md)
+- Jedes Kommando, jedes Flag, jeder Exit-Code: [Manual](manual-skillctl.md)


### PR DESCRIPTION
Drei deutsche Tutorials, jedes in sich geschlossen und per Copy-Paste nachspielbar. Sie beantworten die Frage, die bisher nur verstreut beantwortet war: **was muss ein Nutzer tun, bevor er den ersten Skill signiert und veroeffentlicht?**

| Dokument | Inhalt |
|---|---|
| `tutorial-szenario-01-…` | Ein Prinzipal, mehrere Maschinen. Signierstation, zweite Maschine, fremde Skills per Re-Admit ins eigene Registry, Gate scharfschalten, Widerruf. |
| `tutorial-szenario-02-…` | Autor, Freigeber, Konsument. Teil 1 ist ein **vollstaendig offline lauffaehiger Trockenlauf** inklusive beider Ablehnungen und einer Kuer, die ein echtes `local://`-Registry aufbaut. Teil 2 ist der Produktivweg ueber ein Git-Registry. |
| `tutorial-katas-und-test-ride…` | Die vier Stufen, `demo/kup-training` Schritt fuer Schritt, die fuenf Katas, ein Kohorten-Ablauf. |

## Jedes Kommando ist gemessen, nicht abgeleitet

Der Ablauf wurde gegen einen echten `skillctl`-Build in einer Wegwerf-Sandbox durchgespielt, einschliesslich der kompletten Kette gegen ein bares `local://`-Repo (`registry init` → `pack` → `sign` → `publish` → `publish --attest` → `pull --install`). Vier Fallen, die sich dabei zeigten, stehen im **Haupttext** statt im Kleingedruckten, und jede hat ein eigenes Ticket:

- `pack` und `sign` melden zwei verschiedene Digests, ohne zu sagen welcher gilt (#200)
- `export-verification-kit` verlangt genau die Datei, die es laut Fehlertext erzeugt (#201)
- `peer add` kann keinen getrennten Reviewer-Schluessel ausdruecken (#196)
- `verify <name>` ist nach einem Pull aus einem Git-Registry nicht verdrahtet (#197)

Dazu #198 (HTTP-Registry-Client ohne Authentifizierung) und #199 (Smoke-Gate gegen Drift dieser Tutorials).

## Nur Dokumentation

Keine Code-Aenderung. `check-no-emdash`, `docaudit` und `verbaudit` sind gruen.

Spec: SPEC-0407 auf der privaten Wartungsebene, aus WF-003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)