### PR TITLE
feat(test): der Zwei-Parteien-Akzeptanztest als Regression, T01 bis T15 (SPEC-0406)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,18 @@ jobs:
       - name: Every dispatched verb registered (FR-0113)
         run: go run ./cmd/verbaudit
 
+      # SPEC-0406: the acceptance REHEARSAL, the Unix half of the twin pair.
+      # Its Windows twin runs in skillctl-windows-smoke.yml with the same step
+      # ids, so a report from each machine compares line by line.
+      #
+      # Running both halves in CI is what keeps them a PAIR. A twin script that
+      # only ever runs on one platform is a claim about the other, not a check
+      # of it, and the pair exists precisely so Eric runs what CI runs.
+      - name: Acceptance rehearsal (SPEC-0406, Unix half)
+        run: |
+          go build -o build/skillctl ./cmd/skillctl
+          bash scripts/skillctl-acceptance.sh --skillctl ./build/skillctl
+
   test:
     name: Unit Tests
     runs-on: macos-latest

--- a/.github/workflows/skillctl-windows-smoke.yml
+++ b/.github/workflows/skillctl-windows-smoke.yml
@@ -19,6 +19,7 @@ on:
       - "pkg/skillctl/**"
       - "pkg/skillbundle/**"
       - "scripts/skillctl-quickstart-windows.ps1"
+      - "scripts/skillctl-acceptance.ps1"
       - "tools/skillctl-install.ps1"
       - ".github/workflows/skillctl-windows-smoke.yml"
 
@@ -58,6 +59,19 @@ jobs:
         run: |
           powershell -ExecutionPolicy Bypass -File scripts\skillctl-quickstart-windows.ps1
           if ($LASTEXITCODE -ne 0) { Write-Error "quickstart smoke failed (exit $LASTEXITCODE)"; exit $LASTEXITCODE }
+
+      # SPEC-0406: the acceptance REHEARSAL, the Windows half of the twin pair.
+      # Its Unix twin is scripts/skillctl-acceptance.sh; the two carry the same
+      # step ids so a report from each machine compares line by line.
+      #
+      # Running it here is what keeps the PowerShell twin honest. A script that
+      # only ever runs on the author's Mac is a claim about Windows, not a check
+      # of it, and the twin exists precisely so Eric runs what CI runs.
+      - name: Run acceptance rehearsal (SPEC-0406)
+        run: |
+          powershell -ExecutionPolicy Bypass -File scripts\skillctl-acceptance.ps1 -Skillctl $env:SKILLCTL
+          if ($LASTEXITCODE -ne 0) { Write-Error "acceptance rehearsal failed (exit $LASTEXITCODE)"; exit $LASTEXITCODE }
+        shell: pwsh
         shell: pwsh
 
   # BUG-0193 regression guard: reproduce the FIELD environment, Windows PowerShell

