### PR TITLE
fix(cli): sagen, welcher Digest gilt, und die Kit-Meldung aus dem Kreis holen (BUG-0213, BUG-0215)

### DIFF
--- a/cmd/skillctl/pack.go
+++ b/cmd/skillctl/pack.go
@@ -108,7 +108,12 @@ func runPack(args []string, stdout, stderr io.Writer) int {
 		return exitGeneric
 	}
 
-	fmt.Fprintf(stdout, "bundle_digest: %s\n", digest)
+	// BUG-0213: `pack` and `sign` print two different SHA-256 values for the same
+	// file, and the one that belongs in `attest` / `publish --digest` /
+	// `revoke --digest` is the one SIGN prints. Say so at both ends. The field
+	// names and their positions are unchanged, so anything parsing
+	// `^bundle_digest:` keeps working; only a trailing note is added.
+	fmt.Fprintf(stdout, "bundle_digest: %s  (manifest digest; NOT the value attest/publish/revoke take)\n", digest)
 	fmt.Fprintf(stdout, "output:        %s\n", in.outFile)
 	if len(in.manifest.DataDependencies) > 0 {
 		fmt.Fprintf(stdout, "data_scopes:   %d declared (author-signed, in bundle.json)\n", len(in.manifest.DataDependencies))

--- a/cmd/skillctl/signing_cmds.go
+++ b/cmd/skillctl/signing_cmds.go
@@ -137,7 +137,14 @@ func runSign(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, err)
 		return exitGeneric
 	}
+	// BUG-0213: this is the bundle digest, the SHA-256 of the .skb bytes, and it
+	// is the value every later step wants. `pack` prints a DIFFERENT one (the
+	// manifest digest), and nothing used to say which was which; the wrong value
+	// does not fail here, it fails much later at the consumer as
+	// "gate 4: no attestation ...", which points at a different problem entirely.
+	// The `digest: <hex>` shape is unchanged so existing parsers keep working.
 	fmt.Fprintf(stdout, "digest: %s\n", digestHex)
+	fmt.Fprintf(stdout, "        ^ bundle digest: use this for `attest`, `publish --digest` and `revoke --digest`\n")
 	fmt.Fprintf(stdout, "signature: %s\n", sigPath)
 	return exitOK
 }

--- a/cmd/skillctl/verify_bundle_cmds.go
+++ b/cmd/skillctl/verify_bundle_cmds.go
@@ -387,9 +387,20 @@ func loadBundleMetaSidecar(path string) (*registry.BundleMeta, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			// BUG-0215: the old text said "produce one with
+			// `skillctl export-verification-kit`", and that command fails with THIS
+			// SAME message, so the advice was a circle. No CLI verb produces the
+			// envelope: it carries the author, registry and governance signatures
+			// and comes into existence when the bundle is ADMITTED to a registry.
+			// That is the model working as intended, the hint was simply wrong.
 			return nil, fmt.Errorf(
-				"verify --bundle: BundleMeta sidecar not found at %s "+
-					"(produce one with `skillctl export-verification-kit`, or pass --meta <file>)", path)
+				"verify --bundle: BundleMeta sidecar not found at %s\n"+
+					"  It is produced when a bundle is ADMITTED to a registry, not locally: no skillctl\n"+
+					"  verb creates one. Fetch it from the registry the bundle was admitted to\n"+
+					"  (`skillctl registry show <digest>`), or pass an existing one with --meta <file>.\n"+
+					"  A bundle that has never been through a registry can only be checked with\n"+
+					"  `skillctl verify-sig --pubkey <author.pub> <file.skb>`, which proves authorship\n"+
+					"  and nothing about governance, revocation or tenant scope.", path)
 		}
 		return nil, fmt.Errorf("verify --bundle: read sidecar %s: %w", path, err)
 	}

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -1183,6 +1183,14 @@ skillctl export-verification-kit --bundle <file.skb> --out <dir> [flags]
 Builds a portable, offline verification kit that a third party can check with no network and
 no trust in you.
 
