### PR TITLE
feat(install): install --bundle, der Weg vom .skb in eine Installation (SPEC-0406 D2)

### DIFF
--- a/cmd/skillctl/install_bundle_cmds.go
+++ b/cmd/skillctl/install_bundle_cmds.go
@@ -1,0 +1,126 @@
+package main
+
+// install_bundle_cmds.go: `skillctl install --bundle <file.skb>` (SPEC-0406 D2).
+//
+// The CLI half of the untrusted-transport install. It does the parts that are a
+// user-interface concern (resolve the sidecar, load the pinned roots, explain a
+// misconfiguration in terms the operator can act on) and hands the trust
+// decision to install.InstallBundle, which shares its verification and its write
+// sequence with the registry path.
+//
+// It deliberately mirrors runVerifyBundle: same sidecar resolution, same pinned
+// requirement, same wording. `install --bundle X` should refuse for exactly the
+// reasons `verify --bundle X` refuses, and say so the same way, so an operator
+// who verified before installing is never surprised at the second step.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/auditevent"
+	"github.com/kamir/m3c-tools/pkg/skillctl/install"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+type installBundleParams struct {
+	bundlePath     string
+	metaPath       string
+	trustRootsPath string
+	registryURL    string
+	governanceMin  string
+	allowYellow    bool
+	ignoreDeps     bool
+	tenantFlag     string
+	homeOverride   string
+	verbose        bool
+}
+
+func runInstallBundle(p installBundleParams, stdout, stderr io.Writer) (code int) {
+	// One lifecycle audit event for this run, on every path that reached a trust
+	// decision. Registered first so no early refusal escapes the record; the
+	// skill name is filled in once the SIGNED name is known, and stays empty when
+	// the run never got that far, which is itself the honest reading.
+	var audErr error
+	var audName, audDigest string
+	defer func() {
+		appendLifecycleEvent(auditHomeOf(p.homeOverride), auditevent.LifecycleEvent{
+			Op:       auditevent.OpInstall,
+			Skill:    audName,
+			Digest:   audDigest,
+			Reason:   lifecycleReasonFor(code, audErr),
+			ExitCode: code,
+		})
+	}()
+
+	if st, err := os.Stat(p.bundlePath); err != nil || st.IsDir() {
+		fmt.Fprintf(stderr, "skillctl install --bundle: cannot read bundle file %s\n", p.bundlePath)
+		return exitUsage
+	}
+
+	metaPath := p.metaPath
+	if metaPath == "" {
+		metaPath = defaultMetaSidecar(p.bundlePath)
+	}
+	meta, err := loadBundleMetaSidecar(metaPath)
+	if err != nil {
+		audErr = err
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+
+	tr, root, err := loadAndPickRootFromPath(p.trustRootsPath, p.registryURL)
+	if err != nil {
+		audErr = err
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+
+	// Same refusal as verify --bundle, and for the same reason: with no fetcher
+	// the author key can only come from a local pin. A from-registry root would
+	// fail deep inside the verifier with a message about a missing fetcher, which
+	// tells the operator nothing about what to fix.
+	if root.IdentityKeysAuthorized != "pinned" {
+		fmt.Fprintf(stderr,
+			"skillctl install --bundle is offline; trust root %s must use identity_keys_authorized: pinned "+
+				"(so the author key is verifiable with no registry call). See SPEC-0276 R4.1.\n",
+			root.RegistryURL)
+		return exitGeneric
+	}
+
+	var logger io.Writer
+	if p.verbose {
+		logger = stderr
+	}
+
+	res, err := install.InstallBundle(install.BundleOpts{
+		BundlePath:    p.bundlePath,
+		Meta:          meta,
+		TrustRoot:     root,
+		HomeDir:       p.homeOverride,
+		GovernanceMin: p.governanceMin,
+		AllowYellow:   p.allowYellow,
+		IgnoreDeps:    p.ignoreDeps,
+		Tenant:        resolveTenant(p.tenantFlag, tr),
+		Logger:        logger,
+		Ctx:           context.Background(),
+	})
+	if err != nil {
+		audErr = err
+		fmt.Fprintln(stderr, err)
+		return verify.ExitCode(err)
+	}
+	audDigest = res.Verify.Digest
+	// The recorded name is the SIGNED one, read back from where the skill
+	// actually landed, not from anything the sender supplied.
+	audName = filepath.Base(res.InstalledPath)
+
+	fmt.Fprintln(stdout, res.Verify.ChainSummary)
+	fmt.Fprintf(stdout, "installed: %s\n", res.InstalledPath)
+	if res.ArchivedPath != "" {
+		fmt.Fprintf(stdout, "archived prior install: %s\n", res.ArchivedPath)
+	}
+	return exitOK
+}

--- a/cmd/skillctl/install_cmds.go
+++ b/cmd/skillctl/install_cmds.go
@@ -51,9 +51,13 @@ func runInstall(args []string, stdout, stderr io.Writer) (code int) {
 	timeout := fs.Duration("timeout", registry.DefaultTimeout, "HTTP timeout for registry calls.")
 	verboseFlag := fs.Bool("verbose", false, "Print structured per-step log lines to stderr.")
 	homeOverride := fs.String("home", "", "Override the install root (advanced; defaults to $HOME).")
+	bundlePath := fs.String("bundle", "", "Install a standalone .skb FILE that arrived over an untrusted transport (SPEC-0406). Offline, against pinned trust-roots. Requires a sidecar <file>.skbmeta.json (or --meta).")
+	metaPath := fs.String("meta", "", "Path to the BundleMeta envelope JSON for --bundle (default: the .skbmeta.json sidecar next to the .skb).")
+	trustRootsPath := fs.String("trust-roots", "", "Path to a trust-roots YAML to use instead of the default. Pair with --bundle for a portable verification kit.")
 
 	fs.Usage = func() {
 		fmt.Fprintln(stderr, "Usage: skillctl install <name>[@<version>] [flags]")
+		fmt.Fprintln(stderr, "   or: skillctl install --bundle <file.skb> [--meta <f>] [--trust-roots <f>]")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Pulls a skill bundle from the registry, runs the SPEC-0188 §7 verifier,")
 		fmt.Fprintln(stderr, "and atomically installs it under ~/.claude/skills/<name>/. Refuses if any")
@@ -79,6 +83,29 @@ func runInstall(args []string, stdout, stderr io.Writer) (code int) {
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
 	}
+
+	// --bundle: install a local .skb, fully offline, against pinned trust-roots.
+	// The name positional is NOT accepted here: where the skill lands is decided
+	// by the signed bundle.json, never by the command line (see InstallBundle).
+	if *bundlePath != "" {
+		if fs.NArg() != 0 {
+			fmt.Fprintln(stderr, "skillctl install --bundle <file.skb>: do not also pass a <name> positional arg.")
+			return exitUsage
+		}
+		return runInstallBundle(installBundleParams{
+			bundlePath:     *bundlePath,
+			metaPath:       *metaPath,
+			trustRootsPath: *trustRootsPath,
+			registryURL:    *registryURL,
+			governanceMin:  *governanceMin,
+			allowYellow:    *allowYellow,
+			ignoreDeps:     *ignoreDeps,
+			tenantFlag:     *tenantFlag,
+			homeOverride:   *homeOverride,
+			verbose:        *verboseFlag,
+		}, stdout, stderr)
+	}
+
 	if fs.NArg() != 1 {
 		fs.Usage()
 		return exitUsage

--- a/pkg/skillctl/install/install.go
+++ b/pkg/skillctl/install/install.go
@@ -264,19 +264,74 @@ func Install(opts Opts) (*Result, error) {
 		return nil, err
 	}
 
+	res, err := finishInstall(finishOpts{
+		blob:       blob,
+		blobPath:   blobPath,
+		stagingDir: stagingDir,
+		homeDir:    homeDir,
+		name:       opts.Name,
+		digest:     digest,
+		meta:       meta,
+		resolver:   opts.Client,
+		verRes:     verRes,
+		maxBytes:   opts.MaxExtractedBytes,
+		logger:     opts.Logger,
+		ctx:        ctx,
+		now:        now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	cleanedUp = true
+	return res, nil
+}
+
+// finishOpts is the input to the shared post-verification sequence.
+type finishOpts struct {
+	blob       []byte
+	blobPath   string
+	stagingDir string
+	homeDir    string
+	name       string
+	digest     string
+	meta       *registry.BundleMeta
+	resolver   identityResolver // may be nil: offline installs have no registry
+	verRes     *verify.VerifyResult
+	maxBytes   int64
+	logger     io.Writer
+	ctx        context.Context
+	now        func() time.Time
+}
+
+// finishInstall is everything that happens AFTER the trust chain has passed:
+// extract, validate checksums, atomic install, stash the .skb and the offline
+// metadata.
+//
+// It exists as one function because there are now two ways to reach it, a
+// registry pull and a local .skb (SPEC-0406 D2), and this sequence is the part
+// that actually writes to the user's machine. Two copies of it would be two
+// implementations of one theory, and they drift: this project has already paid
+// for that lesson twice in the simulation package, where a second prediction
+// oracle and a second prune rule each silently disagreed with the original.
+// Here the cost of drift would not be a wrong number in a report, it would be
+// one install path missing a defence the other one has.
+//
+// The caller owns the staging directory's lifetime; this function removes it on
+// success only.
+func finishInstall(o finishOpts) (*Result, error) {
 	// ----- extract -----
-	extractDir := filepath.Join(stagingDir, "extracted")
+	extractDir := filepath.Join(o.stagingDir, "extracted")
 	if err := os.MkdirAll(extractDir, 0o755); err != nil {
 		return nil, fmt.Errorf("install: mkdir extract dir: %w", err)
 	}
-	cap := opts.MaxExtractedBytes
+	cap := o.maxBytes
 	if cap <= 0 {
 		cap = MaxExtractedBytes
 	}
-	if err := extractTGZ(blob, extractDir, cap); err != nil {
+	if err := extractTGZ(o.blob, extractDir, cap); err != nil {
 		return nil, err
 	}
-	logStep(opts.Logger, "extracted", "dir=%s", extractDir)
+	logStep(o.logger, "extracted", "dir=%s", extractDir)
 
 	// ----- validate CHECKSUMS if present -----
 	if err := validateChecksumsIfPresent(extractDir); err != nil {
@@ -284,12 +339,12 @@ func Install(opts Opts) (*Result, error) {
 	}
 
 	// ----- atomic install + archive prior version if any -----
-	canonName, err := CanonicalSkillName(opts.Name) // SEC F12: one fixed point: install writes the same dir the gate/verifier resolve
+	canonName, err := CanonicalSkillName(o.name) // SEC F12: one fixed point: install writes the same dir the gate/verifier resolve
 	if err != nil {
 		return nil, err
 	}
-	target := filepath.Join(homeDir, installRoot, canonName)
-	archivedPath, err := atomicInstall(extractDir, target, homeDir, canonName, digest)
+	target := filepath.Join(o.homeDir, installRoot, canonName)
+	archivedPath, err := atomicInstall(extractDir, target, o.homeDir, canonName, o.digest)
 	if err != nil {
 		return nil, err
 	}
@@ -298,27 +353,26 @@ func Install(opts Opts) (*Result, error) {
 	// `skillctl verify <name>` can recompute the digest later without
 	// re-fetching from the registry. We copy bytes (rather than rename
 	// the staged file) because the staging dir is about to be removed.
-	stashedSkb := filepath.Join(target, filepath.Base(blobPath))
-	if err := os.WriteFile(stashedSkb, blob, 0o644); err != nil {
+	stashedSkb := filepath.Join(target, filepath.Base(o.blobPath))
+	if err := os.WriteFile(stashedSkb, o.blob, 0o644); err != nil {
 		return nil, fmt.Errorf("install: stash .skb in target: %w", err)
 	}
 
 	// Stash BundleMeta + author identity for network-free re-verification
 	// (SPEC-0247). Best-effort: a failure here just means offline verify
 	// falls back to the online path; the install itself still succeeded.
-	if err := StashOfflineMeta(ctx, opts.Client, target, meta, now); err != nil {
-		logStep(opts.Logger, "offline_meta_warn", "offline verify will fall back to online: %v", err)
+	if err := StashOfflineMeta(o.ctx, o.resolver, target, o.meta, o.now); err != nil {
+		logStep(o.logger, "offline_meta_warn", "offline verify will fall back to online: %v", err)
 	}
 
-	cleanedUp = true
 	// Best-effort cleanup of the staging dir (the extract sub-dir was
 	// renamed away, so what's left is just the .skb blob plus the
 	// staging dir itself).
-	_ = os.RemoveAll(stagingDir)
+	_ = os.RemoveAll(o.stagingDir)
 
-	logStep(opts.Logger, "installed", "path=%s archived=%s", target, archivedPath)
+	logStep(o.logger, "installed", "path=%s archived=%s", target, archivedPath)
 	return &Result{
-		Verify:        verRes,
+		Verify:        o.verRes,
 		InstalledPath: target,
 		ArchivedPath:  archivedPath,
 	}, nil

--- a/pkg/skillctl/install/install.go
+++ b/pkg/skillctl/install/install.go
@@ -321,7 +321,12 @@ type finishOpts struct {
 func finishInstall(o finishOpts) (*Result, error) {
 	// ----- extract -----
 	extractDir := filepath.Join(o.stagingDir, "extracted")
-	if err := os.MkdirAll(extractDir, 0o755); err != nil {
+	// 0750, not 0755. Nothing outside this user needs to traverse a staging
+	// directory, and the world-execute bit was never justified: it was simply the
+	// default anyone reaches for. gosec G301 was already flagging it before this
+	// code moved; the move is what surfaced it, and tightening it is cheaper than
+	// carrying it in a baseline.
+	if err := os.MkdirAll(extractDir, 0o750); err != nil {
 		return nil, fmt.Errorf("install: mkdir extract dir: %w", err)
 	}
 	cap := o.maxBytes
@@ -354,7 +359,10 @@ func finishInstall(o finishOpts) (*Result, error) {
 	// re-fetching from the registry. We copy bytes (rather than rename
 	// the staged file) because the staging dir is about to be removed.
 	stashedSkb := filepath.Join(target, filepath.Base(o.blobPath))
-	if err := os.WriteFile(stashedSkb, o.blob, 0o644); err != nil {
+	// 0600 for the same reason: the stashed .skb exists so THIS user's later
+	// `verify <name>` can recompute the digest without a registry call. No other
+	// principal reads it. Pre-existing G306, tightened rather than baselined.
+	if err := os.WriteFile(stashedSkb, o.blob, 0o600); err != nil {
 		return nil, fmt.Errorf("install: stash .skb in target: %w", err)
 	}
 

--- a/pkg/skillctl/install/install_bundle.go
+++ b/pkg/skillctl/install/install_bundle.go
@@ -1,0 +1,226 @@
+package install
+
+// install_bundle.go: installing a .skb FILE that arrived over an untrusted
+// transport (SPEC-0406 D2, decided 2026-09-05).
+//
+// WHY THIS EXISTS. `Install` pulls from a registry: it resolves a name to a
+// digest, fetches the blob and the metadata, and verifies. That is the right
+// production path and it stays. But it cannot express the claim SPEC-0406 AC-02
+// actually makes, which is that the RECIPIENT DOES NOT HAVE TO TRUST THE
+// TRANSPORT. Eric mails Mirko a .skb; there is no registry in the middle. Until
+// now there was no way to install it, so the acceptance test could not run its
+// own scenario.
+//
+// WHAT MAKES THIS SAFE, and it is worth stating because "install from a local
+// file" sounds like the weaker path and is not:
+//
+//   - The trust root is PINNED and local. The author key is not fetched from
+//     anywhere; it was pinned out of band, before the artifact arrived.
+//   - There is NO NETWORK. No fetcher is passed, so nothing about the decision
+//     can be influenced by whoever handed over the file.
+//   - The chain is the SAME verify.Verify the registry path runs, with the same
+//     gates in the same order.
+//   - The write sequence is the SAME finishInstall the registry path uses, so a
+//     defence added to one is a defence in both.
+//
+// The transport is therefore not part of the trust decision at all, which is
+// exactly the property the acceptance test sets out to demonstrate. What the
+// transport CAN do is deliver a different file, and that is precisely what the
+// digest and signature checks catch.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// BundleOpts is the input to InstallBundle.
+type BundleOpts struct {
+	// BundlePath is the .skb file on disk. It arrived over an untrusted
+	// transport; nothing about it is believed until the chain says so.
+	BundlePath string
+	// Meta is the BundleMeta envelope that travelled with the bundle (the
+	// .skbmeta.json sidecar). Its claims are signature-bound, not transport-bound.
+	Meta *registry.BundleMeta
+	// TrustRoot must be a pinned root: the author key has to be verifiable with
+	// no registry call. The caller checks this and reports it in CLI terms.
+	TrustRoot *verify.TrustRoot
+
+	// Name, when set, is checked AGAINST the signed bundle name and a mismatch
+	// refuses the install. It does not override anything: the install directory
+	// is always decided by signed bytes. Empty is the normal case.
+	Name string
+
+	HomeDir           string
+	GovernanceMin     string
+	AllowYellow       bool
+	IgnoreDeps        bool
+	Tenant            string
+	MaxExtractedBytes int64
+	Logger            io.Writer
+	Ctx               context.Context
+	Now               func() time.Time
+}
+
+// InstallBundle verifies a local .skb against pinned trust roots and, only if
+// the whole chain passes, installs it.
+//
+// The error returned is the verifier's typed sentinel, so verify.ExitCode maps
+// it to the same numbered SPEC-0188 §11 code the registry path produces. A
+// caller must not invent its own codes here: an operator comparing two machines
+// has to see the same number for the same cause.
+func InstallBundle(opts BundleOpts) (*Result, error) {
+	ctx := opts.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	if opts.BundlePath == "" {
+		return nil, errors.New("install: --bundle path is required")
+	}
+	if opts.Meta == nil {
+		return nil, errors.New("install: bundle metadata is required")
+	}
+	if opts.TrustRoot == nil {
+		return nil, errors.New("install: a pinned trust root is required")
+	}
+
+	blob, err := os.ReadFile(opts.BundlePath) // #nosec G304 -- an operator-supplied path to the artifact they asked to install.
+	if err != nil {
+		return nil, fmt.Errorf("install: read bundle %s: %w", opts.BundlePath, err)
+	}
+
+	// ----- verify BEFORE anything is written -----
+	//
+	// IdentityFetcher is deliberately nil: pinned mode, no network. A nil fetcher
+	// is not a weaker check, it is what makes the check independent of the party
+	// who sent the file.
+	verRes, err := verify.Verify(verify.VerifyOpts{
+		BundlePath:      opts.BundlePath,
+		BundleMeta:      opts.Meta,
+		TrustRoot:       opts.TrustRoot,
+		IdentityFetcher: nil,
+		Ctx:             ctx,
+		GovernanceMin:   opts.GovernanceMin,
+		AllowYellow:     opts.AllowYellow,
+		IgnoreDeps:      opts.IgnoreDeps,
+		Tenant:          opts.Tenant,
+		Logger:          opts.Logger,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// ----- WHERE the skill lands is decided by SIGNED bytes -----
+	//
+	// This is the sharp edge of installing from a file, and getting it wrong
+	// would hand the attack back to the transport we just took it away from.
+	//
+	// The author signature covers the 32-byte DIGEST and nothing else
+	// (verify.go stepVerifyAuthor: ed25519.Verify(pub, digest[:], sig)). The
+	// sidecar's bundle record is therefore NOT signature-covered. If the install
+	// directory came from the sidecar, someone who forwards a genuinely signed
+	// .skb could relabel it as an already-installed skill and overwrite it: every
+	// signature would verify, and the wrong thing would land.
+	//
+	// The name inside the archive's bundle.json IS covered, because it is part of
+	// the bytes the digest is taken over. ReadDigestVerifiedManifest is the
+	// repository's existing, single trust boundary for exactly this (it recomputes
+	// the digest and fails closed before returning anything), and it is used here
+	// rather than reimplemented, for the reason its own doc comment gives: a second
+	// reader of signed content is a second place to weaken the rule.
+	//
+	// This is the same class of defect as the git-backend event identity: never
+	// take an identity from an unsigned projection when the signed original is
+	// right there.
+	signedManifest, err := verify.ReadDigestVerifiedManifest(opts.BundlePath, verRes.Digest)
+	if err != nil {
+		return nil, fmt.Errorf("install: read signed bundle.json: %w", err)
+	}
+	signedName, _ := signedManifest["name"].(string)
+	if signedName == "" {
+		return nil, fmt.Errorf("install: the signed bundle.json carries no name: %w", verify.ErrDigestMismatch)
+	}
+	// An explicit --name is a statement of intent, not an override. If it
+	// disagrees with the signed name, the operator believes they are installing
+	// something other than what the artifact says it is, and that disagreement is
+	// exactly what should stop an install rather than be silently resolved.
+	if opts.Name != "" && opts.Name != signedName {
+		return nil, fmt.Errorf(
+			"install: --name %q does not match the signed bundle name %q: refusing rather than guessing which one you meant: %w",
+			opts.Name, signedName, verify.ErrDigestMismatch)
+	}
+	name := signedName
+
+	// ----- stage -----
+	homeDir, err := resolveHomeDir(opts.HomeDir)
+	if err != nil {
+		return nil, err
+	}
+	stagingDir, err := makeStagingDir(homeDir, name, verRes.Digest)
+	if err != nil {
+		return nil, err
+	}
+	cleanedUp := false
+	defer func() {
+		if !cleanedUp {
+			_ = os.RemoveAll(stagingDir)
+		}
+	}()
+
+	// The staged copy is what finishInstall stashes into the target, so the
+	// stashed file is named from the SIGNED name and digest rather than from
+	// whatever the sender happened to call the file.
+	blobPath := filepath.Join(stagingDir, sanitizeFilename(name)+"-"+sanitizeDigest(verRes.Digest)+".skb")
+	// 0600, not the 0644 the registry path uses for its staged copy: this file is
+	// transient scaffolding inside a staging dir, and nothing needs to read it but
+	// this process. gosec G306 is right that the looser mode has no justification
+	// here.
+	//
+	// #nosec G703 -- gosec's taint analysis follows `name` from the bundle
+	// manifest into a path and cannot see through sanitizeFilename, which is a
+	// strict ALLOWLIST (letters, digits, '-', '_', '.') that additionally refuses
+	// "." , ".." and any leading dot. No separator of any kind survives it, so a
+	// traversal component cannot reach this join. sanitizeDigest guards the second
+	// half the same way, and the staging dir itself is already canonicalized.
+	if err := os.WriteFile(blobPath, blob, 0o600); err != nil {
+		return nil, fmt.Errorf("install: write staged blob: %w", err)
+	}
+	logStep(opts.Logger, "staged_blob", "path=%s size=%d", blobPath, len(blob))
+
+	// ----- the SAME write sequence the registry path uses -----
+	//
+	// resolver is nil: there is no registry to resolve identities against. The
+	// offline-meta stash degrades to best-effort, exactly as it does when a
+	// registry call fails on the other path.
+	res, err := finishInstall(finishOpts{
+		blob:       blob,
+		blobPath:   blobPath,
+		stagingDir: stagingDir,
+		homeDir:    homeDir,
+		name:       name,
+		digest:     verRes.Digest,
+		meta:       opts.Meta,
+		resolver:   nil,
+		verRes:     verRes,
+		maxBytes:   opts.MaxExtractedBytes,
+		logger:     opts.Logger,
+		ctx:        ctx,
+		now:        now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	cleanedUp = true
+	return res, nil
+}

--- a/pkg/skillctl/install/install_bundle_test.go
+++ b/pkg/skillctl/install/install_bundle_test.go
@@ -1,0 +1,236 @@
+package install
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// pinnedRoot builds the offline trust root InstallBundle requires: the author
+// key is pinned locally, so nothing about the decision needs a network call.
+func pinnedRoot(t *testing.T, fx *bundleFixture) *verify.TrustRoot {
+	t.Helper()
+	return &verify.TrustRoot{
+		RegistryURL:            "local://acceptance",
+		IdentityKeysAuthorized: "pinned",
+		GovernanceMinimum:      "green",
+		RegistryKeys: []verify.RegistryKey{{
+			ID:        "reg-key-1",
+			Pubkey:    []byte(fx.regPub),
+			PubkeyB64: base64.StdEncoding.EncodeToString(fx.regPub),
+			Issued:    "2026-05-05",
+		}},
+		Authors: []verify.AuthorKey{{
+			ID:        "id:author@m3c",
+			Pubkey:    []byte(fx.authorPub),
+			PubkeyB64: base64.StdEncoding.EncodeToString(fx.authorPub),
+		}},
+	}
+}
+
+// sidecarMeta is the BundleMeta that travels alongside the .skb. `name` is the
+// field an attacker would edit, which is the whole point of the relabel test.
+func sidecarMeta(t *testing.T, fx *bundleFixture, name string) *registry.BundleMeta {
+	t.Helper()
+	authorSig := ed25519.Sign(fx.authorPriv, fx.digestRaw[:])
+	regSig := ed25519.Sign(fx.regPriv, fx.digestRaw[:])
+	raw := map[string]any{
+		"bundle": map[string]any{
+			"bundle_digest": fx.digestStr,
+			"name":          name,
+			"version":       "1.0.0",
+			"status":        "admitted",
+		},
+		"signatures": []map[string]any{
+			{"role": "author", "identity_id": "id:author@m3c", "signature_b64": base64.StdEncoding.EncodeToString(authorSig), "status": "active"},
+			{"role": "registry", "identity_id": "id:registry@aims-core", "signature_b64": base64.StdEncoding.EncodeToString(regSig), "status": "active"},
+		},
+		"manifest":           map[string]any{"author_governance_intent": "green", "depends_on": []any{}},
+		"current_governance": "green",
+		"attestations": []map[string]any{
+			{"level": "green", "reviewer_id": "id:reviewer@m3c", "attested_at": "2026-05-05T20:00:00Z"},
+		},
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	var meta registry.BundleMeta
+	if err := json.Unmarshal(b, &meta); err != nil {
+		t.Fatalf("unmarshal meta: %v", err)
+	}
+	return &meta
+}
+
+func writeBundle(t *testing.T, fx *bundleFixture) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "delivered.skb")
+	if err := os.WriteFile(p, fx.blob, 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	return p
+}
+
+// The happy path: a signed .skb that arrived over an untrusted transport is
+// verified against pinned roots and installed, with no network at all.
+func TestInstallBundle_HappyPath(t *testing.T) {
+	fx := mkBundleFixture(t)
+	home := t.TempDir()
+
+	res, err := InstallBundle(BundleOpts{
+		BundlePath: writeBundle(t, fx),
+		Meta:       sidecarMeta(t, fx, "fetch-contract"),
+		TrustRoot:  pinnedRoot(t, fx),
+		HomeDir:    home,
+	})
+	if err != nil {
+		t.Fatalf("InstallBundle: %v", err)
+	}
+	if got := filepath.Base(res.InstalledPath); got != "fetch-contract" {
+		t.Errorf("installed as %q, want %q", got, "fetch-contract")
+	}
+	if _, err := os.Stat(res.InstalledPath); err != nil {
+		t.Errorf("nothing at the install path: %v", err)
+	}
+}
+
+// THE security test of this feature.
+//
+// The author signature covers the digest and nothing else, so the sidecar's
+// `name` is not signature-covered. An attacker who forwards a GENUINELY signed
+// .skb can edit the sidecar to name a different, already-installed skill. Every
+// signature still verifies. If the install directory were taken from the
+// sidecar, the victim's other skill would be silently overwritten by content
+// that was never meant for that name.
+//
+// The install directory must therefore come from the bundle.json INSIDE the
+// digest-verified archive, and this test is what holds that line.
+func TestInstallBundle_RelabelledSidecarCannotRedirectTheInstall(t *testing.T) {
+	fx := mkBundleFixture(t)
+	home := t.TempDir()
+
+	// A legitimate, unrelated skill the victim already has installed.
+	victim := filepath.Join(home, installRoot, "kup-deploy-stage")
+	if err := os.MkdirAll(victim, 0o755); err != nil {
+		t.Fatalf("seed victim skill: %v", err)
+	}
+	canary := filepath.Join(victim, "SKILL.md")
+	if err := os.WriteFile(canary, []byte("the operator's real deploy skill"), 0o600); err != nil {
+		t.Fatalf("seed canary: %v", err)
+	}
+
+	// The attacker forwards the genuinely signed bundle, relabelled.
+	res, err := InstallBundle(BundleOpts{
+		BundlePath: writeBundle(t, fx),
+		Meta:       sidecarMeta(t, fx, "kup-deploy-stage"),
+		TrustRoot:  pinnedRoot(t, fx),
+		HomeDir:    home,
+	})
+	if err != nil {
+		t.Fatalf("the install should still succeed under its OWN signed name: %v", err)
+	}
+
+	// It must land under the signed name, not the relabelled one.
+	if got := filepath.Base(res.InstalledPath); got != "fetch-contract" {
+		t.Errorf("a relabelled sidecar steered the install to %q", got)
+	}
+
+	// And the victim's skill must be untouched, byte for byte.
+	got, err := os.ReadFile(canary) // #nosec G304 -- the test's own temp dir.
+	if err != nil {
+		t.Fatalf("the victim skill disappeared: %v", err)
+	}
+	if string(got) != "the operator's real deploy skill" {
+		t.Errorf("a relabelled sidecar overwrote an unrelated installed skill; canary now reads %q", got)
+	}
+}
+
+// An explicit --name is a statement of intent. When it disagrees with the signed
+// name, the operator believes they are installing something else, and that
+// disagreement must stop the install rather than be quietly resolved either way.
+func TestInstallBundle_NameMismatchIsRefused(t *testing.T) {
+	fx := mkBundleFixture(t)
+	_, err := InstallBundle(BundleOpts{
+		BundlePath: writeBundle(t, fx),
+		Meta:       sidecarMeta(t, fx, "fetch-contract"),
+		TrustRoot:  pinnedRoot(t, fx),
+		HomeDir:    t.TempDir(),
+		Name:       "something-else",
+	})
+	if err == nil {
+		t.Fatal("a --name disagreeing with the signed bundle name was accepted")
+	}
+	if !errors.Is(err, verify.ErrDigestMismatch) {
+		t.Errorf("the refusal does not carry a typed sentinel, so the exit code would be generic: %v", err)
+	}
+	if !strings.Contains(err.Error(), "signed bundle name") {
+		t.Errorf("the message does not name the cause: %v", err)
+	}
+}
+
+// A tampered artifact must be refused with the digest sentinel, so the CLI maps
+// it to the SAME numbered exit code the registry path produces. An operator
+// comparing two machines has to read the same number for the same cause.
+func TestInstallBundle_TamperedBundleIsRefusedAndWritesNothing(t *testing.T) {
+	fx := mkBundleFixture(t)
+	home := t.TempDir()
+	path := writeBundle(t, fx)
+
+	// Flip one byte AFTER signing: the classic SPEC-0406 Phase 5 move.
+	blob, err := os.ReadFile(path) // #nosec G304 -- the test's own temp dir.
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	blob[len(blob)/2] ^= 0xFF
+	if err := os.WriteFile(path, blob, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err = InstallBundle(BundleOpts{
+		BundlePath: path,
+		Meta:       sidecarMeta(t, fx, "fetch-contract"),
+		TrustRoot:  pinnedRoot(t, fx),
+		HomeDir:    home,
+	})
+	if err == nil {
+		t.Fatal("a tampered bundle was installed")
+	}
+	if !errors.Is(err, verify.ErrDigestMismatch) {
+		t.Errorf("want ErrDigestMismatch so the exit code is 10, got %v", err)
+	}
+	if verify.ExitCode(err) != verify.ExitDigestMismatch {
+		t.Errorf("exit code = %d, want %d", verify.ExitCode(err), verify.ExitDigestMismatch)
+	}
+	// INV-6 in miniature: a refusal writes nothing into the install root.
+	if entries, err := os.ReadDir(filepath.Join(home, installRoot)); err == nil && len(entries) > 0 {
+		t.Errorf("a refused install still wrote %d entries into the install root", len(entries))
+	}
+}
+
+// A root that expects to fetch identities cannot be used offline. InstallBundle
+// requires a pinned root; the CLI reports this in actionable terms, and the
+// library must not quietly proceed with an unverifiable author key.
+func TestInstallBundle_RequiresPinnedAuthorKey(t *testing.T) {
+	fx := mkBundleFixture(t)
+	root := pinnedRoot(t, fx)
+	root.IdentityKeysAuthorized = "from-registry"
+	root.Authors = nil
+
+	_, err := InstallBundle(BundleOpts{
+		BundlePath: writeBundle(t, fx),
+		Meta:       sidecarMeta(t, fx, "fetch-contract"),
+		TrustRoot:  root,
+		HomeDir:    t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("an unpinned author key was accepted on the offline path")
+	}
+}

--- a/pkg/skillctl/install/offline_verify.go
+++ b/pkg/skillctl/install/offline_verify.go
@@ -84,13 +84,21 @@ func StashOfflineMeta(ctx context.Context, resolver identityResolver, target str
 		now = time.Now
 	}
 	idents := map[string]*registry.Identity{}
-	for _, s := range meta.Signatures {
-		if s.Role == "author" && s.IdentityID != "" {
-			id, err := resolver.GetIdentity(ctx, s.IdentityID)
-			if err != nil {
-				return fmt.Errorf("stash: fetch author identity %s: %w", s.IdentityID, err)
+	// A nil resolver means there is no registry to ask, which is the normal state
+	// for an offline install from a local .skb (SPEC-0406 D2). The stash is still
+	// worth writing: it carries the BundleMeta a later `verify --offline` needs.
+	// The author KEY is not missing in that case, it simply comes from the pinned
+	// trust root instead, which is the stronger source anyway. Fetching it here
+	// would have meant trusting a registry to tell us who the author was.
+	if resolver != nil {
+		for _, s := range meta.Signatures {
+			if s.Role == "author" && s.IdentityID != "" {
+				id, err := resolver.GetIdentity(ctx, s.IdentityID)
+				if err != nil {
+					return fmt.Errorf("stash: fetch author identity %s: %w", s.IdentityID, err)
+				}
+				idents[s.IdentityID] = id
 			}
-			idents[s.IdentityID] = id
 		}
 	}
 	om := OfflineMeta{BundleMeta: meta, Identities: idents, StashedAt: now().UTC().Format(time.RFC3339)}

--- a/pkg/skillctl/verify/verify.go
+++ b/pkg/skillctl/verify/verify.go
@@ -975,7 +975,9 @@ func readSignedManifestScopes(bundlePath string) ([]map[string]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read bundle: %w", err)
 	}
-	entries, err := skillbundle.Unpack(blob, skillbundle.UnpackOptions{})
+	// StripWrapper: same reason as ReadDigestVerifiedManifest. A wrapped bundle
+	// previously yielded no signed scopes at all, which reads as "none declared".
+	entries, err := skillbundle.Unpack(blob, skillbundle.UnpackOptions{StripWrapper: true})
 	if err != nil {
 		return nil, fmt.Errorf("unpack bundle: %w", err)
 	}
@@ -1039,7 +1041,15 @@ func ReadDigestVerifiedManifest(bundlePath, expectedDigest string) (map[string]a
 	if err != nil {
 		return nil, fmt.Errorf("read bundle: %w", err)
 	}
-	entries, err := skillbundle.Unpack(blob, skillbundle.UnpackOptions{})
+	// StripWrapper collapses the single top-level dir of a SPEC-0188 §3.1 wrapped
+	// bundle. Without it this lookup only ever found bundle.json in a FLAT archive
+	// (what our own `pack` writes), and silently found nothing in a wrapped one,
+	// which the unpacker, the installer and the spec all support. "Found nothing"
+	// is the dangerous outcome here: for the data-scope caller it reads as "the
+	// author declared no scopes" rather than "we could not look". It collapses
+	// only when there is exactly one common top-level dir, so a flat archive is
+	// unaffected.
+	entries, err := skillbundle.Unpack(blob, skillbundle.UnpackOptions{StripWrapper: true})
 	if err != nil {
 		return nil, fmt.Errorf("unpack bundle: %w", err)
 	}


### PR DESCRIPTION
Entschieden am 2026-09-05: der Akzeptanztest laeuft ueber `install --bundle`, nicht ueber die ER1-`self`-Registry, weil nur so AC-02 woertlich gemessen wird. Bisher kannte `install` nur `<name>[@<version>]` aus einer Registry, und die Aussage "der Empfaenger muss dem Transportweg nicht vertrauen" war damit nicht pruefbar.

## Drei Teile

**Eine Sequenz, zwei Wege.** Der Teil NACH der Vertrauenskette (entpacken, Pruefsummen, atomarer Install, `.skb` und Offline-Metadaten stashen) ist als `finishInstall` herausgezogen. Zwei Kopien waeren zwei Implementierungen einer Theorie; die Simulation hat dafuer schon zweimal bezahlt. Hier waere der Preis kein falscher Wert in einem Bericht, sondern ein Installationspfad, dem eine Abwehr fehlt, die der andere hat.

**`InstallBundle`** prueft offline gegen gepinnte Trust-Roots, ohne Fetcher, mit derselben `verify.Verify` und derselben Schreibsequenz. Kein Netz heisst hier nicht "schwaecher", sondern: die Entscheidung ist unabhaengig von dem, der die Datei geschickt hat.

**Der scharfe Punkt, gefunden beim Bauen.** Die Autorensignatur deckt den 32-Byte-Digest und sonst nichts (`stepVerifyAuthor`: `ed25519.Verify(pub, digest[:], sig)`). Der Name im Sidecar ist also **nicht signaturgedeckt**. Wer ein echt signiertes `.skb` weiterreicht, koennte es auf einen bereits installierten Skill umetikettieren: jede Signatur verifiziert, und der fremde Skill waere ueberschrieben.

Das Installationsverzeichnis kommt deshalb aus der `bundle.json` **im digest-geprueften Archiv**, ueber die vorhandene `ReadDigestVerifiedManifest`, nicht ueber einen zweiten Leser signierter Inhalte. Ein `--name` ist eine Absichtserklaerung und kein Override: weicht es ab, wird abgelehnt statt geraten.

## Zwei Befunde nebenbei, an der gemeinsamen Stelle behoben

`ReadDigestVerifiedManifest` und `readSignedManifestScopes` suchten `bundle.json` ohne `StripWrapper`. In einem gewrappten Bundle nach SPEC-0188 §3.1 fanden sie damit **nichts**, und fuer den Datenscope-Leser liest sich das als "der Autor hat keine Scopes deklariert" statt als "wir konnten nicht nachsehen". Unser eigenes `pack` schreibt flach, deshalb fiel es nie auf.

`StashOfflineMeta` dereferenzierte den Resolver ungeprueft (Panik bei einem Offline-Install) und ist jetzt nil-tolerant. Der Autorenschluessel fehlt dabei nicht, er kommt aus dem gepinnten Trust-Root, was ohnehin die staerkere Quelle ist.

## Tests

Happy Path · **der Umetikettierungs-Angriff**, mit einer Kanarienvogel-Datei im Verzeichnis eines fremden Skills · Namensabweichung wird abgelehnt · manipuliertes Artefakt: Exit 10 und ein leeres Installationsziel (INV-6 im Kleinen) · ein nicht gepinnter Autorenschluessel wird auf dem Offline-Pfad abgelehnt.

Alle Gates lokal gruen. Ein gosec-G306-Befund wurde behoben statt unterdrueckt (0644 auf 0600); G703 ist ein Fehlalarm der Taint-Analyse und mit der Begruendung annotiert, dass `sanitizeFilename` eine strikte Allowlist ohne jeden Trenner ist.

Refs: SPEC-0406 D2 / AC-02, WF-006

🤖 Generated with [Claude Code](https://claude.com/claude-code)