### PR TITLE
feat(audit): install und verify hinterlassen ein Audit-Event (SPEC-0406 T15)

### DIFF
--- a/cmd/skillctl/install_cmds.go
+++ b/cmd/skillctl/install_cmds.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kamir/m3c-tools/pkg/skillctl/auditevent"
 	"github.com/kamir/m3c-tools/pkg/skillctl/install"
 	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
 	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
@@ -38,7 +39,7 @@ import (
 // builds the registry client, and runs install.Install.
 //
 // Returns the SPEC-0188 §11 numeric exit code on failure; 0 on success.
-func runInstall(args []string, stdout, stderr io.Writer) int {
+func runInstall(args []string, stdout, stderr io.Writer) (code int) {
 	fs := flag.NewFlagSet("install", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 
@@ -89,6 +90,28 @@ func runInstall(args []string, stdout, stderr io.Writer) int {
 		return exitUsage
 	}
 
+	// SPEC-0406 AC-07: emit exactly one lifecycle audit event for this run, on
+	// EVERY path that reached a trust decision. A single deferred emitter rather
+	// than a call at each return, because the returns are many and one forgotten
+	// branch is a silently missing record, which is the failure mode this whole
+	// feature exists to prevent.
+	//
+	// Registered here, after the name resolves, so a usage error never reaches
+	// it: a mistyped command is not a trust decision and does not belong in an
+	// evidence log. Fire-and-forget, so nothing below can change `code`.
+	var audErr error
+	var audDigest string
+	defer func() {
+		appendLifecycleEvent(auditHomeOf(*homeOverride), auditevent.LifecycleEvent{
+			Op:       auditevent.OpInstall,
+			Skill:    name,
+			Version:  version,
+			Digest:   audDigest,
+			Reason:   lifecycleReasonFor(code, audErr),
+			ExitCode: code,
+		})
+	}()
+
 	tr, root, err := loadAndPickRoot(*registryURL)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
@@ -130,9 +153,11 @@ func runInstall(args []string, stdout, stderr io.Writer) int {
 		Ctx:           context.Background(),
 	})
 	if err != nil {
+		audErr = err
 		fmt.Fprintln(stderr, err)
 		return verify.ExitCode(err)
 	}
+	audDigest = res.Verify.Digest
 
 	// One-line chain summary on success, plus the install path so the
 	// user can find what just landed.
@@ -153,7 +178,7 @@ func runInstall(args []string, stdout, stderr io.Writer) int {
 // `--all` switches to the SPEC-0247 P0.2 sweep (runVerifyAll): verify every
 // installed skill, optionally quarantining trust-failures. Detected before
 // flag parsing because the sweep takes a different flag set.
-func runVerify(args []string, stdout, stderr io.Writer) int {
+func runVerify(args []string, stdout, stderr io.Writer) (code int) {
 	for _, a := range args {
 		if a == "--" {
 			break
@@ -237,6 +262,25 @@ func runVerify(args []string, stdout, stderr io.Writer) int {
 		return exitUsage
 	}
 
+	// SPEC-0406 AC-07, the verify half. Same single-deferred-emitter reasoning as
+	// runInstall: verify has more return paths than install (sidecar tier,
+	// offline, online), and each one is a trust verdict a reader may later need.
+	//
+	// Re-verification is where AC-06 lives: a skill that was installed cleanly
+	// and tampered with afterwards is caught HERE, and without this event that
+	// detection left no trace at all.
+	var audErr error
+	var audDigest string
+	defer func() {
+		appendLifecycleEvent(auditHomeOf(*homeOverride), auditevent.LifecycleEvent{
+			Op:       auditevent.OpVerify,
+			Skill:    name,
+			Digest:   audDigest,
+			Reason:   lifecycleReasonFor(code, audErr),
+			ExitCode: code,
+		})
+	}()
+
 	// FR-0116: the HTTP trust-roots file is only ONE of the two carriers. A skill
 	// pulled from a self/ER1 or a git registry is anchored by
 	// ~/.claude/trust-roots.yaml or by a pinned peer, and it carries the signed
@@ -276,9 +320,11 @@ func runVerify(args []string, stdout, stderr io.Writer) int {
 			Ctx:           context.Background(),
 		})
 		if err != nil {
+			audErr = err
 			fmt.Fprintln(stderr, err)
 			return verify.ExitCode(err)
 		}
+		audDigest = res.Digest
 		fmt.Fprintln(stdout, res.ChainSummary+" (offline)")
 		return exitOK
 	}
@@ -298,9 +344,11 @@ func runVerify(args []string, stdout, stderr io.Writer) int {
 		Ctx:           context.Background(),
 	})
 	if err != nil {
+		audErr = err
 		fmt.Fprintln(stderr, err)
 		return verify.ExitCode(err)
 	}
+	audDigest = res.Digest
 	fmt.Fprintln(stdout, res.ChainSummary)
 	return exitOK
 }
@@ -455,4 +503,19 @@ func verifySidecarTier(name, homeOverride, governanceMin string, verbose bool, s
 	fmt.Fprintf(stdout, "%s: content bound to the signed bundle, governance %s, anchored on %s (offline)\n",
 		name, strOr(side.GovernanceLevel, "unknown"), src)
 	return exitOK, true
+}
+
+// auditHomeOf resolves the root the lifecycle audit log lives under: the
+// --home override when given, else the user's home. An unresolvable home
+// returns "", which appendLifecycleEvent treats as "nowhere to write" and
+// skips. Never returns an error: a missing home must not affect a decision.
+func auditHomeOf(override string) string {
+	if override != "" {
+		return override
+	}
+	h, err := userHome()
+	if err != nil {
+		return ""
+	}
+	return h
 }

--- a/cmd/skillctl/lifecycle_audit.go
+++ b/cmd/skillctl/lifecycle_audit.go
@@ -1,0 +1,187 @@
+package main
+
+// lifecycle_audit.go: the install/verify audit producer (SPEC-0406 AC-07 / T15).
+//
+// WHAT WAS MISSING. SPEC-0403 built the shared skillctl.audit.v1 envelope and a
+// complete taxonomy, and only the SPEC-0255 gate ever wrote to it. `install` and
+// `verify` ran the whole §7 trust chain, refused artifacts, and left no record,
+// so the SPEC-0406 acceptance matrix row T15 ("the tampering attempt is visible
+// in the audit trail") could not pass. This file is the second producer.
+//
+// CRITICAL CONTRACT, identical to gate_audit.go and load-bearing for the same
+// reason: this is fire-and-forget accountability, NOT a trust input.
+// appendLifecycleEvent swallows every error and recovers from any panic, so a
+// logging failure (read-only home, full disk, marshal panic, an unclassified
+// reason) can NEVER change the install/verify exit code or its output. Callers
+// invoke it as a bare statement and never branch on a result.
+//
+// The direction of that rule matters and is easy to get backwards: an audit
+// system that can refuse an install has become a trust component, and then its
+// own availability is part of the attack surface. It is not one here.
+//
+// WHY A SEPARATE FILE FROM gate-audit.jsonl. Same envelope, same directory,
+// different volume and different half-life. The gate log is high-frequency
+// telemetry from every tool call; the lifecycle log is a handful of lines per
+// day, each one a trust decision somebody may have to defend years later.
+// Mixing them would make retention a single compromise between the two, and the
+// SPEC-0406 evidence question ("show me the refusals") would start with a
+// filter instead of a file.
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/auditevent"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// lifecycleAuditMaxBytes bounds the live log; beyond it the file rotates to
+// lifecycle-audit.jsonl.1 (single generation). A var, not a const, so a test can
+// exercise rotation without writing megabytes.
+var lifecycleAuditMaxBytes int64 = 5 << 20 // 5 MiB
+
+// lifecycleAuditPath reuses verdictDir so the ~/.claude/skillctl 0700 convention
+// is identical to the verdict cache and the gate log.
+func lifecycleAuditPath(home string) string {
+	return filepath.Join(verdictDir(home), "lifecycle-audit.jsonl")
+}
+
+// lifecycleAuditSink is the write seam. A test injects a failing sink to prove
+// the install/verify exit code is unchanged when logging fails: the whole point
+// of the decision-invariance contract above.
+var lifecycleAuditSink = defaultLifecycleAuditSink
+
+func defaultLifecycleAuditSink(home string, line []byte) error {
+	dir := verdictDir(home)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	path := lifecycleAuditPath(home)
+	// Best-effort size rotation BEFORE the append. A lost rotation race just
+	// means one extra line in the old generation.
+	if fi, err := os.Stat(path); err == nil && fi.Size() >= lifecycleAuditMaxBytes {
+		_ = os.Rename(path, path+".1")
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(append(line, '\n'))
+	return err
+}
+
+// lifecycleReason resolves a verifier error into the stable audit reason code.
+//
+// The order mirrors verify.ExitCode deliberately: that function is the shipped
+// definition of "which failure won", and a second, independently-ordered switch
+// would eventually disagree with it and put one cause in the exit code and a
+// different one in the audit record. A test pins the two against each other.
+//
+// A nil error is ReasonOK. An error nobody classified is ReasonInternalError,
+// never a refusal: reporting an unrecognised fault as a policy denial would
+// inflate the refusal count with our own bugs.
+func lifecycleReason(err error) auditevent.ReasonCode {
+	switch {
+	case err == nil:
+		return auditevent.ReasonOK
+	case errors.Is(err, verify.ErrDigestMismatch):
+		return auditevent.ReasonDigestMismatch
+	case errors.Is(err, verify.ErrAuthorSigInvalid):
+		return auditevent.ReasonAuthorSigInvalid
+	case errors.Is(err, verify.ErrRegistryNotTrusted):
+		return auditevent.ReasonRegistryNotTrusted
+	case errors.Is(err, verify.ErrGovernanceBelowMin):
+		return auditevent.ReasonGovernanceBelowMin
+	case errors.Is(err, verify.ErrDepsUnsatisfied):
+		return auditevent.ReasonDepsUnsatisfied
+	case errors.Is(err, verify.ErrBlobMissing):
+		return auditevent.ReasonBlobMissing
+	case errors.Is(err, verify.ErrTenantBlocked):
+		return auditevent.ReasonTenantBlocked
+	case errors.Is(err, verify.ErrIntentInconsistent):
+		return auditevent.ReasonIntentInconsistent
+	case errors.Is(err, verify.ErrIdentityMismatch):
+		return auditevent.ReasonIdentityMismatch
+	case errors.Is(err, verify.ErrIdentityRevoked):
+		return auditevent.ReasonIdentityRevoked
+	case errors.Is(err, verify.ErrDataSourceDenied):
+		return auditevent.ReasonDataSourceDenied
+	case errors.Is(err, verify.ErrSelfAttested):
+		return auditevent.ReasonSelfAttested
+	case errors.Is(err, verify.ErrRevocationStale):
+		return auditevent.ReasonRevocationStale
+	case errors.Is(err, verify.ErrLogInclusionMissing):
+		return auditevent.ReasonLogInclusionMissing
+	default:
+		return auditevent.ReasonInternalError
+	}
+}
+
+// lifecycleReasonFor resolves the reason from BOTH the captured error and the
+// exit code, and it exists because relying on the error alone was wrong.
+//
+// The bug it fixes, found by running the real binary rather than the test: a
+// refusal path that returns a numbered code without routing its error through
+// the audit variable produced `outcome: success` next to `exit_code: 1`. A
+// refusal recorded as a success is the single worst record this log can hold,
+// and it happened on the FIRST branch anyone checked.
+//
+// Discipline at every return was the wrong mechanism, because there are many
+// returns and one missed branch is silent. So the invariant is structural
+// instead: a non-zero exit can never be a success, whatever the caller did or
+// forgot to do. An unattributed failure becomes an internal error, which is the
+// honest reading (we do not know why) and never inflates the refusal count.
+func lifecycleReasonFor(code int, err error) auditevent.ReasonCode {
+	if err != nil {
+		return lifecycleReason(err)
+	}
+	if code == exitOK {
+		return auditevent.ReasonOK
+	}
+	return auditevent.ReasonInternalError
+}
+
+// appendLifecycleEvent records one install or verify outcome.
+//
+// Fire-and-forget: any error or panic is swallowed. Fills Ts when the caller
+// left it empty. `home` is the resolved install root; an empty home means there
+// is nowhere to write and the call is skipped (a pre-home usage error, which is
+// not a trust decision and does not belong in this log anyway).
+func appendLifecycleEvent(home string, ev auditevent.LifecycleEvent) {
+	defer func() { _ = recover() }()
+	if home == "" {
+		return
+	}
+	if ev.Ts == "" {
+		ev.Ts = time.Now().UTC().Format(time.RFC3339)
+	}
+	e, err := auditevent.FromLifecycleEvent(ev, "skillctl/"+version)
+	if err != nil {
+		return // an unclassified reason costs a line, never a decision.
+	}
+	_ = newLifecycleAuditDispatcher(home).Dispatch(e)
+}
+
+// newLifecycleAuditDispatcher builds the best-effort dispatcher for this
+// producer. Redaction is the package default, the same one the gate uses: the
+// two producers must not disagree about what may be written down.
+func newLifecycleAuditDispatcher(home string) *auditevent.Dispatcher {
+	return auditevent.NewDispatcher(auditevent.DefaultRedactor(), &lifecycleAuditSeamSink{home: home})
+}
+
+// lifecycleAuditSeamSink adapts auditevent.Sink onto the injectable write seam.
+type lifecycleAuditSeamSink struct{ home string }
+
+func (s *lifecycleAuditSeamSink) Name() string { return "lifecycle-audit" }
+func (s *lifecycleAuditSeamSink) Close() error { return nil }
+func (s *lifecycleAuditSeamSink) Write(e *auditevent.Event) error {
+	line, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	return lifecycleAuditSink(s.home, line)
+}

--- a/cmd/skillctl/lifecycle_audit.go
+++ b/cmd/skillctl/lifecycle_audit.go
@@ -65,6 +65,11 @@ func defaultLifecycleAuditSink(home string, line []byte) error {
 	if fi, err := os.Stat(path); err == nil && fi.Size() >= lifecycleAuditMaxBytes {
 		_ = os.Rename(path, path+".1")
 	}
+	// #nosec G304 -- `path` is lifecycleAuditPath(home) under the caller's OWN
+	// resolved home (the --home flag or $HOME). It is the operator choosing where
+	// their own audit log lives on their own machine, not attacker-controlled
+	// input crossing a boundary: anyone who can set --home can already write the
+	// file directly. Same construction as gate_audit.go and invocation_trail.go.
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err

--- a/cmd/skillctl/lifecycle_audit_test.go
+++ b/cmd/skillctl/lifecycle_audit_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -136,8 +137,14 @@ func TestLifecycleEventIsWrittenAndParses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("no lifecycle audit file at %s: %v", path, err)
 	}
-	if perm := fi.Mode().Perm(); perm != 0o600 {
-		t.Errorf("lifecycle audit file mode = %o, want 600", perm)
+	// 0600 file (POSIX). Windows has no Unix permission bits: Go reports 0666
+	// there regardless, and access is governed by ACLs instead. Asserting the
+	// bits on Windows would test Go's mapping, not our security property. Same
+	// guard as invocation_trail_test.go.
+	if runtime.GOOS != "windows" {
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Errorf("lifecycle audit file mode = %o, want 600", perm)
+		}
 	}
 	if got := filepath.Base(path); got != "lifecycle-audit.jsonl" {
 		t.Errorf("audit file is named %q; it must stay separate from gate-audit.jsonl", got)

--- a/cmd/skillctl/lifecycle_audit_test.go
+++ b/cmd/skillctl/lifecycle_audit_test.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/auditevent"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// THE test of this feature, and the reason the whole producer is fire-and-forget.
+//
+// An audit layer that can change a trust decision has become a trust component,
+// and then its availability is part of the attack surface: an attacker who can
+// fill the disk could steer an install. This pins the opposite property. The
+// same run is executed twice, once with a working sink and once with a sink that
+// fails every write, and the exit code, stdout and stderr must be identical
+// byte for byte.
+func TestLifecycleAuditFailureDoesNotChangeTheDecision(t *testing.T) {
+	home := t.TempDir()
+	hermeticTrustRoots(t)
+
+	run := func(sink func(string, []byte) error) (int, string, string) {
+		orig := lifecycleAuditSink
+		lifecycleAuditSink = sink
+		defer func() { lifecycleAuditSink = orig }()
+
+		var stdout, stderr bytes.Buffer
+		// A name that cannot resolve against any configured trust root: the run
+		// reaches a verdict and refuses, which is exactly the path an audit
+		// failure could plausibly disturb.
+		code := runVerify([]string{"--home", home, "--offline", "no-such-skill"}, &stdout, &stderr)
+		return code, stdout.String(), stderr.String()
+	}
+
+	// Anti-vacuity: a test that compares two runs which never emitted anything
+	// would compare nothing twice and pass. Count the writes and require them.
+	okCalls, badCalls := 0, 0
+	okCode, okOut, okErr := run(func(string, []byte) error { okCalls++; return nil })
+	badCode, badOut, badErr := run(func(string, []byte) error { badCalls++; return errors.New("disk full") })
+	if okCalls == 0 || badCalls == 0 {
+		t.Fatalf("the audit sink was never reached (ok=%d, bad=%d): this test would pass while measuring nothing", okCalls, badCalls)
+	}
+
+	if okCode != badCode {
+		t.Errorf("exit code changed when the audit sink failed: %d then %d", okCode, badCode)
+	}
+	if okOut != badOut {
+		t.Errorf("stdout changed when the audit sink failed:\n ok: %q\nbad: %q", okOut, badOut)
+	}
+	if okErr != badErr {
+		t.Errorf("stderr changed when the audit sink failed:\n ok: %q\nbad: %q", okErr, badErr)
+	}
+}
+
+// A panicking sink is the harsher version of the same property: a marshal panic
+// or a nil map deep in a sink must not take the command down with it.
+func TestLifecycleAuditPanicIsContained(t *testing.T) {
+	home := t.TempDir()
+	hermeticTrustRoots(t)
+	orig := lifecycleAuditSink
+	lifecycleAuditSink = func(string, []byte) error { panic("sink exploded") }
+	defer func() { lifecycleAuditSink = orig }()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("a panicking audit sink escaped into the command: %v", r)
+		}
+	}()
+
+	var stdout, stderr bytes.Buffer
+	_ = runVerify([]string{"--home", home, "--offline", "no-such-skill"}, &stdout, &stderr)
+}
+
+// The mapping from a verifier sentinel to an audit reason must agree with the
+// mapping from that same sentinel to an exit code. If they drift, an operator
+// reads one cause in the shell and a different one in the evidence log, and the
+// log is the one that outlives the shell.
+func TestReasonAgreesWithExitCode(t *testing.T) {
+	cases := []struct {
+		err      error
+		wantCode int
+		wantRsn  auditevent.ReasonCode
+	}{
+		{verify.ErrDigestMismatch, verify.ExitDigestMismatch, auditevent.ReasonDigestMismatch},
+		{verify.ErrAuthorSigInvalid, verify.ExitAuthorSigInvalid, auditevent.ReasonAuthorSigInvalid},
+		{verify.ErrRegistryNotTrusted, verify.ExitRegistryNotTrusted, auditevent.ReasonRegistryNotTrusted},
+		{verify.ErrGovernanceBelowMin, verify.ExitGovernanceBelowMin, auditevent.ReasonGovernanceBelowMin},
+		{verify.ErrDepsUnsatisfied, verify.ExitDepsUnsatisfied, auditevent.ReasonDepsUnsatisfied},
+		{verify.ErrBlobMissing, verify.ExitBlobMissing, auditevent.ReasonBlobMissing},
+		{verify.ErrTenantBlocked, verify.ExitTenantBlocked, auditevent.ReasonTenantBlocked},
+		{verify.ErrIntentInconsistent, verify.ExitIntentInconsistent, auditevent.ReasonIntentInconsistent},
+		{verify.ErrIdentityMismatch, verify.ExitIdentityMismatch, auditevent.ReasonIdentityMismatch},
+		{verify.ErrDataSourceDenied, verify.ExitDataSourceDenied, auditevent.ReasonDataSourceDenied},
+		{verify.ErrSelfAttested, verify.ExitSelfAttested, auditevent.ReasonSelfAttested},
+		{verify.ErrRevocationStale, verify.ExitRevocationStale, auditevent.ReasonRevocationStale},
+		{verify.ErrLogInclusionMissing, verify.ExitLogInclusionMissing, auditevent.ReasonLogInclusionMissing},
+	}
+	for _, tc := range cases {
+		if got := verify.ExitCode(tc.err); got != tc.wantCode {
+			t.Errorf("%v: exit code = %d, want %d", tc.err, got, tc.wantCode)
+		}
+		if got := lifecycleReason(tc.err); got != tc.wantRsn {
+			t.Errorf("%v: reason = %q, want %q", tc.err, got, tc.wantRsn)
+		}
+	}
+	if got := lifecycleReason(nil); got != auditevent.ReasonOK {
+		t.Errorf("nil error mapped to %q, want %q", got, auditevent.ReasonOK)
+	}
+	// An error nobody classified must be an internal fault, never a refusal.
+	if got := lifecycleReason(errors.New("some transport hiccup")); got != auditevent.ReasonInternalError {
+		t.Errorf("unclassified error mapped to %q, want %q", got, auditevent.ReasonInternalError)
+	}
+}
+
+// The written line must be a valid event on the shared envelope, at 0600, in the
+// dedicated lifecycle file. SPEC-0406 Phase 9 asks a reader to find the refusal;
+// this proves there is something to find and that it parses.
+func TestLifecycleEventIsWrittenAndParses(t *testing.T) {
+	home := t.TempDir()
+	appendLifecycleEvent(home, auditevent.LifecycleEvent{
+		Op:       auditevent.OpInstall,
+		Skill:    "eric-demo-skill",
+		Digest:   "sha256:deadbeef",
+		Reason:   auditevent.ReasonDigestMismatch,
+		ExitCode: verify.ExitDigestMismatch,
+	})
+
+	path := lifecycleAuditPath(home)
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("no lifecycle audit file at %s: %v", path, err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("lifecycle audit file mode = %o, want 600", perm)
+	}
+	if got := filepath.Base(path); got != "lifecycle-audit.jsonl" {
+		t.Errorf("audit file is named %q; it must stay separate from gate-audit.jsonl", got)
+	}
+
+	data, err := os.ReadFile(path) // #nosec G304 -- path is under the test's own TempDir.
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	line := strings.TrimSpace(string(data))
+	var e auditevent.Event
+	if err := json.Unmarshal([]byte(line), &e); err != nil {
+		t.Fatalf("the written line is not a valid event: %v\nline: %s", err, line)
+	}
+	if e.Schema != auditevent.SchemaV1 {
+		t.Errorf("schema = %q, want %q", e.Schema, auditevent.SchemaV1)
+	}
+	if e.EventType != auditevent.EventSignatureReject {
+		t.Errorf("event_type = %q, want %q", e.EventType, auditevent.EventSignatureReject)
+	}
+	if e.Outcome == auditevent.OutcomeSuccess {
+		t.Error("a refusal was recorded as a success")
+	}
+	if e.Error == nil || e.Error.Code != string(auditevent.ReasonDigestMismatch) {
+		t.Errorf("the record does not name the cause: %+v", e.Error)
+	}
+}
+
+// An empty home means there is nowhere to write. It must be a skip, not a panic
+// and not a write into the current directory.
+func TestEmptyHomeWritesNothing(t *testing.T) {
+	called := false
+	orig := lifecycleAuditSink
+	lifecycleAuditSink = func(string, []byte) error { called = true; return nil }
+	defer func() { lifecycleAuditSink = orig }()
+
+	appendLifecycleEvent("", auditevent.LifecycleEvent{Op: auditevent.OpInstall, Reason: auditevent.ReasonOK})
+	if called {
+		t.Error("an empty home still reached the sink")
+	}
+}
+
+// hermeticTrustRoots points the trust-roots lookup at an empty temp dir for the
+// duration of one test.
+//
+// Without it these tests read the DEVELOPER's ~/.claude/skill-trust-roots.yaml,
+// so the path they exercise depends on whose laptop runs them: an engineer with
+// a configured root walks a different branch than CI, and the test would pass
+// for both while measuring two different things. That exact shape of
+// non-hermeticity once let an over-broad fail-closed through two adversarial
+// review rounds; only a hermetic run caught it.
+func hermeticTrustRoots(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	orig := trustConfigPath
+	trustConfigPath = func() string { return filepath.Join(dir, "skill-trust-roots.yaml") }
+	t.Cleanup(func() { trustConfigPath = orig })
+}
+
+// REGRESSION. A non-zero exit must never be recorded as a success, no matter
+// which branch produced it.
+//
+// The first end-to-end run of the real binary wrote `outcome: success` next to
+// `lifecycle.exit_code: 1`, because one refusal branch returned a code without
+// routing its error through the audit variable. Relying on every return to
+// remember was the wrong mechanism; lifecycleReasonFor makes it structural, and
+// this test is what stops the property from eroding again.
+func TestNonZeroExitIsNeverASuccess(t *testing.T) {
+	for _, code := range []int{1, 2, 10, 11, 12, 13, 17, 23} {
+		if got := lifecycleReasonFor(code, nil); got == auditevent.ReasonOK {
+			t.Errorf("exit %d with no captured error mapped to %q: a failure would be logged as a success", code, got)
+		}
+	}
+	if got := lifecycleReasonFor(exitOK, nil); got != auditevent.ReasonOK {
+		t.Errorf("exit 0 mapped to %q, want %q", got, auditevent.ReasonOK)
+	}
+	// A captured error still wins over the code: the specific cause beats the
+	// generic fallback.
+	if got := lifecycleReasonFor(10, verify.ErrDigestMismatch); got != auditevent.ReasonDigestMismatch {
+		t.Errorf("a captured error was overridden by the code fallback: got %q", got)
+	}
+}

--- a/pkg/skillctl/auditevent/lifecyclemap.go
+++ b/pkg/skillctl/auditevent/lifecyclemap.go
@@ -1,0 +1,242 @@
+package auditevent
+
+// lifecyclemap.go: the SECOND producer mapping onto the shared skillctl.audit.v1
+// envelope, next to gatemap.go.
+//
+// WHY THIS EXISTS. SPEC-0403 defined the envelope and the taxonomy, and exactly
+// one producer used them: the SPEC-0255 gate. `skillctl install` and
+// `skillctl verify` made trust decisions and emitted nothing, which made
+// SPEC-0406 AC-07 ("security-relevant refusals leave an audit event")
+// unsatisfiable and its matrix row T15 permanently red. This file closes that
+// gap for the install/verify lifecycle.
+//
+// THE DESIGN RULE, and it is the same one gatemap.go follows: the taxonomy
+// CLASSIFIES, the source vocabulary is PRESERVED. `event_type` says which family
+// a refusal belongs to; `error.code` carries the exact reason the verifier
+// named, and `ext` carries the SPEC-0188 §11 numbered exit code verbatim. A
+// reader who only knows the taxonomy learns the shape; a reader who knows
+// skillctl learns the precise cause. Neither is derived from the other after the
+// fact.
+//
+// WHY THE REASON CODE IS A STRING AND NOT AN ERROR. This package is a leaf: it
+// must not import pkg/skillctl/verify, or the audit layer would depend on the
+// trust layer it audits. The caller resolves its typed sentinel into one of the
+// stable ReasonCode constants below and passes that. The mapping from sentinel
+// to code lives with the caller (cmd/skillctl/lifecycle_audit.go), the mapping
+// from code to taxonomy lives here, and a test pins both ends.
+
+import (
+	"fmt"
+	"time"
+)
+
+// LifecycleOp is the lifecycle verb an event describes. It is deliberately not
+// the whole CLI surface: only the two verbs that run the SPEC-0188 §7 trust
+// chain and therefore make a trust decision worth auditing.
+type LifecycleOp string
+
+const (
+	OpInstall LifecycleOp = "install"
+	OpVerify  LifecycleOp = "verify"
+)
+
+// ReasonCode is the stable, machine-readable cause of a lifecycle outcome. These
+// strings are a CONTRACT: they appear in audit records that outlive the binary
+// that wrote them, so renaming one is a breaking change and needs a schema
+// version bump, exactly like an event type (REQ-4.2).
+//
+// They are also the answer to SPEC-0406 AC-16 for this surface: a stable code a
+// machine can match on, paired with a message a human can read. Neither replaces
+// the other.
+type ReasonCode string
+
+const (
+	// ReasonOK marks a completed operation. It is a value rather than the empty
+	// string so "the operation succeeded" and "nobody set a reason" are
+	// distinguishable in a stored record.
+	ReasonOK ReasonCode = "ok"
+
+	// Integrity and signature: the artifact is not what the signed statement says.
+	ReasonDigestMismatch      ReasonCode = "digest_mismatch"
+	ReasonAuthorSigInvalid    ReasonCode = "author_signature_invalid"
+	ReasonLogInclusionMissing ReasonCode = "log_inclusion_missing"
+
+	// Provenance: the artifact may be intact, but its origin does not check out.
+	ReasonRegistryNotTrusted ReasonCode = "registry_not_trusted"
+	ReasonBlobMissing        ReasonCode = "blob_missing"
+	ReasonIdentityMismatch   ReasonCode = "identity_mismatch"
+
+	// Policy: the chain verified, and a rule still says no.
+	ReasonGovernanceBelowMin ReasonCode = "governance_below_minimum"
+	ReasonDepsUnsatisfied    ReasonCode = "deps_unsatisfied"
+	ReasonTenantBlocked      ReasonCode = "tenant_blocked"
+	ReasonIntentInconsistent ReasonCode = "intent_inconsistent"
+	ReasonSelfAttested       ReasonCode = "self_attested"
+	ReasonDataSourceDenied   ReasonCode = "data_source_denied"
+
+	// Revocation: someone pulled the brake, or we cannot prove nobody did.
+	ReasonIdentityRevoked ReasonCode = "identity_revoked"
+	ReasonRevocationStale ReasonCode = "revocation_stale"
+
+	// ReasonInternalError is the catch-all for a non-trust failure (a broken
+	// config file, an unreachable registry). It is deliberately NOT folded into
+	// a refusal reason: "we refused you" and "we broke" are different events,
+	// and conflating them is how an outage gets read as an attack.
+	ReasonInternalError ReasonCode = "internal_error"
+)
+
+// lifecycleClass is the taxonomy + outcome + severity a reason maps to.
+type lifecycleClass struct {
+	refusalType EventType
+	outcome     Outcome
+	severity    Severity
+	category    string // error.category: the coarse grouping a dashboard filters on.
+}
+
+// reasonClasses is the closed mapping from reason to classification. Keeping it
+// as data rather than a switch is deliberate: a test iterates it to prove every
+// declared ReasonCode has a class and every class names a KNOWN event type, so a
+// new reason cannot be added without also being classified.
+//
+// On the choice of event_type for the integrity family: the taxonomy has no
+// `integrity.reject`, and adding one is a taxonomy change that would need its
+// own decision. A digest mismatch IS a failure of the signed statement about the
+// bytes, so signature.reject is the honest family for it, and error.code says
+// digest_mismatch so nothing is lost. SPEC-0406 §Phase 9 names exactly this pair.
+var reasonClasses = map[ReasonCode]lifecycleClass{
+	ReasonDigestMismatch:      {EventSignatureReject, OutcomeFailure, SeverityError, "integrity"},
+	ReasonAuthorSigInvalid:    {EventSignatureReject, OutcomeFailure, SeverityError, "signature"},
+	ReasonLogInclusionMissing: {EventSignatureReject, OutcomeFailure, SeverityError, "transparency_log"},
+
+	ReasonRegistryNotTrusted: {EventProvenanceReject, OutcomeFailure, SeverityError, "provenance"},
+	ReasonBlobMissing:        {EventProvenanceReject, OutcomeFailure, SeverityError, "provenance"},
+	ReasonIdentityMismatch:   {EventProvenanceReject, OutcomeFailure, SeverityError, "provenance"},
+
+	ReasonGovernanceBelowMin: {EventPolicyDeny, OutcomeDeny, SeverityWarning, "governance"},
+	ReasonDepsUnsatisfied:    {EventPolicyDeny, OutcomeDeny, SeverityWarning, "dependencies"},
+	ReasonTenantBlocked:      {EventPolicyDeny, OutcomeDeny, SeverityWarning, "tenancy"},
+	ReasonIntentInconsistent: {EventPolicyDeny, OutcomeDeny, SeverityWarning, "intent"},
+	ReasonSelfAttested:       {EventPolicyDeny, OutcomeDeny, SeverityWarning, "governance"},
+	ReasonDataSourceDenied:   {EventPolicyDeny, OutcomeDeny, SeverityWarning, "data_source"},
+
+	// A detected revocation is critical: it is the one refusal that says an
+	// artifact which once passed must now be treated as hostile.
+	ReasonIdentityRevoked: {EventRevocationDetect, OutcomeDeny, SeverityCritical, "revocation"},
+	// A stale snapshot is a refusal because we cannot SEE a revocation, which is
+	// a weaker statement than having seen one. Warning, not critical.
+	ReasonRevocationStale: {EventPolicyDeny, OutcomeDeny, SeverityWarning, "revocation_freshness"},
+}
+
+// KnownReasonCodes returns every declared reason code. The returned slice is a
+// copy the caller may sort or mutate.
+func KnownReasonCodes() []ReasonCode {
+	out := make([]ReasonCode, 0, len(reasonClasses)+2)
+	out = append(out, ReasonOK, ReasonInternalError)
+	for r := range reasonClasses {
+		out = append(out, r)
+	}
+	return out
+}
+
+// LifecycleEvent is the flat record an install/verify run hands to the mapper.
+// It mirrors GateEvent: a plain struct with no behaviour, so the producer stays
+// free of taxonomy knowledge and the mapper stays free of CLI knowledge.
+type LifecycleEvent struct {
+	Ts        string      // RFC3339 UTC. Filled by the caller if empty.
+	Op        LifecycleOp // install | verify
+	Skill     string
+	Version   string
+	Digest    string     // sha256:<hex> when known.
+	Reason    ReasonCode // ReasonOK on success.
+	ExitCode  int        // the SPEC-0188 §11 numbered code, verbatim.
+	SessionID string
+	Message   string // short human-readable note. Never a full error string with a path (REQ-5.4).
+}
+
+// FromLifecycleEvent maps one install/verify outcome onto the shared envelope.
+//
+// A success becomes skill.install / skill.verify with outcome success. A refusal
+// becomes the family its reason belongs to (signature.reject, provenance.reject,
+// policy.deny, revocation.detect) so a reader filtering on "why do installs get
+// refused here" gets an answer without knowing skillctl's exit codes. In BOTH
+// cases the exit code and the reason travel with the event.
+//
+// An unknown reason is an error rather than a silent "other": a reason nobody
+// classified is a gap in this table, and returning it lets the caller drop the
+// event instead of writing a misleading one. The caller is fire-and-forget, so a
+// gap costs a missing line, never a changed decision.
+func FromLifecycleEvent(l LifecycleEvent, producer string) (*Event, error) {
+	if l.Op != OpInstall && l.Op != OpVerify {
+		return nil, fmt.Errorf("%w: unknown lifecycle op %q", ErrInvalidEvent, l.Op)
+	}
+	ts := l.Ts
+	if ts == "" {
+		ts = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	e := &Event{
+		Schema:    SchemaV1,
+		Timestamp: ts,
+		EventID:   NewEventID(),
+		Producer:  producer,
+		SessionID: l.SessionID,
+		Actor:     &ActorRef{Type: "workload", ID: "skillctl/" + string(l.Op)},
+	}
+	if l.Skill != "" || l.Version != "" || l.Digest != "" {
+		e.Skill = &SkillRef{Name: l.Skill, Version: l.Version, Digest: l.Digest}
+	}
+	if l.Message != "" {
+		e.Message = l.Message
+	}
+
+	switch {
+	case l.Reason == ReasonOK:
+		e.EventType = successTypeFor(l.Op)
+		e.Outcome = OutcomeSuccess
+		e.Severity = SeverityInfo
+
+	case l.Reason == ReasonInternalError:
+		// Not a refusal. The operation did not reach a verdict, and saying
+		// otherwise would let an outage read as a wall of denials.
+		e.EventType = successTypeFor(l.Op)
+		e.Outcome = OutcomeError
+		e.Severity = SeverityError
+		e.Error = &ErrorRef{Code: string(ReasonInternalError), Category: "internal"}
+
+	default:
+		cls, ok := reasonClasses[l.Reason]
+		if !ok {
+			return nil, fmt.Errorf("%w: unclassified lifecycle reason %q", ErrInvalidEvent, l.Reason)
+		}
+		e.EventType = cls.refusalType
+		e.Outcome = cls.outcome
+		e.Severity = cls.severity
+		e.Error = &ErrorRef{Code: string(l.Reason), Category: cls.category}
+		// Preserve the source vocabulary alongside the classification, the same
+		// way FromGateEvent keeps policy.decision: a policy refusal also carries
+		// the deny verdict in the field a SPEC-0247 reader already looks at.
+		if cls.outcome == OutcomeDeny {
+			e.Policy = &PolicyRef{Decision: "deny"}
+		}
+	}
+
+	// The numbered exit code is the operator's primary handle (it is what a
+	// script branched on) and it is NOT derivable from the taxonomy, so it
+	// travels verbatim. Prefixed to avoid colliding with a canonical field.
+	_ = e.SetExt("lifecycle.exit_code", l.ExitCode) //nolint:errcheck // marshaling an int cannot fail.
+	_ = e.SetExt("lifecycle.op", string(l.Op))      //nolint:errcheck // marshaling a string cannot fail.
+
+	if err := e.Validate(); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// successTypeFor is the taxonomy family a lifecycle op belongs to when it is not
+// reporting a refusal.
+func successTypeFor(op LifecycleOp) EventType {
+	if op == OpInstall {
+		return EventSkillInstall
+	}
+	return EventSkillVerify
+}

--- a/pkg/skillctl/auditevent/lifecyclemap.go
+++ b/pkg/skillctl/auditevent/lifecyclemap.go
@@ -189,13 +189,13 @@ func FromLifecycleEvent(l LifecycleEvent, producer string) (*Event, error) {
 		e.Message = l.Message
 	}
 
-	switch {
-	case l.Reason == ReasonOK:
+	switch l.Reason {
+	case ReasonOK:
 		e.EventType = successTypeFor(l.Op)
 		e.Outcome = OutcomeSuccess
 		e.Severity = SeverityInfo
 
-	case l.Reason == ReasonInternalError:
+	case ReasonInternalError:
 		// Not a refusal. The operation did not reach a verdict, and saying
 		// otherwise would let an outage read as a wall of denials.
 		e.EventType = successTypeFor(l.Op)

--- a/pkg/skillctl/auditevent/lifecyclemap_test.go
+++ b/pkg/skillctl/auditevent/lifecyclemap_test.go
@@ -1,0 +1,155 @@
+package auditevent
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// Every declared reason must be classified, and every classification must name a
+// type the taxonomy knows. This is the test the reasonClasses table exists for:
+// it makes "add a reason, forget to classify it" a build-time-ish failure rather
+// than a runtime event that silently never gets written.
+func TestEveryReasonIsClassifiedAndKnown(t *testing.T) {
+	for _, r := range KnownReasonCodes() {
+		if r == ReasonOK || r == ReasonInternalError {
+			continue // handled explicitly, not via the table.
+		}
+		cls, ok := reasonClasses[r]
+		if !ok {
+			t.Errorf("reason %q has no classification", r)
+			continue
+		}
+		if !IsKnownEventType(cls.refusalType) {
+			t.Errorf("reason %q maps to event type %q, which is not in the taxonomy", r, cls.refusalType)
+		}
+		if cls.category == "" {
+			t.Errorf("reason %q has an empty error category", r)
+		}
+	}
+}
+
+// A refusal must never be reported as a success, and the exit code must survive
+// verbatim. Both halves matter: the first is the security statement, the second
+// is what an operator actually greps for.
+func TestRefusalIsNotASuccessAndKeepsItsExitCode(t *testing.T) {
+	e, err := FromLifecycleEvent(LifecycleEvent{
+		Op:       OpInstall,
+		Skill:    "eric-demo-skill",
+		Digest:   "sha256:abc",
+		Reason:   ReasonDigestMismatch,
+		ExitCode: 10,
+	}, "skillctl/test")
+	if err != nil {
+		t.Fatalf("FromLifecycleEvent: %v", err)
+	}
+	if e.Outcome == OutcomeSuccess {
+		t.Fatal("a digest mismatch was reported as a success")
+	}
+	if e.EventType != EventSignatureReject {
+		t.Errorf("event_type = %q, want %q", e.EventType, EventSignatureReject)
+	}
+	if e.Error == nil || e.Error.Code != string(ReasonDigestMismatch) {
+		t.Errorf("error.code did not carry the reason: %+v", e.Error)
+	}
+	// The numbered code is not derivable from the taxonomy, so it has to be
+	// carried, and it has to survive the JSON round trip.
+	raw, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back map[string]any
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, ok := back["lifecycle.exit_code"].(float64); !ok || int(got) != 10 {
+		t.Errorf("lifecycle.exit_code = %v, want 10", back["lifecycle.exit_code"])
+	}
+}
+
+// An internal fault is not a refusal. Conflating them would make an outage read
+// as a wall of policy denials, which is exactly backwards for an operator
+// deciding whether they are under attack or merely broken.
+func TestInternalErrorIsNotADenial(t *testing.T) {
+	e, err := FromLifecycleEvent(LifecycleEvent{
+		Op: OpVerify, Skill: "s", Reason: ReasonInternalError, ExitCode: 1,
+	}, "skillctl/test")
+	if err != nil {
+		t.Fatalf("FromLifecycleEvent: %v", err)
+	}
+	if e.Outcome != OutcomeError {
+		t.Errorf("outcome = %q, want %q", e.Outcome, OutcomeError)
+	}
+	if e.Outcome == OutcomeDeny {
+		t.Fatal("an internal fault was classified as a policy denial")
+	}
+	if e.EventType != EventSkillVerify {
+		t.Errorf("event_type = %q, want %q", e.EventType, EventSkillVerify)
+	}
+}
+
+// A revoked artifact is the one refusal that says "this passed before and must
+// not now". It is pinned at critical so it cannot quietly be demoted to the same
+// severity as a governance shortfall.
+func TestRevocationIsCritical(t *testing.T) {
+	e, err := FromLifecycleEvent(LifecycleEvent{
+		Op: OpInstall, Skill: "s", Reason: ReasonIdentityRevoked, ExitCode: 17,
+	}, "skillctl/test")
+	if err != nil {
+		t.Fatalf("FromLifecycleEvent: %v", err)
+	}
+	if e.Severity != SeverityCritical {
+		t.Errorf("severity = %q, want %q", e.Severity, SeverityCritical)
+	}
+	if e.EventType != EventRevocationDetect {
+		t.Errorf("event_type = %q, want %q", e.EventType, EventRevocationDetect)
+	}
+}
+
+// An unclassified reason must be refused rather than written as something
+// plausible. The producer is fire-and-forget, so refusing costs a missing line;
+// guessing would cost a misleading record, which is worse in an evidence log.
+func TestUnclassifiedReasonIsRefused(t *testing.T) {
+	_, err := FromLifecycleEvent(LifecycleEvent{
+		Op: OpInstall, Skill: "s", Reason: ReasonCode("something_nobody_declared"),
+	}, "skillctl/test")
+	if err == nil {
+		t.Fatal("an unclassified reason produced an event instead of an error")
+	}
+	if !errors.Is(err, ErrInvalidEvent) {
+		t.Errorf("error does not wrap ErrInvalidEvent: %v", err)
+	}
+}
+
+// The op is part of the contract: an unknown verb must not silently become an
+// install record.
+func TestUnknownOpIsRefused(t *testing.T) {
+	if _, err := FromLifecycleEvent(LifecycleEvent{Op: LifecycleOp("pack"), Reason: ReasonOK}, "p"); err == nil {
+		t.Fatal("an unknown lifecycle op was accepted")
+	}
+}
+
+// Success on both verbs lands in the right family, and carries no error block.
+func TestSuccessMapsPerVerb(t *testing.T) {
+	for _, tc := range []struct {
+		op   LifecycleOp
+		want EventType
+	}{
+		{OpInstall, EventSkillInstall},
+		{OpVerify, EventSkillVerify},
+	} {
+		e, err := FromLifecycleEvent(LifecycleEvent{Op: tc.op, Skill: "s", Reason: ReasonOK}, "skillctl/test")
+		if err != nil {
+			t.Fatalf("%s: %v", tc.op, err)
+		}
+		if e.EventType != tc.want {
+			t.Errorf("%s: event_type = %q, want %q", tc.op, e.EventType, tc.want)
+		}
+		if e.Outcome != OutcomeSuccess {
+			t.Errorf("%s: outcome = %q, want success", tc.op, e.Outcome)
+		}
+		if e.Error != nil {
+			t.Errorf("%s: a success carried an error block: %+v", tc.op, e.Error)
+		}
+	}
+}


### PR DESCRIPTION
Schliesst die Luecke, die SPEC-0406 AC-07 unerfuellbar und die Matrixzeile T15 dauerhaft rot machte.

## Der Befund

SPEC-0403 baute den gemeinsamen Umschlag `skillctl.audit.v1` und eine vollstaendige, per Test gepinnte Taxonomie (`skill.install`, `skill.verify`, `signature.reject`, ...). Genau ein Produzent benutzte sie: das SPEC-0255-Gate. `runInstall` und `runVerify` liefen die ganze SPEC-0188-Vertrauenskette, lehnten Artefakte ab und hinterliessen **nichts**.

## Was hinzukommt

**`pkg/skillctl/auditevent/lifecyclemap.go`**, neben `gatemap.go`, mit derselben Regel: die Taxonomie **klassifiziert**, das Quellvokabular bleibt **erhalten**. `event_type` nennt die Familie, `error.code` den genauen Grund, und der nummerierte SPEC-0188-Exit-Code reist unveraendert mit. Die Zuordnung liegt als Tabelle vor, nicht als switch, damit ein Test beweisen kann, dass jeder deklarierte Grund klassifiziert ist.

Zur Wahl fuer die Integritaetsfamilie: der Umschlag kennt kein `integrity.reject`, und eines hinzuzufuegen waere eine Taxonomie-Aenderung mit eigener Entscheidung. Ein Digest-Mismatch ist das Scheitern der signierten Aussage ueber die Bytes, also `signature.reject` mit `error.code: digest_mismatch`. Genau das Paar, das SPEC-0406 Phase 9 nennt.

**`cmd/skillctl/lifecycle_audit.go`**, der Produzent, mit demselben fire-and-forget-Vertrag wie `gate_audit.go`. Das ist keine Bequemlichkeit: eine Audit-Schicht, die eine Installation verweigern kann, ist ein Vertrauensbestandteil geworden, und dann gehoert ihre Verfuegbarkeit zur Angriffsflaeche. Eigene Datei neben `gate-audit.jsonl`, weil die beiden Logs verschiedene Frequenz und verschiedene Halbwertszeit haben.

## Ein Fehler, den erst das echte Binary zeigte

Der erste Ende-zu-Ende-Lauf schrieb `outcome: success` neben `lifecycle.exit_code: 1`, weil ein Ablehnungspfad seinen Fehler nicht durch die Audit-Variable fuehrte. Eine als Erfolg protokollierte Ablehnung ist der schlimmste Eintrag, den dieses Log halten kann, und sie stand im ersten Zweig, den jemand geprueft hat.

Disziplin an jedem `return` war das falsche Mittel. `lifecycleReasonFor` macht die Invariante **strukturell**: ein Exit ungleich null kann nie ein Erfolg sein, egal was der Aufrufer vergisst. Ein nicht zugeordneter Fehlschlag wird `internal_error` statt einer Ablehnung, damit ein Ausfall nicht als Angriff gelesen wird.

## Tests

- **Entscheidungsinvarianz** gegen eine scheiternde und gegen eine panickende Senke: Exit-Code, stdout und stderr byteweise identisch.
- **Anti-Vakuitaet**: der Vergleich zaehlt die Schreibvorgaenge und schlaegt fehl, wenn die Senke nie erreicht wurde. Ein Test, der zweimal nichts vergleicht, besteht sonst.
- **Hermetisch** ueber die vorhandene `trustConfigPath`-Naht. Ohne das lesen die Tests die echten Trust-Roots des Entwicklers und messen auf jedem Rechner etwas anderes.
- **Grund und Exit-Code stimmen ueberein**, ueber alle 13 Sentinels aus `verify.ExitCode`.
- **Regression** fuer den oben gefundenen Fehler.

Alle Gates gruen: 34 Pakete, 0 Fehlschlaege, `go vet` sauber, prose-gate und docaudit bestanden.

Refs: SPEC-0406 AC-07 / T15, SPEC-0403, WF-005

🤖 Generated with [Claude Code](https://claude.com/claude-code)