+**Prerequisite, and it is easy to miss:** the kit is built around the `BundleMeta` envelope
+(`<name>.skbmeta.json`), which carries the author, registry and governance signatures and
+comes into existence when the bundle is **admitted to a registry**. No verb produces it
+locally, so a bundle that has only been packed and signed cannot be turned into a kit yet.
+Fetch the envelope from the registry the bundle was admitted to, or pass it with `--meta`.
+Offline, without it, the available check is `verify-sig` against the author key, which proves
+authorship and nothing about governance, revocation or tenant scope (BUG-0215).
+
 | Flag | Purpose |
 |------|---------|
 | `-bundle` | Signed `.skb` to package. **Required.** |

--- a/docs/tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md
+++ b/docs/tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md
@@ -445,7 +445,8 @@ Widerrufsprüfung, keinen Tenant-Scope, und keine spätere Nachprüfbarkeit (sie
 Das ist ein Notweg, kein Regelweg. Der dafür vorgesehene portable Weg,
 `skillctl verify --bundle` mit einer `BundleMeta`-Hülle, setzt voraus, dass das Bundle einmal
 durch ein Registry gelaufen ist: die Hülle `<name>.skbmeta.json` entsteht beim Admit, und
-`export-verification-kit` kann sie heute nicht aus einem frisch signierten Bundle erzeugen.
+`export-verification-kit` kann sie nicht erzeugen, es baut das Kit nur um sie herum. Das
+Kommando sagt das inzwischen selbst und nennt `skillctl registry show <digest>` als Bezugsquelle.
 
 ---
 

--- a/docs/tutorial-szenario-02-erster-signierter-skill.de.md
+++ b/docs/tutorial-szenario-02-erster-signierter-skill.de.md
@@ -614,9 +614,10 @@ Die vollständige Kette prüft mehr als die Autorensignatur: Registry-Signatur, 
 Governance-Level, Tenant-Scope. Offline und ohne Registry können Sie davon nur die
 Autorensignatur prüfen. Der dafür vorgesehene portable Weg (`skillctl verify --bundle` mit
 einer `BundleMeta`-Hülle, oder ein `export-verification-kit`) setzt voraus, dass das Bundle
-einmal durch ein Registry gelaufen ist: die Hülle `<name>.skbmeta.json` entsteht beim Admit.
-Ein frisch gepacktes, sauber signiertes Bundle lässt sich heute nicht in ein solches Kit
-verwandeln.
+einmal durch ein Registry gelaufen ist: die Hülle `<name>.skbmeta.json` entsteht beim Admit,
+kein Kommando erzeugt sie lokal. Ein frisch gepacktes, sauber signiertes Bundle lässt sich
+deshalb nicht in ein solches Kit verwandeln, und die Fehlermeldung sagt inzwischen, woher die
+Hülle stattdessen kommt.
 
 ### 3.3 Von Hand entpackte Skills sind stumm
 

--- a/scripts/tutorial-smoke.sh
+++ b/scripts/tutorial-smoke.sh
@@ -223,12 +223,16 @@ run "pack" 0 "$SKILLCTL" pack \
   --name hello-kup --version 0.1.0 --summary "Uebungsskill" \
   --author-intent green --author-intent-rationale "kein Netzwerk; schreibt nur ./out"
 expect_in "pack nennt einen bundle_digest" "bundle_digest:"
+expect_in "pack sagt, dass es NICHT der Digest fuer attest ist" "manifest digest"
 PACK_DIGEST="$(printf '%s' "$LAST_OUT" | awk '/^bundle_digest:/ {print $2}')"
 
 run "sign" 0 "$SKILLCTL" sign \
   --key "$WS/keys/mitarbeiter.priv" --identity-id id:mitarbeiter@kup \
   "$WS/hello-kup@0.1.0.skb"
 expect_in "sign nennt einen digest" "digest:"
+# BUG-0213: die Ausgabe muss selbst sagen, welcher der beiden Digests gilt. Genau
+# das ist die Zusage, die das Tutorial an dieser Stelle macht.
+expect_in "sign sagt, wofuer der Digest gilt" "use this for"
 DIGEST_HEX="$(printf '%s' "$LAST_OUT" | awk '/^digest:/ {print $2}')"
 DIGEST="sha256:$DIGEST_HEX"
 note "pack: $PACK_DIGEST"


### PR DESCRIPTION
Schliesst #200 und #201.

> **Basis ist #203, nicht master.** Beide Fixes aendern Ausgabetexte, die das Smoke-Gate aus #203 prueft, und dieser PR zieht das Gate mit. Merge zuerst #203, danach faellt dieser PR automatisch auf `master` zurueck. (Alternativ kann die Basis nach dem Merge von #203 auf `master` umgestellt werden.)

## BUG-0213: zwei Digests, und keiner sagte, welcher gilt

`pack` und `sign` melden fuer dieselbe Datei zwei verschiedene SHA-256-Werte. Massgeblich fuer `attest`, `publish --digest` und `revoke --digest` ist der von **`sign`**; der von `pack` ist der Manifest-Digest.

Der falsche Wert scheitert nicht sofort und nicht laut. Er wandert in eine Attestierung, die auf einen Digest zeigt, den es im Registry nicht gibt, und faellt erst beim Konsumenten auf, als `gate 4: no attestation ...`, also als eine Meldung, die auf ein voellig anderes Problem zeigt.

Unsere eigene Demo umging die Falle stillschweigend, indem sie die `sign`-Ausgabe parst. Bekannt war sie also den Skripten, nicht den Menschen.

```
bundle_digest: sha256:755e1a...  (manifest digest; NOT the value attest/publish/revoke take)
output:        /tmp/x.skb

digest: 30912e...
        ^ bundle digest: use this for `attest`, `publish --digest` and `revoke --digest`
signature: /tmp/x.skb.30912e....author.sig
```

Feldnamen und Positionen bleiben unveraendert: `^bundle_digest:` und `^digest:` parsen sich weiter wie vorher, inklusive `awk '{print $2}'`.

## BUG-0215: die Meldung schickte im Kreis

`verify --bundle` empfahl, die fehlende `BundleMeta`-Huelle "mit `skillctl export-verification-kit`" zu erzeugen, und genau dieses Kommando scheiterte mit **derselben** Meldung.

Kein Verb erzeugt die Huelle. Sie traegt Autor-, Registry- und Governance-Signatur und entsteht beim **Admit im Registry**. Das Modell ist richtig, der Hinweis war falsch. Neu:

```
verify --bundle: BundleMeta sidecar not found at /tmp/x.skbmeta.json
  It is produced when a bundle is ADMITTED to a registry, not locally: no skillctl
  verb creates one. Fetch it from the registry the bundle was admitted to
  (`skillctl registry show <digest>`), or pass an existing one with --meta <file>.
  A bundle that has never been through a registry can only be checked with
  `skillctl verify-sig --pubkey <author.pub> <file.skb>`, which proves authorship
  and nothing about governance, revocation or tenant scope.
```

Der letzte Satz ist der wichtigste: er sagt, was offline ohne die Huelle ueberhaupt beweisbar ist, statt Vollstaendigkeit zu suggerieren.

## Mitgezogen

- Das Smoke-Gate prueft beide Zusagen jetzt (`pack sagt, dass es NICHT der Digest fuer attest ist`, `sign sagt, wofuer der Digest gilt`), damit die Texte nicht wieder auseinanderlaufen.
- Manual: der Kit-Abschnitt nennt die Voraussetzung, statt sie den Leser entdecken zu lassen.
- Beide Szenario-Tutorials an den zwei Stellen, die das alte Verhalten beschrieben.

33 Pakete gruen, 0 rot. `check-docs` inklusive Smoke-Gate gruen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)