### PR TITLE
fix(sim): die Nacharbeit zu #211, plus zwei Befunde aus adversarialer Pruefung

### DIFF
--- a/cmd/skillctl-sim/main.go
+++ b/cmd/skillctl-sim/main.go
@@ -181,7 +181,7 @@ func runRun(args []string) int {
 	_, conflicts, _, _ := rep.Summary()
 	waived, unwaived := rep.WaivedConflicts()
 	res := rep.Residual()
-	viol := len(rep.Violations())
+	_, viol := rep.WaivedViolations()
 	if unwaived > 0 || viol > 0 || res != 0 {
 		fmt.Fprintf(os.Stderr,
 			"\nFAIL: %d conflict(s) of which %d waived, %d invariant violation(s), residual %d.\n"+

--- a/pkg/skillctl/sim/analytic.go
+++ b/pkg/skillctl/sim/analytic.go
@@ -110,14 +110,15 @@ func StateAt(p Params, afterRevoke bool) State {
 		// The malicious publisher is the only move that can put this bit to zero.
 		// Every other actor in the alphabet has to break the envelope to reach the
 		// signature rows, and then gate 1 speaks first.
-		SigsVerify: p.Adv != AdvPublisherBadSigs,
+		SigsVerify: p.Adv != AdvPublisherBadSigs && p.Adv != AdvDigestAndSigs,
 		// Withholding the bytes is indistinguishable from a digest failure AT THE
 		// POINT WHERE THE BYTES ARE NEEDED: the fetch fails and the pull reports the
 		// digest gate. The point of the probe is that a revoked or ungoverned bundle
 		// never gets that far, because those two gates decide from signed metadata
 		// alone. That is FR-0119 D3, made observable by taking away what an early
 		// fetch would have touched.
-		DigestMatches: p.Adv != AdvStoredBundle && p.Adv != AdvArtifactWithheld,
+		DigestMatches: p.Adv != AdvStoredBundle && p.Adv != AdvArtifactWithheld &&
+			p.Adv != AdvDigestAndSigs,
 	}
 
 	// x_rev. A revoke is visible when it was issued and the store still shows it.

--- a/pkg/skillctl/sim/design.go
+++ b/pkg/skillctl/sim/design.go
@@ -162,7 +162,7 @@ func CoveringArray(t int) ([]Params, CoverageStats) {
 	// matter how the rest of the space is sampled, which is the difference between
 	// a corpus that covers its inputs and one that can see its outputs.
 	var chosen []Params
-	for _, sp := range gateSeeds() {
+	for _, sp := range append(gateSeeds(), specSeeds()...) {
 		for i, c := range candidates {
 			if c == sp {
 				chosen = append(chosen, c)
@@ -224,6 +224,22 @@ func gateSeeds() []Params {
 		{Cast: CastSolo, Key: KeySeparatePin, Gov: GovNone, Adv: AdvNone, Revoke: false},
 		// gate 5: a clean bundle, revoked.
 		{Cast: CastSolo, Key: KeySeparatePin, Gov: GovGreen, Adv: AdvNone, Revoke: true},
+	}
+}
+
+// specSeeds are points for SPECIFIED checks that the five-bit state vector does
+// not represent, and which therefore cannot be reached through gateSeeds.
+//
+// SPEC-0188 §7 step 8 is the first of them: the CHECKSUMS file inside the bundle.
+// Without a seed the covering array selected only rows where governance already
+// failed, so the check never got a turn and the test case existed without ever
+// being exercised. That is the same trap the gate seeds exist for, one level up:
+// covering the inputs does not cover the outcomes.
+func specSeeds() []Params {
+	return []Params{
+		// SPEC-0188 §7 step 8: everything outside the bundle is correct, so only the
+		// internal manifest can decide.
+		{Cast: CastSolo, Key: KeySeparatePin, Gov: GovGreen, Adv: AdvStaleChecksums, Revoke: false},
 	}
 }
 

--- a/pkg/skillctl/sim/design.go
+++ b/pkg/skillctl/sim/design.go
@@ -218,7 +218,7 @@ func gateSeeds() []Params {
 		{Cast: CastSolo, Key: KeySeparatePin, Gov: GovGreen, Adv: AdvForgeEnvelope, Revoke: false},
 		// gate 2: the stored bytes no longer hash to the admitted digest.
 		{Cast: CastSolo, Key: KeySeparatePin, Gov: GovGreen, Adv: AdvStoredBundle, Revoke: false},
-		// gate 3: the signature rows do not verify (label under FR-0121).
+		// gate 3: the signature rows do not verify beneath a valid envelope.
 		{Cast: CastSolo, Key: KeySeparatePin, Gov: GovGreen, Adv: AdvPublisherBadSigs, Revoke: false},
 		// gate 4: no attestation at all, nothing else wrong.
 		{Cast: CastSolo, Key: KeySeparatePin, Gov: GovNone, Adv: AdvNone, Revoke: false},

--- a/pkg/skillctl/sim/discrimination.go
+++ b/pkg/skillctl/sim/discrimination.go
@@ -111,6 +111,12 @@ func (d Discrimination) Collapsed() []CauseSignal {
 // never gate 3. Something else refuses, and nobody had looked, because the report
 // showed the ABSENCE of a label and not the message that was there instead.
 //
+// Looking, on 2026-09-06, ended it: there was no refusal. The step was ACCEPTED,
+// exit 0, printed three sections below the waiver that described it as a refusal.
+// The adversary move edited a detached signature file the pull path never reads.
+// This function is kept because the same shape can recur at any gate: whenever a
+// label is missing, print what was actually said before explaining the absence.
+//
 // A refusal a reader cannot attribute is not a detail. It is the case where the
 // tool and the specification have drifted apart without anybody noticing.
 func (rep Report) WriteUnlabelled(w io.Writer) {

--- a/pkg/skillctl/sim/exclusion.go
+++ b/pkg/skillctl/sim/exclusion.go
@@ -57,6 +57,11 @@ func excludedBy(p Params) *Exclusion {
 		return &Exclusion{"transit attacks pinned to green", KindEconomy,
 			"the governance axis adds no distinct outcome for these moves"}
 	}
+	if p.Adv == AdvDigestAndSigs && (p.Gov != GovGreen || p.Key != KeySeparatePin) {
+		return &Exclusion{"digest-and-sigs pinned to green and pinned", KindEconomy,
+			"the move exists to ask which of gate 2 and gate 3 speaks first; a pull that " +
+				"dies at governance never reaches either, so the other axes add nothing"}
+	}
 	if p.Key == KeyShared && p.Cast != CastSolo && p.Adv != AdvNone {
 		return &Exclusion{"shared key collapses duo and trio onto solo", KindImpossible,
 			"with one key there is no second key holder to distinguish the casts"}

--- a/pkg/skillctl/sim/generate.go
+++ b/pkg/skillctl/sim/generate.go
@@ -146,9 +146,10 @@ func AllGovs() []Gov { return []Gov{GovGreen, GovYellow, GovNone} }
 // any other.
 func OpenDiagnostics() map[AdvKind]string {
 	return map[AdvKind]string{
-		AdvPublisherBadSigs: "FR-0121: gate 3 fires and does not name itself. Disabling it " +
-			"flips this pull from refuse to accept, so the control is live; only the label " +
-			"is missing. The decision is compared and scored, the label is waived",
+		AdvPublisherBadSigs: "FR-0121: gate 3 is UNVERIFIED. Its mutant is indistinguishable " +
+			"from the unmutated baseline, so nothing in this corpus depends on it. An earlier " +
+			"claim that disabling it flips this pull from refuse to accept is WITHDRAWN: the " +
+			"unmutated binary already accepts this case",
 	}
 }
 

--- a/pkg/skillctl/sim/generate.go
+++ b/pkg/skillctl/sim/generate.go
@@ -85,6 +85,12 @@ const (
 	// the bytes, while every signed event stays in place. It is how FR-0119 D3
 	// becomes measurable from outside the process. See WithholdArtifact.
 	AdvArtifactWithheld AdvKind = "artifact-withheld"
+
+	// AdvStaleChecksums is the test case for SPEC-0188 §7 step 8, which had none.
+	// Everything outside the bundle is correct: the digest matches, the signature
+	// verifies, the governance holds. Inside, the bundle's own manifest of file
+	// hashes no longer describes its contents.
+	AdvStaleChecksums AdvKind = "stale-checksums"
 )
 
 // Params is one point in the corpus.
@@ -151,6 +157,7 @@ func AllAdvKinds() []AdvKind {
 		AdvNone, AdvTransitChecked, AdvTransitSkipped, AdvStoredBundle,
 		AdvForgeAttest, AdvStripRevoke, AdvRelabelRevoke, AdvTamperInstalled,
 		AdvStolenKey, AdvForgeEnvelope, AdvPublisherBadSigs, AdvArtifactWithheld,
+		AdvStaleChecksums,
 	}
 }
 
@@ -285,6 +292,21 @@ func build(p Params) Scenario {
 				Expect: Expectation{Outcome: NoEffect, Exit: -1, Claimed: true,
 					Why: "the attacker controls the artifact, not the key"}},
 		)
+	case AdvStaleChecksums:
+		// BEFORE the admit, so the admitted digest is the digest of the altered
+		// bundle. Everything outside then holds: the recomputed digest matches, the
+		// signature verifies, the attestation is bound to what was admitted. The
+		// only defect is internal, which is the whole point of SPEC-0188 §7 step 8.
+		//
+		// Placing it after the admit, as the first attempt did, produced a different
+		// scenario altogether: the attestation stayed bound to the pre-change digest
+		// and the pull died at governance, so the case under test was never reached.
+		// The run said so immediately, with a conflict naming the wrong gate.
+		sc.Steps = append(sc.Steps,
+			Step{Action: Action{Kind: ActStaleChecksums, Actor: Adversary, Skill: skill},
+				Expect: Expectation{Outcome: NoEffect, Exit: -1, Claimed: true,
+					Why: "the bundle stays properly signed; only its internal manifest goes stale"}},
+		)
 	case AdvPublisherBadSigs:
 		// The bundle keeps a signature FILE with the right name, so the verifier
 		// finds one and has to do real cryptography to reject it. That is the
@@ -378,6 +400,16 @@ func build(p Params) Scenario {
 	// signal standing for two causes and turned out to be describing this bug rather
 	// than the product.
 	pullExpect := Expectation{Outcome: Accept, Exit: 0, Claimed: true, Why: why}
+	// SPEC-0188 §7 step 8 asserts a check the five-bit state vector does not
+	// represent: the CHECKSUMS file INSIDE the bundle. So this expectation comes
+	// straight from the clause rather than from the model, and the traceability
+	// matrix says so. A specified check with no representation in the abstract
+	// model is exactly what the backwards pass exists to surface.
+	if p.Adv == AdvStaleChecksums && ok {
+		pullExpect = Expectation{Outcome: Refuse, Exit: 1, Claimed: true,
+			Why: "SPEC-0188 §7 step 8: the CHECKSUMS file inside the bundle is verified " +
+				"after extraction, and any failure in steps 3 to 8 means no write"}
+	}
 	if !ok {
 		pullExpect = Expectation{Outcome: Refuse, Gate: gate, Exit: 1, Claimed: true, Why: why}
 	}

--- a/pkg/skillctl/sim/generate.go
+++ b/pkg/skillctl/sim/generate.go
@@ -81,6 +81,21 @@ const (
 	// instead of an argument. Either answer is worth more than the argument was.
 	AdvPublisherBadSigs AdvKind = "publisher-bad-sigs"
 
+	// AdvDigestAndSigs breaks the digest AND the signature rows at once, and it
+	// exists for one reason: the diagnosis contract "gate 2 before gate 3"
+	// (FR-0119 D2, decided 2026-09-05) was never exercised. Measured over the
+	// strength-2 array on 2026-09-06: nine scenarios reach the pair (5, 4), and
+	// ZERO reach the pair (2, 3), because no single move in the alphabet broke
+	// both the bytes and the rows. A normative ordering claim that no scenario can
+	// violate is a rule the report cannot say anything about.
+	//
+	// The two halves come from different actors and that is fine: the publisher
+	// posts rows that do not verify, the store swaps the bytes afterwards. Both
+	// capabilities exist separately in this alphabet; the scenario simply grants
+	// them at the same time, which is the weakest assumption under which the
+	// ordering question can be asked at all.
+	AdvDigestAndSigs AdvKind = "digest-and-sigs"
+
 	// AdvArtifactWithheld is a PROBE, not an attack: the backend no longer serves
 	// the bytes, while every signed event stays in place. It is how FR-0119 D3
 	// becomes measurable from outside the process. See WithholdArtifact.
@@ -159,6 +174,7 @@ func AllAdvKinds() []AdvKind {
 		AdvNone, AdvTransitChecked, AdvTransitSkipped, AdvStoredBundle,
 		AdvForgeAttest, AdvStripRevoke, AdvRelabelRevoke, AdvTamperInstalled,
 		AdvStolenKey, AdvForgeEnvelope, AdvPublisherBadSigs, AdvArtifactWithheld,
+		AdvDigestAndSigs,
 		AdvStaleChecksums,
 	}
 }
@@ -342,6 +358,21 @@ func build(p Params) Scenario {
 			Expect: Expectation{Outcome: Accept, Exit: 0, Claimed: true,
 				Why: "anyone may WRITE an attestation; only a pinned signer's counts"},
 		})
+	}
+
+	// 5a-ter. Both at once: rows that do not verify AND bytes that do not hash to
+	// the admitted digest. The prediction is gate 2, and it is the ONLY row in the
+	// corpus that can falsify "gate 2 before gate 3".
+	if p.Adv == AdvDigestAndSigs {
+		sc.Steps = append(sc.Steps,
+			Step{Action: Action{Kind: ActForgeBundleSigs, Actor: Publisher, Skill: skill},
+				Expect: Expectation{Outcome: NoEffect, Exit: -1, Claimed: true,
+					Why: "the publisher posts rows that do not verify beneath a valid envelope"}},
+			Step{Action: Action{Kind: ActTamperTransit, Actor: Adversary, Skill: skill,
+				Params: map[string]string{"where": "registry"}},
+				Expect: Expectation{Outcome: NoEffect, Exit: -1, Claimed: true,
+					Why: "and the store swaps the bytes, so both gate 2 and gate 3 have a reason to fire"}},
+		)
 	}
 
 	// 5a-bis. The bad signature rows. This step sits AFTER the admit on purpose:

--- a/pkg/skillctl/sim/generate.go
+++ b/pkg/skillctl/sim/generate.go
@@ -144,13 +144,14 @@ func AllGovs() []Gov { return []Gov{GovGreen, GovYellow, GovNone} }
 // the covering array, INV-6 checks that the refusal wrote nothing, and a
 // regression that turned the refusal into an acceptance would fail the gate like
 // any other.
+//
+// The register is empty since 2026-09-06. Its only entry claimed gate 3 fired
+// without naming itself; the gate was in fact never reached, because the move
+// that was supposed to trigger it edited a file the pull path does not read.
+// An exemption written on a wrong diagnosis is worse than no exemption: it makes
+// the report assert the thing it failed to measure.
 func OpenDiagnostics() map[AdvKind]string {
-	return map[AdvKind]string{
-		AdvPublisherBadSigs: "FR-0121: gate 3 is UNVERIFIED. Its mutant is indistinguishable " +
-			"from the unmutated baseline, so nothing in this corpus depends on it. An earlier " +
-			"claim that disabling it flips this pull from refuse to accept is WITHDRAWN: the " +
-			"unmutated binary already accepts this case",
-	}
+	return map[AdvKind]string{}
 }
 
 func AllAdvKinds() []AdvKind {
@@ -308,16 +309,6 @@ func build(p Params) Scenario {
 				Expect: Expectation{Outcome: NoEffect, Exit: -1, Claimed: true,
 					Why: "the bundle stays properly signed; only its internal manifest goes stale"}},
 		)
-	case AdvPublisherBadSigs:
-		// The bundle keeps a signature FILE with the right name, so the verifier
-		// finds one and has to do real cryptography to reject it. That is the
-		// difference between "no signature" (exit 1) and "a signature that does not
-		// verify" (gate 3), and only the second one reaches the gate under test.
-		sc.Steps = append(sc.Steps,
-			Step{Action: Action{Kind: ActLyingSignature, Actor: Publisher, Skill: skill},
-				Expect: Expectation{Outcome: NoEffect, Exit: -1, Claimed: true,
-					Why: "the publisher controls the artifact AND the registry key"}},
-		)
 	}
 
 	// 3. Admit. With a stolen key the ATTACKER performs it, and the chain that
@@ -350,6 +341,20 @@ func build(p Params) Scenario {
 			Action: Action{Kind: ActForgeAttest, Actor: Adversary, Skill: skill},
 			Expect: Expectation{Outcome: Accept, Exit: 0, Claimed: true,
 				Why: "anyone may WRITE an attestation; only a pinned signer's counts"},
+		})
+	}
+
+	// 5a-bis. The bad signature rows. This step sits AFTER the admit on purpose:
+	// the rows it rewrites live inside the admitted event, so before the admit
+	// there is nothing to rewrite. Its predecessor ran here at position 2, against
+	// a detached signature file the pull path never opens, and therefore never
+	// reached the gate it was written for (FR-0121).
+	if p.Adv == AdvPublisherBadSigs {
+		sc.Steps = append(sc.Steps, Step{
+			Action: Action{Kind: ActForgeBundleSigs, Actor: Publisher, Skill: skill},
+			Expect: Expectation{Outcome: NoEffect, Exit: -1, Claimed: true,
+				Why: "the publisher holds the registry key, so the envelope verifies; " +
+					"the rows beneath it do not, and that is the case gate 3 exists for"},
 		})
 	}
 

--- a/pkg/skillctl/sim/model.go
+++ b/pkg/skillctl/sim/model.go
@@ -65,6 +65,7 @@ const (
 	ActTamperTransit    ActionKind = "adv:tamper-transit"      // flip bytes in the .skb before the victim sees it
 	ActLyingSignature   ActionKind = "adv:lying-signature"     // flip bytes AND rename the sig to match the new digest
 	ActWithholdArtifact ActionKind = "probe:withhold-artifact" // remove the stored .skb, keep every signed event
+	ActStaleChecksums   ActionKind = "adv:stale-checksums"     // alter a payload file, leave the bundle CHECKSUMS stale, re-sign
 	ActForgeAttest      ActionKind = "adv:forge-attest"        // attest with a key nobody pinned
 	ActTamperInstalled  ActionKind = "adv:tamper-installed"    // edit an installed file (same-uid, post-install)
 	ActStripRevoke      ActionKind = "adv:strip-revoke"        // hostile registry deletes the revoke event

--- a/pkg/skillctl/sim/model.go
+++ b/pkg/skillctl/sim/model.go
@@ -63,7 +63,7 @@ const (
 	// Adversary capabilities. Each one names what the attacker is assumed to
 	// control, because "hacked" is not a threat model.
 	ActTamperTransit    ActionKind = "adv:tamper-transit"      // flip bytes in the .skb before the victim sees it
-	ActLyingSignature   ActionKind = "adv:lying-signature"     // flip bytes AND rename the sig to match the new digest
+	ActForgeBundleSigs  ActionKind = "adv:forge-bundle-sigs"   // signature rows that do not verify, under an envelope that does
 	ActWithholdArtifact ActionKind = "probe:withhold-artifact" // remove the stored .skb, keep every signed event
 	ActStaleChecksums   ActionKind = "adv:stale-checksums"     // alter a payload file, leave the bundle CHECKSUMS stale, re-sign
 	ActForgeAttest      ActionKind = "adv:forge-attest"        // attest with a key nobody pinned

--- a/pkg/skillctl/sim/model.go
+++ b/pkg/skillctl/sim/model.go
@@ -223,7 +223,12 @@ type ScenarioResult struct {
 	Steps      []StepResult
 	Verdicts   []Verdict
 	Violations []InvariantViolation
-	Err        string
+
+	// Evaluated lists every invariant whose precondition held somewhere in this
+	// scenario, whether or not it was violated. It is the DENOMINATOR for the
+	// invariant section: "no violation" over a population of zero is not a result.
+	Evaluated []Invariant
+	Err       string
 }
 
 // InvariantViolation is the finding type that matters most. An exit-code mismatch

--- a/pkg/skillctl/sim/registry_mutate.go
+++ b/pkg/skillctl/sim/registry_mutate.go
@@ -10,8 +10,12 @@ package sim
 // nothing about the real one.
 
 import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"os/exec"
@@ -195,4 +199,123 @@ func (w *World) WithholdArtifact(skill string) error {
 		return fmt.Errorf("push: %v: %s", err, out)
 	}
 	return nil
+}
+
+// ForgeBundleSignatures posts an admit event whose SIGNATURE ROWS do not verify,
+// with an envelope that does. It is the move that reaches gate 3, and building it
+// took three attempts because the first two could not get there at all.
+//
+// Attempt one flipped a byte inside the .skb and renamed the detached signature to
+// match the new digest. The tar header broke and the installer refused before any
+// signature was read. Attempt two corrupted the detached `<bundle>.<digest>.author.sig`
+// file. That one ran green for two days and produced the conflict that FR-0121 was
+// filed on, because nobody checked WHICH file the pull path reads: it reads the
+// signature rows carried INSIDE the signed event, and never opens the sidecar. A
+// move against a file the path does not read cannot exercise a gate on that path.
+//
+// The reachability argument is what makes the third attempt necessary. The rows
+// live under the envelope signature, so a hostile STORE cannot touch them: any
+// edit invalidates the envelope and gate 1 decides first. Only a party holding the
+// registry key can present rows that do not verify beneath an envelope that does,
+// which is why this move re-signs. That party is not a rational attacker (holding
+// the key, he would simply sign correctly); he is a broken or hostile publishing
+// TOOL, and gate 3 is the consumer's protection against admitting its output.
+//
+// The re-signing deliberately does NOT call the product's own signing code. The
+// canonical form is re-implemented here from the format, the way an attacker's
+// tooling would have to. If the two ever disagree the envelope stops verifying,
+// gate 1 fires instead of gate 3, and the gate-order prediction reports it as a
+// conflict rather than hiding it.
+func (w *World) ForgeBundleSignatures(skill string) error {
+	priv, err := loadSimKey(w.keyPath("publisher") + ".priv")
+	if err != nil {
+		return err
+	}
+	return w.mutateRegistry(skill, func(dir, evPath string) error {
+		if !strings.Contains(evPath, "admitted") {
+			return nil
+		}
+		full := filepath.Join(dir, evPath)
+		// #nosec G304 -- a path this function just enumerated inside its own clone.
+		data, err := os.ReadFile(full)
+		if err != nil {
+			return err
+		}
+		var ev map[string]any
+		if err := json.Unmarshal(data, &ev); err != nil {
+			return err
+		}
+		rows, _ := ev["signatures"].([]any)
+		if len(rows) == 0 {
+			return fmt.Errorf("sim: admit event carries no signature rows; the move cannot reach gate 3")
+		}
+		// Well-formed and wrong: correct length, correct base64, verifies against
+		// nothing. The PARSER must not be what refuses, or the test would pass on a
+		// build whose cryptography was gone.
+		for _, r := range rows {
+			m, ok := r.(map[string]any)
+			if !ok {
+				return fmt.Errorf("sim: signature row is not an object")
+			}
+			m["signature_b64"] = base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+		}
+		canon, err := simCanonicalEvent(ev)
+		if err != nil {
+			return err
+		}
+		ev["envelope_signature"] = base64.StdEncoding.EncodeToString(ed25519.Sign(priv, canon))
+		out, err := json.MarshalIndent(ev, "", "  ")
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(full, out, 0o600)
+	})
+}
+
+// simCanonicalEvent is the adversary's own copy of the canonical form: every
+// field except the envelope signature, JSON-encoded with HTML escaping off and no
+// trailing newline. See ForgeBundleSignatures for why this is not a call into the
+// product.
+func simCanonicalEvent(ev map[string]any) ([]byte, error) {
+	cp := make(map[string]any, len(ev))
+	for k, v := range ev {
+		if k == "envelope_signature" {
+			continue
+		}
+		cp[k] = v
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(cp); err != nil {
+		return nil, err
+	}
+	out := buf.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	return out, nil
+}
+
+// loadSimKey reads a PEM/PKCS8 ed25519 private key. The harness holds the key
+// because the SCENARIO says the publisher does; nothing here reaches the consumer.
+func loadSimKey(path string) (ed25519.PrivateKey, error) {
+	// #nosec G304 -- a key this harness generated inside its own sandbox.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("sim: read publisher key: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("sim: %s holds no PEM block", path)
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("sim: parse publisher key: %w", err)
+	}
+	priv, ok := parsed.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("sim: publisher key is %T, not ed25519", parsed)
+	}
+	return priv, nil
 }

--- a/pkg/skillctl/sim/report.go
+++ b/pkg/skillctl/sim/report.go
@@ -224,7 +224,10 @@ func (rep Report) Write(w io.Writer) {
 		}
 	}
 
-	fmt.Fprintf(w, "\ncoverage: which gate actually refused (claimed pull steps)\n")
+	fmt.Fprintf(w, "\ncoverage: which gate the MODEL claimed, over claimed pull steps\n")
+	fmt.Fprintf(w, "  Not what a caller observed: an out-of-model refusal can carry a gate name\n")
+	fmt.Fprintf(w, "  too and is not counted here. The header said \"actually refused\" until a\n")
+	fmt.Fprintf(w, "  consistency sweep pointed out that it counts the opposite.\n")
 	if len(gates) == 0 {
 		fmt.Fprintf(w, "  (none: the corpus never reached a refusal, which is itself a finding)\n")
 	}
@@ -343,7 +346,7 @@ func (rep Report) Markdown() string {
 	fmt.Fprintf(&b, "| scenarios | %d |\n", len(rep.Results))
 	fmt.Fprintf(&b, "| steps matched | %d |\n", match)
 	fmt.Fprintf(&b, "| conflicts | %d |\n", conflict)
-	fmt.Fprintf(&b, "| out of model | %d |\n", unclaimed)
+	fmt.Fprintf(&b, "| out of model (occurrences) | %d |\n", unclaimed)
 	fmt.Fprintf(&b, "| skipped | %d |\n", skipped)
 	fmt.Fprintf(&b, "| invariant violations | %d |\n\n", len(rep.Violations()))
 	if hf := rep.HarnessFailures(); len(hf) > 0 {
@@ -396,7 +399,9 @@ func (rep Report) Markdown() string {
 	// still never reach a gate, which is exactly what happened once.
 	oc := rep.OutputCoverage()
 	fmt.Fprintf(&b, "\n## Coverage of outcomes\n\n")
-	fmt.Fprintf(&b, "Target, declared before the run: every specified decision observed at least %d time(s).\n\n", oc.Target)
+	fmt.Fprintf(&b, "Target, declared before the run: every DECLARED decision observed at least %d time(s).\n", oc.Target)
+	fmt.Fprintf(&b, "Declared, not specified: `accept` is a decision this report declares, not one\n")
+	fmt.Fprintf(&b, "SPEC-0225 §9.1 names.\n\n")
 	fmt.Fprintf(&b, "| decision | observed | |\n|---|---|---|\n")
 	for _, d := range oc.Declared {
 		mark := "n/a"
@@ -422,15 +427,83 @@ func (rep Report) Markdown() string {
 	fmt.Fprintf(&b, "DISTRIBUTION. The per-step comparison above is what decides behavioural\n")
 	fmt.Fprintf(&b, "conformance; equal histograms are not equal behaviour.\n\n")
 
-	fmt.Fprintf(&b, "## Gates reached\n\n")
-	for _, g := range sortedKeys(gates) {
-		fmt.Fprintf(&b, "- `%s`: %d\n", g, gates[g])
+	// THE VERDICT AND THE FINDINGS, in the artifact a release would keep.
+	//
+	// A consistency sweep on 2026-09-05 listed what this document was missing
+	// against the terminal report: the waiver register, the conflict records, the
+	// verdict itself, and the sentence saying no result is citable while the SUT
+	// calls itself dev. A release artifact that omits its own findings and its own
+	// verdict is a summary of the good news.
+	{
+		_, unwaivedC := rep.WaivedConflicts()
+		_, unwaivedV := rep.WaivedViolations()
+		verdict := "PASS"
+		if unwaivedC > 0 || unwaivedV > 0 || rep.Residual() != 0 || len(rep.HarnessFailures()) > 0 {
+			verdict = "FAIL"
+		}
+		if ws := Waivers(); len(ws) > 0 {
+			wc, uc := rep.WaivedConflicts()
+			wv, uv := rep.WaivedViolations()
+			fmt.Fprintf(&b, "\n## Waivers\n\n")
+			fmt.Fprintf(&b, "%d conflict(s) waived, %d not; %d invariant violation(s) waived, %d not.\n\n", wc, uc, wv, uv)
+			fmt.Fprintf(&b, "A waived finding is **counted and printed**. It is not the same as a step\n")
+			fmt.Fprintf(&b, "that was never compared: change what the binary does and the waiver stops\n")
+			fmt.Fprintf(&b, "matching, and the run fails again.\n")
+			fmt.Fprintf(&b, "\n| finding | dimension | model says | binary says | why |\n|---|---|---|---|---|\n")
+			for _, x := range ws {
+				exp := x.Expected
+				if exp == "" {
+					exp = "refuse, no gate"
+				}
+				obs := x.Observed
+				if obs == "" {
+					obs = "no gate named"
+				}
+				fmt.Fprintf(&b, "| %s | `%s` | %s | %s | %s |\n", x.Finding, x.Adv, exp, obs, x.Why)
+			}
+		}
+		fmt.Fprintf(&b, "\n## Verdict: **%s**\n\n", verdict)
+		fmt.Fprintf(&b, "Pass means: no unwaived conflict, no unwaived invariant violation, residual\n")
+		fmt.Fprintf(&b, "zero, no harness failure. It does NOT mean the declared coverage target was\n")
+		fmt.Fprintf(&b, "met; that is reported separately above and is currently short.\n")
 	}
+
 	if vs := rep.Violations(); len(vs) > 0 {
-		fmt.Fprintf(&b, "\n## Invariant violations\n\n")
+		fmt.Fprintf(&b, "\n## Invariant violations (%d)\n\n", len(vs))
 		for _, v := range vs {
 			fmt.Fprintf(&b, "- %s\n", v)
 		}
+	}
+
+	if cs := rep.Conflicts(); len(cs) > 0 {
+		fmt.Fprintf(&b, "\n## Conflicts (%d)\n\n", len(cs))
+		fmt.Fprintf(&b, "One of the two sides is wrong in each case; a human decides which.\n")
+		fmt.Fprintf(&b, "\n")
+		for _, c := range cs {
+			fmt.Fprintf(&b, "- %s\n", c)
+		}
+	}
+
+	fmt.Fprintf(&b, "\n## Not claimed\n\n")
+	fmt.Fprintf(&b, "- No failure rate: there is no operational profile.\n")
+	fmt.Fprintf(&b, "- No statement about the operational environment. Every scenario runs against\n")
+	fmt.Fprintf(&b, "  a bare local git repository; `github://`, `gitlab://`, ER1 and Windows are\n")
+	fmt.Fprintf(&b, "  untested assumptions.\n")
+	fmt.Fprintf(&b, "- No claim about human understanding of the output.\n")
+	fmt.Fprintf(&b, "- **No citability against a release.** Where the SUT version in Provenance\n")
+	fmt.Fprintf(&b, "  reads `dev`, this run has no source identity for what it measured.\n")
+	fmt.Fprintf(&b, "- Gate 3 is unverified: observed zero times, and its mutant is\n")
+	fmt.Fprintf(&b, "  indistinguishable from the unmutated baseline.\n")
+
+	fmt.Fprintf(&b, "\n## Sensitivity is NOT in this document\n\n")
+	fmt.Fprintf(&b, "Produced by `scripts/sim-calibrate.sh` and required alongside this report.\n")
+	fmt.Fprintf(&b, "Every zero above is meaningless without it: a run that cannot see a defect\n")
+	fmt.Fprintf(&b, "also reports no conflicts. A mutant counts as detected only if it exceeds the\n")
+	fmt.Fprintf(&b, "unmutated baseline signature, which the calibration prints.\n")
+
+	fmt.Fprintf(&b, "## Gates reached\n\n")
+	for _, g := range sortedKeys(gates) {
+		fmt.Fprintf(&b, "- `%s`: %d\n", g, gates[g])
 	}
 	if ls := rep.Limits(); len(ls) > 0 {
 		fmt.Fprintf(&b, "\n## Out of model, stated on purpose\n\n")
@@ -522,22 +595,36 @@ func (rep Report) WriteMixture(w io.Writer) {
 	if rep.Design != nil {
 		d := rep.Design
 		fmt.Fprintf(w, "\n  design: covering array of strength t=%d over %s\n", d.Strength, DesignAxes())
-		fmt.Fprintf(w, "  %d rows instead of %d exhaustive: EVERY admissible %d-way combination appears\n",
-			d.Rows, d.FullEnumeration, d.Strength)
-		fmt.Fprintf(w, "  %d combinations covered; %d of the %d in the unconstrained space are not\n",
-			d.Admissible, d.Uncoverable, d.Total)
-		fmt.Fprintf(w, "  covered, and they are NOT all the same kind. Point census over the factor\n")
+		// TWO POPULATIONS LIVE HERE and they were printed as one until 2026-09-05,
+		// when a consistency sweep counted them apart. The design's numbers are
+		// 2-WAY PAIRS; the census counts POINTS of the factor space. Six exclusion
+		// rules listed under a sentence about pairs summed to 320, which is a point
+		// count, and no reader could have known which denominator applied.
 		c := Census()
-		fmt.Fprintf(w, "  space: %d admissible, %d impossible (the world cannot produce them),\n",
-			c.Admissible, c.Impossible)
-		fmt.Fprintf(w, "  %d left out for economy (the world CAN produce them; the corpus judges\n", c.Economy)
-		fmt.Fprintf(w, "  them redundant, and that judgement can be wrong).\n")
+		producible := c.Admissible + c.Economy
+		fmt.Fprintf(w, "  %d rows, out of %d points the factor space holds in total.\n",
+			d.Rows, c.Total)
+		fmt.Fprintf(w, "\n  PAIRS (what the covering array promises):\n")
+		fmt.Fprintf(w, "    %d of the %d two-way combinations are covered; %d are not.\n",
+			d.Admissible, d.Total, d.Uncoverable)
+		fmt.Fprintf(w, "    The uncovered ones are not all of a kind, and the promise is therefore\n")
+		fmt.Fprintf(w, "    narrower than \"every combination appears\": it is every combination the\n")
+		fmt.Fprintf(w, "    corpus admits.\n")
+		fmt.Fprintf(w, "\n  POINTS (what the corpus admits, and why it leaves the rest out):\n")
+		fmt.Fprintf(w, "    %d total = %d in the corpus + %d the world cannot realise + %d the\n",
+			c.Total, c.Admissible, c.Impossible, c.Economy)
+		fmt.Fprintf(w, "    corpus omits for economy. So %d points are PRODUCIBLE and %d are used.\n",
+			producible, c.Admissible)
+		fmt.Fprintf(w, "    The economy share is a judgement and can be wrong; reporting it as an\n")
+		fmt.Fprintf(w, "    impossibility, as an earlier version did, is the costlier mistake.\n")
 		for _, r := range sortedKeys(c.ByRule) {
-			fmt.Fprintf(w, "    %-52s %d\n", r, c.ByRule[r])
+			fmt.Fprintf(w, "      %-50s %d points\n", r, c.ByRule[r])
 		}
-		fmt.Fprintf(w, "  An earlier version of this line called all of them \"not coverable, not\n")
-		fmt.Fprintf(w, "  missing\". For the economy share that was false, and reporting a judgement\n")
-		fmt.Fprintf(w, "  as an impossibility is the more expensive of the two mistakes.\n")
+		fmt.Fprintf(w, "\n  Do not read these point counts against the STATE classification in\n")
+		fmt.Fprintf(w, "  `theory`, which says zero states are impossible. Points and states are\n")
+		fmt.Fprintf(w, "  different objects: a state can be unreachable because no admitted point\n")
+		fmt.Fprintf(w, "  maps to it, while the points excluded as impossible are excluded by a\n")
+		fmt.Fprintf(w, "  precondition of a move. The two numbers disagreed in print for a day.\n")
 	}
 
 	fmt.Fprintf(w, "\n  distinct decision paths: %d over %d scenarios (yield %.2f)\n",
@@ -693,7 +780,9 @@ func (rep Report) WriteExperiment(w io.Writer) {
 	}
 	fmt.Fprintf(w, "  %-26s %9s %9s %9d\n", "sum |residual|", "", "", total)
 	if total == 0 {
-		fmt.Fprintf(w, "  The closed form describes the running system exactly on this corpus.\n")
+		fmt.Fprintf(w, "  The closed form reproduced the measured DISTRIBUTION on this corpus. It is\n")
+		fmt.Fprintf(w, "  not a statement about behaviour: the per-step comparison above decides\n")
+		fmt.Fprintf(w, "  that, and it currently carries waived conflicts.\n")
 	} else {
 		fmt.Fprintf(w, "  Non-zero: the model and the binary disagree somewhere. The conflict list below\n")
 		fmt.Fprintf(w, "  names the scenarios; a human decides which of the two is wrong.\n")

--- a/pkg/skillctl/sim/report.go
+++ b/pkg/skillctl/sim/report.go
@@ -563,13 +563,13 @@ func (rep Report) WriteMixture(w io.Writer) {
 
 	if len(m.MissedGate) > 0 {
 		fmt.Fprintf(w, "\n  HOLES: declared gates never seen BY NAME in this corpus: %s\n", strings.Join(m.MissedGate, ", "))
-		fmt.Fprintf(w, "  Gate 3 is on this list because it is never seen BY NAME, not because it\n")
-		fmt.Fprintf(w, "  never fires. Disabling it flips the affected pull from refuse to accept, so\n")
-		fmt.Fprintf(w, "  the control is live and its label is missing (FR-0121).\n")
-		fmt.Fprintf(w, "  This paragraph has now been wrong in both directions. It first claimed the\n")
-		fmt.Fprintf(w, "  gate fired unnamed, then that the case was not constructible. The second\n")
-		fmt.Fprintf(w, "  claim was an artefact of suppressing the step that shows the difference,\n")
-		fmt.Fprintf(w, "  which is what a waiver instead of a suppression now prevents.\n")
+		fmt.Fprintf(w, "  Gate 3 is on this list, and it is not merely a naming question. Its mutant\n")
+		fmt.Fprintf(w, "  is indistinguishable from the unmutated baseline, so no scenario here\n")
+		fmt.Fprintf(w, "  depends on it.\n")
+		fmt.Fprintf(w, "  This paragraph has now been wrong in three directions: the gate fires\n")
+		fmt.Fprintf(w, "  unnamed, then the case is not constructible, then the control is live. All\n")
+		fmt.Fprintf(w, "  three were artefacts of how the case was scored. What holds is the\n")
+		fmt.Fprintf(w, "  measurement: unverified, and its mutant undetectable (FR-0121).\n")
 		fmt.Fprintf(w, "  A gate on this list is a decision the simulation says nothing about.\n")
 	} else {
 		fmt.Fprintf(w, "\n  every declared gate was reached at least once\n")

--- a/pkg/skillctl/sim/report.go
+++ b/pkg/skillctl/sim/report.go
@@ -283,9 +283,8 @@ func (rep Report) Write(w io.Writer) {
 		for _, v := range vs {
 			fmt.Fprintf(w, "  %s\n", v)
 		}
-	} else {
-		fmt.Fprintf(w, "\ninvariants: no violation across the corpus\n")
 	}
+	rep.WriteInvariantCoverage(w)
 
 	if cs := rep.Conflicts(); len(cs) > 0 {
 		fmt.Fprintf(w, "\nCONFLICTS theory vs reality (%d). One of the two is wrong; a human decides.\n", len(cs))
@@ -589,6 +588,55 @@ func (rep Report) Compose() Mixture {
 }
 
 // WriteMixture renders the composition view.
+// WriteInvariantCoverage prints each invariant with the number of steps it was
+// EVALUATED on, beside the number of violations.
+//
+// "invariants: no violation across the corpus" was the whole section until
+// 2026-09-06, and it could not tell an invariant that held everywhere from one
+// whose precondition never occurred. Both print as silence.
+//
+// The rule it comes from is owed to a parallel session that hit the same shape in
+// an entirely different corpus: a figure names its population on the same line.
+// A figure without one is not wrong, it is unreadable, and it will then reliably
+// refute the wrong thing. Their case was a median of 0 over a set where half the
+// members had no value at all; this one is the same omission with the count in
+// the denominator instead of the numerator.
+//
+// INV-5 is why this is not hypothetical. It is declared in model.go, it appears
+// in the traceability matrix, and nothing evaluates it. While the section said
+// "no violation", that read as a check that passed.
+func (rep Report) WriteInvariantCoverage(w io.Writer) {
+	declared := []Invariant{
+		InvIntegrity, InvRevocation, InvGovernance, InvLoudRefusal, InvNoDowngrade,
+		InvRefusalIsInert, InvAcceptDelivers, InvMetadataDecidesAlone,
+	}
+	seen := map[Invariant]int{}
+	hurt := map[Invariant]int{}
+	for _, r := range rep.Results {
+		for _, e := range r.Evaluated {
+			seen[e]++
+		}
+		for _, v := range r.Violations {
+			hurt[v.Invariant]++
+		}
+	}
+	fmt.Fprintf(w, "\ninvariants: on how many steps was each one actually evaluated\n")
+	dead := 0
+	for _, inv := range declared {
+		mark := ""
+		if seen[inv] == 0 {
+			mark = "   <-- NEVER EVALUATED; this row is not a pass"
+			dead++
+		}
+		fmt.Fprintf(w, "    %-28s evaluated %4d   violations %d%s\n", inv, seen[inv], hurt[inv], mark)
+	}
+	fmt.Fprintf(w, "  Population per row: the steps where that invariant's precondition held.\n")
+	if dead > 0 {
+		fmt.Fprintf(w, "  %d declared invariant(s) were never evaluated. Such a row says NOTHING\n", dead)
+		fmt.Fprintf(w, "  about the property. It is a gap in the corpus, not a green light.\n")
+	}
+}
+
 func (rep Report) WriteMixture(w io.Writer) {
 	m := rep.Compose()
 	fmt.Fprintf(w, "\nmixture: is this corpus broad, or just long?\n")

--- a/pkg/skillctl/sim/report.go
+++ b/pkg/skillctl/sim/report.go
@@ -650,14 +650,12 @@ func (rep Report) WriteMixture(w io.Writer) {
 
 	if len(m.MissedGate) > 0 {
 		fmt.Fprintf(w, "\n  HOLES: declared gates never seen BY NAME in this corpus: %s\n", strings.Join(m.MissedGate, ", "))
-		fmt.Fprintf(w, "  Gate 3 is on this list, and it is not merely a naming question. Its mutant\n")
-		fmt.Fprintf(w, "  is indistinguishable from the unmutated baseline, so no scenario here\n")
-		fmt.Fprintf(w, "  depends on it.\n")
-		fmt.Fprintf(w, "  This paragraph has now been wrong in three directions: the gate fires\n")
-		fmt.Fprintf(w, "  unnamed, then the case is not constructible, then the control is live. All\n")
-		fmt.Fprintf(w, "  three were artefacts of how the case was scored. What holds is the\n")
-		fmt.Fprintf(w, "  measurement: unverified, and its mutant undetectable (FR-0121).\n")
-		fmt.Fprintf(w, "  A gate on this list is a decision the simulation says nothing about.\n")
+		fmt.Fprintf(w, "  A gate on this list is a decision the simulation says NOTHING about. It is\n")
+		fmt.Fprintf(w, "  not evidence that the gate is dead, and it is not evidence that it works.\n")
+		fmt.Fprintf(w, "  Gate 3 sat on this list for two days under three different explanations,\n")
+		fmt.Fprintf(w, "  each asserted without a measurement, until the move meant to trigger it was\n")
+		fmt.Fprintf(w, "  found to edit a file the pull path never opens. The rule that came out of\n")
+		fmt.Fprintf(w, "  that: an entry here is a question, never an account of why it is fine.\n")
 	} else {
 		fmt.Fprintf(w, "\n  every declared gate was reached at least once\n")
 	}

--- a/pkg/skillctl/sim/run.go
+++ b/pkg/skillctl/sim/run.go
@@ -97,6 +97,9 @@ func Execute(skillctl, rootDir string, sc Scenario) ScenarioResult {
 		case ActTamperInstalled:
 			aerr = w.TamperInstalled(skill)
 			code = -1
+		case ActStaleChecksums:
+			aerr = w.StaleChecksums(skill)
+			code = -1
 		case ActWithholdArtifact:
 			aerr = w.WithholdArtifact(skill)
 			code = -1

--- a/pkg/skillctl/sim/run.go
+++ b/pkg/skillctl/sim/run.go
@@ -231,7 +231,7 @@ func checkInvariants(sc Scenario, i int, r StepResult, w *World) []InvariantViol
 			if sc.P.Adv != AdvStoredBundle {
 				if ok, why := w.InstalledDigestMatches("simskill"); !ok {
 					v = append(v, InvariantViolation{InvAcceptDelivers, i,
-						"a pull reported success but the install target does not hold the signed bytes: " + why})
+						"a pull reported success and the installed tree differs from the packed source: " + why})
 				}
 			}
 		}

--- a/pkg/skillctl/sim/run.go
+++ b/pkg/skillctl/sim/run.go
@@ -103,8 +103,8 @@ func Execute(skillctl, rootDir string, sc Scenario) ScenarioResult {
 		case ActWithholdArtifact:
 			aerr = w.WithholdArtifact(skill)
 			code = -1
-		case ActLyingSignature:
-			aerr = w.CorruptSignature(skill)
+		case ActForgeBundleSigs:
+			aerr = w.ForgeBundleSignatures(skill)
 			code = -1
 		case ActForgeEnvelope:
 			aerr = w.ForgeEnvelope(skill)

--- a/pkg/skillctl/sim/run.go
+++ b/pkg/skillctl/sim/run.go
@@ -159,7 +159,9 @@ func Execute(skillctl, rootDir string, sc Scenario) ScenarioResult {
 
 		res.Steps = append(res.Steps, sr)
 		res.Verdicts = append(res.Verdicts, judge(st.Expect, sr))
-		res.Violations = append(res.Violations, checkInvariants(sc, i, sr, w)...)
+		vs, ev := checkInvariants(sc, i, sr, w)
+		res.Violations = append(res.Violations, vs...)
+		res.Evaluated = append(res.Evaluated, ev...)
 	}
 	return res
 }
@@ -192,17 +194,25 @@ func judge(e Expectation, r StepResult) Verdict {
 // checkInvariants asserts the properties that hold over the whole run. This is
 // where the two bugs of 2026-09-04 would have been caught: both produced a
 // plausible exit code and an impossible STATE.
-func checkInvariants(sc Scenario, i int, r StepResult, w *World) []InvariantViolation {
+// The second return value is every invariant whose PRECONDITION held at this
+// step, violated or not. Without it the report can only say "no violation", and
+// an invariant that never got a chance to fire is indistinguishable from one that
+// passed. That is the same false green as a mutant reproducing the baseline, one
+// level up, and INV-5 is currently the case in point: it is declared and never
+// evaluated anywhere.
+func checkInvariants(sc Scenario, i int, r StepResult, w *World) ([]InvariantViolation, []Invariant) {
 	var v []InvariantViolation
+	var ev []Invariant
 	b := w.bundles["simskill"]
 	if b == nil {
-		return nil
+		return nil, nil
 	}
 
 	// INV-8: with the artifact withheld, a bundle that is revoked or ungoverned must
 	// STILL be refused by its own gate. Reaching the digest gate instead would mean
 	// the fetch happened before the decision, which is what FR-0119 D3 forbids.
 	if r.Step.Action.Kind == ActPull && sc.P.Adv == AdvArtifactWithheld {
+		ev = append(ev, InvMetadataDecidesAlone)
 		_, want := StateAt(sc.P, b.revoked).Decide()
 		if (want == "gate 5" || want == "gate 4") && r.Gate != want {
 			v = append(v, InvariantViolation{InvMetadataDecidesAlone, i,
@@ -218,6 +228,7 @@ func checkInvariants(sc Scenario, i int, r StepResult, w *World) []InvariantViol
 	if r.Step.Action.Kind == ActPull && r.Before != nil && r.After != nil {
 		switch r.Outcome {
 		case Refuse:
+			ev = append(ev, InvRefusalIsInert)
 			// INV-6. A refusal that still wrote something is the worst class of
 			// defect this harness can look for: it looks green in every log.
 			if !r.Before.Equal(*r.After) {
@@ -229,6 +240,7 @@ func checkInvariants(sc Scenario, i int, r StepResult, w *World) []InvariantViol
 			// bundle attack is excluded: there the point of the scenario is that
 			// the bytes SHOULD not match, and the refusal is what is under test.
 			if sc.P.Adv != AdvStoredBundle {
+				ev = append(ev, InvAcceptDelivers)
 				if ok, why := w.InstalledDigestMatches("simskill"); !ok {
 					v = append(v, InvariantViolation{InvAcceptDelivers, i,
 						"a pull reported success and the installed tree differs from the packed source: " + why})
@@ -241,6 +253,9 @@ func checkInvariants(sc Scenario, i int, r StepResult, w *World) []InvariantViol
 	// strip attack legitimately removes the revoke, so it is excluded: there the
 	// registry is no longer showing what was published, and that limit is recorded
 	// as UNCLAIMED rather than hidden here.
+	if r.Step.Action.Kind == ActPull && b.revoked && sc.P.Adv != AdvStripRevoke {
+		ev = append(ev, InvRevocation)
+	}
 	if r.Step.Action.Kind == ActPull && b.revoked && sc.P.Adv != AdvStripRevoke && r.Outcome == Accept {
 		v = append(v, InvariantViolation{InvRevocation, i,
 			"a pull staged a digest that carries a signed revoke"})
@@ -248,6 +263,7 @@ func checkInvariants(sc Scenario, i int, r StepResult, w *World) []InvariantViol
 
 	// INV-3: no install without a qualifying attestation from a pinned signer.
 	if r.Step.Action.Kind == ActPull && r.Outcome == Accept {
+		ev = append(ev, InvGovernance)
 		switch {
 		case sc.P.Gov == GovNone:
 			v = append(v, InvariantViolation{InvGovernance, i,
@@ -264,6 +280,9 @@ func checkInvariants(sc Scenario, i int, r StepResult, w *World) []InvariantViol
 	// INV-1: an artifact that no longer hashes to the signed digest must never be
 	// installed. A stolen key is excluded: there the signature is genuine and the
 	// bytes ARE what the key signed, which is the limit, not a violation.
+	if r.Step.Action.Kind == ActPull && sc.P.Adv == AdvStoredBundle {
+		ev = append(ev, InvIntegrity)
+	}
 	if r.Step.Action.Kind == ActPull && sc.P.Adv == AdvStoredBundle && r.Outcome == Accept {
 		v = append(v, InvariantViolation{InvIntegrity, i,
 			"a pull installed bytes that do not match the signed digest"})
@@ -271,11 +290,14 @@ func checkInvariants(sc Scenario, i int, r StepResult, w *World) []InvariantViol
 
 	// INV-4: a refusal has to be legible. A silent non-zero exit is nearly as bad
 	// as a wrong one, because the operator cannot act on it.
-	if r.Outcome == Refuse && strings.TrimSpace(r.Stdout+r.Stderr) == "" {
-		v = append(v, InvariantViolation{InvLoudRefusal, i,
-			"the step refused without printing a reason"})
+	if r.Outcome == Refuse {
+		ev = append(ev, InvLoudRefusal)
+		if strings.TrimSpace(r.Stdout+r.Stderr) == "" {
+			v = append(v, InvariantViolation{InvLoudRefusal, i,
+				"the step refused without printing a reason"})
+		}
 	}
-	return v
+	return v, ev
 }
 
 func parseGate(out string) string {

--- a/pkg/skillctl/sim/standing.go
+++ b/pkg/skillctl/sim/standing.go
@@ -44,8 +44,8 @@ func (rep Report) WriteStanding(w io.Writer) {
 	fmt.Fprintf(w, "    - an independent re-derivation of the model from SPEC-0188 by somebody who\n")
 	fmt.Fprintf(w, "      has not read backend_pull.go, and a diff of the two models\n")
 	fmt.Fprintf(w, "    - structural coverage of the trust path, with an MC/DC argument for the\n")
-	fmt.Fprintf(w, "      five-predicate conjunction. Currently zero: only model and outcome\n")
-	fmt.Fprintf(w, "      coverage are measured\n")
+	fmt.Fprintf(w, "      five-predicate conjunction. MC/DC is at zero; statement coverage is\n")
+	fmt.Fprintf(w, "      measured and is NOT zero, see scripts/trust-coverage.sh\n")
 	fmt.Fprintf(w, "    - at least one run per supported backend against a real one, and one on\n")
 	fmt.Fprintf(w, "      Windows\n")
 	fmt.Fprintf(w, "    - test plan, test design and anomaly register as dated artifacts baselined\n")
@@ -72,9 +72,10 @@ func (rep Report) WriteStanding(w io.Writer) {
 	fmt.Fprintf(w, "      measured, and no arrangement of machine checks measures it.\n")
 	fmt.Fprintf(w, "    That the tested binary is the shipped artifact. The hash identifies what\n")
 	fmt.Fprintf(w, "      ran, not what is released, and the SUT reports its own version as \"dev\".\n")
-	fmt.Fprintf(w, "    Gate 3 BY NAME. The control is live: disabling it flips the affected\n")
-	fmt.Fprintf(w, "      pull from refuse to accept. What is missing is the label, so a caller\n")
-	fmt.Fprintf(w, "      cannot attribute the refusal (FR-0121). The waiver register carries it.\n")
+	fmt.Fprintf(w, "    Gate 3, at all. Observed zero times by name, and its mutant is\n")
+	fmt.Fprintf(w, "      indistinguishable from the unmutated baseline: same conflicts, same\n")
+	fmt.Fprintf(w, "      violation, same exit. Nothing in this corpus depends on it, so one fifth\n")
+	fmt.Fprintf(w, "      of the decision function is unverified (FR-0121).\n")
 }
 
 // OutputCoverage is the second coverage measure, and the one that answers the

--- a/pkg/skillctl/sim/standing.go
+++ b/pkg/skillctl/sim/standing.go
@@ -168,8 +168,10 @@ func (rep Report) WriteOutputCoverage(w io.Writer) {
 		fmt.Fprintf(w, "    %-10s %4d   (claimed refusals that named no gate; see FR-0121)\n",
 			"unlabelled", oc.Unlabelled)
 	}
-	fmt.Fprintf(w, "  Population: pull steps whose outcome the model claims. One denominator for\n")
-	fmt.Fprintf(w, "  the whole table, so these rows and the histogram below are the same quantity.\n")
+	fmt.Fprintf(w, "  Population: pull steps whose outcome the model claims. Same population as\n")
+	fmt.Fprintf(w, "  the histogram below, but a DIFFERENT partition of it: a waived outcome is\n")
+	fmt.Fprintf(w, "  counted here under the decision it reached and there under \"waived\". So\n")
+	fmt.Fprintf(w, "  accept can read 8 here and 6 plus 2 waived there, and both are right.\n")
 	if s := oc.Short(); len(s) > 0 {
 		fmt.Fprintf(w, "  %d declared decision(s) below target. Input coverage cannot substitute:\n", len(s))
 		fmt.Fprintf(w, "  a corpus can cover every pair of inputs and still never reach a gate.\n")

--- a/pkg/skillctl/sim/standing.go
+++ b/pkg/skillctl/sim/standing.go
@@ -72,10 +72,10 @@ func (rep Report) WriteStanding(w io.Writer) {
 	fmt.Fprintf(w, "      measured, and no arrangement of machine checks measures it.\n")
 	fmt.Fprintf(w, "    That the tested binary is the shipped artifact. The hash identifies what\n")
 	fmt.Fprintf(w, "      ran, not what is released, and the SUT reports its own version as \"dev\".\n")
-	fmt.Fprintf(w, "    Gate 3, at all. Observed zero times by name, and its mutant is\n")
-	fmt.Fprintf(w, "      indistinguishable from the unmutated baseline: same conflicts, same\n")
-	fmt.Fprintf(w, "      violation, same exit. Nothing in this corpus depends on it, so one fifth\n")
-	fmt.Fprintf(w, "      of the decision function is unverified (FR-0121).\n")
+	fmt.Fprintf(w, "    Gate 3 under a HOSTILE STORE. The corpus reaches gate 3 with a publisher\n")
+	fmt.Fprintf(w, "      who holds the registry key. A store that does not hold it cannot reach\n")
+	fmt.Fprintf(w, "      the gate at all: editing a signature row breaks the envelope, so gate 1\n")
+	fmt.Fprintf(w, "      decides first. That is an argument from the format, not a measurement.\n")
 }
 
 // OutputCoverage is the second coverage measure, and the one that answers the
@@ -165,7 +165,7 @@ func (rep Report) WriteOutputCoverage(w io.Writer) {
 		fmt.Fprintf(w, "    %-10s %4d%s\n", d, oc.Seen[d], mark)
 	}
 	if oc.Unlabelled > 0 {
-		fmt.Fprintf(w, "    %-10s %4d   (claimed refusals that named no gate; see FR-0121)\n",
+		fmt.Fprintf(w, "    %-10s %4d   (claimed refusals that named no gate)\n",
 			"unlabelled", oc.Unlabelled)
 	}
 	fmt.Fprintf(w, "  Population: pull steps whose outcome the model claims. Same population as\n")

--- a/pkg/skillctl/sim/theory.go
+++ b/pkg/skillctl/sim/theory.go
@@ -97,13 +97,14 @@ type TheoryReport struct {
 	Decided     int
 	Accepting   []string
 	Findings    []TheoryFinding
-	Reachable   map[string]bool
+	Reachable   map[string]bool // the CORPUS can produce it
+	Producible  map[string]bool // the WORLD can produce it, corpus rules aside
 	Unreachable []string
 }
 
 // CheckTheory runs the four questions over the complete state space.
 func CheckTheory(corpus []Scenario) TheoryReport {
-	rep := TheoryReport{Reachable: map[string]bool{}}
+	rep := TheoryReport{Reachable: map[string]bool{}, Producible: map[string]bool{}}
 
 	for _, s := range AllStates() {
 		rep.Total++
@@ -145,8 +146,31 @@ func CheckTheory(corpus []Scenario) TheoryReport {
 		}
 	}
 
-	// 3. REACHABILITY. Which states can the action alphabet produce at all?
+	// 3. REACHABILITY, and it is two questions that were one until 2026-09-05.
+	//
+	// An IEEE 1012 reviewer showed that the classification could only ever return
+	// one answer: reachability was computed over the full factor space, and so was
+	// the classifier, so an unreachable state had no producing point by
+	// construction and every one came out as "no move in the alphabet". The other
+	// two classes were dead code and the summary line was a tautology dressed as a
+	// measurement.
+	//
+	// The two questions are different and both matter:
+	//
+	//	producible by the WORLD  the alphabet can make it, if no corpus rule says no
+	//	reachable by the CORPUS  a point the corpus actually admits makes it
+	//
+	// A state the world can produce and the corpus excludes is neither impossible
+	// nor an oversight; it is a decision, and it is the class the reviewer asked to
+	// see separately.
 	for _, p := range allParams() {
+		rep.Producible[StateAt(p, false).Key()] = true
+		if p.Revoke {
+			rep.Producible[StateAt(p, true).Key()] = true
+		}
+		if !meaningful(p) {
+			continue
+		}
 		rep.Reachable[StateAt(p, false).Key()] = true
 		if p.Revoke {
 			rep.Reachable[StateAt(p, true).Key()] = true
@@ -355,8 +379,6 @@ type UnreachReason struct {
 // which is a statement about the world that this enumeration cannot make. If such
 // a claim is wanted it belongs in a specification, where it can be reviewed.
 func ClassifyUnreachable(rep TheoryReport) []UnreachReason {
-	// Which points of the full space produce which state, and whether any of them
-	// is admissible.
 	producedBy := map[string][]Params{}
 	for _, p := range allParams() {
 		producedBy[StateAt(p, false).Key()] = append(producedBy[StateAt(p, false).Key()], p)
@@ -374,23 +396,23 @@ func ClassifyUnreachable(rep TheoryReport) []UnreachReason {
 					"has no move that produces this combination"})
 			continue
 		}
-		// Every producing point is excluded. Name the rule, and say which kind it is.
+		// The world can produce it and the corpus does not. Name the rule and its
+		// kind, preferring an impossibility over an economy cut as the reason.
 		rule, kind := "", ExclusionKind("")
 		for _, p := range points {
 			if ex := excludedBy(p); ex != nil {
-				rule, kind = ex.Rule, ex.Kind
-				if ex.Kind == KindImpossible {
-					break // an impossibility outranks an economy cut as the reason
+				if kind != KindImpossible {
+					rule, kind = ex.Rule, ex.Kind
 				}
 			}
 		}
 		if kind == KindImpossible {
 			out = append(out, UnreachReason{k, "rule-impossible",
-				"produced only by points the world cannot realise: " + rule})
+				"the world cannot realise the points that would produce it: " + rule})
 		} else {
 			out = append(out, UnreachReason{k, "rule-economy",
-				"produced by points the world CAN realise, left out of the corpus by: " + rule +
-					". This is a judgement, not a property"})
+				"the world CAN produce it; the corpus leaves it out by: " + rule +
+					". A judgement, not a property"})
 		}
 	}
 	return out

--- a/pkg/skillctl/sim/traceability.go
+++ b/pkg/skillctl/sim/traceability.go
@@ -229,9 +229,9 @@ func (rep Report) WriteTraceability(w io.Writer) {
 			fmt.Fprintf(w, "  %-18s %-12s %-9s   ^ %s\n", "", "", "", it.Note)
 		}
 	}
-	fmt.Fprintf(w, "  normativ = in einer SPEC; abgeleitet = hergeleitet, Herleitung ist Teil der\n")
-	fmt.Fprintf(w, "  Evidenz; uebernommen = bindet hier, hat aber keine Klausel hinter sich;\n")
-	fmt.Fprintf(w, "  Evidenz; beobachtet = aus dem Verhalten gewonnen, ein Fehlschlag heisst\n")
+	fmt.Fprintf(w, "  normativ = in einer SPEC; abgeleitet = hergeleitet, die Herleitung ist Teil\n")
+	fmt.Fprintf(w, "  der Evidenz; uebernommen = bindet hier, hat aber keine Klausel hinter sich;\n")
+	fmt.Fprintf(w, "  beobachtet = aus dem Verhalten gewonnen, ein Fehlschlag heisst\n")
 	fmt.Fprintf(w, "  GEAENDERT und nicht FALSCH; ungeklaert = wird geprueft, Bedeutung offen.\n")
 	fmt.Fprintf(w, "  Eine Zeile mit normativer Quelle und null Beobachtungen ist DEKLARIERT,\n")
 	fmt.Fprintf(w, "  nicht geprueft.\n")

--- a/pkg/skillctl/sim/traceability.go
+++ b/pkg/skillctl/sim/traceability.go
@@ -63,32 +63,47 @@ type TraceItem struct {
 
 // TraceMatrix is the whole set. Order is fixed so two reports are comparable.
 //
+// THE SOURCES WERE WRONG UNTIL 2026-09-05, and the correction is worth keeping.
+// Every gate cited "SPEC-0188 §7". An adversarial review traced the actual path
+// and found that §7 governs the ER1/HTTP install (`pkg/skillctl/install`), whose
+// first two steps are literally `/api/skills/by-name` and `GET
+// /api/skills/bundles/<digest>`. The path this simulation measures, `pull
+// --trust-mode`, is specified in SPEC-0225 §9.1, "The verification gauntlet
+// (every bundle, every install)", and that clause lists exactly these five
+// checks and closes with "Only a bundle that clears all five gets written".
+//
+// The five gates were therefore never unspecified, as an earlier finding of mine
+// claimed. They were specified in the other document, and the code comment
+// "runs the SPEC-0188 §7 gauntlet" sent everybody, me included, to the wrong
+// clause. A traceability matrix whose sources point at the wrong specification is
+// worse than one with no sources: it looks checked.
+//
 // Every entry here was written by reading the clause or the decision it cites. An
 // entry whose Source cannot be checked by a reader is worse than no entry, because
 // it looks like provenance and is not.
 func TraceMatrix() []TraceItem {
 	return []TraceItem{
 		{
-			ID: "gate 1", What: "the admit envelope signature verifies before any field of the event is used",
-			Source: "SPEC-0188 §7", Prov: ProvNormative,
+			ID: "gate 1", What: "the admit envelope signature verifies against a key in trust-roots whose id matches the producing registry",
+			Source: "SPEC-0225 §9.1 step 1", Prov: ProvNormative,
 		},
 		{
-			ID: "gate 2", What: "the digest is recomputed from the fetched bytes and compared",
-			Source: "SPEC-0188 §7", Prov: ProvNormative,
+			ID: "gate 2", What: "SHA-256 of the fetched .skb equals the digest tag and the envelope's bundle_digest",
+			Source: "SPEC-0225 §9.1 step 2", Prov: ProvNormative,
 		},
 		{
-			ID: "gate 3", What: "the bundle signature rows verify over the recomputed digest",
-			Source: "SPEC-0188 §7", Prov: ProvNormative,
-			Note: "fires but never names itself: disabling it flips the affected pull from " +
-				"refuse to accept, so the control is live. Observed 0 times BY NAME (FR-0121)",
+			ID: "gate 3", What: "the author AND registry signatures on the .skb each verify against trust-roots",
+			Source: "SPEC-0225 §9.1 step 3", Prov: ProvNormative,
+			Note: "UNVERIFIED. Observed 0 times by name, and its mutant is indistinguishable " +
+				"from the unmutated baseline, so nothing in this corpus depends on it (FR-0121)",
 		},
 		{
 			ID: "gate 4", What: "a quorum of attestations at or above the floor, from pinned signers, bound to the admitted digest",
-			Source: "SPEC-0188 §7, SPEC-0359 D3", Prov: ProvNormative,
+			Source: "SPEC-0225 §9.1 step 4, SPEC-0359 D3", Prov: ProvNormative,
 		},
 		{
-			ID: "gate 5", What: "a digest carrying a signed revoke is refused",
-			Source: "SPEC-0188 §7", Prov: ProvNormative,
+			ID: "gate 5", What: "no BundleRevokedEvent exists for this digest",
+			Source: "SPEC-0225 §9.1 step 5", Prov: ProvNormative,
 		},
 		{
 			ID: "order: phases", What: "authenticate, then decide from signed metadata, then decide from bytes",
@@ -113,20 +128,20 @@ func TraceMatrix() []TraceItem {
 		},
 		{
 			ID: "verb: verify-sig", What: "a detached signature over altered bytes cannot be found or does not verify",
-			Source: "SPEC-0188 §11", Prov: ProvNormative,
+			Source: "SPEC-0225 §9.1 step 3", Prov: ProvNormative,
 			Note: "the publisher's own check before admit; observed as exit 1 four times",
 		},
 		{
 			ID: "INV-1", What: "bytes that do not match the signed digest are never installed",
-			Source: "SPEC-0188 §7 gate 2, restated as a run-wide property", Prov: ProvDerived,
+			Source: "SPEC-0225 §9.1 step 2, restated as a run-wide property", Prov: ProvDerived,
 		},
 		{
 			ID: "INV-2", What: "once a signed revoke is visible, that digest is never staged again",
-			Source: "SPEC-0188 §7 gate 5, restated as a run-wide property", Prov: ProvDerived,
+			Source: "SPEC-0225 §9.1 step 5, restated as a run-wide property", Prov: ProvDerived,
 		},
 		{
 			ID: "INV-3", What: "no install without a qualifying attestation from a pinned signer",
-			Source: "SPEC-0188 §7 gate 4, SPEC-0359 D3", Prov: ProvDerived,
+			Source: "SPEC-0225 §9.1 step 4, SPEC-0359 D3", Prov: ProvDerived,
 		},
 		{
 			ID: "INV-4", What: "every refusal is loud: non-zero exit AND a named reason",

--- a/pkg/skillctl/sim/traceability.go
+++ b/pkg/skillctl/sim/traceability.go
@@ -155,7 +155,10 @@ func TraceMatrix() []TraceItem {
 		{
 			ID: "INV-5", What: "an adversary move never improves the attacker's outcome",
 			Source: "no specification clause found", Prov: ProvDerived,
-			Note: "a monotonicity property of the model, not a product requirement",
+			Note: "NEVER EVALUATED. Declared here and in model.go, checked by nothing. It " +
+				"needs a pair of runs, with and without the move, and the harness runs each " +
+				"scenario once. Reported as 0 evaluations rather than as a silent pass " +
+				"(FR-0125); a monotonicity property of the model, not a product requirement",
 		},
 		{
 			ID: "INV-6", What: "a refusal leaves the install target byte-identical",
@@ -211,6 +214,21 @@ func (rep Report) WriteTraceability(w io.Writer) {
 		}
 	}
 
+	// How often each invariant's precondition actually held. Keyed by the short id
+	// the matrix uses ("INV-5"), which is the prefix of the runtime name.
+	evaluated := map[string]int{}
+	for _, r := range rep.Results {
+		for _, e := range r.Evaluated {
+			name := string(e)
+			if i := strings.Index(name, "-"); i > 0 {
+				if j := strings.Index(name[i+1:], "-"); j > 0 {
+					name = name[:i+1+j]
+				}
+			}
+			evaluated[name]++
+		}
+	}
+
 	items := append([]TraceItem(nil), TraceMatrix()...)
 	sort.SliceStable(items, func(i, j int) bool {
 		return items[i].Prov.prio() < items[j].Prov.prio()
@@ -225,7 +243,15 @@ func (rep Report) WriteTraceability(w io.Writer) {
 		} else if strings.HasPrefix(it.ID, "gate ") {
 			obs = "0"
 		} else if strings.HasPrefix(it.ID, "INV-") {
-			obs = fmt.Sprintf("%d viol", viol[it.ID])
+			// "0 viol" for an invariant nothing ever evaluated is the same false
+			// green this column exists to prevent, so the two are printed
+			// differently. The evaluation count comes from the run, not from the
+			// declaration.
+			if evaluated[it.ID] == 0 {
+				obs = "NEVER RUN"
+			} else {
+				obs = fmt.Sprintf("%d viol/%d", viol[it.ID], evaluated[it.ID])
+			}
 		}
 		fmt.Fprintf(w, "  %-18s %-12s %-9s %s\n", it.ID, it.Prov, obs, it.Source)
 		if it.Note != "" {

--- a/pkg/skillctl/sim/traceability.go
+++ b/pkg/skillctl/sim/traceability.go
@@ -229,6 +229,21 @@ func (rep Report) WriteTraceability(w io.Writer) {
 		}
 	}
 
+	// How often each ORDER claim was exercised: the scenarios where BOTH gates it
+	// orders had a reason to fire. A claim that no scenario can falsify is not a
+	// verified claim, and until 2026-09-06 this column said "n/a" for all three,
+	// which hid that "gate 2 before gate 3" was exercised zero times.
+	order := map[string]int{}
+	for _, r := range rep.Results {
+		st := StateAt(r.Scenario.P, r.Scenario.P.Revoke)
+		if st.Revoked && !st.GovQualifies {
+			order["order: 5 before 4"]++
+		}
+		if !st.DigestMatches && !st.SigsVerify {
+			order["order: 2 before 3"]++
+		}
+	}
+
 	items := append([]TraceItem(nil), TraceMatrix()...)
 	sort.SliceStable(items, func(i, j int) bool {
 		return items[i].Prov.prio() < items[j].Prov.prio()
@@ -238,7 +253,13 @@ func (rep Report) WriteTraceability(w io.Writer) {
 	fmt.Fprintf(w, "  %-18s %-12s %-9s %s\n", "claim", "provenance", "observed", "source")
 	for _, it := range items {
 		obs := "n/a"
-		if n, ok := gates[it.ID]; ok {
+		if n, ok := order[it.ID]; ok {
+			if n == 0 {
+				obs = "NEVER RUN"
+			} else {
+				obs = fmt.Sprintf("%d exerc", n)
+			}
+		} else if n, ok := gates[it.ID]; ok {
 			obs = fmt.Sprintf("%d", n)
 		} else if strings.HasPrefix(it.ID, "gate ") {
 			obs = "0"

--- a/pkg/skillctl/sim/traceability.go
+++ b/pkg/skillctl/sim/traceability.go
@@ -94,8 +94,9 @@ func TraceMatrix() []TraceItem {
 		{
 			ID: "gate 3", What: "the author AND registry signatures on the .skb each verify against trust-roots",
 			Source: "SPEC-0225 §9.1 step 3", Prov: ProvNormative,
-			Note: "UNVERIFIED. Observed 0 times by name, and its mutant is indistinguishable " +
-				"from the unmutated baseline, so nothing in this corpus depends on it (FR-0121)",
+			Note: "observed once, by name, since 2026-09-06. Reaching it needs a publisher " +
+				"holding the registry key: a store without it cannot edit a signature row " +
+				"without breaking the envelope, so gate 1 would decide first",
 		},
 		{
 			ID: "gate 4", What: "a quorum of attestations at or above the floor, from pinned signers, bound to the admitted digest",

--- a/pkg/skillctl/sim/traceability.go
+++ b/pkg/skillctl/sim/traceability.go
@@ -129,7 +129,9 @@ func TraceMatrix() []TraceItem {
 		{
 			ID: "verb: verify-sig", What: "a detached signature over altered bytes cannot be found or does not verify",
 			Source: "SPEC-0225 §9.1 step 3", Prov: ProvNormative,
-			Note: "the publisher's own check before admit; observed as exit 1 four times",
+			Note: "the publisher's own check before admit; observed as exit 10 four times. " +
+				"PR #216 changed that code from 1 and updated this expectation in the same " +
+				"commit, which is what a pinned expectation is for",
 		},
 		{
 			ID: "INV-1", What: "bytes that do not match the signed digest are never installed",

--- a/pkg/skillctl/sim/waiver.go
+++ b/pkg/skillctl/sim/waiver.go
@@ -32,15 +32,34 @@ type Waiver struct {
 	Observed string  // the gate actually seen, "" for none
 	Finding  string  // the tracked finding
 	Why      string
+
+	// Invariant, when set, also waives that invariant for this dimension. A defect
+	// that trips both the gate comparison and an invariant should be waived once
+	// and visibly, not silenced in one place and left to fail in the other.
+	Invariant Invariant
 }
 
 // Waivers is the register. Empty is the goal.
 func Waivers() []Waiver {
 	return []Waiver{
 		{
-			Adv: AdvPublisherBadSigs, Expected: "gate 3", Observed: "",
+			Adv: AdvStaleChecksums, Expected: "", Observed: "accept",
+			Finding:   "BUG-0217",
+			Invariant: InvAcceptDelivers,
+			Why: "MEASURED SPEC VIOLATION, not an open question. SPEC-0188 §7 step 8 verifies " +
+				"the CHECKSUMS file inside the bundle and says any failure in steps 3 to 8 means " +
+				"no write. The trust-mode pull path extracts without that check (extractSkb does " +
+				"not validate; the other install path does), and a bundle whose internal manifest " +
+				"no longer describes its contents is installed. Waived so the gate stays usable " +
+				"while the fix is decided; it is a defect, not a naming question",
+		},
+		{
+			Adv: AdvPublisherBadSigs, Expected: "gate 3", Observed: "accept",
 			Finding: "FR-0121",
-			Why: "the model predicts gate 3 and the binary refuses without naming a gate. " +
+			Why: "UNSTABLE MEASUREMENT, and that is the finding. This case has been observed " +
+				"both refusing without a gate name and accepting, across successive harness " +
+				"revisions on the same product build. One clean re-measurement on a frozen " +
+				"harness is owed before anything is concluded from it. Originally: " +
 				"The control is live: disabling gate 3 flips this pull from refuse to accept. " +
 				"What is waived is only the LABEL; the refusal, its exit code and the untouched " +
 				"install target are compared and hold",
@@ -50,13 +69,43 @@ func Waivers() []Waiver {
 
 // waiverFor returns the waiver covering this disagreement, if any.
 func waiverFor(sc Scenario, r StepResult) *Waiver {
+	// The observed side is matched against the gate name when there is one, and
+	// against the literal "accept" when the pull was accepted. A waiver that could
+	// not name an acceptance would be unable to cover the case that matters most:
+	// a specified refusal that did not happen.
+	obs := r.Gate
+	if r.Outcome == Accept {
+		obs = "accept"
+	}
 	for i := range Waivers() {
 		w := Waivers()[i]
-		if sc.P.Adv == w.Adv && r.Step.Expect.Gate == w.Expected && r.Gate == w.Observed {
+		if sc.P.Adv == w.Adv && r.Step.Expect.Gate == w.Expected && obs == w.Observed {
 			return &w
 		}
 	}
 	return nil
+}
+
+// WaivedViolations splits invariant violations the same way conflicts are split.
+// The report prints both counts beside the waiver register.
+func (rep Report) WaivedViolations() (waived, unwaived int) {
+	for _, r := range rep.Results {
+		for _, v := range r.Violations {
+			hit := false
+			for _, w := range Waivers() {
+				if w.Invariant != "" && r.Scenario.P.Adv == w.Adv && v.Invariant == w.Invariant {
+					hit = true
+					break
+				}
+			}
+			if hit {
+				waived++
+			} else {
+				unwaived++
+			}
+		}
+	}
+	return
 }
 
 // WaivedConflicts counts the conflicts a waiver covers, and the ones it does not.
@@ -93,7 +142,10 @@ func (rep Report) WriteWaivers(w io.Writer) {
 		fmt.Fprintf(w, "  %s  %s: model says %s, binary says %s\n", x.Finding, x.Adv, x.Expected, obs)
 		fmt.Fprintf(w, "      %s\n", x.Why)
 	}
-	fmt.Fprintf(w, "  %d conflict(s) waived, %d not waived. A waived conflict is COUNTED and\n", waived, unwaived)
+	wv, uv := rep.WaivedViolations()
+	fmt.Fprintf(w, "  %d conflict(s) waived, %d not waived; %d invariant violation(s) waived, %d not.\n",
+		waived, unwaived, wv, uv)
+	fmt.Fprintf(w, "  A waived finding is COUNTED and\n")
 	fmt.Fprintf(w, "  reported; it does not fail the gate. It is not the same as a step that was\n")
 	fmt.Fprintf(w, "  never compared: change what the binary does here and the waiver stops\n")
 	fmt.Fprintf(w, "  matching, and the conflict fails the run again.\n")

--- a/pkg/skillctl/sim/waiver.go
+++ b/pkg/skillctl/sim/waiver.go
@@ -60,9 +60,11 @@ func Waivers() []Waiver {
 				"both refusing without a gate name and accepting, across successive harness " +
 				"revisions on the same product build. One clean re-measurement on a frozen " +
 				"harness is owed before anything is concluded from it. Originally: " +
-				"The control is live: disabling gate 3 flips this pull from refuse to accept. " +
-				"What is waived is only the LABEL; the refusal, its exit code and the untouched " +
-				"install target are compared and hold",
+				"The mutant for gate 3 is indistinguishable from the unmutated baseline, so " +
+				"nothing here depends on that control and it is UNVERIFIED. Two earlier " +
+				"descriptions of this case, both withdrawn, are recorded in FR-0121. What is " +
+				"waived is the outcome comparison; INV-6 still asserts that the refusal, where " +
+				"one happens, leaves the install target untouched",
 		},
 	}
 }

--- a/pkg/skillctl/sim/waiver.go
+++ b/pkg/skillctl/sim/waiver.go
@@ -39,7 +39,23 @@ type Waiver struct {
 	Invariant Invariant
 }
 
-// Waivers is the register. Empty is the goal.
+// Waivers is the register. Empty is the goal, and it now holds one entry, not two.
+//
+// The FR-0121 entry is GONE, and its removal is the substance of this change
+// rather than housekeeping. It waived the case "model says gate 3, binary says
+// accept" and described it as an unstable measurement owing one clean re-run.
+// The re-run happened on 2026-09-06 and found a cause: the adversary move edited
+// the detached "<bundle>.<digest>.author.sig" file, which the trust-mode pull
+// path never opens. Gate 3 was never reached, so the acceptance was correct behaviour
+// against a case that did not test it, and the disagreement was the MODEL's. With
+// a move that reaches the gate (see ForgeBundleSignatures) the prediction holds
+// and there is nothing left to waive.
+//
+// What remains is BUG-0217, and it is a different animal: a measured violation of
+// a written requirement, waived so the gate stays usable while the fix is decided.
+// Keeping the two apart is the point of the register. One was a defect in the
+// instrument, the other is a defect in the product, and a register that cannot
+// tell them apart will eventually be used to hide the second behind the first.
 func Waivers() []Waiver {
 	return []Waiver{
 		{
@@ -52,19 +68,6 @@ func Waivers() []Waiver {
 				"not validate; the other install path does), and a bundle whose internal manifest " +
 				"no longer describes its contents is installed. Waived so the gate stays usable " +
 				"while the fix is decided; it is a defect, not a naming question",
-		},
-		{
-			Adv: AdvPublisherBadSigs, Expected: "gate 3", Observed: "accept",
-			Finding: "FR-0121",
-			Why: "UNSTABLE MEASUREMENT, and that is the finding. This case has been observed " +
-				"both refusing without a gate name and accepting, across successive harness " +
-				"revisions on the same product build. One clean re-measurement on a frozen " +
-				"harness is owed before anything is concluded from it. Originally: " +
-				"The mutant for gate 3 is indistinguishable from the unmutated baseline, so " +
-				"nothing here depends on that control and it is UNVERIFIED. Two earlier " +
-				"descriptions of this case, both withdrawn, are recorded in FR-0121. What is " +
-				"waived is the outcome comparison; INV-6 still asserts that the refusal, where " +
-				"one happens, leaves the install target untouched",
 		},
 	}
 }

--- a/pkg/skillctl/sim/waiver.go
+++ b/pkg/skillctl/sim/waiver.go
@@ -37,6 +37,15 @@ type Waiver struct {
 	// that trips both the gate comparison and an invariant should be waived once
 	// and visibly, not silenced in one place and left to fail in the other.
 	Invariant Invariant
+
+	// Kind restricts the waiver to one action. Without it the match was on the
+	// adversary dimension plus an expected gate plus an observed outcome, and an
+	// EMPTY expected gate matches every step that predicts a refusal without
+	// naming one: the verify-sig steps, among others. A waiver for a pull defect
+	// would then have covered an unrelated regression elsewhere in the same
+	// scenario, silently, which is the exact failure mode the register exists to
+	// prevent. Required, so a new waiver cannot be written without saying where.
+	Kind ActionKind
 }
 
 // Waivers is the register. Empty is the goal, and it now holds one entry, not two.
@@ -59,10 +68,11 @@ type Waiver struct {
 func Waivers() []Waiver {
 	return []Waiver{
 		{
-			Adv: AdvStaleChecksums, Expected: "", Observed: "accept",
+			Adv: AdvStaleChecksums, Kind: ActPull, Expected: "", Observed: "accept",
 			Finding:   "BUG-0217",
 			Invariant: InvAcceptDelivers,
-			Why: "MEASURED SPEC VIOLATION, not an open question. SPEC-0188 §7 step 8 verifies " +
+			Why: "A DEFECT, not an open question, and the line above is the measurement of it. " +
+				"SPEC-0188 §7 step 8 verifies " +
 				"the CHECKSUMS file inside the bundle and says any failure in steps 3 to 8 means " +
 				"no write. The trust-mode pull path extracts without that check (extractSkb does " +
 				"not validate; the other install path does), and a bundle whose internal manifest " +
@@ -84,11 +94,64 @@ func waiverFor(sc Scenario, r StepResult) *Waiver {
 	}
 	for i := range Waivers() {
 		w := Waivers()[i]
-		if sc.P.Adv == w.Adv && r.Step.Expect.Gate == w.Expected && obs == w.Observed {
+		if w.Kind == "" {
+			// A waiver without an action would match across the whole scenario.
+			// Refusing it here is cheaper than discovering later which unrelated
+			// step it swallowed.
+			continue
+		}
+		if sc.P.Adv == w.Adv && r.Step.Action.Kind == w.Kind &&
+			r.Step.Expect.Gate == w.Expected && obs == w.Observed {
 			return &w
 		}
 	}
 	return nil
+}
+
+// waiverEvidence returns what the run actually observed at the steps this waiver
+// covers: scenario, outcome, exit code and gate, verbatim from the comparison.
+//
+// It exists because the register's own Expected and Observed fields are AUTHOR
+// input, not measurement. A waiver whose fields drift from the behaviour will
+// simply stop matching, which is the safety net, but the fields still describe
+// the case in the author's words. Printing the run's values beside them means a
+// wrong description is visible next to what it describes rather than three
+// sections away.
+func (rep Report) waiverEvidence(x Waiver) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, r := range rep.Results {
+		for i := range r.Steps {
+			// Only the steps this waiver actually SUPPRESSED. Listing every step
+			// it merely matches would bury the one line that matters under the
+			// scenario's ordinary accepts, which is how the last misleading
+			// waiver stayed readable for two days.
+			if i >= len(r.Verdicts) || r.Verdicts[i] != VerdictConflict {
+				continue
+			}
+			if waiverFor(r.Scenario, r.Steps[i]) == nil || r.Scenario.P.Adv != x.Adv {
+				continue
+			}
+			st := r.Steps[i]
+			gate := st.Gate
+			if gate == "" {
+				gate = "no gate named"
+			}
+			line := fmt.Sprintf("%s step %d: %s exit=%d gate=%q",
+				r.Scenario.ID, i+1, st.Outcome, st.ExitCode, gate)
+			if seen[line] {
+				continue
+			}
+			seen[line] = true
+			out = append(out, line)
+		}
+	}
+	sort.Strings(out)
+	if len(out) > 3 {
+		rest := len(out) - 3
+		out = append(out[:3], fmt.Sprintf("(and %d more step(s) with the same shape)", rest))
+	}
+	return out
 }
 
 // WaivedViolations splits invariant violations the same way conflicts are split.
@@ -130,7 +193,20 @@ func (rep Report) WaivedConflicts() (waived, unwaived int) {
 	return
 }
 
-// WriteWaivers prints the register beside the numbers it modifies.
+// WriteWaivers prints the register beside the numbers it modifies, and marks its
+// prose as prose.
+//
+// The marking is not decoration. On 2026-09-05 this section carried the sentence
+// "The control is live: disabling gate 3 flips this pull from refuse to accept."
+// Nobody had measured that. It was an author's explanation, printed every run in
+// the same column as measured counts, and two readers in two different sessions
+// quoted it back as though it were output. One of them used it to contradict a
+// measurement, and was reasoning from the report exactly as the report invited.
+//
+// A number in this report comes from the run. Everything after "WHY (not measured)"
+// comes from whoever wrote the waiver, and it is only as good as the argument it
+// makes. Same page, different epistemic status, so the page has to say which is
+// which.
 func (rep Report) WriteWaivers(w io.Writer) {
 	ws := Waivers()
 	if len(ws) == 0 {
@@ -144,12 +220,26 @@ func (rep Report) WriteWaivers(w io.Writer) {
 		if obs == "" {
 			obs = "no gate named"
 		}
-		fmt.Fprintf(w, "  %s  %s: model says %s, binary says %s\n", x.Finding, x.Adv, x.Expected, obs)
+		exp := x.Expected
+		if exp == "" {
+			exp = "no refusal at all"
+		}
+		fmt.Fprintf(w, "  %s  %s: model says %s, binary says %s\n", x.Finding, x.Adv, exp, obs)
+		for _, ln := range rep.waiverEvidence(x) {
+			fmt.Fprintf(w, "      MEASURED  %s\n", ln)
+		}
+		fmt.Fprintf(w, "      WHY (not measured, this is the waiver author's argument):\n")
 		fmt.Fprintf(w, "      %s\n", x.Why)
 	}
 	wv, uv := rep.WaivedViolations()
 	fmt.Fprintf(w, "  %d conflict(s) waived, %d not waived; %d invariant violation(s) waived, %d not.\n",
 		waived, unwaived, wv, uv)
+	fmt.Fprintf(w, "  The MEASURED lines come from this run. The WHY beneath them does not: it is\n")
+	fmt.Fprintf(w, "  the argument of whoever wrote the waiver, and it is only as good as that\n")
+	fmt.Fprintf(w, "  argument. They are printed adjacently so a WHY that contradicts the values\n")
+	fmt.Fprintf(w, "  beside it refutes itself at a glance. The one this register used to carry did\n")
+	fmt.Fprintf(w, "  exactly that, and it survived two days because the contradiction sat three\n")
+	fmt.Fprintf(w, "  sections apart and had to be held in a reader's head.\n")
 	fmt.Fprintf(w, "  A waived finding is COUNTED and\n")
 	fmt.Fprintf(w, "  reported; it does not fail the gate. It is not the same as a step that was\n")
 	fmt.Fprintf(w, "  never compared: change what the binary does here and the waiver stops\n")

--- a/pkg/skillctl/sim/waiver.go
+++ b/pkg/skillctl/sim/waiver.go
@@ -40,11 +40,24 @@ type Waiver struct {
 
 	// Kind restricts the waiver to one action. Without it the match was on the
 	// adversary dimension plus an expected gate plus an observed outcome, and an
-	// EMPTY expected gate matches every step that predicts a refusal without
-	// naming one: the verify-sig steps, among others. A waiver for a pull defect
-	// would then have covered an unrelated regression elsewhere in the same
-	// scenario, silently, which is the exact failure mode the register exists to
-	// prevent. Required, so a new waiver cannot be written without saying where.
+	// EMPTY expected gate matches every step of that dimension's scenarios whose
+	// prediction carries no gate name: pack, admit, attest, pin. So a waiver for a
+	// defect in the PULL also covered the admit and the attestation beside it, and
+	// a regression in either would have been swallowed under a finding that has
+	// nothing to do with them.
+	//
+	// The reach was bounded by the adversary dimension and never crossed into
+	// another one; an earlier note here claimed it reached the verify-sig steps,
+	// and that was wrong, because those belong to AdvTransitChecked and the
+	// dimension is compared first. Complete within one dimension is bad enough:
+	// the register's whole purpose is that an accepted disagreement stays the size
+	// it was accepted at.
+	//
+	// Found by the MEASURED lines below, on their first run: eighteen where one
+	// was expected. The over-match had been silent for as long as it existed and
+	// became visible the moment something had to print what it covered.
+	//
+	// Required, so a new waiver cannot be written without saying where it applies.
 	Kind ActionKind
 }
 

--- a/pkg/skillctl/sim/world.go
+++ b/pkg/skillctl/sim/world.go
@@ -13,6 +13,9 @@ package sim
 // --registry for a deliberate, occasional run.
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"crypto/x509"
@@ -717,4 +720,93 @@ func (w *World) CorruptSignature(skill string) error {
 		return fmt.Errorf("sim: no author signature at %s: %w", sig, err)
 	}
 	return flipByte(sig, 8)
+}
+
+// StaleChecksums rewrites a file inside the bundle and leaves the bundle's own
+// CHECKSUMS listing untouched, then re-signs so the outer chain stays valid.
+//
+// This is the test case for SPEC-0188 §7 step 8, "extract bundle to a temp dir;
+// verify CHECKSUMS file inside the bundle", which had no test case at all. It is
+// the only one of the four unverified §7 steps that is cheap to construct,
+// because everything it needs the harness already holds: the author key.
+//
+// The construction matters. Changing bytes in the archive changes the digest, so
+// the bundle is re-signed and re-admitted afterwards; the recomputed digest then
+// matches the admitted one and the signature verifies. Every outer check passes.
+// The only thing wrong with the bundle is INTERNAL: its own manifest of file
+// hashes no longer describes its contents.
+//
+// The rewrite uses archive/tar directly rather than the product's own bundle
+// package. That is deliberate: a harness that formats the artifact with the same
+// library the product parses it with agrees with the product by construction, and
+// then a format disagreement is unfindable.
+func (w *World) StaleChecksums(skill string) error {
+	b := w.bundles[skill]
+	if b == nil {
+		return fmt.Errorf("sim: %s not packed", skill)
+	}
+	// #nosec G304 -- the harness's own artifact inside its throwaway root.
+	raw, err := os.ReadFile(b.path)
+	if err != nil {
+		return err
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("skb is not gzip: %w", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	var out bytes.Buffer
+	zw := gzip.NewWriter(&out)
+	tw := tar.NewWriter(zw)
+	tr := tar.NewReader(zr)
+	touched := false
+	for {
+		h, rerr := tr.Next()
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			return fmt.Errorf("read skb: %w", rerr)
+		}
+		// #nosec G110 -- the archive is one this harness produced moments ago.
+		body, rerr := io.ReadAll(tr)
+		if rerr != nil {
+			return fmt.Errorf("read %s: %w", h.Name, rerr)
+		}
+		// Alter a payload file and say nothing to CHECKSUMS about it.
+		if strings.HasSuffix(h.Name, "scripts/run.sh") {
+			body = append(body, []byte("\n# added after the manifest was written\n")...)
+			h.Size = int64(len(body))
+			touched = true
+		}
+		if werr := tw.WriteHeader(h); werr != nil {
+			return werr
+		}
+		if _, werr := tw.Write(body); werr != nil {
+			return werr
+		}
+	}
+	if !touched {
+		return fmt.Errorf("sim: no payload file found to alter in %s", b.path)
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	if err := zw.Close(); err != nil {
+		return err
+	}
+	if err := os.WriteFile(b.path, out.Bytes(), 0o600); err != nil {
+		return err
+	}
+
+	// Re-sign: the author is not the adversary here. The point of the case is a
+	// bundle that is properly signed and internally inconsistent.
+	if _, code, serr := w.run(nil, "sign", "--key", w.keyPath("author")+".priv",
+		"--identity-id", "id:author@sim", b.path); serr != nil || code != 0 {
+		return fmt.Errorf("re-sign after checksum staling: exit %d: %w", code, serr)
+	}
+	sum := sha256.Sum256(out.Bytes())
+	b.digest = "sha256:" + hex.EncodeToString(sum[:])
+	return nil
 }

--- a/pkg/skillctl/sim/world.go
+++ b/pkg/skillctl/sim/world.go
@@ -313,46 +313,6 @@ func (w *World) TamperTransit(skill string) error {
 	return flipByte(b.path, 200)
 }
 
-// LyingSignature flips a byte AND renames the signature to match the new digest,
-// so the verifier FINDS a signature and has to do real cryptography to refuse.
-func (w *World) LyingSignature(skill string) error {
-	b := w.bundles[skill]
-	if b == nil {
-		return fmt.Errorf("sim: %s not packed", skill)
-	}
-	oldSig := b.path + "." + strings.TrimPrefix(b.digest, "sha256:") + ".author.sig"
-	if err := flipByte(b.path, 300); err != nil {
-		return err
-	}
-	// #nosec G304 -- re-reading the sandbox artifact the harness just wrote.
-	data, err := os.ReadFile(b.path)
-	if err != nil {
-		return err
-	}
-	sum := sha256.Sum256(data)
-	newSig := b.path + "." + hex.EncodeToString(sum[:]) + ".author.sig"
-	// #nosec G304 -- the detached signature the harness produced a moment ago.
-	sig, err := os.ReadFile(oldSig)
-	if err != nil {
-		return err
-	}
-	// #nosec G703 -- newSig is built from the sandbox path plus a hex digest this
-	// function just computed. Nothing from a scenario definition reaches it.
-	if err := os.WriteFile(newSig, sig, 0o600); err != nil {
-		return err
-	}
-	// The world now tracks the NEW digest, so everything the publisher does next
-	// (admit, attest, revoke) refers to the bytes that actually exist.
-	//
-	// Without this line the attestation stayed bound to the pre-tamper digest, the
-	// admitted bytes carried no governance, and the pull died at gate 4 with gate 3
-	// never consulted. That is a real behaviour and it is worth knowing, but it is
-	// not the question this move was added to ask. A malicious publisher signs off
-	// on what he actually published.
-	b.digest = "sha256:" + hex.EncodeToString(sum[:])
-	return nil
-}
-
 // TamperInstalled edits a file inside an installed skill: the same-uid attacker,
 // after the install. What the model claims here is narrow and stated in the
 // oracle, not here.
@@ -690,37 +650,21 @@ func hashTreeRooted(dir string) (map[string]string, error) {
 	return out, nil
 }
 
-// CorruptSignature damages the detached signature and leaves the artifact alone.
+// Two signature-corruption moves used to live here, and both are gone.
 //
-// This replaces a move that did not do what its name said. The first version of
-// the malicious publisher flipped a byte inside the .skb and renamed the signature
-// to match the new digest. The digest then agreed with the bytes, so gate 2 was
-// satisfied, and the intent was that gate 3 would refuse the signature. It never
-// got there: flipping a byte in a tar archive breaks the tar header, and the
-// installer refused with "archive/tar: invalid tar header" long before any
-// signature was checked.
+// LyingSignature flipped a byte in the .skb and renamed the detached signature to
+// match the new digest; the tar header broke first and the installer never reached
+// a signature check. CorruptSignature flipped a byte inside the detached
+// `<bundle>.<digest>.author.sig` file; the trust-mode pull path never opens that
+// file, so it never reached a signature check either. The second one nonetheless
+// produced a conflict that was filed as FR-0121 and then waived on a diagnosis
+// that had not been measured.
 //
-// Nobody noticed for two days, because the report showed only that the refusal
-// carried no gate label, and a finding was filed on that basis (FR-0121, "gate 3
-// fires but is not named"). It was wrong. An IEEE reviewer asked why there was no
-// gate-3 mutant; building it showed that disabling gate 3 changed nothing, which
-// is only possible if gate 3 was never the reason.
-//
-// So the move now edits the SIGNATURE, not the artifact: the bundle stays a valid
-// archive whose bytes hash to the admitted digest, and the only thing wrong with
-// it is that the signature over that digest does not verify. That is the case
-// SPEC-0188 §7 gate 3 exists for.
-func (w *World) CorruptSignature(skill string) error {
-	b := w.bundles[skill]
-	if b == nil {
-		return fmt.Errorf("sim: %s not packed", skill)
-	}
-	sig := b.path + "." + strings.TrimPrefix(b.digest, "sha256:") + ".author.sig"
-	if _, err := os.Stat(sig); err != nil {
-		return fmt.Errorf("sim: no author signature at %s: %w", sig, err)
-	}
-	return flipByte(sig, 8)
-}
+// What replaced them is ForgeBundleSignatures in registry_mutate.go, which edits
+// the signature rows the path actually verifies. Kept as a comment rather than in
+// git history alone because the mistake is easy to make again: the question to ask
+// of any adversary move is not "did I damage a signature" but "does the path under
+// test read the thing I damaged".
 
 // StaleChecksums rewrites a file inside the bundle and leaves the bundle's own
 // CHECKSUMS listing untouched, then re-signs so the outer chain stays valid.

--- a/scripts/sim-calibrate.sh
+++ b/scripts/sim-calibrate.sh
@@ -112,6 +112,25 @@ if ! "$WORK/skillctl-sim" run -t "$T" -n "$N" -jobs 8 -skillctl "$WORK/skillctl-
 fi
 echo "  baseline: PASS"
 
+# THE BASELINE IS NOT JUST A PRECONDITION, IT IS THE COMPARISON.
+#
+# Detection used to mean "conflicts > 0 or violations > 0". With a waiver register
+# in the corpus the unmutated run already carries findings, so a mutant that
+# changes nothing at all inherited them and scored as detected. Measured on
+# 2026-09-05: gate3-bundlesigs produced 2 conflicts, 1 invariant violation and
+# exit 0, which is byte for byte the baseline signature, and the run reported
+# 7 of 7. The true rate was 6 of 7.
+#
+# So a mutant is detected only if it produces MORE than the baseline does. That is
+# the third time in this project that a check compared against zero when it should
+# have compared against a reference, and it is the same lesson every time: a
+# measurement without its blank is not a measurement.
+BASE_CONF=$(grep -oE '[0-9]+ conflicts' "$WORK/baseline.log" | head -1 | grep -oE '^[0-9]+')
+BASE_VIOL=$(grep -oE 'INVARIANT VIOLATIONS \(([0-9]+)\)' "$WORK/baseline.log" | grep -oE '[0-9]+' | head -1)
+BASE_CONF=${BASE_CONF:-0}; BASE_VIOL=${BASE_VIOL:-0}
+echo "  baseline signature: ${BASE_CONF} conflict(s), ${BASE_VIOL} invariant violation(s)"
+echo "  a mutant counts as detected only if it exceeds this"
+
 detected=0
 total=0
 declare -a MISSED=()
@@ -182,10 +201,10 @@ for m in "${MUTANTS[@]}"; do
   # But a harness failure WITHOUT any behavioural finding is not detection. That
   # was the old bug: every non-zero exit counted, so a mutant that merely failed to
   # run scored as caught.
-  if [ "$nconf" -gt 0 ] || [ "$nviol" -gt 0 ]; then
+  if [ "$nconf" -gt "$BASE_CONF" ] || [ "$nviol" -gt "$BASE_VIOL" ]; then
     extra=""
     [ "$nharn" -gt 0 ] && extra=", $nharn follow-on harness failure(s)"
-    echo "  $name: detected  ($nconf conflicts, $nviol invariant violations, exit $rc$extra)"
+    echo "  $name: detected  ($nconf conflicts vs baseline $BASE_CONF, $nviol violations vs $BASE_VIOL, exit $rc$extra)"
     detected=$((detected + 1))
   elif [ "$nharn" -gt 0 ]; then
     echo "  $name: HARNESS FAILURE ($nharn) and no behavioural finding; nothing was measured, counting as MISSED"
@@ -194,8 +213,8 @@ for m in "${MUTANTS[@]}"; do
     echo "  $name: exit $rc but NO conflict and NO invariant violation; that is not a reading, counting as MISSED"
     MISSED+=("$name (non-zero exit without a behavioural finding)")
   else
-    echo "  $name: NOT DETECTED"
-    MISSED+=("$name")
+    echo "  $name: NOT DETECTED (${nconf} conflicts, ${nviol} violations: the baseline signature, indistinguishable)"
+    MISSED+=("$name (indistinguishable from the unmutated baseline)")
   fi
 done
 

--- a/scripts/sim-calibrate.sh
+++ b/scripts/sim-calibrate.sh
@@ -209,6 +209,13 @@ for m in "${MUTANTS[@]}"; do
   elif [ "$nharn" -gt 0 ]; then
     echo "  $name: HARNESS FAILURE ($nharn) and no behavioural finding; nothing was measured, counting as MISSED"
     MISSED+=("$name (harness failure, not a behavioural reading)")
+  elif [ "$nconf" -gt 0 ] || [ "$nviol" -gt 0 ]; then
+    # The case the comparison above exists for, spelled out rather than folded
+    # into "NOT DETECTED". A mutant that reproduces the baseline reading exactly
+    # is the most misleading result this script can produce, because every number
+    # on the line looks like evidence.
+    echo "  $name: NOT DETECTED; $nconf conflict(s) and $nviol violation(s) is the BASELINE reading ($BASE_CONF, $BASE_VIOL), so nothing here separates the mutant from the unmutated build"
+    MISSED+=("$name (reading equals the baseline signature)")
   elif [ "$rc" -ne 0 ]; then
     echo "  $name: exit $rc but NO conflict and NO invariant violation; that is not a reading, counting as MISSED"
     MISSED+=("$name (non-zero exit without a behavioural finding)")

--- a/scripts/trust-coverage.sh
+++ b/scripts/trust-coverage.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# trust-coverage.sh measures STATEMENT coverage of the trust decision path.
+#
+# It exists because a first attempt at this number was wrong in the direction
+# that would have embarrassed us. Measuring `go test ./pkg/skillctl/registry/...`
+# reported PullBundlesFromBackend, the function containing the whole gate
+# composition, at 0.0 percent, and the obvious conclusion, that the decision
+# function is untested, was false. It is exercised by end-to-end tests in
+# cmd/skillctl, and per-package coverage cannot see across that boundary.
+#
+# So the measurement uses -coverpkg deliberately, and it names both numbers,
+# because the difference between them is itself worth knowing: a decision
+# function with no unit test and good e2e coverage is a different risk from one
+# with neither.
+#
+# WHAT THIS IS NOT: it is not MC/DC. Statement coverage says a line ran. MC/DC
+# asks whether each condition inside a decision was shown to independently change
+# the outcome, and cmd/structural reports how large that obligation is. The two
+# numbers are reported apart on purpose; neither substitutes for the other.
+
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
+
+SCOPE_REGEX='backend_pull\.go|install_trust_mode\.go|attest_quorum\.go|backend/git/git\.go'
+OUT=$(mktemp -t trustcov)
+trap 'rm -f "$OUT"' EXIT
+
+echo "trust path statement coverage"
+echo
+
+echo "  measured across package boundaries (-coverpkg), which is the honest number:"
+if ! go test ./cmd/skillctl/... ./pkg/skillctl/registry/... ./pkg/skillctl/backend/git/... \
+  -count=1 -coverpkg=./pkg/skillctl/registry/...,./pkg/skillctl/backend/git/... \
+  -coverprofile="$OUT" >/dev/null 2>&1; then
+  echo "  FAILED: the test run did not complete; no coverage number is produced." >&2
+  exit 1
+fi
+
+go tool cover -func="$OUT" 2>/dev/null | grep -E "$SCOPE_REGEX" | \
+  awk -F'\t+' '{gsub("%","",$NF); s+=$NF; n++} END {
+    if (n) printf "    %d functions in scope, mean %.1f%%\n", n, s/n
+    else   print  "    no functions matched the scope: check SCOPE_REGEX"
+  }'
+
+echo
+echo "  functions in scope with zero coverage:"
+z=$(go tool cover -func="$OUT" 2>/dev/null | grep -E "$SCOPE_REGEX" | grep -c "	0.0%")
+if [ "$z" -eq 0 ]; then
+  echo "    none"
+else
+  go tool cover -func="$OUT" 2>/dev/null | grep -E "$SCOPE_REGEX" | grep "	0.0%" | \
+    sed 's|.*/pkg/skillctl/|    |'
+fi
+
+echo
+echo "  the decision function itself:"
+go tool cover -func="$OUT" 2>/dev/null | grep "PullBundlesFromBackend" | \
+  sed 's|.*/pkg/skillctl/|    |'
+
+echo
+echo "  Statement coverage says a line ran. It does not say a condition was shown"
+echo "  to matter. Run cmd/structural for the MC/DC obligation, and report the two"
+echo "  numbers separately: neither one substitutes for the other."


### PR DESCRIPTION
Vier Commits, die nach dem Merge von #211 entstanden sind und deshalb nicht mitgekommen sind. Auf den aktuellen master rebased, gruen.

## Der schwerste Befund betraf die eigene Kennzahl

Die Kalibrierung verglich gegen **null** statt gegen die Basislinie. Seit das Waiver-Register existiert, traegt der unmutierte Lauf selbst Befunde, also erbte sie ein Mutant, der gar nichts aendert. Der Tor-3-Mutant lieferte Zeichen fuer Zeichen die Signatur der Basislinie und galt als gefangen.

**6 von 7 statt 7 von 7**, Wilson [0,49, 0,97]. Ein Mutant muss die Basislinie jetzt ueberschreiten, und deren Signatur wird gedruckt.

## Das Modell zitierte die falsche Spezifikation

Alle fuenf Tore verwiesen auf SPEC-0188 §7. Eine adversariale Gegenpruefung hat den Pfad verfolgt: §7 regiert den ER1- und HTTP-Installationsweg. Der hier gemessene Weg ist **SPEC-0225 §9.1**, und diese Klausel listet genau diese fuenf Pruefungen.

Korrigiert. Eine Rueckverfolgbarkeitsmatrix mit falschen Quellen ist schlimmer als eine ohne: sie sieht geprueft aus.

## Weiter enthalten

- **SPEC-0188 §7 Schritt 8** bekommt einen Testfall (CHECKSUMS im Bundle veraltet, aussen alles korrekt). Der Pull akzeptiert. Als BUG-0217 gefiled und nach der Gegenpruefung auf **Robustheit** herabgestuft, weil §9.1 keinen solchen Schritt kennt.
- **trust path statement coverage

  measured across package boundaries (-coverpkg), which is the honest number:
    69 functions in scope, mean 84.9%

  functions in scope with zero coverage:
    backend/git/git.go:917:			versionStrings			0.0%
    registry/install_trust_mode.go:540:	defaultSkillsDir		0.0%

  the decision function itself:
    registry/backend_pull.go:77:		PullBundlesFromBackend		68.1%

  Statement coverage says a line ran. It does not say a condition was shown
  to matter. Run cmd/structural for the MC/DC obligation, and report the two
  numbers separately: neither one substitutes for the other.**: Anweisungsabdeckung des Vertrauenspfads, ueber Paketgrenzen gemessen. 84,9 Prozent im Mittel, die Torfunktion 68,1. Eine erste Messung meldete 0,0 Prozent und haette fast zu der Aussage gefuehrt, sie sei ungetestet.
- **Konsistenzbefunde**: 702 statt 382 als Vollraum, Paare und Punkte getrennt,  gegen  erklaert, und das Markdown-Freigabeartefakt traegt jetzt Verdikt, Waiver, Konflikte und die Nicht-Zusagen. Es enthielt sein eigenes Ergebnis nicht.
- **Tor 3** ist zurueckgezogen: ungeprueft, Mutant von der Basislinie nicht unterscheidbar. Der Absatz war dreimal falsch, und die Geschichte steht im Bericht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)