### PR TITLE
fix(cli): die zwei irreführenden Texte, der Git-Widerruf, und eine falsche Zusage im Manual

### DIFF
--- a/cmd/skillctl/pack.go
+++ b/cmd/skillctl/pack.go
@@ -108,7 +108,12 @@ func runPack(args []string, stdout, stderr io.Writer) int {
 		return exitGeneric
 	}
 
-	fmt.Fprintf(stdout, "bundle_digest: %s\n", digest)
+	// BUG-0213: `pack` and `sign` print two different SHA-256 values for the same
+	// file, and the one that belongs in `attest` / `publish --digest` /
+	// `revoke --digest` is the one SIGN prints. Say so at both ends. The field
+	// names and their positions are unchanged, so anything parsing
+	// `^bundle_digest:` keeps working; only a trailing note is added.
+	fmt.Fprintf(stdout, "bundle_digest: %s  (manifest digest; NOT the value attest/publish/revoke take)\n", digest)
 	fmt.Fprintf(stdout, "output:        %s\n", in.outFile)
 	if len(in.manifest.DataDependencies) > 0 {
 		fmt.Fprintf(stdout, "data_scopes:   %d declared (author-signed, in bundle.json)\n", len(in.manifest.DataDependencies))

--- a/cmd/skillctl/signing_cmds.go
+++ b/cmd/skillctl/signing_cmds.go
@@ -137,7 +137,14 @@ func runSign(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, err)
 		return exitGeneric
 	}
+	// BUG-0213: this is the bundle digest, the SHA-256 of the .skb bytes, and it
+	// is the value every later step wants. `pack` prints a DIFFERENT one (the
+	// manifest digest), and nothing used to say which was which; the wrong value
+	// does not fail here, it fails much later at the consumer as
+	// "gate 4: no attestation ...", which points at a different problem entirely.
+	// The `digest: <hex>` shape is unchanged so existing parsers keep working.
 	fmt.Fprintf(stdout, "digest: %s\n", digestHex)
+	fmt.Fprintf(stdout, "        ^ bundle digest: use this for `attest`, `publish --digest` and `revoke --digest`\n")
 	fmt.Fprintf(stdout, "signature: %s\n", sigPath)
 	return exitOK
 }

--- a/cmd/skillctl/verify_bundle_cmds.go
+++ b/cmd/skillctl/verify_bundle_cmds.go
@@ -387,9 +387,20 @@ func loadBundleMetaSidecar(path string) (*registry.BundleMeta, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			// BUG-0215: the old text said "produce one with
+			// `skillctl export-verification-kit`", and that command fails with THIS
+			// SAME message, so the advice was a circle. No CLI verb produces the
+			// envelope: it carries the author, registry and governance signatures
+			// and comes into existence when the bundle is ADMITTED to a registry.
+			// That is the model working as intended, the hint was simply wrong.
 			return nil, fmt.Errorf(
-				"verify --bundle: BundleMeta sidecar not found at %s "+
-					"(produce one with `skillctl export-verification-kit`, or pass --meta <file>)", path)
+				"verify --bundle: BundleMeta sidecar not found at %s\n"+
+					"  It is produced when a bundle is ADMITTED to a registry, not locally: no skillctl\n"+
+					"  verb creates one. Fetch it from the registry the bundle was admitted to\n"+
+					"  (`skillctl registry show <digest>`), or pass an existing one with --meta <file>.\n"+
+					"  A bundle that has never been through a registry can only be checked with\n"+
+					"  `skillctl verify-sig --pubkey <author.pub> <file.skb>`, which proves authorship\n"+
+					"  and nothing about governance, revocation or tenant scope.", path)
 		}
 		return nil, fmt.Errorf("verify --bundle: read sidecar %s: %w", path, err)
 	}

--- a/cmd/skillctl/verify_bundle_cmds.go
+++ b/cmd/skillctl/verify_bundle_cmds.go
@@ -400,7 +400,7 @@ func loadBundleMetaSidecar(path string) (*registry.BundleMeta, error) {
 					"  (`skillctl registry show <digest>`), or pass an existing one with --meta <file>.\n"+
 					"  A bundle that has never been through a registry can only be checked with\n"+
 					"  `skillctl verify-sig --pubkey <author.pub> <file.skb>`, which proves authorship\n"+
-					"  and nothing about governance, revocation or tenant scope.", path)
+					"  and nothing about governance, revocation or tenant scope", path)
 		}
 		return nil, fmt.Errorf("verify --bundle: read sidecar %s: %w", path, err)
 	}

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -1179,7 +1179,10 @@ admitted.
 | `-registry` | Registry base URL (default `http://localhost:8080/api/skills`). |
 | `-bump major\|minor\|patch` | Auto-bump the `SKILL.md` version. **Parsed but not yet wired** in v1: it currently changes nothing. |
 
