### PR TITLE
feat(verify): verify <name> erkennt auch Git- und self-Installationen (FR-0116)

### DIFF
--- a/cmd/skillctl/install_cmds.go
+++ b/cmd/skillctl/install_cmds.go
@@ -18,13 +18,11 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -407,8 +405,20 @@ func resolveTenant(cliFlag string, tr *verify.TrustRoots) string {
 // nowhere else, and re-anchoring without it would fail closed on a perfectly good
 // install.
 func verifySidecarTier(name, homeOverride, governanceMin string, verbose bool, stdout, stderr io.Writer) (int, bool) {
-	side, serr := readProvenanceSidecar(name, homeOverride)
-	if serr != nil {
+	home := homeOverride
+	if home == "" {
+		h, herr := userHome()
+		if herr != nil {
+			return 0, false
+		}
+		home = h
+	}
+	canon, cerr := install.CanonicalSkillName(name) // the same fixed point the gate + loader use
+	if cerr != nil {
+		return 0, false
+	}
+	side, ok := loadInstalledSidecar(home, canon)
+	if !ok {
 		return 0, false // no sidecar (or unreadable): not our tier
 	}
 
@@ -445,29 +455,4 @@ func verifySidecarTier(name, homeOverride, governanceMin string, verbose bool, s
 	fmt.Fprintf(stdout, "%s: content bound to the signed bundle, governance %s, anchored on %s (offline)\n",
 		name, strOr(side.GovernanceLevel, "unknown"), src)
 	return exitOK, true
-}
-
-// readProvenanceSidecar reads .m3c-provenance.json for an installed skill.
-func readProvenanceSidecar(name, homeOverride string) (*registry.ProvenanceSidecar, error) {
-	home := homeOverride
-	if home == "" {
-		h, err := userHome()
-		if err != nil {
-			return nil, err
-		}
-		home = h
-	}
-	canon, err := install.CanonicalSkillName(name)
-	if err != nil {
-		return nil, err
-	}
-	b, err := os.ReadFile(filepath.Join(home, ".claude", "skills", canon, registry.ProvenanceSidecarName))
-	if err != nil {
-		return nil, err
-	}
-	var side registry.ProvenanceSidecar
-	if err := json.Unmarshal(b, &side); err != nil {
-		return nil, err
-	}
-	return &side, nil
 }

--- a/cmd/skillctl/install_cmds.go
+++ b/cmd/skillctl/install_cmds.go
@@ -18,11 +18,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -237,8 +239,19 @@ func runVerify(args []string, stdout, stderr io.Writer) int {
 		return exitUsage
 	}
 
+	// FR-0116: the HTTP trust-roots file is only ONE of the two carriers. A skill
+	// pulled from a self/ER1 or a git registry is anchored by
+	// ~/.claude/trust-roots.yaml or by a pinned peer, and it carries the signed
+	// material to prove it (.m3c-provenance.json + .skillctl-attest.json). Before
+	// this, a missing skill-trust-roots.yaml ended the whole command with advice
+	// that is wrong for those installs ("run skillctl trust add", which takes an
+	// HTTP URL). The gate has always fallen through to the sidecar tier here;
+	// `verify <name>` now does the same.
 	tr, root, err := loadAndPickRoot(*registryURL)
 	if err != nil {
+		if code, handled := verifySidecarTier(name, *homeOverride, *governanceMin, *verboseFlag, stdout, stderr); handled {
+			return code
+		}
 		fmt.Fprintln(stderr, err)
 		return exitGeneric
 	}
@@ -380,4 +393,81 @@ func resolveTenant(cliFlag string, tr *verify.TrustRoots) string {
 		return ""
 	}
 	return strings.TrimSpace(tr.TenantScope)
+}
+
+// verifySidecarTier verifies a skill installed by the self/ER1 or git pull path,
+// which anchors on ~/.claude/trust-roots.yaml or on a pinned peer rather than on
+// the HTTP trust-roots file. It reports handled=false when the skill has no
+// provenance sidecar, so the caller can fall back to its own error.
+//
+// The trust root is resolved the way `pull` resolves it (FR-0116): the peer whose
+// locator matches the registry recorded in the provenance sidecar, else the
+// hand-written self trust-roots file. Using the peer matters, because a git
+// registry pinned with `skillctl peer add` has its key in skill-peers.yaml and
+// nowhere else, and re-anchoring without it would fail closed on a perfectly good
+// install.
+func verifySidecarTier(name, homeOverride, governanceMin string, verbose bool, stdout, stderr io.Writer) (int, bool) {
+	side, serr := readProvenanceSidecar(name, homeOverride)
+	if serr != nil {
+		return 0, false // no sidecar (or unreadable): not our tier
+	}
+
+	opts := install.Opts{
+		Name:          name,
+		HomeDir:       homeOverride,
+		GovernanceMin: governanceMin,
+	}
+	if verbose {
+		opts.Logger = stderr
+	}
+	// A pinned peer wins, exactly as in `pull`. Not fatal when absent: the file
+	// path below is the other legitimate carrier.
+	if peers, perr := registry.LoadPeers(peersConfigPath); perr == nil && side.Registry != "" {
+		if pe, ok := peers.FindPeerByLocator(side.Registry); ok {
+			if str, aerr := pe.AsTrustRoots(); aerr == nil {
+				opts.SelfTrustRoots = str
+			}
+		}
+	}
+
+	err := install.VerifyInstalledSidecar(opts)
+	if errors.Is(err, registry.ErrNoSidecar) {
+		return 0, false
+	}
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return verify.ExitCode(err), true
+	}
+	src := side.Registry
+	if src == "" {
+		src = "self"
+	}
+	fmt.Fprintf(stdout, "%s: content bound to the signed bundle, governance %s, anchored on %s (offline)\n",
+		name, strOr(side.GovernanceLevel, "unknown"), src)
+	return exitOK, true
+}
+
+// readProvenanceSidecar reads .m3c-provenance.json for an installed skill.
+func readProvenanceSidecar(name, homeOverride string) (*registry.ProvenanceSidecar, error) {
+	home := homeOverride
+	if home == "" {
+		h, err := userHome()
+		if err != nil {
+			return nil, err
+		}
+		home = h
+	}
+	canon, err := install.CanonicalSkillName(name)
+	if err != nil {
+		return nil, err
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".claude", "skills", canon, registry.ProvenanceSidecarName))
+	if err != nil {
+		return nil, err
+	}
+	var side registry.ProvenanceSidecar
+	if err := json.Unmarshal(b, &side); err != nil {
+		return nil, err
+	}
+	return &side, nil
 }