--- a/cmd/skillctl/acceptance_two_party_test.go
+++ b/cmd/skillctl/acceptance_two_party_test.go
@@ -1,0 +1,414 @@
+package main
+
+// acceptance_two_party_test.go: SPEC-0406, the two-party acceptance test as an
+// automated regression.
+//
+// WHAT IT IS. The machine-checked half of the procedure Mirko and Eric run by
+// hand. It plays both parties in one process, but with NOTHING shared between
+// them except a directory that is explicitly declared to be the untrusted
+// transport: separate homes, separate keys, separate trust-roots files.
+//
+// WHY THE SEPARATION IS THE TEST. If the two parties shared a home, a key, or a
+// trust-roots file, the run would demonstrate that a tool can verify its own
+// output, which nobody doubts. The claim under test is narrower and harder: that
+// the RECIPIENT does not have to trust the sender, the channel, or anything that
+// travelled with the artifact. Every shared value would quietly weaken that.
+//
+// HERMETIC BY CONSTRUCTION. No ER1, no network beyond a local httptest server
+// standing in for the sender's own registry, and the trust-roots lookup is
+// redirected per party so the run never reads the developer's own machine. An
+// ambient registry once masked an over-broad fail-closed through two adversarial
+// review rounds; only a hermetic run caught it.
+//
+// WHAT IT DOES NOT COVER, stated so nobody reads more into a green run than it
+// says: the human steps. Whether a person understands the output, whether the
+// fingerprint really was compared over a second channel, and whether the two
+// machines really were two machines. Those are Phase 0 and the task test, and
+// they stay human.
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/auditevent"
+	"github.com/kamir/m3c-tools/pkg/skillctl/install"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// party is one side of the exchange: their own home, keys and trust roots.
+// Nothing in here is shared with the other party.
+type party struct {
+	name       string
+	home       string
+	trustRoots string
+	authorPub  ed25519.PublicKey
+	authorPriv ed25519.PrivateKey
+	regPub     ed25519.PublicKey
+	regPriv    ed25519.PrivateKey
+	authorID   string
+	skill      string
+	greeting   string
+}
+
+func newParty(t *testing.T, name, skill, greeting string) *party {
+	t.Helper()
+	aPub, aPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("%s author key: %v", name, err)
+	}
+	rPub, rPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("%s registry key: %v", name, err)
+	}
+	return &party{
+		name: name, home: t.TempDir(), authorPub: aPub, authorPriv: aPriv,
+		regPub: rPub, regPriv: rPriv, authorID: "id:" + name + "@acceptance",
+		skill: skill, greeting: greeting,
+	}
+}
+
+// pinTrustRoots writes the RECIPIENT's view of the SENDER: the sender's author
+// key, pinned locally. This stands in for Phase 0, where the fingerprint is
+// compared over a second channel before anything is installed.
+//
+// identity_keys_authorized: pinned is what makes the offline paths possible. It
+// says the author key is not to be fetched from anywhere, which is precisely why
+// the transport cannot influence the decision.
+func (p *party) pinTrustRoots(t *testing.T, sender *party, regURL string) {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("trust_roots:\n")
+	b.WriteString("  - registry_url: " + regURL + "\n")
+	b.WriteString("    registry_keys:\n")
+	b.WriteString("      - id: reg-1\n")
+	b.WriteString("        pubkey: " + base64.StdEncoding.EncodeToString(sender.regPub) + "\n")
+	b.WriteString("    identity_keys_authorized: pinned\n")
+	b.WriteString("    governance_minimum: green\n")
+	b.WriteString("    authors:\n")
+	b.WriteString("      - id: " + sender.authorID + "\n")
+	b.WriteString("        pubkey: " + base64.StdEncoding.EncodeToString(sender.authorPub) + "\n")
+	p.trustRoots = filepath.Join(t.TempDir(), "trust-roots-"+p.name+".yaml")
+	if err := os.WriteFile(p.trustRoots, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("%s trust roots: %v", p.name, err)
+	}
+}
+
+// sealed is what the sender produces and hands over: the artifact and the
+// envelope beside it. Nothing else travels.
+type sealed struct {
+	skb    string
+	meta   string
+	digest string
+}
+
+// seal packs, signs and writes the pair into the transport directory.
+//
+// It builds the envelope directly rather than driving `export-bundle`, because
+// export-bundle needs a live registry and this test is about the RECIPIENT's
+// side of the exchange. The envelope it writes is the same shape export-bundle
+// writes, and a separate test pins that the two agree.
+func (p *party) seal(t *testing.T, transport string) sealed {
+	t.Helper()
+	blob := twoPartyBundle(t, p.skill, p.greeting)
+	sum := sha256.Sum256(blob)
+	digest := "sha256:" + hex.EncodeToString(sum[:])
+
+	base := filepath.Join(transport, p.skill+"@1.0.0.skb")
+	if err := os.WriteFile(base, blob, 0o600); err != nil {
+		t.Fatalf("%s write artifact: %v", p.name, err)
+	}
+	meta := map[string]any{
+		"bundle": map[string]any{
+			"bundle_digest": digest, "name": p.skill, "version": "1.0.0", "status": "admitted",
+		},
+		"signatures": []map[string]any{
+			{"role": "author", "identity_id": p.authorID,
+				"signature_b64": base64.StdEncoding.EncodeToString(ed25519.Sign(p.authorPriv, sum[:])), "status": "active"},
+			{"role": "registry", "identity_id": "id:" + p.name + "-registry",
+				"signature_b64": base64.StdEncoding.EncodeToString(ed25519.Sign(p.regPriv, sum[:])), "status": "active"},
+		},
+		"manifest":           map[string]any{"author_governance_intent": "green", "depends_on": []any{}},
+		"current_governance": "green",
+		"attestations": []map[string]any{
+			{"level": "green", "reviewer_id": "id:reviewer@acceptance", "attested_at": "2026-09-06T00:00:00Z"},
+		},
+	}
+	raw, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		t.Fatalf("%s marshal envelope: %v", p.name, err)
+	}
+	metaPath := defaultMetaSidecar(base)
+	if err := os.WriteFile(metaPath, raw, 0o600); err != nil {
+		t.Fatalf("%s write envelope: %v", p.name, err)
+	}
+	return sealed{skb: base, meta: metaPath, digest: digest}
+}
+
+// verifyBundle and installBundle drive the real CLI entry points, so the test
+// exercises the same argument handling, the same error mapping and the same
+// audit emission an operator gets.
+func (p *party) verifyBundle(s sealed) (int, string) {
+	var out bytes.Buffer
+	code := runVerify([]string{"--bundle", s.skb, "--trust-roots", p.trustRoots, "--home", p.home}, &out, &out)
+	return code, out.String()
+}
+
+func (p *party) installBundle(s sealed) (int, string) {
+	var out bytes.Buffer
+	code := runInstallBundle(installBundleParams{
+		bundlePath: s.skb, trustRootsPath: p.trustRoots, homeOverride: p.home,
+	}, &out, &out)
+	return code, out.String()
+}
+
+func (p *party) installedSkills(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(p.home, ".claude", "skills"))
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		// The tool's own staging directory is not an installed skill. This test
+		// is what found it being counted as one.
+		if e.IsDir() && e.Name() != install.StagingDirName {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+// TestAcceptance_TwoParty is the SPEC-0406 matrix, run end to end.
+func TestAcceptance_TwoParty(t *testing.T) {
+	transport := t.TempDir() // the untrusted channel: e-mail, USB, a shared folder
+
+	mirko := newParty(t, "mirko", "mirko-demo-skill", "Hello from Mirko")
+	eric := newParty(t, "eric", "eric-demo-skill", "Hello from Eric")
+
+	// Phase 0: each side pins the OTHER's author key. Out of band, before
+	// anything arrives. Without this the exchange proves nothing.
+	// The root names the SENDER's own registry. Nothing here ever calls it: the
+	// offline path passes no fetcher, which is exactly what makes the decision
+	// independent of the sender. The URL is a name, not an endpoint.
+	mirko.pinTrustRoots(t, eric, "https://eric.example/api/skills")
+	eric.pinTrustRoots(t, mirko, "https://mirko.example/api/skills")
+
+	// ---- T01..T06: Eric to Mirko ----
+	fromEric := eric.seal(t, transport)
+
+	if code, out := mirko.verifyBundle(fromEric); code != exitOK {
+		t.Fatalf("T04 verify failed (exit %d): %s", code, out)
+	}
+	code, out := mirko.installBundle(fromEric)
+	if code != exitOK {
+		t.Fatalf("T05 install failed (exit %d): %s", code, out)
+	}
+	if got := mirko.installedSkills(t); len(got) != 1 || got[0] != eric.skill {
+		t.Fatalf("T05 installed %v, want [%s]", got, eric.skill)
+	}
+	// T06: the skill is USABLE, not merely present. Reading back the greeting
+	// from the installed tree is the closest this hermetic test gets to running
+	// it, and it is what distinguishes "delivered" from "verified".
+	assertGreeting(t, mirko, eric)
+
+	// ---- T07..T10: the same in reverse. Symmetry is part of the claim: neither
+	// side holds a privileged role, and nothing depends on our machine.
+	fromMirko := mirko.seal(t, transport)
+	if code, out := eric.verifyBundle(fromMirko); code != exitOK {
+		t.Fatalf("T08 verify failed (exit %d): %s", code, out)
+	}
+	if code, out := eric.installBundle(fromMirko); code != exitOK {
+		t.Fatalf("T09 install failed (exit %d): %s", code, out)
+	}
+	assertGreeting(t, eric, mirko)
+
+	// ---- T11..T13: the tamper ----
+	//
+	// A COPY of the already-signed artifact, altered, with its envelope intact.
+	// The signature is deliberately NOT re-made: that is the whole test.
+	tampered := sealed{
+		skb:    filepath.Join(transport, "eric-demo-skill-tampered.skb"),
+		digest: fromEric.digest,
+	}
+	blob, err := os.ReadFile(fromEric.skb) // #nosec G304 -- the test's own temp dir.
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	blob[len(blob)/2] ^= 0xFF
+	if err := os.WriteFile(tampered.skb, blob, 0o600); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+	metaRaw, err := os.ReadFile(fromEric.meta) // #nosec G304 -- the test's own temp dir.
+	if err != nil {
+		t.Fatalf("read envelope: %v", err)
+	}
+	if err := os.WriteFile(defaultMetaSidecar(tampered.skb), metaRaw, 0o600); err != nil {
+		t.Fatalf("write tampered envelope: %v", err)
+	}
+
+	before := snapshotSkills(t, mirko)
+
+	// T11: detected, with the numbered code that names the cause.
+	code, out = mirko.verifyBundle(tampered)
+	if code != verify.ExitDigestMismatch {
+		t.Errorf("T11 verify exit = %d, want %d (digest mismatch): %s", code, verify.ExitDigestMismatch, out)
+	}
+	// A refusal must be legible. A silent non-zero exit is nearly as bad as a
+	// wrong one, because the operator cannot act on it.
+	if strings.TrimSpace(out) == "" {
+		t.Error("T11 refused without printing a reason")
+	}
+
+	// T12: not installed.
+	code, out = mirko.installBundle(tampered)
+	if code == exitOK {
+		t.Errorf("T12 a tampered artifact was INSTALLED: %s", out)
+	}
+	if code != verify.ExitDigestMismatch {
+		t.Errorf("T12 install exit = %d, want %d: %s", code, verify.ExitDigestMismatch, out)
+	}
+
+	// T13: and the refusal changed nothing. This is INV-6 at the acceptance
+	// level: a build that refuses loudly and writes anyway looks green in every
+	// log, so the disk is asked directly.
+	if after := snapshotSkills(t, mirko); !equalSnapshots(before, after) {
+		t.Errorf("T13 a refused install changed the install target\n before: %v\n after:  %v", before, after)
+	}
+
+	// ---- T14: post-install tampering ----
+	//
+	// The most common real case: the artifact was fine on arrival and the file
+	// was edited afterwards. Nothing about the transport catches this; only
+	// re-verification does.
+	victim := filepath.Join(mirko.home, ".claude", "skills", eric.skill, "SKILL.md")
+	if err := os.WriteFile(victim, []byte("# "+eric.skill+"\n\nHello from Eric - LOCAL HACK\n"), 0o600); err != nil {
+		t.Fatalf("local tamper: %v", err)
+	}
+	var vout bytes.Buffer
+	if code := runVerify([]string{"--offline", "--trust-roots", mirko.trustRoots, "--home", mirko.home, eric.skill}, &vout, &vout); code == exitOK {
+		t.Errorf("T14 a locally altered installed skill still verified: %s", vout.String())
+	}
+
+	// ---- T15: the audit trail ----
+	assertRefusalWasRecorded(t, mirko)
+}
+
+// assertGreeting checks the installed tree really carries the sender's content.
+func assertGreeting(t *testing.T, recipient, sender *party) {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(recipient.home, ".claude", "skills", sender.skill, "SKILL.md")) // #nosec G304 -- test temp dir.
+	if err != nil {
+		t.Fatalf("%s: installed skill has no SKILL.md: %v", recipient.name, err)
+	}
+	if !strings.Contains(string(body), sender.greeting) {
+		t.Errorf("%s installed %s but it does not carry %q:\n%s", recipient.name, sender.skill, sender.greeting, body)
+	}
+}
+
+// T15. The refusal has to be findable afterwards, by someone who was not
+// watching the terminal. Without this, "we blocked it" is a claim about a moment
+// that has passed.
+func assertRefusalWasRecorded(t *testing.T, p *party) {
+	t.Helper()
+	path := lifecycleAuditPath(p.home)
+	data, err := os.ReadFile(path) // #nosec G304 -- test temp dir.
+	if err != nil {
+		t.Fatalf("T15 no lifecycle audit log at %s: %v", path, err)
+	}
+	var found bool
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e auditevent.Event
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Errorf("T15 unparseable audit line: %v", err)
+			continue
+		}
+		if e.Outcome == auditevent.OutcomeSuccess || e.Error == nil {
+			continue
+		}
+		if e.Error.Code == string(auditevent.ReasonDigestMismatch) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("T15 the tampering attempt left no digest-mismatch record in %s:\n%s", path, data)
+	}
+}
+
+func snapshotSkills(t *testing.T, p *party) map[string]string {
+	t.Helper()
+	root := filepath.Join(p.home, ".claude", "skills")
+	out := map[string]string{}
+	_ = filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
+		if err != nil || fi == nil || fi.IsDir() {
+			return nil //nolint:nilerr // an unreadable entry is handled by the caller's comparison.
+		}
+		b, rerr := os.ReadFile(path) // #nosec G304 -- test temp dir.
+		if rerr != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		sum := sha256.Sum256(b)
+		out[filepath.ToSlash(rel)] = hex.EncodeToString(sum[:])
+		return nil
+	})
+	return out
+}
+
+func equalSnapshots(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// twoPartyBundle builds a minimal, deterministic .skb whose bundle.json carries
+// the skill name. The name inside the archive is what decides where the skill
+// lands (install_bundle.go reads it from the digest-verified archive), so it has
+// to be real here rather than stubbed.
+func twoPartyBundle(t *testing.T, name, greeting string) []byte {
+	t.Helper()
+	files := map[string]string{
+		"bundle.json": fmt.Sprintf(`{"schema":"m3c-skill-bundle/v1","name":%q,"version":"1.0.0"}`+"\n", name),
+		"SKILL.md":    "# " + name + "\n\n" + greeting + "\n",
+	}
+	var gzBuf bytes.Buffer
+	gw := gzip.NewWriter(&gzBuf)
+	tw := tar.NewWriter(gw)
+	root := name + "-1.0.0"
+	if err := tw.WriteHeader(&tar.Header{Name: root + "/", Typeflag: tar.TypeDir, Mode: 0o755}); err != nil {
+		t.Fatalf("tar dir: %v", err)
+	}
+	for path, content := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: root + "/" + path, Mode: 0o644, Size: int64(len(content)), Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("tar header %s: %v", path, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("tar write %s: %v", path, err)
+		}
+	}
+	_ = tw.Close()
+	_ = gw.Close()
+	return gzBuf.Bytes()
+}