-Exit: `0` gate passed (or `--dry-run`) · `2` gate failed (one or more rows print `FAIL`).
+Exit: `0` gate passed · `2` gate failed (one or more rows print `FAIL`). **`--dry-run` does
+not force a `0`**: it skips the proposal POST, the verdict still rides the exit code. Measured,
+because the earlier wording ("0 gate passed (or --dry-run)") said otherwise and a script that
+believed it would treat every failed gate as a pass.
 
 ---
 

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -1192,6 +1192,14 @@ skillctl export-verification-kit --bundle <file.skb> --out <dir> [flags]
 Builds a portable, offline verification kit that a third party can check with no network and
 no trust in you.
 
+**Prerequisite, and it is easy to miss:** the kit is built around the `BundleMeta` envelope
+(`<name>.skbmeta.json`), which carries the author, registry and governance signatures and
+comes into existence when the bundle is **admitted to a registry**. No verb produces it
+locally, so a bundle that has only been packed and signed cannot be turned into a kit yet.
+Fetch the envelope from the registry the bundle was admitted to, or pass it with `--meta`.
+Offline, without it, the available check is `verify-sig` against the author key, which proves
+authorship and nothing about governance, revocation or tenant scope (BUG-0215).
+
 | Flag | Purpose |
 |------|---------|
 | `-bundle` | Signed `.skb` to package. **Required.** |

