### PR TITLE
fix(verify-sig): die Ursache benennen, nicht ihre Nebenwirkung (WF-005 B1)

### DIFF
--- a/cmd/skillctl/signing_cmds.go
+++ b/cmd/skillctl/signing_cmds.go
@@ -62,6 +62,10 @@ const (
 	exitGeneric  = 1
 	exitUsage    = 2
 	exitSigInval = 11
+	// exitDigestChanged is verify.ExitDigestMismatch. It is spelled out here
+	// rather than imported so this file keeps its flat list of the codes it can
+	// return; the two MUST stay equal, and a test pins them together.
+	exitDigestChanged = 10
 )
 
 // runKeygen implements `skillctl keygen --out PATH`. Writes
@@ -160,7 +164,7 @@ func runVerifySig(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Recomputes the bundle's SHA-256 digest, locates the matching")
 		fmt.Fprintln(stderr, "<BUNDLE.skb>.<digest_hex>.author.sig file, and verifies it.")
-		fmt.Fprintln(stderr, "Exit codes: 0 ok | 11 signature invalid | 1 other error | 2 usage.")
+		fmt.Fprintln(stderr, "Exit codes: 0 ok | 10 bytes changed after signing | 11 signature invalid | 1 other error | 2 usage.")
 		fmt.Fprintln(stderr, "BUNDLE.skb may appear before or after the flags.")
 		fs.PrintDefaults()
 	}