--- a/cmd/skillctl/doctor_cmds.go
+++ b/cmd/skillctl/doctor_cmds.go
@@ -37,6 +37,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/kamir/m3c-tools/pkg/skillctl/install"
 	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
 	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
 )
@@ -218,7 +219,10 @@ func checkSkillsDir(override string) check {
 	n := 0
 	if entries, err := os.ReadDir(dir); err == nil {
 		for _, e := range entries {
-			if e.IsDir() {
+			// Same reservation as the sweep: our own staging directory is not an
+			// installed skill, and reporting it as one would make the count
+			// disagree with `verify --all` for no reason a reader could guess.
+			if e.IsDir() && e.Name() != install.StagingDirName {
 				n++
 			}
 		}

--- a/cmd/skillctl/verify_all_cmds.go
+++ b/cmd/skillctl/verify_all_cmds.go
@@ -168,6 +168,12 @@ func runVerifyAll(args []string, stdout, stderr io.Writer) int {
 
 	for _, e := range entries {
 		name := e.Name()
+		// The tool's own staging directory is not a skill. Counting it made the
+		// sweep apply the unmanaged-skill policy to our own scratch space, which
+		// under a deny policy is noise at best and a wrong verdict at worst.
+		if name == install.StagingDirName {
+			continue
+		}
 		dir := filepath.Join(skillsDir, name)
 		// os.Stat FOLLOWS symlinks. A symlinked skill dir (common here:
 		// gstack symlinks like `browse → gstack/browse`) still has its

--- a/pkg/skillctl/install/install.go
+++ b/pkg/skillctl/install/install.go
@@ -554,8 +554,20 @@ func resolveDigest(ctx context.Context, c *registry.Client, name, version string
 }
 
 // makeStagingDir creates ~/.claude/skills/.tmp/<name>-<digest>/.
+// StagingDirName is the ONE name of the tool's own staging directory inside the
+// skills root. It lives there on purpose: the final step is an atomic rename,
+// and a rename is only atomic within one filesystem.
+//
+// It is exported because every READER of the skills root has to skip it, and
+// before this there was no single place that said so. `verify --all` counted it
+// as an installed skill, found no .skb inside, and applied the unmanaged-skill
+// gate policy to the tool's own scratch space; `doctor` counted it in "N
+// installed". A reserved name that only some readers know about is a name that
+// will be forgotten by the next reader.
+const StagingDirName = ".tmp"
+
 func makeStagingDir(homeDir, name, digest string) (string, error) {
-	tmpRoot := filepath.Join(homeDir, installRoot, ".tmp")
+	tmpRoot := filepath.Join(homeDir, installRoot, StagingDirName)
 	if err := os.MkdirAll(tmpRoot, 0o700); err != nil {
 		return "", fmt.Errorf("install: mkdir tmp root: %w", err)
 	}

--- a/scripts/skillctl-acceptance.ps1
+++ b/scripts/skillctl-acceptance.ps1
@@ -1,0 +1,263 @@
+<#
+.SYNOPSIS
+  skillctl-acceptance.ps1: the SPEC-0406 acceptance rehearsal, by hand.
+
+.DESCRIPTION
+  The twin of scripts/skillctl-acceptance.sh: same steps, same ids, same report,
+  so a run from a Mac and a run from a Windows box compare line by line. When you
+  change one, change the other; the pair is only useful while it stays a pair.
+
+  It sits one level above scripts/skillctl-test.ps1. That one asks "can this
+  machine build and test skillctl". This one asks "does this machine REFUSE
+  correctly", which is the only half of the question a machine can answer alone.
+
+  WHAT IT RUNS, and why it stops where it does.
+
+  Two parties live in two separate HOME directories with two separate keys, and a
+  third directory stands in for the untrusted transport. The script drives the
+  real binary through:
+
+    R1   this machine is usable                                (doctor)
+    R2   the build under test is named in the report            (version)
+    R3a  the sender packs a skill                               (pack)
+    R3b  the sender signs it                                    (sign)
+    R3c  the sender checks their OWN work before sending        (verify-sig)
+    R3d  the artifact travels, unaltered, and still verifies    (verify-sig)
+    R3e  an artifact ALTERED after signing is refused           (verify-sig, exit 10)
+    R3f  the refusal names the cause, not a missing file        (AC-08)
+    R4a..R4f  the same in the other direction                   (symmetry)
+
+  It stops before install. `install --bundle` needs the BundleMeta envelope, and
+  that envelope carries author, registry AND governance signatures: a script that
+  minted it would have to hold every key, and a run in which one actor holds every
+  key demonstrates nothing about two actors. The install half therefore lives in
+  the automated regression, which builds each party's keys in isolation:
+
+      go test ./cmd/skillctl/ -run TestAcceptance_TwoParty -v
+
+  and in the real two-machine run, SPEC-0406 section 4.
+
+.PARAMETER Skillctl
+  The binary under test. Defaults to .\build\skillctl.exe, then PATH.
+
+.PARAMETER Work
+  Workspace directory. Defaults to a temp dir, removed unless -Keep.
+
+.PARAMETER Keep
+  Keep the workspace so the artifacts can be inspected.
+
+.NOTES
+  Exit: 0 every step passed; 1 a step failed; 2 usage or setup error.
+#>
+[CmdletBinding()]
+param(
+  [string]$Skillctl = "",
+  [string]$Work = "",
+  [switch]$Keep
+)
+
+$ErrorActionPreference = 'Continue'
+
+$script:Ids = @(); $script:States = @(); $script:Notes = @()
+$script:Failed = $false
+$script:LastOut = ""
+
+function Record {
+  param([string]$Id, [string]$State, [string]$Note)
+  $script:Ids += $Id; $script:States += $State; $script:Notes += $Note
+  if ($State -eq 'FAIL') { $script:Failed = $true }
+}
+
+# Step runs a command and compares the exit code against the one SPEC-0406
+# predicts. A step that fails for the WRONG reason is a failure: "non-zero" is
+# not a result, it is the absence of one.
+function Step {
+  param([string]$Id, [int]$Want, [string]$Label, [string]$HomeDir, [string[]]$ArgList)
+  $old = $env:HOME; $oldUp = $env:USERPROFILE
+  $env:HOME = $HomeDir; $env:USERPROFILE = $HomeDir
+  try {
+    $script:LastOut = (& $script:Bin @ArgList 2>&1 | Out-String)
+    $rc = $LASTEXITCODE
+  } finally {
+    $env:HOME = $old; $env:USERPROFILE = $oldUp
+  }
+  if ($rc -eq $Want) {
+    Record $Id 'PASS' $Label
+    Write-Host ("  {0,-5} PASS  {1} (exit {2})" -f $Id, $Label, $rc) -ForegroundColor Green
+  } else {
+    Record $Id 'FAIL' ("{0}: wanted exit {1}, got {2}" -f $Label, $Want, $rc)
+    Write-Host ("  {0,-5} FAIL  {1}: wanted exit {2}, got {3}" -f $Id, $Label, $Want, $rc) -ForegroundColor Red
+    ($script:LastOut -split "`n") | ForEach-Object { Write-Host ("          " + $_) }
+  }
+}
+
+# Says checks the PREVIOUS step's output for a phrase. This is the AC-08 check:
+# a refusal that exits correctly and explains the wrong thing still sends its
+# reader after the wrong problem.
+function Says {
+  param([string]$Id, [string]$Needle, [string]$Label)
+  if ($script:LastOut -like ("*" + $Needle + "*")) {
+    Record $Id 'PASS' $Label
+    Write-Host ("  {0,-5} PASS  {1}" -f $Id, $Label) -ForegroundColor Green
+  } else {
+    Record $Id 'FAIL' ("{0}: output never mentioned '{1}'" -f $Label, $Needle)
+    Write-Host ("  {0,-5} FAIL  {1}: output never mentioned {2}" -f $Id, $Label, $Needle) -ForegroundColor Red
+    ($script:LastOut -split "`n") | ForEach-Object { Write-Host ("          " + $_) }
+  }
+}
+
+# ---- setup ---------------------------------------------------------------
+
+if (-not $Skillctl) {
+  if (Test-Path ".\build\skillctl.exe") { $Skillctl = ".\build\skillctl.exe" }
+  elseif (Get-Command skillctl -ErrorAction SilentlyContinue) { $Skillctl = (Get-Command skillctl).Source }
+  else {
+    Write-Error "no skillctl found: build it (go build -o build\skillctl.exe .\cmd\skillctl) or pass -Skillctl"
+    exit 2
+  }
+}
+$script:Bin = (Resolve-Path $Skillctl).Path
+
+if (-not $Work) {
+  $Work = Join-Path ([System.IO.Path]::GetTempPath()) ("skillctl-acc-" + [guid]::NewGuid().ToString("N").Substring(0,8))
+}
+New-Item -ItemType Directory -Force -Path $Work | Out-Null
+
+$Version = (& $script:Bin version 2>$null | Select-Object -First 1)
+if (-not $Version) { Write-Error "the binary at $script:Bin does not answer 'version'"; exit 2 }
+
+Write-Host "skillctl acceptance rehearsal (SPEC-0406)"
+Write-Host "binary  : $script:Bin"
+Write-Host "version : $Version"
+Write-Host ("platform: {0} {1}" -f [System.Environment]::OSVersion.Platform, $env:PROCESSOR_ARCHITECTURE)
+Write-Host "work    : $Work"
+Write-Host ""
+
+$Transport = Join-Path $Work "transport"
+New-Item -ItemType Directory -Force -Path $Transport | Out-Null
+
+# OneParty sets up a home, a key and a demo skill. Each party gets its own of
+# everything: a shared value here would quietly weaken the whole exercise.
+function OneParty {
+  param([string]$Who, [string]$Skill, [string]$Greeting)
+  $src = Join-Path $Work "$Who\src\$Skill"
+  New-Item -ItemType Directory -Force -Path $src | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $Work "$Who\keys") | Out-Null
+  Set-Content -Path (Join-Path $src "SKILL.md") -Value "# $Skill`n`n$Greeting" -NoNewline
+  $old = $env:HOME; $oldUp = $env:USERPROFILE
+  $env:HOME = (Join-Path $Work $Who); $env:USERPROFILE = $env:HOME
+  try { & $script:Bin keygen --out (Join-Path $Work "$Who\keys\$Who") | Out-Null }
+  finally { $env:HOME = $old; $env:USERPROFILE = $oldUp }
+}
+
+Write-Host "== Phase 1: both sides check their installation =="
+OneParty -Who "mirko" -Skill "mirko-demo-skill" -Greeting "Hello from Mirko"
+OneParty -Who "eric"  -Skill "eric-demo-skill"  -Greeting "Hello from Eric"
+
+$MirkoHome = Join-Path $Work "mirko"
+$EricHome  = Join-Path $Work "eric"
+
+# doctor is asked ONCE, about THIS machine, and deliberately not twice as if it
+# were two of them.
+#
+# Two reasons. It reports the real environment, which is the point of the
+# command, and a sandboxed answer would say nothing useful. And on Windows a
+# SHIPPING build ignores $HOME for the trust-root path by design (WIN-09
+# confinement), so a per-party sandbox would silently collapse into one machine
+# here while still looking like two on the Unix twin. A check whose meaning
+# changes between the twins is worse than a check that only runs once.
+Step -Id "R1" -Want 0 -Label "this machine is usable (doctor)" -HomeDir $env:USERPROFILE -ArgList @("doctor")
+Says -Id "R2" -Needle $Version -Label "the build under test is named in the report"
+
+# Exchange plays one direction: sender seals, the artifact travels, the recipient
+# checks it, then a tampered copy is checked too.
+function Exchange {
+  param([string]$Who, [string]$Skill, [string]$Px)
+  $home = Join-Path $Work $Who
+  $key  = Join-Path $Work "$Who\keys\$Who"
+  $skb  = Join-Path $home "$Skill@1.0.0.skb"
+  $src  = Join-Path $home "src\$Skill"
+
+  Step -Id "$($Px)a" -Want 0 -Label "$Who`: packs the skill" -HomeDir $home `
+    -ArgList @("pack","--skill",$src,"-o",$skb,"--name",$Skill,"--version","1.0.0")
+  Step -Id "$($Px)b" -Want 0 -Label "$Who`: signs it" -HomeDir $home `
+    -ArgList @("sign","--key","$key.priv",$skb)
+  Step -Id "$($Px)c" -Want 0 -Label "$Who`: checks their OWN work before sending" -HomeDir $home `
+    -ArgList @("verify-sig","--pubkey","$key.pub",$skb)
+
+  # The artifact travels. Its signature travels with it, which is what actually
+  # happens when someone sends you a signed file.
+  Copy-Item $skb $Transport
+  Get-ChildItem -Path (Split-Path $skb) -Filter ((Split-Path $skb -Leaf) + ".*.author.sig") |
+    ForEach-Object { Copy-Item $_.FullName (Join-Path $Transport $_.Name) }
+  $arrived = Join-Path $Transport (Split-Path $skb -Leaf)
+
+  Step -Id "$($Px)d" -Want 0 -Label "the unaltered artifact still verifies after transport" -HomeDir $home `
+    -ArgList @("verify-sig","--pubkey","$key.pub",$arrived)
+
+  # Now the tamper: a copy, altered, with the signature NOT re-made.
+  $bad = Join-Path $Transport "$Skill-tampered.skb"
+  Copy-Item $arrived $bad
+  Get-ChildItem -Path $Transport -Filter ((Split-Path $arrived -Leaf) + ".*.author.sig") |
+    ForEach-Object {
+      $suffix = $_.Name.Substring((Split-Path $arrived -Leaf).Length + 1)
+      Copy-Item $_.FullName (Join-Path $Transport ("$Skill-tampered.skb." + $suffix))
+    }
+  $bytes = [System.IO.File]::ReadAllBytes($bad)
+  $bytes[200] = $bytes[200] -bxor 0xFF
+  [System.IO.File]::WriteAllBytes($bad, $bytes)
+
+  Step -Id "$($Px)e" -Want 10 -Label "the altered artifact is REFUSED" -HomeDir $home `
+    -ArgList @("verify-sig","--pubkey","$key.pub",$bad)
+  Says -Id "$($Px)f" -Needle "changed after signing" -Label "the refusal names the cause, not a missing file"
+}
+
+Write-Host ""
+Write-Host "== Eric to Mirko =="
+Exchange -Who "eric" -Skill "eric-demo-skill" -Px "R3"
+
+Write-Host ""
+Write-Host "== Mirko to Eric (symmetry: neither side has a privileged role) =="
+Exchange -Who "mirko" -Skill "mirko-demo-skill" -Px "R4"
+
+# ---- summary -------------------------------------------------------------
+
+Write-Host ""
+Write-Host "========================================"
+if ($script:Failed) { Write-Host " FAIL" } else { Write-Host " PASS (rehearsal)" }
+Write-Host "========================================"
+Write-Host ""
+Write-Host ("Platform : {0} {1}" -f [System.Environment]::OSVersion.Platform, $env:PROCESSOR_ARCHITECTURE)
+Write-Host "Binary   : $script:Bin"
+Write-Host "Version  : $Version"
+Write-Host ""
+for ($i = 0; $i -lt $script:Ids.Count; $i++) {
+  $c = switch ($script:States[$i]) { 'PASS' { 'Green' } 'FAIL' { 'Red' } default { 'Yellow' } }
+  Write-Host ("  {0,-5} {1,-5} {2}" -f $script:Ids[$i], $script:States[$i], $script:Notes[$i]) -ForegroundColor $c
+}
+
+Write-Host @"
+
+WHAT THIS RUN DID NOT ESTABLISH
+  * that two machines and two people were involved: both parties ran here,
+  * that a fingerprint was compared over a SECOND channel (SPEC-0406 section 3.2),
+    which is what makes "the recipient need not trust the transport" TRUE
+    rather than merely asserted,
+  * that a human understood any of the output,
+  * the install half (T05, T09, T12, T14, T15). That needs the BundleMeta
+    envelope, which carries author, registry AND governance signatures; a
+    script that minted it would hold every key, and a run where one actor
+    holds every key demonstrates nothing about two actors.
+
+  For the install half:  go test ./cmd/skillctl/ -run TestAcceptance_TwoParty -v
+  For the acceptance:    SPEC-0406 section 4, with a person on each end.
+
+  A rehearsal reported as a passed acceptance is the failure this note exists
+  to prevent.
+"@
+
+if ($Keep) { Write-Host ""; Write-Host "workspace kept: $Work" }
+elseif (Test-Path $Work) { Remove-Item -Recurse -Force $Work -ErrorAction SilentlyContinue }
+
+if ($script:Failed) { exit 1 }
+exit 0

--- a/scripts/skillctl-acceptance.sh
+++ b/scripts/skillctl-acceptance.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+#
+# skillctl-acceptance.sh: the SPEC-0406 acceptance rehearsal, by hand.
+#
+# The twin of scripts/skillctl-acceptance.ps1, same steps, same report, so a run
+# from a Mac and a run from a Windows box compare line by line.
+#
+# It sits one level above scripts/skillctl-test.sh. That one asks "can this
+# machine build and test skillctl". This one asks "does this machine REFUSE
+# correctly", which is the only half of the question a machine can answer alone.
+#
+# ---------------------------------------------------------------------------
+# WHAT IT RUNS, and why it stops where it does.
+#
+# Two parties live in two separate HOME directories with two separate keys, and
+# a third directory stands in for the untrusted transport. The script drives the
+# real binary through:
+#
+#   R1   this machine is usable                                (doctor)
+#   R2   the build under test is named in the report            (version)
+#   R3a  the sender packs a skill                               (pack)
+#   R3b  the sender signs it                                    (sign)
+#   R3c  the sender checks their OWN work before sending        (verify-sig)
+#   R3d  the artifact travels, unaltered, and still verifies    (verify-sig)
+#   R3e  an artifact ALTERED after signing is refused           (verify-sig, exit 10)
+#   R3f  the refusal names the cause, not a missing file        (AC-08)
+#   R4a..R4f  the same in the other direction                   (symmetry)
+#
+# It stops before install. `install --bundle` needs the BundleMeta envelope, and
+# that envelope carries author, registry AND governance signatures: a script that
+# minted it would have to hold every key, and a run in which one actor holds
+# every key demonstrates nothing about two actors. The install half therefore
+# lives in the automated regression, which builds each party's keys in isolation:
+#
+#     go test ./cmd/skillctl/ -run TestAcceptance_TwoParty -v
+#
+# and in the real two-machine run, SPEC-0406 §4.
+# ---------------------------------------------------------------------------
+#
+# Usage:
+#   ./scripts/skillctl-acceptance.sh [--skillctl PATH] [--work DIR] [--keep]
+#
+# Exit: 0 every step passed; 1 a step failed; 2 usage or setup error.
+
+set -uo pipefail
+
+SKILLCTL=""
+WORK=""
+KEEP=0
+
+usage() {
+  cat <<'USAGE'
+skillctl-acceptance.sh: the SPEC-0406 acceptance rehearsal.
+
+  --skillctl PATH   the binary under test (default: ./build/skillctl, then PATH)
+  --work DIR        workspace (default: a temp dir, removed unless --keep)
+  --keep            keep the workspace so the artifacts can be inspected
+  -h, --help        this text
+
+A rehearsal exercises the commands and the refusals on ONE machine. It does not
+establish that two machines, two people, or an out-of-band fingerprint check
+were involved. The summary says so; please do not report it as an acceptance.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skillctl) SKILLCTL="${2:?--skillctl needs a path}"; shift 2 ;;
+    --work)     WORK="${2:?--work needs a path}";         shift 2 ;;
+    --keep)     KEEP=1; shift ;;
+    -h|--help)  usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; NC=$'\033[0m'
+[ -t 1 ] || { RED=""; GREEN=""; YELLOW=""; NC=""; }
+
+IDS=(); STATES=(); NOTES=(); FAILED=0; LAST_OUT=""
+
+record() {                           # record <id> <PASS|FAIL|SKIP> <note>
+  IDS+=("$1"); STATES+=("$2"); NOTES+=("$3")
+  [ "$2" = "FAIL" ] && FAILED=1
+  return 0
+}
+
+# step runs a command and compares the exit code against the one SPEC-0406
+# predicts. A step that fails for the WRONG reason is a failure: "non-zero" is
+# not a result, it is the absence of one.
+step() {                             # step <id> <want-exit> <label> -- cmd...
+  local id="$1" want="$2" label="$3"; shift 4
+  LAST_OUT="$("$@" 2>&1)"; local rc=$?
+  if [ "$rc" -eq "$want" ]; then
+    record "$id" PASS "$label"
+    printf '  %s%-4s PASS%s  %s (exit %d)\n' "$GREEN" "$id" "$NC" "$label" "$rc"
+  else
+    record "$id" FAIL "$label: wanted exit $want, got $rc"
+    printf '  %s%-4s FAIL%s  %s: wanted exit %d, got %d\n' "$RED" "$id" "$NC" "$label" "$want" "$rc"
+    printf '%s\n' "$LAST_OUT" | sed 's/^/          /'
+  fi
+}
+
+# says checks the PREVIOUS step's output for a phrase. This is the AC-08 check:
+# a refusal that exits correctly and explains the wrong thing still sends its
+# reader after the wrong problem.
+says() {                             # says <id> <needle> <label>
+  local id="$1" needle="$2" label="$3"
+  if printf '%s' "$LAST_OUT" | grep -qiF -- "$needle"; then
+    record "$id" PASS "$label"
+    printf '  %s%-4s PASS%s  %s\n' "$GREEN" "$id" "$NC" "$label"
+  else
+    record "$id" FAIL "$label: output never mentioned '$needle'"
+    printf '  %s%-4s FAIL%s  %s: output never mentioned %s\n' "$RED" "$id" "$NC" "$label" "$needle"
+    printf '%s\n' "$LAST_OUT" | sed 's/^/          /'
+  fi
+}
+
+# ---- setup ---------------------------------------------------------------
+
+if [ -z "$SKILLCTL" ]; then
+  if [ -x "./build/skillctl" ]; then SKILLCTL="./build/skillctl"
+  elif command -v skillctl >/dev/null 2>&1; then SKILLCTL="$(command -v skillctl)"
+  else echo "no skillctl found: build it (make build-skillctl) or pass --skillctl" >&2; exit 2; fi
+fi
+SKILLCTL="$(cd "$(dirname "$SKILLCTL")" && pwd)/$(basename "$SKILLCTL")"
+
+if [ -z "$WORK" ]; then
+  WORK="$(mktemp -d)"
+  [ "$KEEP" -eq 1 ] || trap 'rm -rf "$WORK"' EXIT
+fi
+mkdir -p "$WORK"
+
+VERSION="$("$SKILLCTL" version 2>/dev/null | head -1)"
+[ -n "$VERSION" ] || { echo "the binary at $SKILLCTL does not answer 'version'" >&2; exit 2; }
+
+echo "skillctl acceptance rehearsal (SPEC-0406)"
+echo "binary  : $SKILLCTL"
+echo "version : $VERSION"
+echo "platform: $(uname -s) $(uname -m)"
+echo "work    : $WORK"
+echo ""
+
+TRANSPORT="$WORK/transport"; mkdir -p "$TRANSPORT"
+
+# one_party sets up a home, a key and a demo skill. Each party gets its own of
+# everything: a shared value here would quietly weaken the whole exercise.
+one_party() {                        # one_party <name> <skill> <greeting>
+  local who="$1" skill="$2" greet="$3"
+  mkdir -p "$WORK/$who/src/$skill" "$WORK/$who/keys"
+  printf '# %s\n\n%s\n' "$skill" "$greet" > "$WORK/$who/src/$skill/SKILL.md"
+  env HOME="$WORK/$who" "$SKILLCTL" keygen --out "$WORK/$who/keys/$who" >/dev/null 2>&1
+}
+
+echo "== Phase 1: both sides check their installation =="
+one_party mirko mirko-demo-skill "Hello from Mirko"
+one_party eric  eric-demo-skill  "Hello from Eric"
+
+# doctor is asked ONCE, about THIS machine, and deliberately not twice as if it
+# were two of them.
+#
+# Two reasons. It reports the real environment, which is the point of the
+# command, and a sandboxed answer would say nothing useful. And on Windows a
+# SHIPPING build ignores $HOME for the trust-root path by design (WIN-09
+# confinement), so a per-party sandbox would silently collapse into one machine
+# there while still looking like two here. A check whose meaning changes between
+# the twins is worse than a check that only runs once.
+step R1 0 "this machine is usable (doctor)" -- \
+  "$SKILLCTL" doctor
+says R2 "$VERSION" "the build under test is named in the report"
+
+# exchange plays one direction: sender seals, the artifact travels, the
+# recipient checks it, then a tampered copy is checked too.
+exchange() {                         # exchange <sender> <skill> <prefix>
+  local who="$1" skill="$2" px="$3"
+  local key="$WORK/$who/keys/$who"
+  local skb="$WORK/$who/$skill@1.0.0.skb"
+
+  step "${px}a" 0 "$who: packs the skill" -- \
+    env HOME="$WORK/$who" "$SKILLCTL" pack --skill "$WORK/$who/src/$skill" \
+      -o "$skb" --name "$skill" --version 1.0.0
+  step "${px}b" 0 "$who: signs it" -- \
+    env HOME="$WORK/$who" "$SKILLCTL" sign --key "$key.priv" "$skb"
+  step "${px}c" 0 "$who: checks their OWN work before sending" -- \
+    env HOME="$WORK/$who" "$SKILLCTL" verify-sig --pubkey "$key.pub" "$skb"
+
+  # The artifact travels. Its signature travels with it, which is what actually
+  # happens when someone sends you a signed file.
+  cp "$skb" "$TRANSPORT/"
+  local sig
+  for sig in "$skb".*.author.sig; do
+    [ -e "$sig" ] && cp "$sig" "$TRANSPORT/$(basename "$sig")"
+  done
+  local arrived="$TRANSPORT/$(basename "$skb")"
+
+  step "${px}d" 0 "the unaltered artifact still verifies after transport" -- \
+    env HOME="$WORK/$who" "$SKILLCTL" verify-sig --pubkey "$key.pub" "$arrived"
+
+  # Now the tamper: a copy, altered, with the signature NOT re-made.
+  local bad="$TRANSPORT/${skill}-tampered.skb"
+  cp "$arrived" "$bad"
+  for sig in "$arrived".*.author.sig; do
+    [ -e "$sig" ] && cp "$sig" "$bad.$(basename "$sig" | sed "s|^$(basename "$arrived")\.||")"
+  done
+  printf '\xff' | dd of="$bad" bs=1 seek=200 count=1 conv=notrunc 2>/dev/null
+
+  step "${px}e" 10 "the altered artifact is REFUSED" -- \
+    env HOME="$WORK/$who" "$SKILLCTL" verify-sig --pubkey "$key.pub" "$bad"
+  says "${px}f" "changed after signing" "the refusal names the cause, not a missing file"
+}
+
+echo ""
+echo "== Eric to Mirko =="
+exchange eric eric-demo-skill R3
+
+echo ""
+echo "== Mirko to Eric (symmetry: neither side has a privileged role) =="
+exchange mirko mirko-demo-skill R4
+
+# ---- summary -------------------------------------------------------------
+
+echo ""
+echo "========================================"
+if [ "$FAILED" -ne 0 ]; then echo " FAIL"; else echo " PASS (rehearsal)"; fi
+echo "========================================"
+echo ""
+echo "Platform : $(uname -s) $(uname -m)"
+echo "Binary   : $SKILLCTL"
+echo "Version  : $VERSION"
+echo ""
+for i in "${!IDS[@]}"; do
+  case "${STATES[$i]}" in
+    PASS) c="$GREEN" ;; FAIL) c="$RED" ;; *) c="$YELLOW" ;;
+  esac
+  printf '  %s%-5s %-5s%s %s\n' "$c" "${IDS[$i]}" "${STATES[$i]}" "$NC" "${NOTES[$i]}"
+done
+
+cat <<'CAVEAT'
+
+WHAT THIS RUN DID NOT ESTABLISH
+  * that two machines and two people were involved: both parties ran here,
+  * that a fingerprint was compared over a SECOND channel (SPEC-0406 §3.2),
+    which is what makes "the recipient need not trust the transport" TRUE
+    rather than merely asserted,
+  * that a human understood any of the output,
+  * the install half (T05, T09, T12, T14, T15). That needs the BundleMeta
+    envelope, which carries author, registry AND governance signatures; a
+    script that minted it would hold every key, and a run where one actor
+    holds every key demonstrates nothing about two actors.
+
+  For the install half:  go test ./cmd/skillctl/ -run TestAcceptance_TwoParty -v
+  For the acceptance:    SPEC-0406 §4, with a person on each end.
+
+  A rehearsal reported as a passed acceptance is the failure this note exists
+  to prevent.
+CAVEAT
+
+[ "$KEEP" -eq 1 ] && echo "" && echo "workspace kept: $WORK"
+[ "$FAILED" -ne 0 ] && exit 1
+exit 0


### PR DESCRIPTION
Die maschinengepruefte Haelfte der Prozedur, die Mirko und Eric von Hand durchlaufen.

## Die Trennung ist der Test

Beide Parteien laufen in einem Prozess, teilen aber **nichts** ausser einem Verzeichnis, das ausdruecklich als unvertrauenswuerdiger Transportweg deklariert ist: getrennte Homes, getrennte Schluessel, getrennte Trust-Roots-Dateien.

Teilten die beiden ein Home, einen Schluessel oder eine Roots-Datei, zeigte der Lauf, dass ein Werkzeug seine eigene Ausgabe verifizieren kann. Das bezweifelt niemand. Die Behauptung ist enger und schwerer: der **Empfaenger** muss weder dem Absender noch dem Kanal noch irgendetwas trauen, das mit dem Artefakt mitgereist ist. Jeder geteilte Wert wuerde das still abschwaechen.

## Abgedeckt

Phase 0 als gegenseitiges Pinnen · beide Austauschrichtungen (Symmetrie gehoert zur Behauptung: keine Seite hat eine privilegierte Rolle) · die **Ausfuehrbarkeit** des uebernommenen Skills, nicht nur seine Anwesenheit · das manipulierte Artefakt mit Exit 10 und lesbarer Begruendung · die verweigerte Installation · die **unveraenderte Platte danach**, gegen einen Schnappschuss statt gegen ein Logbuch, denn ein Werkzeug, das laut ablehnt und trotzdem schreibt, sieht in jedem Log gruen aus · die nachtraegliche lokale Manipulation · und der Audit-Eintrag, ohne den „wir haben es blockiert" eine Aussage ueber einen vergangenen Augenblick bleibt.

Hermetisch: kein ER1, kein Netz, Trust-Roots je Partei umgeleitet.

## Ein Befund, den erst dieser Test zutage brachte

Das Staging-Verzeichnis `.tmp` liegt im Skills-Root, damit das abschliessende Umbenennen atomar bleibt (ein Rename ist nur innerhalb eines Dateisystems atomar). Es wurde aber von **jedem Leser als installierter Skill gezaehlt**:

- `verify --all` fand darin kein `.skb` und wandte die Gate-Policy fuer unverwaltete Skills auf den eigenen Kratzplatz an. Unter einer `deny`-Policy ist das im besten Fall Laerm.
- `doctor` zaehlte es in „N installed" mit.

Der Name heisst jetzt `install.StagingDirName`, an **einer** Stelle, und beide Leser ueberspringen ihn. Ein reservierter Name, den nur manche Leser kennen, ist einer, den der naechste Leser vergisst.

## Nicht abgedeckt

Ausdruecklich benannt, damit niemand mehr in einen gruenen Lauf liest, als er sagt: die menschlichen Schritte. Ob ein Mensch die Ausgabe versteht, ob der Fingerprint wirklich ueber einen zweiten Kanal verglichen wurde, und ob die zwei Maschinen wirklich zwei Maschinen waren. Das bleiben Phase 0 und der Aufgabentest.

Refs: SPEC-0406 §6 (T01..T15), §8

🤖 Generated with [Claude Code](https://claude.com/claude-code)