### PR TITLE
fix: der Widerruf darf nicht sterben, wenn ein Reviewer gepinnt ist (dringend)

### DIFF
--- a/pkg/skillctl/install/offline_verify.go
+++ b/pkg/skillctl/install/offline_verify.go
@@ -284,7 +284,11 @@ func VerifyInstalledSidecar(opts Opts) error {
 		if rerr != nil {
 			return fmt.Errorf("verify-sidecar: read stashed .skb: %w", rerr)
 		}
-		level, verr := ac.Reverify(str.PubKey(), skbBytes)
+		// FR-0115 seam: the governance attestation may be signed by a REVIEWER key
+		// that is not the registry key. Pass the whole trust-root so the pinned
+		// signer set is honoured, exactly as the pull gauntlet does. Without this,
+		// `peer add --signer` admits an install that the later `verify` refuses.
+		level, verr := ac.ReverifyWithRoots(str, skbBytes)
 		if verr != nil {
 			// Repacked .skb or forged governance → the body Claude would load is
 			// not what the pinned key signed. Map to a digest mismatch (exit 10).

--- a/pkg/skillctl/registry/attest_quorum.go
+++ b/pkg/skillctl/registry/attest_quorum.go
@@ -145,12 +145,37 @@ func (a *AttestAccumulator) OfferRevoke(ev map[string]any) {
 	if rb, _ := ev["revoked_by"].(string); rb == "" {
 		return
 	}
+	// A revoke is issued by the REGISTRY, not by a reviewer, so the registry key
+	// must be accepted here. Before pinned signers existed, the signer set WAS the
+	// registry key (the implicit single signer), so the loop below covered it by
+	// accident. The moment a peer pins a separate reviewer key (FR-0115), the set
+	// no longer contains the registry key, and a publisher-signed revoke stopped
+	// verifying: the kill switch went silently dead while everything else looked
+	// green. That is a fail-OPEN, the one direction this code must never take, and
+	// it was found by replaying user scenario 01 end to end.
+	//
+	// Governance-trusted signers keep their say (SPEC-0359 D5 lets a peer
+	// contribute revokes), so the accepted set is the union: the registry key OR
+	// any pinned signer. That is strictly the old behaviour plus the federated one,
+	// never less.
+	if pub := a.registryPub(); len(pub) > 0 && VerifyEnvelopeSignature(pub, ev) == nil {
+		a.revoked[digest] = struct{}{}
+		return
+	}
 	for _, s := range a.signers {
 		if VerifyEnvelopeSignature(s.pub, ev) == nil {
 			a.revoked[digest] = struct{}{}
 			return
 		}
 	}
+}
+
+// registryPub is the trust-root's own key: the issuer of admits and revokes.
+func (a *AttestAccumulator) registryPub() ed25519.PublicKey {
+	if a == nil || a.tr == nil {
+		return nil
+	}
+	return a.tr.PubKey()
 }
 
 // Qualifying returns the accepted attestations from DISTINCT signers whose NEWEST

--- a/pkg/skillctl/registry/attest_quorum_test.go
+++ b/pkg/skillctl/registry/attest_quorum_test.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
+	"strings"
 	"testing"
 	"time"
 )
@@ -304,5 +306,67 @@ func TestOfferAttestRequiresSignedReviewerAndLevel(t *testing.T) {
 	accC.OfferAttest(signedAttest(t, priv, "id:kamir@m3c", qd, "green", "2026-08-01T00:00:00Z", nil))
 	if len(accC.Qualifying(qd)) != 1 {
 		t.Error("a genuine signed attestation must still qualify")
+	}
+}
+
+// The fail-OPEN that pinning a reviewer key introduced: a revoke is issued by the
+// REGISTRY, but OfferRevoke only accepted the pinned SIGNER set. Before signers
+// existed the set WAS the registry key, so it worked by accident; the moment a
+// peer pinned a separate reviewer, publisher-signed revokes were silently
+// dropped and a revoked bundle installed clean. Found by replaying user scenario
+// 01 end to end (FR-0115).
+func TestOfferRevoke_RegistryKeyCountsAlongsidePinnedSigners(t *testing.T) {
+	regPub, regPriv, _ := ed25519.GenerateKey(nil)
+	revPub, _, _ := ed25519.GenerateKey(nil) // a DIFFERENT pinned reviewer
+	tr := &SelfTrustRoots{
+		Registry: "github://kup/reg", PubKeyB64: base64.StdEncoding.EncodeToString(regPub),
+		GovernanceMinimum: "green", pub: regPub,
+		Signers: []Signer{{ReviewerID: "id:rev@org", PubKeyB64: base64.StdEncoding.EncodeToString(revPub)}},
+	}
+	if err := tr.resolveSigners("test"); err != nil {
+		t.Fatalf("resolveSigners: %v", err)
+	}
+
+	digest := "sha256:" + strings.Repeat("b", 64)
+	ev := map[string]any{
+		"schema_version": "1.0.0",
+		"bundle_digest":  digest,
+		"revoked_by":     "id:registry@kup",
+		"reason_code":    "superseded",
+		"occurred_at":    time.Now().UTC().Format(time.RFC3339),
+	}
+	if _, err := SignEnvelopeSignature(regPriv, ev); err != nil {
+		t.Fatalf("sign revoke: %v", err)
+	}
+
+	acc := NewAttestAccumulator(tr, time.Now())
+	acc.OfferRevoke(ev)
+	if !acc.IsRevoked(digest) {
+		t.Fatal("a revoke signed by the REGISTRY key must count even when reviewer keys are pinned")
+	}
+}
+
+// Not a widening: an envelope signed by a key that is neither the registry key
+// nor a pinned signer still cannot revoke anything.
+func TestOfferRevoke_ForeignKeyStillCannotRevoke(t *testing.T) {
+	regPub, _, _ := ed25519.GenerateKey(nil)
+	_, foreignPriv, _ := ed25519.GenerateKey(nil)
+	tr := &SelfTrustRoots{
+		Registry: "github://kup/reg", PubKeyB64: base64.StdEncoding.EncodeToString(regPub),
+		GovernanceMinimum: "green", pub: regPub,
+	}
+	digest := "sha256:" + strings.Repeat("c", 64)
+	ev := map[string]any{
+		"schema_version": "1.0.0", "bundle_digest": digest,
+		"revoked_by": "id:attacker@evil", "reason_code": "lol",
+		"occurred_at": time.Now().UTC().Format(time.RFC3339),
+	}
+	if _, err := SignEnvelopeSignature(foreignPriv, ev); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	acc := NewAttestAccumulator(tr, time.Now())
+	acc.OfferRevoke(ev)
+	if acc.IsRevoked(digest) {
+		t.Fatal("a revoke from an unpinned key must be ignored (revoke-DoS bound)")
 	}
 }

--- a/pkg/skillctl/registry/attestation_stash.go
+++ b/pkg/skillctl/registry/attestation_stash.go
@@ -111,6 +111,39 @@ func (c *AttestationContext) Reverify(pub ed25519.PublicKey, stashedSkb []byte) 
 // gate + tests are deterministic; the expiry check is a no-op when expires_at is
 // absent (legacy stashes byte-identical).
 func (c *AttestationContext) ReverifyAt(pub ed25519.PublicKey, stashedSkb []byte, now time.Time) (string, error) {
+	return c.reverifyAt(pub, nil, stashedSkb, now)
+}
+
+// ReverifyWithRoots re-anchors against a full trust-root: the registry key for
+// the admit envelope and the bundle signatures, and the pinned SIGNER SET for the
+// governance attestation.
+//
+// This exists because the two are not the same key any more. Once `peer add
+// --signer` (FR-0115) let a publisher and a reviewer hold DIFFERENT keys, which is
+// what makes a separation of duties cryptographic rather than organisational, the
+// single-key re-anchor started refusing perfectly good installs: the pull admitted
+// them (its gauntlet checks every attestation against every pinned signer) and the
+// later `verify` said "digest mismatch". A false alarm, and a tool that cries wolf
+// on a correct setup gets switched off.
+//
+// The signer rule is the pull's rule, not a second one: the envelope must verify
+// against a pinned signer's key, and when that signer declares a reviewer_id the
+// event's reviewer_id must match it (key/id binding, fail closed).
+func (c *AttestationContext) ReverifyWithRoots(tr *SelfTrustRoots, stashedSkb []byte) (string, error) {
+	return c.ReverifyWithRootsAt(tr, stashedSkb, time.Now())
+}
+
+// ReverifyWithRootsAt is ReverifyWithRoots with an injectable clock.
+func (c *AttestationContext) ReverifyWithRootsAt(tr *SelfTrustRoots, stashedSkb []byte, now time.Time) (string, error) {
+	if tr == nil {
+		return "", fmt.Errorf("%w: no trust roots", ErrAttestationReanchor)
+	}
+	return c.reverifyAt(tr.PubKey(), tr.signerSet(), stashedSkb, now)
+}
+
+// reverifyAt does the work. signers == nil keeps the pre-FR-0115 behaviour: the
+// governance envelope is verified against the registry key itself.
+func (c *AttestationContext) reverifyAt(pub ed25519.PublicKey, signers []Signer, stashedSkb []byte, now time.Time) (string, error) {
 	if c == nil || c.AdmitEvent == nil {
 		return "", fmt.Errorf("%w: missing admit event", ErrAttestationReanchor)
 	}
@@ -136,7 +169,7 @@ func (c *AttestationContext) ReverifyAt(pub ed25519.PublicKey, stashedSkb []byte
 	if c.GovernanceAttestation == nil {
 		return "", fmt.Errorf("%w: missing governance attestation", ErrAttestationReanchor)
 	}
-	if err := VerifyEnvelopeSignature(pub, c.GovernanceAttestation); err != nil {
+	if err := verifyGovernanceSigner(pub, signers, c.GovernanceAttestation); err != nil {
 		return "", fmt.Errorf("%w: governance envelope: %v", ErrAttestationReanchor, err)
 	}
 	govDigest, _ := c.GovernanceAttestation["bundle_digest"].(string)
@@ -153,4 +186,29 @@ func (c *AttestationContext) ReverifyAt(pub ed25519.PublicKey, stashedSkb []byte
 		return "", fmt.Errorf("%w: governance attestation expired (expires_at lapsed)", ErrAttestationReanchor)
 	}
 	return level, nil
+}
+
+// verifyGovernanceSigner checks the governance attestation against the pinned
+// signer set, mirroring AttestAccumulator.OfferAttest so the runtime re-anchor and
+// the pull gauntlet cannot drift into two different answers for the same event.
+//
+// With no signers pinned the registry key is the implicit signer, which is the
+// D2 single-key model and the behaviour every existing install relies on.
+func verifyGovernanceSigner(pub ed25519.PublicKey, signers []Signer, ev map[string]any) error {
+	if len(signers) == 0 {
+		return VerifyEnvelopeSignature(pub, ev)
+	}
+	reviewerID, _ := ev["reviewer_id"].(string)
+	for _, s := range signers {
+		if s.pub == nil || VerifyEnvelopeSignature(s.pub, ev) != nil {
+			continue // not this signer's key
+		}
+		// Key/id binding: a pinned signer that names a reviewer_id only vouches
+		// for THAT reviewer. A mismatch is fail-closed, never "close enough".
+		if s.ReviewerID != "" && reviewerID != s.ReviewerID {
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("registry: envelope_signature does not verify against any of the %d pinned signer(s)", len(signers))
 }

--- a/pkg/skillctl/registry/attestation_stash_test.go
+++ b/pkg/skillctl/registry/attestation_stash_test.go
@@ -2,10 +2,14 @@ package registry
 
 import (
 	"crypto/ed25519"
+	"encoding/base64"
 	"errors"
 	"path/filepath"
 	"testing"
 )
+
+// b64 is the raw-key encoding the trust-roots files use.
+func b64(pub ed25519.PublicKey) string { return base64.StdEncoding.EncodeToString(pub) }
 
 // buildAC mints a fully-signed admit + attestation pair and returns the
 // AttestationContext plus the exact .skb bytes the digest was computed over.
@@ -114,5 +118,109 @@ func TestAttestationStash_RoundTrip(t *testing.T) {
 	// Absent stash → ErrNoAttestationStash.
 	if _, err := ReadAttestationStash(filepath.Join(dir, "nope")); !errors.Is(err, ErrNoAttestationStash) {
 		t.Errorf("missing stash: err = %v, want ErrNoAttestationStash", err)
+	}
+}
+
+// buildACSplitKeys mints an admit signed by the PUBLISHER key and an attestation
+// signed by a DIFFERENT reviewer key: the shape `peer add --signer` (FR-0115)
+// made reachable, and the one the single-key re-anchor used to refuse.
+func buildACSplitKeys(t *testing.T, pubPriv, revPriv ed25519.PrivateKey, level string) (*AttestationContext, []byte) {
+	t.Helper()
+	admitItem, digest := mintAdmitItem(t, pubPriv, "split", "1.0.0", "the-real-bundle-bytes")
+	attestItem := mintAttestItem(t, revPriv, "split", "1.0.0", digest, level, "reviewed by someone else")
+	admitEv, err := extractEvent(itemBody(admitItem))
+	if err != nil {
+		t.Fatalf("extract admit: %v", err)
+	}
+	attestEv, err := extractEvent(itemBody(attestItem))
+	if err != nil {
+		t.Fatalf("extract attest: %v", err)
+	}
+	skb, err := extractSkbBytes(itemBody(admitItem))
+	if err != nil {
+		t.Fatalf("extract skb: %v", err)
+	}
+	return &AttestationContext{AdmitEvent: admitEv, GovernanceAttestation: attestEv}, skb
+}
+
+func splitKeyRoots(t *testing.T, regPub, revPub ed25519.PublicKey, reviewerID string) *SelfTrustRoots {
+	t.Helper()
+	tr := &SelfTrustRoots{
+		Registry:          "github://kup/skill-registry",
+		PubKeyB64:         b64(regPub),
+		GovernanceMinimum: "green",
+		pub:               regPub,
+		Signers:           []Signer{{ReviewerID: reviewerID, PubKeyB64: b64(revPub)}},
+	}
+	if err := tr.resolveSigners("test"); err != nil {
+		t.Fatalf("resolveSigners: %v", err)
+	}
+	return tr
+}
+
+// The seam FR-0115 opened: publisher and reviewer are different keys. The pull
+// admits it, so the later re-anchor must too, or `verify` cries wolf on a correct
+// install.
+func TestReverifyWithRoots_SeparateReviewerKey(t *testing.T) {
+	regPub, regPriv, _ := ed25519.GenerateKey(nil)
+	revPub, revPriv, _ := ed25519.GenerateKey(nil)
+	ac, skb := buildACSplitKeys(t, regPriv, revPriv, "green")
+
+	// The old single-key path is exactly what used to fail. Keep it pinned as the
+	// reason this function exists.
+	if _, err := ac.Reverify(regPub, skb); err == nil {
+		t.Fatal("single-key re-anchor should not accept a foreign reviewer signature")
+	}
+
+	level, err := ac.ReverifyWithRoots(splitKeyRoots(t, regPub, revPub, "id:test@m3c"), skb)
+	if err != nil {
+		t.Fatalf("a pinned reviewer key must re-anchor: %v", err)
+	}
+	if level != "green" {
+		t.Errorf("governance level = %q, want green from the SIGNED attestation", level)
+	}
+}
+
+// Not a bypass: an attestation signed by a key nobody pinned is still refused.
+func TestReverifyWithRoots_UnpinnedReviewerRefused(t *testing.T) {
+	regPub, regPriv, _ := ed25519.GenerateKey(nil)
+	_, revPriv, _ := ed25519.GenerateKey(nil)
+	otherPub, _, _ := ed25519.GenerateKey(nil) // pinned, but NOT the signer
+	ac, skb := buildACSplitKeys(t, regPriv, revPriv, "green")
+
+	_, err := ac.ReverifyWithRoots(splitKeyRoots(t, regPub, otherPub, "id:test@m3c"), skb)
+	if err == nil {
+		t.Fatal("an attestation from an unpinned key must be refused")
+	}
+	if !errors.Is(err, ErrAttestationReanchor) {
+		t.Errorf("want ErrAttestationReanchor, got %v", err)
+	}
+}
+
+// Key/id binding: the right key but the wrong reviewer_id is refused, the same
+// rule the pull's accumulator applies. A pinned signer vouches for one identity.
+func TestReverifyWithRoots_ReviewerIDMismatchRefused(t *testing.T) {
+	regPub, regPriv, _ := ed25519.GenerateKey(nil)
+	revPub, revPriv, _ := ed25519.GenerateKey(nil)
+	ac, skb := buildACSplitKeys(t, regPriv, revPriv, "green")
+
+	_, err := ac.ReverifyWithRoots(splitKeyRoots(t, regPub, revPub, "id:somebody-else@org"), skb)
+	if err == nil {
+		t.Fatal("a reviewer_id that does not match the pinned signer must be refused")
+	}
+}
+
+// With no signers pinned nothing changes: the registry key stays the implicit
+// signer, which is what every pre-FR-0115 install relies on.
+func TestReverifyWithRoots_NoSignersKeepsSingleKey(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	ac, skb := buildAC(t, priv, "green")
+	tr := &SelfTrustRoots{Registry: "self", PubKeyB64: b64(pub), GovernanceMinimum: "green", pub: pub}
+	level, err := ac.ReverifyWithRoots(tr, skb)
+	if err != nil {
+		t.Fatalf("single-key re-anchor must keep working: %v", err)
+	}
+	if level != "green" {
+		t.Errorf("level = %q, want green", level)
 	}
 }


### PR DESCRIPTION
**Dringend: `master` traegt seit dem Merge von #204 einen Fail-open.** #204 wurde gemergt, bevor diese beiden Nachbesserungen darauf lagen. Sie sind das Ergebnis des Szenario-Durchlaufs (Welle 2) und schliessen zwei Naehte, die #204 selbst aufgemacht hat.

## 1. Der Widerruf wird verworfen, sobald Reviewer gepinnt sind (fail-OPEN)

Ein Widerruf wird vom **Registry** ausgestellt, nicht von einem Reviewer. `OfferRevoke` prueft die Signatur aber ausschliesslich gegen den gepinnten **Signer-Satz**. Solange es keine Signer gab, WAR dieser Satz der Registry-Schluessel, und es funktionierte zufaellig. Sobald ein Peer mit `--signer` einen getrennten Reviewer pinnt, enthaelt der Satz den Registry-Schluessel nicht mehr, und der vom Herausgeber signierte Widerruf verifiziert gegen keinen Eintrag: **er wird stillschweigend verworfen.**

Gemessen im Szenario-Durchlauf:

```
$ skillctl publish --revoke mein-skill --digest sha256:... --reason superseded
==> revoked: events/<hex>/0003-revoked.json   (Exit 0, Ereignis liegt im Repo)

$ skillctl pull --registry ... --skill mein-skill --install ...
✅ mein-skill@1.0.0 ... gov=green            <-- der Widerruf wird ignoriert
```

Die Notbremse war tot, waehrend alles gruen aussah. Das ist die eine Richtung, die dieser Code nie nehmen darf.

Der akzeptierte Kreis ist jetzt die **Vereinigung**: Registry-Schluessel ODER ein gepinnter Signer. Das ist das alte Verhalten plus das foederierte aus SPEC-0359 D5, nie weniger. Ein Umschlag von einem ungepinnten Schluessel kann weiterhin nichts widerrufen.

## 2. `verify` schlaegt falschen Alarm, sobald Reviewer gepinnt sind (fail-CLOSED)

Der Re-Anchor prueft die hinterlegte Attestierung gegen genau einen Schluessel. Mit getrenntem Reviewer-Schluessel meldet `verify <name>` auf einer **einwandfreien** Installation:

```
digest mismatch: re-anchor: attestation re-anchor failed:
governance envelope: registry: envelope_signature does not verify   (Exit 10)
```

`ReverifyWithRoots` nimmt jetzt den ganzen Trust-Root: Registry-Schluessel fuer Admit und Bundle-Signaturen, gepinnter Signer-Satz fuer die Governance-Attestierung. Die Signer-Regel ist die des Pulls, keine zweite (Bindung Schluessel/reviewer_id, fail-closed).

## Tests

Sechs neue Faelle: getrennter Reviewer passt, ungepinnter Schluessel wird abgelehnt, falsche `reviewer_id` wird abgelehnt, ohne Signer bleibt es beim Einschluessel-Modell, ein Registry-signierter Widerruf zaehlt AUCH bei gepinnten Reviewern, ein fremder Schluessel kann weiterhin nichts widerrufen.

33 Pakete gruen. Beide User-Szenarien laufen mit diesen beiden Fixes ohne Abweichung durch (US-01: 32 Pruefungen, US-02: 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)