### PR TITLE
feat(peer): --signer und --quorum, damit ein Peer den Reviewer benennen kann (FR-0115)

### DIFF
--- a/cmd/skillctl/peer_cmds.go
+++ b/cmd/skillctl/peer_cmds.go
@@ -3,6 +3,7 @@ package main
 // `skillctl peer`: SPEC-0359 D2 peer discovery + trust pinning.
 //
 //	peer add <name> <locator> --pubkey <b64> --pin sha256:<hex> [--floor green|yellow]
+//	                          [--signer <reviewer-id>:<b64>]... [--quorum <n>]
 //	peer ls
 //	peer verify <name>          # dry-run the §7 gauntlet against the peer's pinned key
 //	peer rm <name>
@@ -71,6 +72,9 @@ func runPeerAdd(args []string, stdout, stderr io.Writer) int {
 	pin := fs.String("pin", "", "Peer's trust-root fingerprint sha256:<hex> (verified out-of-band; REQUIRED).")
 	floor := fs.String("floor", "green", "governance_minimum for this peer: green | yellow.")
 	contributes := fs.Bool("contributes-revokes", false, "Union this peer's SIGNED revoke events into the local revoked set (`revoke feed --gossip`). Set ONLY for a governance-trusted peer: bounds revoke-DoS.")
+	var signers multiFlag
+	fs.Var(&signers, "signer", "Reviewer whose attestations count for this peer, as <reviewer-id>:<pubkey_b64> (repeatable). Omit when the publisher and the reviewer are the same key.")
+	quorum := fs.Int("quorum", 0, "Number of DISTINCT pinned signers that must attest at or above the floor (default 1). Requires at least that many --signer entries.")
 	if err := fs.Parse(reorderFlagArgs(fs, args)); err != nil {
 		return 2
 	}
@@ -100,7 +104,20 @@ func runPeerAdd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "peer add: %v\n", err)
 		return 1
 	}