@@ -180,6 +184,17 @@ func runVerifySig(args []string, stdout, stderr io.Writer) int {
 
 	if err := signing.VerifyDetached(bundlePath, *pubPath); err != nil {
 		fmt.Fprintln(stderr, err)
+		// Checked BEFORE ErrSignatureInvalid, which this error also wraps: an
+		// altered bundle is a digest mismatch first and a signature failure as a
+		// consequence, and the more specific cause has to win.
+		//
+		// Exit 10, the SAME code `verify --bundle` gives for the same situation
+		// (verify.ExitDigestMismatch). SPEC-0406 has two people compare results
+		// across two machines and two commands; reading a different number for the
+		// same cause is precisely the confusion the numbered codes exist to prevent.
+		if errors.Is(err, signing.ErrDigestChanged) {
+			return exitDigestChanged
+		}
 		if errors.Is(err, signing.ErrSignatureInvalid) {
 			return exitSigInval
 		}

--- a/cmd/skillctl/signing_cmds_test.go
+++ b/cmd/skillctl/signing_cmds_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
 	"os"
 	"path/filepath"
 	"strings"
@@ -233,5 +234,17 @@ func TestExtractBundlePositional(t *testing.T) {
 				t.Errorf("bundle=%q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// The two exit codes for "the bytes changed after signing" must be the SAME
+// number on both paths that can report it. SPEC-0406 has two people compare
+// results across two machines and two commands; reading 10 from one and
+// something else from the other is exactly the confusion the numbered codes
+// exist to prevent.
+func TestVerifySigDigestExitMatchesTheVerifierExit(t *testing.T) {
+	if exitDigestChanged != verify.ExitDigestMismatch {
+		t.Errorf("verify-sig reports %d for altered bytes, the trust chain reports %d",
+			exitDigestChanged, verify.ExitDigestMismatch)
 	}
 }

--- a/docs/CLI-VERBS.md
+++ b/docs/CLI-VERBS.md
@@ -61,7 +61,7 @@ same way `cmd/docaudit` gates the flag surface.
 | `pack` | SPEC-0188 (Phase 1 PoC) | 0/1/2, 18 |
 | `keygen` | SPEC-0188 §11 | 0/1/2 |
 | `sign` | SPEC-0188 §11 | 0/1/2 |
-| `verify-sig` | SPEC-0188 §11 | 0/1/2, 11 |
+| `verify-sig` | SPEC-0188 §11 | 0/1/2, 10, 11 |
 | `trust` | SPEC-0188 (S7) | 0/1/2 |
 | `peer` | SPEC-0359 (D2) | 0/1/2 |
 | `cross-sign` | SPEC-0359 (D3) | 0/1/2 |

--- a/docs/security/gosec-inci-baseline.txt
+++ b/docs/security/gosec-inci-baseline.txt
@@ -173,7 +173,6 @@ G301	pkg/skillbundle/unpack.go	} if err := os.MkdirAll(filepath.Dir(full), 0o755
 G301	pkg/skillctl/backend/git/git.go	p := filepath.Join(dir, rel) if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil { return err
 G301	pkg/skillctl/install/install.go	// Make sure the parent of `target` exists. if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil { return "", fmt.Errorf("install: mkdir target parent: %w", err)
 G301	pkg/skillctl/install/install.go	archDir := filepath.Join(homeDir, installRoot, ".archive") if err := os.MkdirAll(archDir, 0o755); err != nil { return "", fmt.Errorf("install: mkdir archive dir: %w", err)
-G301	pkg/skillctl/install/install.go	extractDir := filepath.Join(stagingDir, "extracted") if err := os.MkdirAll(extractDir, 0o755); err != nil { return nil, fmt.Errorf("install: mkdir extract dir: %w", err)
 G301	pkg/skillctl/registry/backend_pull.go	cacheRoot := defaultCacheRoot() if err := os.MkdirAll(cacheRoot, 0o755); err != nil { return nil, fmt.Errorf("pull: mkdir cache: %w", err)
 G301	pkg/skillctl/registry/backend_pull.go	dir := filepath.Join(cacheRoot, strings.TrimPrefix(digest, "sha256:")) if err := os.MkdirAll(dir, 0o755); err != nil { return nil, fmt.Errorf("pull: mkdir %s: %w", dir, err)
 G301	pkg/skillctl/registry/er1_pull.go	cacheRoot := defaultCacheRoot() if err := os.MkdirAll(cacheRoot, 0o755); err != nil { return nil, fmt.Errorf("pull: mkdir cache: %w", err)
@@ -358,7 +357,6 @@ G306	pkg/recorder/wav.go	func writeFile(path string, data []byte) error { return
 G306	pkg/skillbundle/pack.go	if err := os.WriteFile(outFile, finalArchive, 0644); err != nil { return "", fmt.Errorf("writing %s: %w", outFile, err)
 G306	pkg/skillctl/backend/git/git.go	} return os.WriteFile(p, data, 0o644) }
 G306	pkg/skillctl/install/install.go	blobPath := filepath.Join(stagingDir, sanitizeFilename(opts.Name)+"-"+sanitizeFilename(resolvedVersion)+".skb") if err := os.WriteFile(blobPath, blob, 0o644); err != nil { return nil, fmt.Errorf("install: write staged blob: %w", err)
-G306	pkg/skillctl/install/install.go	stashedSkb := filepath.Join(target, filepath.Base(blobPath)) if err := os.WriteFile(stashedSkb, blob, 0o644); err != nil { return nil, fmt.Errorf("install: stash .skb in target: %w", err)
 G306	pkg/skillctl/install/offline_verify.go	} return os.WriteFile(filepath.Join(target, offlineMetaFile), b, 0o644) }
 G306	pkg/skillctl/registry/attestation_stash.go	} return os.WriteFile(filepath.Join(dir, AttestationStashName), b, 0o644) }
 G306	pkg/skillctl/registry/backend_pull.go	skbPath := filepath.Join(dir, "bundle.skb") if err := os.WriteFile(skbPath, skbBytes, 0o644); err != nil { return nil, fmt.Errorf("pull: write %s: %w", skbPath, err)

--- a/docs/tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md
+++ b/docs/tutorial-szenario-01-eigene-skills-mehrere-maschinen.de.md
@@ -131,9 +131,10 @@ echo "rc=$?"          # 0 = OK: signature verified
 ```
 
 Exit `0` heißt: diese Bytes wurden von diesem Schlüssel versiegelt. Exit `11` heißt: die
-Signatur passt nicht zu den Bytes. Exit `1` mit „signature file not found" heißt: zu diesen
-Bytes existiert überhaupt keine Signatur, meist weil die Datei nach dem Signieren verändert
-wurde (der Signaturdateiname enthält den Digest).
+Signatur passt nicht zu den Bytes. Exit `10` heißt: die Datei hasht jetzt anders, als die
+Signatur daneben deckt, sie wurde also nach dem Signieren verändert; die Meldung nennt beide
+Digests, damit Sie den Unterschied sehen. Exit `1` heißt: es liegt überhaupt keine Signatur
+neben der Datei, sie wurde hier vermutlich nie signiert.
 
 ### A5. Publizieren und attestieren
 
@@ -570,7 +571,8 @@ Alles oben gilt, mit drei Unterschieden:
 | `pull` Exit `13` | keine grüne Attestierung | A5 zweiter Block |
 | `publish` HTTP 403 | Publish in einen fremden Kontext | nur in den **eigenen** `--er1-context skills` publizieren |
 | `verify <name>`: „no .skb found" | der Skill wurde von Hand entpackt | über `pull --install` oder `install` neu installieren |
-| `verify-sig` Exit `1`, „signature file not found" | die Bytes wurden nach dem Signieren verändert | Bundle neu beziehen |
+| `verify-sig` Exit `10`, „bundle bytes changed after signing" | die Bytes wurden nach dem Signieren verändert | Bundle neu beziehen |
+| `verify-sig` Exit `1`, „no signature found" | es liegt keine Signatur daneben, vermutlich nie signiert | beim Absender nach der `.sig` fragen |
 
 ---
 

--- a/docs/tutorial-szenario-02-erster-signierter-skill.de.md
+++ b/docs/tutorial-szenario-02-erster-signierter-skill.de.md
@@ -193,16 +193,32 @@ Ihnen, was fehlt, bevor ein Mensch seine Zeit darauf verwendet.
 
 Zuerst der Unfall: jemand ändert das Bundle nach dem Signieren.
 
+So kommt ein signiertes Bundle wirklich an: die Datei **und** ihre Signatur. Beide werden
+kopiert, dann werden die Bytes verändert.
+
 ```bash
 cp hello-kup@0.1.0.skb kaputt.skb
+for sig in hello-kup@0.1.0.skb.*.author.sig; do
+  cp "$sig" "kaputt.skb.${sig#hello-kup@0.1.0.skb.}"
+done
 printf '\xff' | dd of=kaputt.skb bs=1 seek=200 count=1 conv=notrunc 2>/dev/null
 skillctl verify-sig --pubkey "$WS/keys/mitarbeiter.pub" kaputt.skb
 echo "rc=$?"
 ```
 
-Erwartet: `signature file not found …`, `rc=1`. Die Begründung ist wörtlich zu nehmen: der
-Name der Signaturdatei enthält den Digest, und zu diesen neuen Bytes existiert schlicht keine
-Signatur.
+Erwartet: `bundle bytes changed after signing …`, `rc=10`. Die Meldung nennt beide Digests:
+den, zu dem die Datei jetzt hasht, und den, den die Signatur daneben deckt. Genau dieser
+Unterschied ist der Befund.
+
+Früher stand hier `signature file not found`, `rc=1`. Das war technisch wahr und praktisch
+irreführend: der Name der Signaturdatei enthält den Digest, eine Änderung an den Bytes lässt
+die Suche daher ins Leere laufen. Gemeldet wurde damit die *Nebenwirkung* der Manipulation
+statt ihrer Ursache, und wer der Meldung folgte, suchte eine fehlende Datei statt ein
+gebrochenes Siegel.
+
+Liegt tatsächlich **gar keine** Signatur neben der Datei, sagt das Werkzeug jetzt genau das:
+`no signature found … It appears never to have been signed here`, `rc=1`. Das ist eine andere
+Lage und verlangt eine andere Handlung, nämlich beim Absender nach der Signatur zu fragen.
 
 Jetzt der Angriff: derselbe Byte-Tausch, aber der Angreifer benennt die Originalsignatur so
 um, dass sie zu den neuen Bytes zu gehören scheint.

--- a/pkg/skillctl/signing/verify.go
+++ b/pkg/skillctl/signing/verify.go
@@ -2,10 +2,14 @@ package signing
 
 import (
 	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 )
 
 // ErrSignatureInvalid is returned by VerifyDetached when the cryptographic
@@ -13,6 +17,22 @@ import (
 // code 11 in the CLI and is sentinel-comparable so tests and downstream
 // callers can branch on it without parsing strings.
 var ErrSignatureInvalid = errors.New("signature is invalid")
+
+// ErrDigestChanged means the bundle carries a signature, but for DIFFERENT
+// bytes than the ones on disk now. In other words: it was signed, and then it
+// changed.
+//
+// It exists because the previous message for this case was actively misleading.
+// The detached signature is stored under a filename that contains the digest it
+// covers (SignaturePath). Tamper with a byte and the recomputed digest changes,
+// so the lookup misses and the tool said "signature file not found". That is
+// true and useless: it describes a consequence of the tampering, and it reads
+// like a packaging mistake rather than a broken seal. An operator following it
+// would go looking for a missing file.
+//
+// SPEC-0406 AC-08 asks that a refusal name the condition that was violated
+// rather than its side effect, and this is the case that forced the rule.
+var ErrDigestChanged = errors.New("bundle bytes changed after signing")
 
 // VerifyDetached recomputes the bundle's SHA-256 digest, locates the
 // matching `<bundle>.<digest_hex>.author.sig` file, and verifies it
@@ -50,11 +70,23 @@ func VerifyDetached(bundlePath, pubkeyPath string) error {
 	sigPath := SignaturePath(bundlePath, digestHex)
 	sig, err := os.ReadFile(sigPath)
 	if err != nil {
-		// A missing sig file is the most common cause of "verify
-		// fails" in practice: say so explicitly. Don't reveal
-		// anything that wasn't already on the filesystem.
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("verify-sig: signature file not found at %s (digest %s)", sigPath, digestHex)
+			// Two very different situations reach this line, and the whole point
+			// of separating them is that they call for opposite actions.
+			//
+			// If signatures exist for this bundle under OTHER digests, the bundle
+			// was signed and then its bytes changed. Say that, and say which
+			// digest was signed, so the reader can see the two values differ.
+			//
+			// If there are none at all, it was simply never signed here. That is
+			// a packaging step someone forgot, not a broken seal.
+			if others := siblingSignatureDigests(bundlePath); len(others) > 0 {
+				return fmt.Errorf(
+					"verify-sig: %w: this file now hashes to %s, but the signature next to it covers %s. "+
+						"The signature was not re-made, so the bytes were altered after signing: %w",
+					ErrDigestChanged, digestHex, strings.Join(others, ", "), ErrSignatureInvalid)
+			}
+			return fmt.Errorf("verify-sig: no signature found for %s (looked for %s). It appears never to have been signed here", bundlePath, sigPath)
 		}
 		return fmt.Errorf("verify-sig: read signature %s: %w", sigPath, err)
 	}
@@ -68,4 +100,43 @@ func VerifyDetached(bundlePath, pubkeyPath string) error {
 		return fmt.Errorf("verify-sig: %w (digest=%s, sig=%s, pubkey=%s)", ErrSignatureInvalid, digestHex, sigPath, pubkeyPath)
 	}
 	return nil
+}
+
+// siblingSignatureDigests returns the digests of every detached author signature
+// sitting next to bundlePath, whatever content they cover.
+//
+// It reads only file NAMES, never their contents, and it is used only to choose
+// between two error messages. Nothing about a trust decision depends on it: a
+// wrong answer here changes the wording of a refusal, never the refusal itself.
+// That is deliberate, because the directory it scans is attacker-influenced in
+// exactly the scenario this function exists for.
+func siblingSignatureDigests(bundlePath string) []string {
+	dir := filepath.Dir(bundlePath)
+	prefix := filepath.Base(bundlePath) + "."
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if !strings.HasPrefix(n, prefix) || !strings.HasSuffix(n, authorSigSuffix) {
+			continue
+		}
+		d := strings.TrimSuffix(strings.TrimPrefix(n, prefix), authorSigSuffix)
+		// Only accept something that actually looks like a sha256 hex digest, so a
+		// crafted filename cannot put arbitrary text into our error message.
+		if len(d) != sha256.Size*2 {
+			continue
+		}
+		if _, err := hex.DecodeString(d); err != nil {
+			continue
+		}
+		out = append(out, d)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/pkg/skillctl/signing/verify_test.go
+++ b/pkg/skillctl/signing/verify_test.go
@@ -1,9 +1,11 @@
 package signing
 
 import (
+	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -148,4 +150,107 @@ func hexLower(b []byte) string {
 		out[i*2+1] = hexChars[x&0x0f]
 	}
 	return string(out)
+}
+
+// SPEC-0406 AC-08 for this surface: a refusal must name the condition that was
+// violated, not its side effect.
+//
+// The detached signature is stored under a filename containing the digest it
+// covers. Change a byte and the lookup misses, and the tool used to answer
+// "signature file not found": true, useless, and it sends the reader after a
+// missing file instead of a broken seal.
+func TestTamperedBundleNamesTheCauseNotTheSideEffect(t *testing.T) {
+	dir := t.TempDir()
+	bundle := makeFakeBundle(t, dir, "b.skb")
+	keyOut := filepath.Join(dir, "k")
+	if err := Generate(keyOut); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := SignBundle(bundle, keyOut+".priv", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// The digest the signature actually covers, captured before the tamper.
+	digest, err := ComputeBundleDigest(bundle)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	signedHex := hex.EncodeToString(digest[:])
+
+	// Anti-vacuity: if the clean bundle does not verify, everything below is
+	// measuring a broken fixture rather than the property under test.
+	if err := VerifyDetached(bundle, keyOut+".pub"); err != nil {
+		t.Fatalf("the untampered bundle must verify first, or this test proves nothing: %v", err)
+	}
+
+	// The tamper. The signature stays where it is, under its old name: exactly
+	// what a recipient sees when a signed file is altered in transit.
+	if err := os.WriteFile(bundle, []byte("ALTERED, and not a valid archive"), 0o600); err != nil {
+		t.Fatalf("tamper: %v", err)
+	}
+
+	err = VerifyDetached(bundle, keyOut+".pub")
+	if err == nil {
+		t.Fatal("a tampered bundle verified")
+	}
+	if !errors.Is(err, ErrDigestChanged) {
+		t.Errorf("the refusal does not carry ErrDigestChanged, so the CLI cannot map it to exit 10: %v", err)
+	}
+	// It still IS a signature failure; the specific cause simply wins.
+	if !errors.Is(err, ErrSignatureInvalid) {
+		t.Errorf("the refusal dropped ErrSignatureInvalid: %v", err)
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "not found") {
+		t.Errorf("the message still reports a missing file rather than altered bytes: %v", msg)
+	}
+	if !strings.Contains(msg, signedHex) {
+		t.Errorf("the message does not name the digest the signature covers, so the reader cannot see the two differ: %v", msg)
+	}
+}
+
+// The opposite case must stay distinguishable: a bundle nobody ever signed here
+// is a forgotten packaging step, not a broken seal, and it calls for a different
+// action (ask the sender for the signature).
+func TestUnsignedBundleIsNotReportedAsTampering(t *testing.T) {
+	dir := t.TempDir()
+	bundle := makeFakeBundle(t, dir, "never-signed.skb")
+	keyOut := filepath.Join(dir, "k")
+	if err := Generate(keyOut); err != nil {
+		t.Fatal(err)
+	}
+
+	err := VerifyDetached(bundle, keyOut+".pub")
+	if err == nil {
+		t.Fatal("an unsigned bundle verified")
+	}
+	if errors.Is(err, ErrDigestChanged) {
+		t.Errorf("an unsigned bundle was reported as tampering: %v", err)
+	}
+	if !strings.Contains(err.Error(), "never to have been signed") {
+		t.Errorf("the message does not say what is actually the case: %v", err)
+	}
+}
+
+// The sibling scan reads filenames from a directory an attacker may influence in
+// exactly the scenario it runs in. It must not put arbitrary text into an error
+// message, so anything that is not a sha256 hex digest is ignored.
+func TestSiblingScanIgnoresNonDigestFilenames(t *testing.T) {
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "b.skb")
+	if err := os.WriteFile(bundle, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	for _, name := range []string{
+		"b.skb.not-a-digest.author.sig",
+		"b.skb.deadbeef.author.sig", // hex, but too short
+		"b.skb." + strings.Repeat("z", 64) + ".author.sig",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("junk"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	if got := siblingSignatureDigests(bundle); len(got) != 0 {
+		t.Errorf("non-digest filenames leaked into the scan result: %v", got)
+	}
 }

--- a/pkg/skillctl/sim/generate.go
+++ b/pkg/skillctl/sim/generate.go
@@ -261,11 +261,23 @@ func build(p Params) Scenario {
 			Step{Action: Action{Kind: ActTamperTransit, Actor: Adversary, Skill: skill},
 				Expect: Expectation{Outcome: NoEffect, Exit: -1, Claimed: true,
 					Why: "the attacker controls the artifact, not the key"}},
-			// The publisher's own check is the control here. Without a matching
-			// signature file the verifier cannot even find one: exit 1, not 11.
+			// The publisher's own check is the control here.
+			//
+			// This expectation was Exit 1 with the reason "the signature filename
+			// carries the digest, so altered bytes have no signature at all". That
+			// reason was the tool's OLD diagnosis, and WF-005 B1 found it to be a
+			// description of a side effect rather than of the fault. It is changed
+			// here because the SPECIFICATION changed (SPEC-0406 AC-08, decided
+			// 2026-09-05), not because the binary now prints something else: the
+			// decision is that a refusal names the violated condition, and 10 is
+			// the number the trust chain already uses for that condition.
+			//
+			// The distinction matters for this package's whole method. Fitting the
+			// model to an observation is the one move this simulation exists to
+			// forbid; following a recorded decision is not that move.
 			Step{Action: Action{Kind: ActVerifySig, Actor: Publisher, Skill: skill},
-				Expect: Expectation{Outcome: Refuse, Exit: 1, Claimed: true,
-					Why: "SPEC-0188 §11: the signature filename carries the digest, so altered bytes have no signature at all"}},
+				Expect: Expectation{Outcome: Refuse, Exit: 10, Claimed: true,
+					Why: "SPEC-0406 AC-08: the bytes changed after signing, and the refusal names that rather than the missing signature file it causes"}},
 		)
 	case AdvTransitSkipped:
 		sc.Steps = append(sc.Steps,

--- a/scripts/tutorial-smoke.sh
+++ b/scripts/tutorial-smoke.sh
@@ -364,15 +364,25 @@ pause
 # ----------------------------------------------- 10. Negativprobe B: tamper --
 step "NEGATIVPROBE B: ein veraendertes Bundle mit umbenannter Signatur"
 why "Zuerst der Unfall: Bytes veraendert, Signatur unter altem Namen. Das ergibt
-   Exit 1, 'signature file not found', denn der Dateiname traegt den Digest.
+   Exit 10, denn die Datei hasht jetzt anders als die Signatur daneben deckt.
+   Die Meldung nennt die Ursache (die Bytes wurden nach dem Signieren geaendert)
+   und nicht ihre Nebenwirkung (eine Datei wurde nicht gefunden), SPEC-0406 AC-08.
    Dann der Angriff: die Signatur wird auf den neuen Digest umbenannt, damit sie
    dazuzugehoeren scheint. Jetzt greift die Kryptografie, Exit 11."
 
+# So kommt ein signiertes Bundle wirklich an: die Datei UND ihre Signatur.
+# Beide werden kopiert, dann werden die Bytes veraendert. Genau das ist der Fall,
+# den ein Empfaenger sieht, und er ist aussagekraeftiger als eine nackte Kopie
+# ohne Signatur, denn nur hier laesst sich der Bruch am Digest zeigen.
 cp "$WS/hello-kup@0.1.0.skb" "$WS/kaputt.skb"
+for sig in "$WS/hello-kup@0.1.0.skb".*.author.sig; do
+  [ -e "$sig" ] || continue
+  cp "$sig" "$WS/kaputt.skb.$(basename "$sig" | sed 's/^hello-kup@0.1.0.skb.//')"
+done
 printf '\xff' | dd of="$WS/kaputt.skb" bs=1 seek=200 count=1 conv=notrunc 2>/dev/null
-run "verify-sig auf veraenderten Bytes (ohne passende Signatur)" 1 \
+run "verify-sig auf veraenderten Bytes (Signatur liegt daneben)" 10 \
   "$SKILLCTL" verify-sig --pubkey "$WS/keys/mitarbeiter.pub" "$WS/kaputt.skb"
-expect_in "die Meldung sagt, dass es zu diesen Bytes keine Signatur gibt" "signature file not found"
+expect_in "die Meldung nennt die Ursache, nicht die Nebenwirkung" "changed after signing"
 
 cp "$WS/hello-kup@0.1.0.skb" "$WS/boese.skb"
 SIZE="$(wc -c < "$WS/boese.skb" | tr -d ' ')"


### PR DESCRIPTION
WF-005 Befund B1, und SPEC-0406 AC-08 in einem Satz: eine Ablehnung muss die verletzte Bedingung nennen, nicht deren Folge.

## Der Befund

Die abgetrennte Signatur liegt unter einem Dateinamen, der den Digest enthaelt, den sie deckt. Wird ein Byte veraendert, aendert sich der Digest, damit der Name, damit findet die Suche nichts. Das Werkzeug meldete `signature file not found`, Exit 1.

Wahr und unbrauchbar. Es beschreibt eine **Folge** der Manipulation und liest sich wie ein Verpackungsfehler statt wie ein gebrochenes Siegel. Wer der Meldung folgte, suchte eine fehlende Datei.

## Zwei Lagen, die entgegengesetzte Handlungen verlangen

| Was vorliegt | Meldung | Exit |
|---|---|---|
| Signaturen fuer ANDERE Digests liegen daneben | `bundle bytes changed after signing`, **mit beiden Digests** | 10 |
| Gar keine Signatur | `no signature found … never to have been signed here` | 1 |

Zur `10`: das ist `verify.ExitDigestMismatch`, dieselbe Zahl, die `verify --bundle` fuer dieselbe Lage liefert. SPEC-0406 laesst zwei Menschen Ergebnisse ueber zwei Maschinen und zwei Kommandos vergleichen; zwei Zahlen fuer eine Ursache sind genau die Verwechslung, gegen die die nummerierten Codes stehen. Ein Test bindet die beiden Konstanten aneinander, damit sie nicht auseinanderlaufen koennen.

Der Sibling-Scan liest nur Dateinamen, nie Inhalte, und akzeptiert nur, was wie ein sha256-Hex aussieht: er waehlt zwischen zwei Formulierungen und darf keinen gestalteten Dateinamen in eine Fehlermeldung tragen. Nichts an einer Vertrauensentscheidung haengt daran.

## Die Tutorials lehrten den Fehler als Tugend

Dort stand woertlich „Die Begruendung ist woertlich zu nehmen". Korrigiert, in drei Dateien plus der Smoke-Kette. Dabei ist der Ablauf realistischer geworden: **die Signatur reist jetzt mit der Datei mit**, wie bei einem echten Versand. Ohne sie danebenliegend ist „nie signiert" die richtige Antwort, und der alte Ablauf zeigte damit gar nicht den Fall, den er zu zeigen behauptete.

Dass das Doku-Gate den Bruch sofort gemeldet hat, ist hier der Mechanismus bei der Arbeit: ein Tutorial versprach eine Zeichenkette, die der Code nicht mehr liefert.

## Baseline

Zwei gosec-Befunde, die mit #214 tatsaechlich verschwunden sind, aus der Baseline entfernt, damit sie ihre Wiedereinfuehrung weiter blockiert. Lokal `new vs baseline: 0`.

## Richtigstellung zu #214

Dort steht, die Baseline merke sich Zeilennummern. **Das stimmt nicht.** Sie schluesselt auf Regel, Datei und Code-Schnipsel. Gemeldet wurde, weil das Herausziehen von `finishInstall` `stagingDir` zu `o.stagingDir` machte und damit den Schnipsel aenderte. Die Korrektur selbst (0755 auf 0750, 0644 auf 0600) war unabhaengig davon richtig.

Refs: WF-005 B1, SPEC-0406 AC-08

🤖 Generated with [Claude Code](https://claude.com/claude-code)