--- a/docs/tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md
+++ b/docs/tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md
@@ -454,7 +454,8 @@ Widerrufsprüfung, keinen Tenant-Scope, und keine spätere Nachprüfbarkeit (sie
 Das ist ein Notweg, kein Regelweg. Der dafür vorgesehene portable Weg,
 `skillctl verify --bundle` mit einer `BundleMeta`-Hülle, setzt voraus, dass das Bundle einmal
 durch ein Registry gelaufen ist: die Hülle `<name>.skbmeta.json` entsteht beim Admit, und
-`export-verification-kit` kann sie heute nicht aus einem frisch signierten Bundle erzeugen.
+`export-verification-kit` kann sie nicht erzeugen, es baut das Kit nur um sie herum. Das
+Kommando sagt das inzwischen selbst und nennt `skillctl registry show <digest>` als Bezugsquelle.
 
 ---
 

--- a/docs/tutorial-szenario-02-erster-signierter-skill.de.md
+++ b/docs/tutorial-szenario-02-erster-signierter-skill.de.md
@@ -181,8 +181,11 @@ Ausgabe: eine Tabelle mit elf Prüfungen. In diesem Übungsskill schlägt `#9 sm
 fehl, weil es kein `tests/smoke.sh` gibt. Das ist der beabsichtigte Anblick: das Tor sagt
 Ihnen, was fehlt, bevor ein Mensch seine Zeit darauf verwendet.
 
-> Zwei Dinge dazu. Mit `--dry-run` ist der Prozess-Exit **immer** `0`, lesen Sie die Tabelle,
-> nicht den Exit-Code; ohne `--dry-run` bedeutet `2`, dass das Tor gehalten hat.
+> Zwei Dinge dazu. Der Exit-Code trägt das Urteil, auch mit `--dry-run`: `0` heißt, das Tor
+> ist bestanden, `2` heißt, es hat gehalten. `--dry-run` lässt nur den Eintrag im Registry
+> weg. (Eine frühere Fassung dieses Absatzes behauptete, `--dry-run` sei immer `0`. Das war
+> falsch, und ein Skript, das es geglaubt hätte, hätte jedes gehaltene Tor als Erfolg
+> gelesen.)
 > Und `tar -xzf` ist hier nur ein Übungsgriff: ein von Hand entpackter Skill ist danach für
 > `skillctl verify` unsichtbar (siehe Teil 3.3).
 

--- a/docs/tutorial-szenario-02-erster-signierter-skill.de.md
+++ b/docs/tutorial-szenario-02-erster-signierter-skill.de.md
@@ -622,9 +622,10 @@ Die vollständige Kette prüft mehr als die Autorensignatur: Registry-Signatur, 
 Governance-Level, Tenant-Scope. Offline und ohne Registry können Sie davon nur die
 Autorensignatur prüfen. Der dafür vorgesehene portable Weg (`skillctl verify --bundle` mit
 einer `BundleMeta`-Hülle, oder ein `export-verification-kit`) setzt voraus, dass das Bundle
-einmal durch ein Registry gelaufen ist: die Hülle `<name>.skbmeta.json` entsteht beim Admit.
-Ein frisch gepacktes, sauber signiertes Bundle lässt sich heute nicht in ein solches Kit
-verwandeln.
+einmal durch ein Registry gelaufen ist: die Hülle `<name>.skbmeta.json` entsteht beim Admit,
+kein Kommando erzeugt sie lokal. Ein frisch gepacktes, sauber signiertes Bundle lässt sich
+deshalb nicht in ein solches Kit verwandeln, und die Fehlermeldung sagt inzwischen, woher die
+Hülle stattdessen kommt.
 
 ### 3.3 Von Hand entpackte Skills sind stumm
 

--- a/pkg/skillctl/backend/git/git.go
+++ b/pkg/skillctl/backend/git/git.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -420,8 +421,18 @@ func (b *gitBackend) Publish(ctx context.Context, req artifact.PublishRequest) (
 	if err := validateName(name); err != nil {
 		return nil, err
 	}
-	if err := validateVersion(ver); err != nil {
-		return nil, err
+	// A DIGEST-BOUND event (attest, revoke, install) needs no version: it is filed
+	// under events/<digesthex>/ and the version appears only in the commit message
+	// and the returned ref. `publish --revoke` legitimately has none, because a
+	// revoke is bound to a digest, not to a version, and requiring one made the
+	// kill switch unusable against a git registry: it failed with
+	// `git: invalid version ""` while the same command worked over ER1. An admit
+	// still requires one, because there the version IS a path (skills/<n>/<v>/)
+	// and a tag. A version that IS supplied is validated for every kind.
+	if req.Kind == artifact.KindAdmit || ver != "" {
+		if err := validateVersion(ver); err != nil {
+			return nil, err
+		}
 	}
 	if err := validateDigest(dig); err != nil {
 		return nil, err
@@ -429,7 +440,13 @@ func (b *gitBackend) Publish(ctx context.Context, req artifact.PublishRequest) (
 
 	var res *artifact.PublishResult
 	err := b.withClone(artifact.ModeWrite, func(dir string) error {
-		tag := tagName(name, ver)
+		// Without a version there is no publish unit to name; the event is
+		// identified by its digest. Keep the tag empty rather than minting the
+		// nonsense "<name>/v".
+		tag := ""
+		if ver != "" {
+			tag = tagName(name, ver)
+		}
 
 		// Admit is idempotent on the tag: an already-published version is a safe
 		// no-op (checked before we stamp anything).
@@ -476,6 +493,9 @@ func (b *gitBackend) Publish(ctx context.Context, req artifact.PublishRequest) (
 			return err
 		}
 		msg := fmt.Sprintf("skill %s@%s (%s) %s", name, ver, req.Kind, dig)
+		if ver == "" {
+			msg = fmt.Sprintf("skill %s (%s) %s", name, req.Kind, dig)
+		}
 		if _, err := b.git(dir, "commit", "--quiet", "-m", msg); err != nil {
 			return err
 		}
@@ -491,7 +511,11 @@ func (b *gitBackend) Publish(ctx context.Context, req artifact.PublishRequest) (
 		} else if _, err := b.gitAuth(artifact.ModeWrite, dir, "push", "--quiet", "origin", "HEAD"); err != nil {
 			return err
 		}
-		res = &artifact.PublishResult{Ref: b.ref(name, ver, dig), NativeID: tag, Transport: "git"}
+		nativeID := tag
+		if nativeID == "" {
+			nativeID = path.Join(eventDir(dig), eventFileName(seq, string(req.Kind)))
+		}
+		res = &artifact.PublishResult{Ref: b.ref(name, ver, dig), NativeID: nativeID, Transport: "git"}
 		return nil
 	})
 	if err != nil {

--- a/pkg/skillctl/backend/git/git.go
+++ b/pkg/skillctl/backend/git/git.go
@@ -525,7 +525,16 @@ func (b *gitBackend) Publish(ctx context.Context, req artifact.PublishRequest) (
 }
 
 func (b *gitBackend) ref(name, ver, dig string) artifact.ArtifactRef {
-	return artifact.ArtifactRef{Name: name, Version: ver, Digest: dig, Locator: tagName(name, ver), Scheme: b.scheme}
+	// A digest-bound event (attest, revoke, install) carries no version, and the
+	// tag is the publish unit of an ADMIT. Naming one here would mint the same
+	// nonsense "<name>/v" that Publish deliberately keeps out of NativeID: an
+	// address that resolves to nothing. A versionless event is addressed by its
+	// digest, which the Digest field already carries.
+	loc := ""
+	if ver != "" {
+		loc = tagName(name, ver)
+	}
+	return artifact.ArtifactRef{Name: name, Version: ver, Digest: dig, Locator: loc, Scheme: b.scheme}
 }
 
 // --- List ---

--- a/pkg/skillctl/backend/git/git_test.go
+++ b/pkg/skillctl/backend/git/git_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -442,4 +443,70 @@ func TestGitBackendHeaderAuthRemote(t *testing.T) {
 		t.Errorf("Fetch = %q", blob)
 	}
 	t.Logf("header-auth OK: clean remote=%s, published+fetched %s", gb.remote, name)
+}
+
+// BUG-0215-Nachbar (aus dem Szenario-Durchlauf): a revoke is bound to a DIGEST,
+// not to a version, so `publish --revoke` supplies none. The backend used to
+// reject that with `git: invalid version ""`, which made the kill switch unusable
+// against a git registry while the same command worked over ER1. The version is a
+// path only for an admit; for a digest-bound event it is decoration.
+func TestPublishDigestBoundEventWithoutVersion(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	ctx := context.Background()
+	regPath := filepath.Join(t.TempDir(), "reg.git")
+	spec := "local://" + regPath
+	if _, err := InitLocalRegistry(spec); err != nil {
+		t.Fatalf("InitLocalRegistry: %v", err)
+	}
+	be, err := artifact.Open(spec, artifact.OpenOptions{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer be.Close()
+
+	d := dig(3)
+	if _, err := be.Publish(ctx, admitEvent("revokeme", "1.0.0", d)); err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+
+	// The revoke, exactly as the CLI sends it: name + digest, NO version.
+	res, err := be.Publish(ctx, artifact.PublishRequest{
+		Kind: artifact.KindRevoke,
+		Event: map[string]any{
+			"kind": "revoked", "skill": "revokeme", "bundle_digest": d,
+			"reason": "superseded", "schema_version": "1.0.0",
+		},
+		Meta: artifact.ArtifactMeta{Name: "revokeme", Digest: d},
+	})
+	if err != nil {
+		t.Fatalf("a revoke without a version must be accepted: %v", err)
+	}
+	if res.NativeID == "" || !strings.Contains(res.NativeID, "events/") {
+		t.Errorf("a digest-bound event should report its event path, got %q", res.NativeID)
+	}
+
+	// It has to LAND in the events tree, otherwise the kill switch is decorative.
+	// Asserted on the committed tree rather than through Events(): that reader
+	// classifies by the SIGNED envelope shape (FR-0090 IS-T1) and correctly drops
+	// this test's hand-built envelope. What this test owns is the WRITE path.
+	out, gerr := exec.Command("git", "-C", regPath, "ls-tree", "-r", "HEAD", "--name-only").Output()
+	if gerr != nil {
+		t.Fatalf("ls-tree: %v", gerr)
+	}
+	want := "events/" + digestHex(d) + "/0002-revoked.json"
+	if !strings.Contains(string(out), want) {
+		t.Errorf("the revoke event is not in the repository\n  want a path containing %s\n  got:\n%s", want, out)
+	}
+
+	// An ADMIT still requires a version: there it IS a path (skills/<n>/<v>/).
+	if _, err := be.Publish(ctx, artifact.PublishRequest{
+		Kind:  artifact.KindAdmit,
+		Event: map[string]any{"kind": "admitted", "skill": "nover", "bundle_digest": dig(4)},
+		Meta:  artifact.ArtifactMeta{Name: "nover", Digest: dig(4)},
+		Blob:  []byte("SKB:nover"),
+	}); err == nil {
+		t.Error("an admit without a version must still be refused")
+	}
 }

--- a/scripts/tutorial-smoke.sh
+++ b/scripts/tutorial-smoke.sh
@@ -223,12 +223,16 @@ run "pack" 0 "$SKILLCTL" pack \
   --name hello-kup --version 0.1.0 --summary "Uebungsskill" \
   --author-intent green --author-intent-rationale "kein Netzwerk; schreibt nur ./out"
 expect_in "pack nennt einen bundle_digest" "bundle_digest:"
+expect_in "pack sagt, dass es NICHT der Digest fuer attest ist" "manifest digest"
 PACK_DIGEST="$(printf '%s' "$LAST_OUT" | awk '/^bundle_digest:/ {print $2}')"
 
 run "sign" 0 "$SKILLCTL" sign \
   --key "$WS/keys/mitarbeiter.priv" --identity-id id:mitarbeiter@kup \
   "$WS/hello-kup@0.1.0.skb"
 expect_in "sign nennt einen digest" "digest:"
+# BUG-0213: die Ausgabe muss selbst sagen, welcher der beiden Digests gilt. Genau
+# das ist die Zusage, die das Tutorial an dieser Stelle macht.
+expect_in "sign sagt, wofuer der Digest gilt" "use this for"
 DIGEST_HEX="$(printf '%s' "$LAST_OUT" | awk '/^digest:/ {print $2}')"
 DIGEST="sha256:$DIGEST_HEX"
 note "pack: $PACK_DIGEST"


### PR DESCRIPTION
**Warum dieser PR existiert: #206 ist nicht auf `master` gelandet.** Sein Basis-Branch war der von #203 (gestapelt, wie im PR-Text angekuendigt), und #203 war zu diesem Zeitpunkt bereits gemergt. Der Merge von #206 ging damit in einen Branch, der niemanden mehr erreicht. Der Inhalt hing in der Luft, bis der Szenario-Durchlauf ihn auf `master` vermisst hat. Hier ist er, plus eine weitere Korrektur.

## BUG-0213: zwei Digests, und keiner sagte, welcher gilt

`pack` und `sign` melden fuer dieselbe Datei zwei verschiedene SHA-256-Werte. Massgeblich fuer `attest`, `publish --digest` und `revoke --digest` ist der von **`sign`**. Der falsche Wert scheitert nicht laut: er landet in einer Attestierung auf einen Digest, den es nicht gibt, und faellt erst beim Konsumenten als `gate 4: no attestation ...` auf, also als eine Meldung, die woanders hinzeigt.

Feldnamen und Positionen bleiben, alle bestehenden Parser laufen weiter.

## BUG-0215: die Kit-Meldung schickte im Kreis

`verify --bundle` empfahl das Kommando, das mit derselben Meldung scheitert. Kein Verb erzeugt die `BundleMeta`-Huelle; sie entsteht beim **Admit im Registry**. Die neue Meldung nennt die echte Quelle und sagt, was offline ohne sie ueberhaupt beweisbar ist.

## Der Widerruf gegen ein Git-Registry (aus dem Szenario-Durchlauf)

```
$ skillctl publish --revoke <name> --digest sha256:... --reason superseded
publish: git: invalid version ""      Exit 1
```

Ein Widerruf ist an einen **Digest** gebunden, nicht an eine Version, und das Kommando verlangt folgerichtig keine. Das Backend validierte sie trotzdem fuer jede Ereignisart. Ueber ER1 fiel das nie auf. Das wiegt schwer, weil Git der Produktivpfad ist: die Notbremse griff auf genau dem Weg nicht, den der Kunde nehmen soll.

Die Version wird jetzt dort verlangt, wo sie ein Pfad ist (Admit). Eine angegebene Version wird weiterhin fuer jede Art validiert.

## Eine falsche Zusage im Manual

`propose --dry-run` endet mit **2**, wenn das Tor haelt, und mit 0, wenn es besteht. Das Manual sagte "0 gate passed (or --dry-run)". Ein Skript, das dem geglaubt haette, haette jedes gehaltene Tor als Erfolg gelesen. Manual und Tutorial korrigiert.

## Nachweis

Test fuer den versionslosen Widerruf (angenommen und im Baum, waehrend ein Admit ohne Version weiterhin abgelehnt wird). Smoke-Gate prueft die beiden neuen Digest-Zusagen mit. `check-docs` gruen, 33 Pakete gruen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)