-	pe := registry.Peer{Name: name, Locator: locator, PubKeyB64: *pubB64, Fingerprint: *pin, GovernanceMinimum: *floor, ContributesRevokes: *contributes}
+	parsed, perr := parseSignerFlags(signers)
+	if perr != nil {
+		fmt.Fprintf(stderr, "peer add: %v\n", perr)
+		return 2
+	}
+	if *quorum > 1 && len(parsed) < *quorum {
+		fmt.Fprintf(stderr, "peer add: --quorum %d needs at least %d --signer entries, got %d\n", *quorum, *quorum, len(parsed))
+		return 2
+	}
+	pe := registry.Peer{
+		Name: name, Locator: locator, PubKeyB64: *pubB64, Fingerprint: *pin,
+		GovernanceMinimum: *floor, ContributesRevokes: *contributes,
+		GovernanceQuorum: *quorum, Signers: parsed,
+	}
 	if err := peers.AddPeer(pe); err != nil {
 		fmt.Fprintf(stderr, "peer add: %v\n", err)
 		return 1
@@ -111,8 +128,45 @@ func runPeerAdd(args []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "pinned peer %q → %s\n", name, locator)
 	fmt.Fprintf(stdout, "  fingerprint: %s (matched)\n", pe.Fingerprint)
+	if len(pe.Signers) > 0 {
+		for _, sg := range pe.Signers {
+			fmt.Fprintf(stdout, "  signer:      %s\n", sg.ReviewerID)
+		}
+		fmt.Fprintf(stdout, "  quorum:      %d of %d pinned signer(s)\n", maxInt(pe.GovernanceQuorum, 1), len(pe.Signers))
+	} else {
+		fmt.Fprintln(stdout, "  signer:      (none pinned: only this registry key may attest)")
+	}
 	fmt.Fprintf(stdout, "  pull with:   skillctl pull --registry %s\n", locator)
 	return 0
+}
+
+// parseSignerFlags turns --signer <reviewer-id>:<pubkey_b64> into pinned signers.
+// The id is split on the LAST colon, because a reviewer id legitimately carries
+// one (id:alice@org) while base64 never does.
+func parseSignerFlags(raw []string) ([]registry.Signer, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]registry.Signer, 0, len(raw))
+	for _, r := range raw {
+		i := strings.LastIndex(r, ":")
+		if i <= 0 || i == len(r)-1 {
+			return nil, fmt.Errorf("--signer %q is not <reviewer-id>:<pubkey_b64>", r)
+		}
+		id, key := strings.TrimSpace(r[:i]), strings.TrimSpace(r[i+1:])
+		if id == "" || key == "" {
+			return nil, fmt.Errorf("--signer %q is not <reviewer-id>:<pubkey_b64>", r)
+		}
+		out = append(out, registry.Signer{ReviewerID: id, PubKeyB64: key})
+	}
+	return out, nil
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func runPeerLs(args []string, stdout, stderr io.Writer) int {
@@ -129,6 +183,9 @@ func runPeerLs(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintln(stdout, strings.Repeat("-", 110))
 	for _, pe := range peers.Peers {
 		fmt.Fprintf(stdout, "%-16s %-40s %-8s %s\n", pe.Name, pe.Locator, strOr(pe.GovernanceMinimum, "green"), pe.Fingerprint)
+		for _, sg := range pe.Signers {
+			fmt.Fprintf(stdout, "%-16s   signer %s\n", "", sg.ReviewerID)
+		}
 	}
 	return 0
 }

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -309,6 +309,8 @@ trust-on-first-use window.
 | `--pubkey <b64>` | The peer's ed25519 signing key, base64. **Required.** |
 | `--pin sha256:<hex>` | The peer's trust-root fingerprint, verified out-of-band. **Required**: `add` fails if it does not match `--pubkey`. |
 | `--floor green\|yellow` | `governance_minimum` for this peer. |
+| `--signer <reviewer-id>:<b64>` | A reviewer whose attestations count for this peer, as `id:alice@org:<pubkey_b64>` (repeatable). Omit it when the publisher and the reviewer are the **same** key: without any signer the registry key itself is the only acceptable attester (the D2 model). |
+| `--quorum <n>` | How many **distinct** pinned signers must attest at or above the floor (default `1`). Refused unless at least that many `--signer` entries are given. |
 | `--contributes-revokes` | Union this peer's **signed** revoke events into the local revoked set for `revoke feed --gossip`. Set it **only** for a governance-trusted peer: that is the bound that keeps a peer from mounting a revoke-DoS. |
 
 **`peer ls`**, list pinned peers (name, locator, fingerprint, floor).
@@ -320,6 +322,13 @@ key and report what would pass or fail. Installs nothing.
 skillctl peer add alice https://alice.example.com/api/skills \
   --pubkey <base64> --pin sha256:<hex> --floor yellow
 skillctl peer verify alice
+
+# publisher and reviewer are DIFFERENT keys: pin the reviewer as a signer, or the
+# pull refuses a perfectly valid attestation with
+# "gate 4: no attestation at or above the trust-roots governance_minimum".
+skillctl peer add kup github://kup/skill-registry \
+  --pubkey <publisher-b64> --pin sha256:<hex> \
+  --signer id:reviewer@kup:<reviewer-b64> --quorum 1
 ```
 
 ---

--- a/docs/tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md
+++ b/docs/tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md
@@ -254,8 +254,17 @@ YAML
 Der Block `signers:` ist nicht optional, wenn Sie in A5 mit einem **zweiten** Schlüssel
 attestiert haben: die Attestierung wird gegen die gepinnten Signer geprüft, und ohne diesen
 Eintrag gilt implizit nur der Signierschlüssel als zulässiger Attestierer. Der Pull würde
-sonst mit Exit `13` abbrechen, obwohl die Attestierung existiert. Wer beide Rollen mit
-demselben Schlüssel fährt, lässt `governance_quorum` und `signers` weg.
+sonst abbrechen, obwohl die Attestierung existiert. Wer beide Rollen mit demselben Schlüssel
+fährt, lässt `governance_quorum` und `signers` weg.
+
+Für ein Git-Registry geht dasselbe kürzer und sicherer, weil `peer add` den
+Fingerprint-Abgleich erzwingt statt ihn Ihnen zu überlassen:
+
+```bash
+skillctl peer add meins "$REG" \
+  --pubkey <Signierschlüssel-b64> --pin sha256:<Fingerprint> \
+  --signer id:eric-reviewer@kup:<Reviewer-Schlüssel-b64> --quorum 1
+```
 
 > **Die zwei Dateien, die man verwechselt.** `~/.claude/trust-roots.yaml` (flach, von Hand)
 > gilt für den ER1-`self`-Weg und wird von `pull` gelesen.

--- a/docs/tutorial-szenario-02-erster-signierter-skill.de.md
+++ b/docs/tutorial-szenario-02-erster-signierter-skill.de.md
@@ -483,15 +483,23 @@ signers:
     pubkey_b64: <Erics Reviewer-Schlüssel, roh, base64>
 ```
 
-> **Warum von Hand und nicht mit `skillctl peer add`.** `peer add` erzwingt den
-> Out-of-Band-Pin (es verweigert, wenn `--pin` nicht zum `--pubkey` passt) und wäre die
-> schönere Form. Es kann heute aber **keinen Reviewer-Schlüssel ausdrücken**: ein gepinnter
-> Peer trägt genau einen Schlüssel, und der Pull weist die Attestierung dann mit
-> `gate 4: no attestation at or above the trust-roots governance_minimum` ab, obwohl sie im
-> Repository liegt (nachgemessen, Prozess-Exit `1`). Solange das so ist, ist die
-> handgeschriebene Datei der Weg, und der Fingerprint-Vergleich ist Ihre Aufgabe, nicht die
-> des Werkzeugs. Wer Herausgeber und Reviewer bewusst mit **einem** Schlüssel fährt, kann
-> `peer add` benutzen und `signers` weglassen.
+> **Der kürzere Weg, und warum er der bessere ist.** Dieselbe Aussage können Sie
+> `skillctl` schreiben lassen, statt sie zu tippen:
+>
+> ```bash
+> skillctl peer add kup "$REG" \
+>   --pubkey <Herausgeberschlüssel-b64> --pin sha256:<Fingerprint> \
+>   --signer id:eric-reviewer@kup:<Reviewer-Schlüssel-b64> --quorum 1
+> ```
+>
+> `peer add` **erzwingt** den Out-of-Band-Pin: es verweigert, wenn `--pin` nicht zum
+> `--pubkey` passt, es gibt also kein Fenster für Vertrauen beim ersten Anblick. Bei der
+> handgeschriebenen Datei ist dieser Abgleich Ihre Aufgabe, nicht die des Werkzeugs.
+> `peer ls` zeigt danach, wem Sie das Urteil erlaubt haben.
+>
+> Lassen Sie `--signer` weg, gilt wieder nur der Herausgeberschlüssel als Attestierer. Das
+> ist richtig für den Fall, dass eine Person beide Rollen mit einem Schlüssel fährt, und es
+> ist genau der Fall, den Sie **nicht** wollen, sobald es zwei Menschen sind.
 
 ```bash
 # K1. Nur Lesetoken setzen. Ein Konsument braucht keinen Schreibzugriff.

--- a/pkg/skillctl/registry/peers.go
+++ b/pkg/skillctl/registry/peers.go
@@ -41,10 +41,15 @@ type Peer struct {
 	Fingerprint       string `yaml:"fingerprint"`
 	GovernanceMinimum string `yaml:"governance_minimum,omitempty"`
 
-	// D3 (federation): omitempty, unused in D2; documented for schema stability.
-	GovernanceQuorum        int    `yaml:"governance_quorum,omitempty"`
-	GovernanceRootPubKeyB64 string `yaml:"governance_root_pubkey_b64,omitempty"`
-	CrossSignPath           string `yaml:"cross_sign_path,omitempty"`
+	// D3 (federation), FR-0115: the reviewer set this peer's attestations are
+	// judged against. Empty → one implicit signer {"", pubkey}, which is the D2
+	// single-key model: only the registry key itself may attest. Fill Signers
+	// when the publisher and the reviewer are DIFFERENT keys, which is what makes
+	// a separation of duties cryptographic rather than merely organisational.
+	GovernanceQuorum        int      `yaml:"governance_quorum,omitempty"`
+	Signers                 []Signer `yaml:"signers,omitempty"`
+	GovernanceRootPubKeyB64 string   `yaml:"governance_root_pubkey_b64,omitempty"`
+	CrossSignPath           string   `yaml:"cross_sign_path,omitempty"`
 
 	// D5(b): when true, this peer's SIGNED revoke events are unioned into the local
 	// revoked set by `revoke feed --gossip` (a governance contributor). Default
@@ -194,11 +199,32 @@ func (pe *Peer) AsTrustRoots() (*SelfTrustRoots, error) {
 	if !ok {
 		return nil, fmt.Errorf("governance_minimum %q is not one of [green, yellow]", pe.GovernanceMinimum)
 	}
-	return &SelfTrustRoots{
+	tr := &SelfTrustRoots{
 		Registry:          pe.Locator,
 		PubKeyB64:         pe.PubKeyB64,
 		Fingerprint:       computed,
 		GovernanceMinimum: norm,
 		pub:               ed25519.PublicKey(pubBytes),
-	}, nil
+
+		// FR-0115: carry the D3 declaration across. Before this, the adapter
+		// dropped it, so a peer could express only the D2 single-key model: the
+		// registry key was the sole acceptable attester. A publisher and a
+		// reviewer holding DIFFERENT keys therefore hit
+		// "gate 4: no attestation at or above the trust-roots governance_minimum"
+		// with a perfectly valid attestation sitting in the registry, and the only
+		// way out was to abandon `peer add` (and its enforced out-of-band pin) for
+		// a hand-written trust-roots file. The capability was always in the
+		// verifier; it was unreachable from here.
+		GovernanceQuorum:        pe.GovernanceQuorum,
+		Signers:                 append([]Signer(nil), pe.Signers...),
+		GovernanceRootPubKeyB64: pe.GovernanceRootPubKeyB64,
+		CrossSignPath:           pe.CrossSignPath,
+	}
+	// Same resolution the hand-written file gets: decode the signer keys, admit
+	// cross-signed members, refuse an unsatisfiable quorum. Shared on purpose, so
+	// the two carriers cannot drift.
+	if err := tr.resolveSigners("peer " + pe.Name); err != nil {
+		return nil, err
+	}
+	return tr, nil
 }

--- a/pkg/skillctl/registry/peers_test.go
+++ b/pkg/skillctl/registry/peers_test.go
@@ -83,3 +83,110 @@ func TestLoadPeersMissingIsEmpty(t *testing.T) {
 		t.Errorf("missing peer store should load empty, got %+v / %v", got, err)
 	}
 }
+
+// FR-0115: a pinned peer must be able to express a reviewer whose key is NOT the
+// registry key. Before the fix, AsTrustRoots dropped the whole D3 declaration, so
+// the registry key was the only acceptable attester and a real separation of
+// duties was unreachable through `peer add`.
+func TestPeerAsTrustRootsCarriesSigners(t *testing.T) {
+	regB64, fp, _ := testPeerKey(t)
+	revB64, _, revPub := testPeerKey(t)
+
+	pe := Peer{
+		Name: "eric", Locator: "github://eric/skills",
+		PubKeyB64: regB64, Fingerprint: fp, GovernanceMinimum: "green",
+		GovernanceQuorum: 1,
+		Signers:          []Signer{{ReviewerID: "id:rev@org", PubKeyB64: revB64}},
+	}
+	tr, err := pe.AsTrustRoots()
+	if err != nil {
+		t.Fatalf("AsTrustRoots: %v", err)
+	}
+	set := tr.signerSet()
+	if len(set) != 1 {
+		t.Fatalf("signerSet() = %d entries, want the 1 pinned reviewer", len(set))
+	}
+	if set[0].ReviewerID != "id:rev@org" {
+		t.Errorf("reviewer_id = %q, want id:rev@org", set[0].ReviewerID)
+	}
+	// The KEY is what counts toward a quorum, so it has to be resolved, not just
+	// carried as base64. An unresolved key never matches an attestation, and the
+	// failure is silent: the pull reports "no attestation at or above the floor".
+	if set[0].pub == nil || !set[0].pub.Equal(revPub) {
+		t.Error("the pinned signer's key was not resolved to a verifying key")
+	}
+	if tr.quorum() != 1 {
+		t.Errorf("quorum() = %d, want 1", tr.quorum())
+	}
+}
+
+// Omitting --signer must NOT relax anything: with no signer pinned, the implicit
+// signer is the registry key itself (the D2 model), which is exactly the
+// behaviour that refuses a foreign reviewer's attestation.
+func TestPeerAsTrustRootsWithoutSignersKeepsD2(t *testing.T) {
+	regB64, fp, regPub := testPeerKey(t)
+	pe := Peer{Name: "eric", Locator: "github://eric/skills", PubKeyB64: regB64, Fingerprint: fp}
+	tr, err := pe.AsTrustRoots()
+	if err != nil {
+		t.Fatalf("AsTrustRoots: %v", err)
+	}
+	set := tr.signerSet()
+	if len(set) != 1 || !set[0].pub.Equal(regPub) || set[0].ReviewerID != "" {
+		t.Fatalf("without signers the implicit signer must be the registry key, got %+v", set)
+	}
+	if tr.quorum() != 1 {
+		t.Errorf("quorum() = %d, want the 1-of-1 default", tr.quorum())
+	}
+}
+
+// A quorum the pinned set cannot satisfy is refused at LOAD, not silently at pull
+// time. Same rule the hand-written trust-roots file already enforced; it now
+// applies to a peer because both go through resolveSigners.
+func TestPeerAsTrustRootsRefusesUnsatisfiableQuorum(t *testing.T) {
+	regB64, fp, _ := testPeerKey(t)
+	revB64, _, _ := testPeerKey(t)
+	pe := Peer{
+		Name: "eric", Locator: "github://eric/skills", PubKeyB64: regB64, Fingerprint: fp,
+		GovernanceQuorum: 2,
+		Signers:          []Signer{{ReviewerID: "id:rev@org", PubKeyB64: revB64}},
+	}
+	_, err := pe.AsTrustRoots()
+	if err == nil {
+		t.Fatal("quorum 2 with 1 pinned signer must be refused")
+	}
+	if !strings.Contains(err.Error(), "governance_quorum") {
+		t.Errorf("the error should name governance_quorum, got: %v", err)
+	}
+}
+
+// A signer key that is not valid base64 is a configuration error, and it must
+// fail loudly: an unresolved key would otherwise degrade into "this reviewer
+// never matches", which reads like a missing attestation.
+func TestPeerAsTrustRootsRefusesBrokenSignerKey(t *testing.T) {
+	regB64, fp, _ := testPeerKey(t)
+	pe := Peer{
+		Name: "eric", Locator: "github://eric/skills", PubKeyB64: regB64, Fingerprint: fp,
+		Signers: []Signer{{ReviewerID: "id:rev@org", PubKeyB64: "not-base64!!"}},
+	}
+	if _, err := pe.AsTrustRoots(); err == nil {
+		t.Fatal("an unparseable signer key must be refused")
+	}
+}
+
+// AddPeer runs the same adapter, so a peer with a broken D3 declaration never
+// reaches the store.
+func TestAddPeerValidatesSigners(t *testing.T) {
+	regB64, fp, _ := testPeerKey(t)
+	p := &Peers{}
+	err := p.AddPeer(Peer{
+		Name: "eric", Locator: "github://eric/skills", PubKeyB64: regB64, Fingerprint: fp,
+		GovernanceQuorum: 3,
+		Signers:          []Signer{{ReviewerID: "id:rev@org", PubKeyB64: regB64}},
+	})
+	if err == nil {
+		t.Fatal("AddPeer must refuse an unsatisfiable quorum")
+	}
+	if len(p.Peers) != 0 {
+		t.Error("a refused peer must not be stored")
+	}
+}

--- a/pkg/skillctl/registry/selftrustroots.go
+++ b/pkg/skillctl/registry/selftrustroots.go
@@ -148,31 +148,8 @@ func LoadSelfTrustRoots(path string) (*SelfTrustRoots, error) {
 	}
 	tr.pub = ed25519.PublicKey(pubBytes)
 
-	// D3: resolve each pinned signer key + ensure the quorum is satisfiable.
-	for i := range tr.Signers {
-		sb, derr := base64.StdEncoding.DecodeString(strings.TrimSpace(tr.Signers[i].PubKeyB64))
-		if derr != nil {
-			return nil, fmt.Errorf("trust-roots: signer %q pubkey_b64 not valid base64: %w", tr.Signers[i].ReviewerID, derr)
-		}
-		if len(sb) != ed25519.PublicKeySize {
-			return nil, fmt.Errorf("trust-roots: signer %q pubkey size %d, want %d", tr.Signers[i].ReviewerID, len(sb), ed25519.PublicKeySize)
-		}
-		tr.Signers[i].pub = ed25519.PublicKey(sb)
-	}
-	// D3(i): admit cross-signed members from the PINNED governance root.
-	if tr.GovernanceRootPubKeyB64 != "" && tr.CrossSignPath != "" {
-		gpub, gerr := base64.StdEncoding.DecodeString(strings.TrimSpace(tr.GovernanceRootPubKeyB64))
-		if gerr != nil || len(gpub) != ed25519.PublicKeySize {
-			return nil, fmt.Errorf("trust-roots: governance_root_pubkey_b64 invalid in %s", path)
-		}
-		records, rerr := loadCrossSignRecords(tr.CrossSignPath)
-		if rerr != nil {
-			return nil, fmt.Errorf("trust-roots: cross_sign_path %s: %w", tr.CrossSignPath, rerr)
-		}
-		tr.Signers = append(tr.Signers, DeriveCrossSignedSigners(ed25519.PublicKey(gpub), records, time.Now())...)
-	}
-	if tr.GovernanceQuorum > 1 && len(tr.Signers) < tr.GovernanceQuorum {
-		return nil, fmt.Errorf("trust-roots: governance_quorum %d exceeds the %d pinned signers in %s", tr.GovernanceQuorum, len(tr.Signers), path)
+	if err := tr.resolveSigners(path); err != nil {
+		return nil, err
 	}
 
 	// Compute fingerprint (or check the one the file declares).
@@ -186,6 +163,48 @@ func LoadSelfTrustRoots(path string) (*SelfTrustRoots, error) {
 }
 
 // PubKey returns the loaded ed25519 public key.
+// resolveSigners turns the DECLARED D3 fields into verifying keys: it decodes
+// each pinned signer key, admits cross-signed members from the pinned governance
+// root, and refuses a quorum the pinned set cannot satisfy.
+//
+// It is one shared method because there are now TWO carriers of the same
+// declaration: the hand-written trust-roots file (LoadSelfTrustRoots) and a
+// pinned peer (Peer.AsTrustRoots, FR-0115). A second copy would be a second
+// place for the two to drift, and the drift would be SILENT: an unresolved
+// signer key does not fail, it simply never matches an attestation, so the pull
+// reports "no attestation at or above the governance_minimum" while the
+// attestation sits right there in the registry.
+//
+// source names the origin (a file path, or a peer name) for error messages.
+func (t *SelfTrustRoots) resolveSigners(source string) error {
+	for i := range t.Signers {
+		sb, derr := base64.StdEncoding.DecodeString(strings.TrimSpace(t.Signers[i].PubKeyB64))
+		if derr != nil {
+			return fmt.Errorf("trust-roots: signer %q pubkey_b64 not valid base64: %w", t.Signers[i].ReviewerID, derr)
+		}
+		if len(sb) != ed25519.PublicKeySize {
+			return fmt.Errorf("trust-roots: signer %q pubkey size %d, want %d", t.Signers[i].ReviewerID, len(sb), ed25519.PublicKeySize)
+		}
+		t.Signers[i].pub = ed25519.PublicKey(sb)
+	}
+	// D3(i): admit cross-signed members from the PINNED governance root.
+	if t.GovernanceRootPubKeyB64 != "" && t.CrossSignPath != "" {
+		gpub, gerr := base64.StdEncoding.DecodeString(strings.TrimSpace(t.GovernanceRootPubKeyB64))
+		if gerr != nil || len(gpub) != ed25519.PublicKeySize {
+			return fmt.Errorf("trust-roots: governance_root_pubkey_b64 invalid in %s", source)
+		}
+		records, rerr := loadCrossSignRecords(t.CrossSignPath)
+		if rerr != nil {
+			return fmt.Errorf("trust-roots: cross_sign_path %s: %w", t.CrossSignPath, rerr)
+		}
+		t.Signers = append(t.Signers, DeriveCrossSignedSigners(ed25519.PublicKey(gpub), records, time.Now())...)
+	}
+	if t.GovernanceQuorum > 1 && len(t.Signers) < t.GovernanceQuorum {
+		return fmt.Errorf("trust-roots: governance_quorum %d exceeds the %d pinned signers in %s", t.GovernanceQuorum, len(t.Signers), source)
+	}
+	return nil
+}
+
 func (t *SelfTrustRoots) PubKey() ed25519.PublicKey {
 	if t == nil {
 		return nil


### PR DESCRIPTION
Schliesst #196.

## Das Problem

`peer add` konnte nur das D2-Modell ausdruecken: ein gepinnter Peer trug genau **einen** Schluessel, also war der Registry-Schluessel der einzige zulaessige Attestierer. Fuehren Herausgeber und Reviewer verschiedene Schluessel, und genau das macht die Gewaltenteilung kryptografisch statt bloss organisatorisch, wies der Pull die **gueltige gruene** Attestierung ab:

```
gate 4: no attestation at or above the trust-roots governance_minimum
Prozess-Exit 1
```

Die Faehigkeit war laengst da: der `AttestAccumulator` prueft jede Attestierung gegen **jeden** gepinnten Signer, und die Entdeckung filtert vorher nicht auf den Registry-Schluessel. Unerreichbar war sie, weil `Peer.AsTrustRoots()` die ganze D3-Deklaration fallen liess.

Die Folge fuer die Dokumentation war die falsche Richtung: sie musste den **schwaecheren** Weg empfehlen (eine handgeschriebene `trust-roots.yaml`, also ohne den von `peer add` erzwungenen Out-of-Band-Pin), um den **staerkeren** Sicherheitsgewinn zu bekommen.

## Die Aenderung

- `Peer` bekommt ein `signers`-Feld; `AsTrustRoots` reicht `Signers`, `GovernanceQuorum`, `GovernanceRootPubKeyB64` und `CrossSignPath` durch.
- Die Aufloesung der Signer-Schluessel wandert in **eine** gemeinsame Methode `resolveSigners`, die beide Traeger benutzen: die handgeschriebene Datei und der gepinnte Peer. Zwei Kopien waeren ein zweiter Ort zum Auseinanderlaufen, und das Auseinanderlaufen waere **still**: ein nicht aufgeloester Signer-Schluessel scheitert nicht, er passt nur nie.
- `peer add --signer <reviewer-id>:<b64>` (wiederholbar) und `--quorum <n>`. Gesplittet wird am **letzten** Doppelpunkt, weil eine Reviewer-ID regulaer einen enthaelt (`id:alice@org`) und base64 nie.
- `peer add` und `peer ls` zeigen die gepinnten Signer.

## Was sich NICHT aendert

Ohne `--signer` bleibt der implizite Signer der Registry-Schluessel. Das Weglassen lockert also nichts: es ist weiterhin genau die Regel, die eine fremde Reviewer-Attestierung zurueckweist. Ein Quorum, das die gepinnte Menge nicht erfuellen kann, wird beim **Laden** abgelehnt, nicht erst beim Pull.

## Gemessen

Derselbe Aufbau in beide Richtungen, gegen ein bares `local://`-Registry:

| Aufruf | Ergebnis |
|---|---|
| `peer add ... ` (ohne `--signer`) | `gate 4`, Exit 1, wie vorher |
| `peer add ... --signer id:rev@x:<b64> --quorum 1` | `✅ gov=green`, Install-Plan + G-23-Token |

Das ist SPEC-0407 AC-12.

## Tests

Fuenf neue Faelle in `peers_test.go`: Signer werden getragen **und zu verifizierenden Schluesseln aufgeloest** (ein bloss mitgefuehrtes base64 waere der stille Fehlerfall), ohne Signer bleibt es beim D2-Modell, ein unerfuellbares Quorum wird abgelehnt, ein kaputter Signer-Schluessel wird abgelehnt, und `AddPeer` speichert einen so kaputten Peer gar nicht erst.

`go test ./cmd/skillctl/... ./pkg/skillctl/...`: 33 Pakete gruen, 0 rot. `docaudit` gruen (202 Flags, beide Richtungen). Manual und beide Szenario-Tutorials mitgezogen: der `peer add`-Weg ist dort jetzt der Regelweg, die handgeschriebene Datei die Alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)