--- a/cmd/skillctl/pull_cmds.go
+++ b/cmd/skillctl/pull_cmds.go
@@ -197,6 +197,7 @@ func runPull(args []string, stdout, stderr io.Writer) int {
 		TrustRootsFingerprint: tr.Fingerprint,
 		ContextID:             *er1Context,
 		AllowDowngrade:        *allowDowngrade,
+		RegistrySpec:          *registryName,
 	})
 	if err != nil {
 		// Per-class diagnostics: every token failure states WHY and the exact FIX.

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -390,6 +390,14 @@ skillctl verify --bundle <file.skb> [--trust-roots <file>] [--json]
 
 Re-runs the SPEC-0188 §7 trust-chain check against an already-installed skill: useful for
 catching post-install revocations or trust-root rotations. `--all` re-verifies everything.
+
+**Two carriers, one command** (FR-0116). A skill installed by `install` is anchored on the
+HTTP trust-roots file; one installed by `pull --install` (self/ER1 or a git registry) is
+anchored on `~/.claude/trust-roots.yaml` or on a peer pinned with `peer add`, and carries
+`.m3c-provenance.json` + `.skillctl-attest.json` to prove it. `verify <name>` tries the HTTP
+model first and falls back to that sidecar tier, resolving the peer whose locator matches the
+registry recorded in the provenance. A missing `skill-trust-roots.yaml` is therefore no longer
+the end of the command: it is the end of only one of the two paths.
 `--bundle` verifies a **standalone `.skb` file** with no install state and no network, against
 locally pinned trust-roots: the trustless third-party path (requires a `<file>.skbmeta.json`
 sidecar or `--meta`).

--- a/docs/tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md
+++ b/docs/tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md
@@ -480,16 +480,13 @@ skillctl verify --all
 skillctl audit --source all --minimum-governance green
 ```
 
-> **Zwei Grenzen, gemessen, bevor Sie das in einen Cronjob schreiben.** Erstens antwortet
-> `skillctl verify <name>` nach einer Installation aus einem Git- oder ER1-Registry mit
-> „trust roots not configured; run `skillctl trust add …`" und zeigt auf
-> `~/.claude/skill-trust-roots.yaml`, die Datei des HTTP-Modells: das Nachprüfen eines
-> einzelnen installierten Skills ist an dieses Modell gebunden. Der belastbare Nachweis ist
-> vorerst der Pull selbst plus `skillctl registry show`. Zweitens fällt `verify --all` unter
-> verwalteten Trust-Roots **fail-closed**, wenn keine Widerrufsquelle erreichbar ist, und
-> würde mit `--quarantine` frisch installierte Skills verschieben. Lassen Sie den Sweep
+> **Eine Grenze, gemessen, bevor Sie das in einen Cronjob schreiben.** `verify --all` fällt
+> unter verwalteten Trust-Roots **fail-closed**, wenn keine Widerrufsquelle erreichbar ist,
+> und würde mit `--quarantine` frisch installierte Skills verschieben. Lassen Sie den Sweep
 > deshalb erst ohne `--quarantine` laufen und lesen Sie die Ausgabe, bis der Widerrufskanal
-> steht.
+> steht. Das Nachprüfen eines **einzelnen** Skills (`skillctl verify <name>`) funktioniert
+> dagegen auch für einen aus dem Git-Registry installierten Skill: es bindet den Inhalt an
+> das signierte Bundle und rechnet die Attestierung gegen den gepinnten Schlüssel nach.
 
 `audit` hat eine eigene Skala: `0` alles in Ordnung, `2` mindestens ein Skill unbestätigt
 oder unter der Schwelle, `3` mindestens ein Skill defekt.

--- a/docs/tutorial-szenario-02-erster-signierter-skill.de.md
+++ b/docs/tutorial-szenario-02-erster-signierter-skill.de.md
@@ -568,12 +568,13 @@ sondern rechnet nach.
 
 Zwei Dinge, die Sie wissen müssen, bevor Sie den Betrieb darauf aufsetzen:
 
-- `skillctl verify <name>` und `verify --offline <name>` antworten nach einer Installation aus
-  einem Git-Registry mit „trust roots not configured; run `skillctl trust add …`" und zeigen
-  auf `~/.claude/skill-trust-roots.yaml`, also auf die Datei des HTTP-Modells. Das Nachprüfen
-  eines installierten Skills ist an dieses Modell gebunden und für Peer- und Git-Registries
-  noch nicht verdrahtet. Der belastbare Nachweis bleibt vorerst der Pull selbst (die
-  `✅`-Zeilen) plus `skillctl registry show`.
+- `skillctl verify <name>` prüft einen aus dem Git-Registry installierten Skill jetzt selbst:
+  es bindet den Inhalt auf der Platte an das signierte Bundle und rechnet die Attestierung
+  gegen den gepinnten Schlüssel nach. Erwartet ist `0` plus eine Zeile, die nennt, worauf der
+  Skill verankert ist. Eine nachträglich veränderte Datei ergibt `10`. Zwei Dinge dazu: der
+  Pfad braucht die Beilagen aus dem verwalteten Install (ein von Hand entpackter Skill bleibt
+  stumm, siehe 3.3), und er verlangt, dass Sie den Herausgeber gepinnt haben, in der
+  `trust-roots.yaml` oder über `peer add`.
 - `skillctl verify --all` fällt unter verwalteten Trust-Roots ohne erreichbare
   Revocation-Quelle **fail-closed** und würde installierte Skills quarantänisieren. Bevor der
   Sweep in den Alltag geht, muss der Widerrufskanal stehen; bis dahin ohne `--quarantine`

--- a/pkg/skillctl/install/install.go
+++ b/pkg/skillctl/install/install.go
@@ -85,6 +85,14 @@ type Opts struct {
 	// registry-trust check (SPEC-0247 OQ-5). Empty = default. Tests inject one.
 	SelfTrustRootsPath string
 
+	// SelfTrustRoots hands VerifyInstalledSidecar an ALREADY-RESOLVED self
+	// trust-root instead of a path (FR-0116). It exists because the second
+	// legitimate carrier of that anchor is not a file at all: a registry pinned
+	// with `skillctl peer add` keeps its key in skill-peers.yaml, so a caller
+	// that resolved the peer must be able to pass the result straight in. When
+	// set it WINS over SelfTrustRootsPath; when nil, nothing changes.
+	SelfTrustRoots *registry.SelfTrustRoots
+
 	// MaxExtractedBytes overrides the gzip-bomb cap. 0 = use default.
 	MaxExtractedBytes int64
 

--- a/pkg/skillctl/install/offline_verify.go
+++ b/pkg/skillctl/install/offline_verify.go
@@ -275,7 +275,13 @@ func VerifyInstalledSidecar(opts Opts) error {
 	if ac, aerr := registry.ReadAttestationStash(target); aerr == nil {
 		// Trust-roots are MANDATORY to re-anchor (policy: parity with the HTTP
 		// path, which errors when the root is nil). Fail closed if absent.
-		str, lerr := registry.LoadSelfTrustRoots(trPath)
+		// FR-0116: a caller that already resolved the anchor (typically from a
+		// pinned peer, whose key lives in skill-peers.yaml and in no file this
+		// function could find) hands it in directly.
+		str, lerr := opts.SelfTrustRoots, error(nil)
+		if str == nil {
+			str, lerr = registry.LoadSelfTrustRoots(trPath)
+		}
 		if lerr != nil || str == nil || len(str.PubKey()) == 0 {
 			return fmt.Errorf("verify-sidecar: self trust-roots required to re-anchor %q but unavailable (%v): %w",
 				opts.Name, lerr, verify.ErrRegistryNotTrusted)

--- a/pkg/skillctl/install/reanchor_test.go
+++ b/pkg/skillctl/install/reanchor_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -187,4 +188,54 @@ func TestSidecarReanchor_GovernanceFromSignedAttestation(t *testing.T) {
 	if !errors.Is(err, verify.ErrGovernanceBelowMin) {
 		t.Fatalf("signed yellow under green floor must be DENIED via the SIGNED level (not the green sidecar), got: %v", err)
 	}
+}
+
+// FR-0116: a caller that resolved the anchor itself, typically from a peer
+// pinned with `skillctl peer add` (whose key lives in skill-peers.yaml and in no
+// file this package could find), hands it in directly. It must be honoured, and
+// it must WIN over the path.
+func TestSidecarReanchor_ResolvedTrustRootsWins(t *testing.T) {
+	home, name, _, _, pub, _ := reanchorFixture(t, "green")
+
+	str := loadRootsFromKey(t, pub, "github://kup/skill-registry")
+	if err := VerifyInstalledSidecar(Opts{
+		Name: name, HomeDir: home,
+		SelfTrustRootsPath: filepath.Join(t.TempDir(), "does-not-exist.yaml"),
+		SelfTrustRoots:     str,
+	}); err != nil {
+		t.Fatalf("a resolved self trust-root must be honoured even when the path is missing: %v", err)
+	}
+}
+
+// The resolved root is not a bypass: hand in the WRONG key and the re-anchor
+// must still refuse. Otherwise the new field would be a way around the pin.
+func TestSidecarReanchor_ResolvedTrustRootsWrongKeyRefused(t *testing.T) {
+	home, name, _, _, _, _ := reanchorFixture(t, "green")
+
+	otherPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	str := loadRootsFromKey(t, otherPub, "github://kup/skill-registry")
+	if err := VerifyInstalledSidecar(Opts{Name: name, HomeDir: home, SelfTrustRoots: str}); err == nil {
+		t.Fatal("a foreign key must not re-anchor the install")
+	}
+}
+
+// loadRootsFromKey builds a RESOLVED *registry.SelfTrustRoots the way production
+// does: through the loader, so the verifying key is actually resolved. A
+// hand-built struct carries base64 and no key, which is precisely the half-built
+// state a caller must not be able to pass off as an anchor.
+func loadRootsFromKey(t *testing.T, pub ed25519.PublicKey, locator string) *registry.SelfTrustRoots {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "trust-roots.yaml")
+	body := "registry: " + locator + "\npubkey_b64: " + base64.StdEncoding.EncodeToString(pub) + "\ngovernance_minimum: green\n"
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	str, err := registry.LoadSelfTrustRoots(p)
+	if err != nil {
+		t.Fatalf("load trust-roots fixture: %v", err)
+	}
+	return str
 }

--- a/pkg/skillctl/registry/install_trust_mode.go
+++ b/pkg/skillctl/registry/install_trust_mode.go
@@ -87,6 +87,14 @@ type InstallOpts struct {
 	TrustRootsFingerprint string
 	ContextID             string
 	AllowDowngrade        bool
+
+	// RegistrySpec records WHERE the bundle came from, verbatim: "self", an
+	// er1://… context, or a git locator (github://…, gitlab://…, local://…).
+	// Empty defaults to "self", which is what the sidecar recorded
+	// unconditionally before FR-0116. It has to be the real locator, because a
+	// later `verify <name>` resolves the anchor from it: a registry pinned with
+	// `peer add` keeps its key in skill-peers.yaml, findable only by locator.
+	RegistrySpec string
 }
 
 // InstallResult reports what changed.
@@ -429,7 +437,7 @@ func installOne(b *StagedBundle, opts InstallOpts) (*InstallResult, error) {
 		Skill:                 b.Name,
 		Version:               b.Version,
 		BundleDigest:          b.Digest,
-		Registry:              "self",
+		Registry:              strOrSelf(opts.RegistrySpec),
 		SourceER1ItemID:       b.SourceDocID,
 		SourceER1Context:      opts.ContextID,
 		PulledAt:              time.Now().UTC().Format(time.RFC3339),
@@ -554,6 +562,14 @@ func loadProvenance(path string) (*ProvenanceSidecar, error) {
 		return nil, err
 	}
 	return &s, nil
+}
+
+// strOrSelf keeps the pre-FR-0116 default: an unset spec still reads "self".
+func strOrSelf(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "self"
+	}
+	return s
 }
 
 func writeProvenance(path string, side ProvenanceSidecar) error {


### PR DESCRIPTION
Schliesst #197.

## Das Problem

Nach einem gruenen `pull --install` aus einem Git-Registry lag der Skill verwaltet da, mit `.m3c-provenance.json` **und** `.skillctl-attest.json` daneben, also mit allem, was eine Offline-Nachpruefung braucht. Trotzdem:

```
$ skillctl verify <name>
trust roots not configured; run `skillctl trust add --registry <url> --pubkey <path>` first
(file: ~/.claude/skill-trust-roots.yaml)
exit 1
```

Der Rat war dazu falsch: `trust add` nimmt eine HTTP-URL und hilft einem Git- oder `self`-Registry nicht.

Ursache war eine Reihenfolge, kein fehlendes Verfahren: `runVerify` liess `loadAndPickRoot` hart scheitern, waehrend das PreToolUse-Gate an genau dieser Stelle laengst auf die Sidecar-Ebene durchfaellt.

## Drei Aenderungen

1. **`runVerify` faellt auf die Sidecar-Ebene durch**, statt abzubrechen. Fehlt auch die, kommt weiterhin die urspruengliche Meldung.
2. **`install.Opts.SelfTrustRoots`**: ein bereits **aufgeloester** Anker statt eines Pfades. Noetig, weil der zweite legitime Traeger gar keine Datei ist, die dieses Paket finden koennte: ein mit `peer add` gepinntes Registry haelt seinen Schluessel in `skill-peers.yaml`. Gesetzt gewinnt er ueber den Pfad; `nil` aendert nichts.
3. **Die Provenienz-Datei zeichnet den echten Locator auf** statt hart `"self"`. Ohne das ist der Peer nicht auffindbar, denn gesucht wird ueber den Locator. Leerer Wert bleibt `"self"`, also das alte Verhalten.

## Gemessen

An einem per `peer add` gepinnten `local://`-Registry:

| | Ergebnis |
|---|---|
| vorher: `verify s` | `trust roots not configured ...`, Exit 1 |
| nachher: `verify s` | **Exit 0**, mit einer Zeile, die den Anker nennt |
| nachher: `verify --offline s` | **Exit 0** |
| Datei nachtraeglich veraendert | **Exit 10**, `digest mismatch: installed file "SKILL.md" does not match the signed bundle` |

Die letzte Zeile ist der Punkt: der neue Pfad ist keine Abkuerzung um die Pruefung herum, er ist die Pruefung an der richtigen Datei. Das ist SPEC-0407 AC-13.

## Tests

Zwei neue Faelle in `reanchor_test.go`: ein aufgeloester Anker wird benutzt und **gewinnt ueber den Pfad**, und ein **fremder** Schluessel wird trotzdem abgelehnt. Das neue Feld darf kein Weg am Pin vorbei sein.

Die Fixture baut den Anker ueber den Loader statt von Hand: ein handgebautes Struct traegt base64 und keinen Schluessel, und genau dieser halbfertige Zustand darf nicht als Anker durchgehen.

`go test ./cmd/skillctl/... ./pkg/skillctl/...`: 33 Pakete gruen, 0 rot. `docaudit`, `verbaudit`, `check-no-emdash` gruen. Manual und beide Tutorials mitgezogen.

## Ein Fund am Rande

Beim Testen ist mir aufgefallen, dass mein erster Einschub in `runInstall` statt in `runVerify` gelandet war. Das waere ein echter Fehler gewesen: `install` darf **nicht** ueber die Sidecar-Ebene durchrutschen. Gefunden, weil der Testlauf die Meldung unveraendert zeigte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)