### PR TITLE
fix(install): BUG-0217, der Trust-Mode-Pfad prueft die CHECKSUMS des Bundles

### DIFF
--- a/pkg/skillbundle/checksums.go
+++ b/pkg/skillbundle/checksums.go
@@ -1,0 +1,115 @@
+package skillbundle
+
+// checksums.go verifies a bundle's own CHECKSUMS manifest against the files it
+// describes, after extraction and before anything is trusted or moved.
+//
+// This lives here, in the format package, rather than next to either installer,
+// because BOTH installers need it and neither may import the other. It used to
+// live unexported in pkg/skillctl/install, which is why the trust-mode path in
+// pkg/skillctl/registry never called it: the code was on the wrong side of an
+// import edge, and the omission was invisible from either side (BUG-0217).
+//
+// SPEC-0188 §7 step 8: extract the bundle to a temp dir and verify the CHECKSUMS
+// file inside it. Any failure in steps 3 to 8 means no write.
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrChecksumMismatch marks every failure this file can produce, so a caller can
+// map the whole class onto its own refusal without matching on message text.
+var ErrChecksumMismatch = errors.New("bundle CHECKSUMS does not describe the extracted files")
+
+// ValidateChecksums checks every entry in the extracted bundle's CHECKSUMS file.
+//
+// A bundle with no CHECKSUMS passes: the manifest is optional in SPEC §3.1, and
+// refusing its absence here would reject bundles from before it existed. What is
+// NOT optional is that a present manifest describes the bytes on disk.
+//
+// Two layouts are accepted because two producers exist: the flat archive that
+// skillbundle.Pack emits, and the one wrapped in a single <name>-<version>/
+// directory. The single-entry directory heuristic is what tells them apart.
+func ValidateChecksums(extractDir string) error {
+	root := extractDir
+	if entries, err := os.ReadDir(extractDir); err == nil && len(entries) == 1 && entries[0].IsDir() {
+		root = filepath.Join(extractDir, entries[0].Name())
+	}
+	checksumPath := filepath.Join(root, "CHECKSUMS")
+	// #nosec G304 -- a path built from the caller's own extraction directory.
+	f, err := os.Open(checksumPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("open CHECKSUMS: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Accept "<hex>  <path>" or "<hex> <path>" (one or two spaces).
+		var wantHex, rel string
+		if i := strings.Index(line, "  "); i >= 0 {
+			wantHex = line[:i]
+			rel = strings.TrimSpace(line[i+2:])
+		} else if i := strings.Index(line, " "); i >= 0 {
+			wantHex = line[:i]
+			rel = strings.TrimSpace(line[i+1:])
+		} else {
+			return fmt.Errorf("CHECKSUMS malformed line %q: %w", line, ErrChecksumMismatch)
+		}
+		if rel == "" {
+			return fmt.Errorf("CHECKSUMS missing path on line %q: %w", line, ErrChecksumMismatch)
+		}
+		// A manifest is attacker-influenced input like any other: an entry that
+		// escapes the root would send the hash check at a file outside the bundle
+		// and could be used to probe the consumer's disk.
+		cleanRel := filepath.Clean(rel)
+		if strings.HasPrefix(cleanRel, "..") || filepath.IsAbs(cleanRel) {
+			return fmt.Errorf("CHECKSUMS entry %q escapes root: %w", rel, ErrChecksumMismatch)
+		}
+		if cleanRel == "CHECKSUMS" {
+			continue
+		}
+		fp := filepath.Join(root, cleanRel)
+		got, err := fileSHA256Hex(fp)
+		if err != nil {
+			return fmt.Errorf("hash %s: %w", fp, errors.Join(ErrChecksumMismatch, err))
+		}
+		if !strings.EqualFold(got, wantHex) {
+			return fmt.Errorf("CHECKSUMS mismatch for %s (got %s, want %s): %w",
+				rel, got, wantHex, ErrChecksumMismatch)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read CHECKSUMS: %w", err)
+	}
+	return nil
+}
+
+func fileSHA256Hex(path string) (string, error) {
+	// #nosec G304 -- a path inside the caller's extraction directory, cleaned and
+	// checked for escape above.
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/pkg/skillbundle/checksums_test.go
+++ b/pkg/skillbundle/checksums_test.go
@@ -1,0 +1,109 @@
+package skillbundle
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// write lays out a bundle root and returns it. Entries whose content is listed
+// in CHECKSUMS are hashed honestly unless the caller overrides the line.
+func write(t *testing.T, files map[string]string, checksums string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if checksums != "" {
+		if err := os.WriteFile(filepath.Join(dir, "CHECKSUMS"), []byte(checksums), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func hashOf(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+func TestValidateChecksumsAcceptsAnHonestManifest(t *testing.T) {
+	dir := write(t, map[string]string{"SKILL.md": "body"},
+		hashOf("body")+"  SKILL.md\n")
+	if err := ValidateChecksums(dir); err != nil {
+		t.Fatalf("an honest manifest must pass: %v", err)
+	}
+}
+
+// The case BUG-0217 was about: the bytes are exactly what was signed, and the
+// bundle's own manifest no longer describes them.
+func TestValidateChecksumsRefusesAStaleManifest(t *testing.T) {
+	dir := write(t, map[string]string{"SKILL.md": "edited after the manifest was built"},
+		hashOf("body")+"  SKILL.md\n")
+	err := ValidateChecksums(dir)
+	if err == nil {
+		t.Fatal("a stale manifest must be refused")
+	}
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("the failure must carry ErrChecksumMismatch so a caller can map the class: %v", err)
+	}
+}
+
+// Absence is not a failure: the manifest is optional in SPEC §3.1, and refusing
+// its absence would reject bundles built before it existed.
+func TestValidateChecksumsAcceptsNoManifest(t *testing.T) {
+	dir := write(t, map[string]string{"SKILL.md": "body"}, "")
+	if err := ValidateChecksums(dir); err != nil {
+		t.Fatalf("a bundle without CHECKSUMS must pass: %v", err)
+	}
+}
+
+// A manifest is attacker-influenced input, so an entry that points outside the
+// bundle must be refused rather than followed.
+func TestValidateChecksumsRefusesAnEscapingEntry(t *testing.T) {
+	dir := write(t, map[string]string{"SKILL.md": "body"},
+		hashOf("body")+"  ../../etc/passwd\n")
+	err := ValidateChecksums(dir)
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("an escaping entry must be refused: %v", err)
+	}
+}
+
+// A missing file named by the manifest is a mismatch, not a silent pass. The
+// difference matters: skipping it would let a bundle delete its way to green.
+func TestValidateChecksumsRefusesAMissingFile(t *testing.T) {
+	dir := write(t, map[string]string{"SKILL.md": "body"},
+		hashOf("body")+"  SKILL.md\n"+hashOf("gone")+"  gone.md\n")
+	if err := ValidateChecksums(dir); !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("a file named by the manifest but absent must be refused: %v", err)
+	}
+}
+
+// Both producers are accepted: the flat archive Pack emits, and the one wrapped
+// in a single <name>-<version>/ directory.
+func TestValidateChecksumsHandlesTheWrappedLayout(t *testing.T) {
+	outer := t.TempDir()
+	inner := filepath.Join(outer, "demo-1.0.0")
+	if err := os.MkdirAll(inner, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inner, "SKILL.md"), []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inner, "CHECKSUMS"),
+		[]byte(hashOf("wrong")+"  SKILL.md\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateChecksums(outer); !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("the wrapped layout must be checked, not skipped: %v", err)
+	}
+}

--- a/pkg/skillctl/install/install.go
+++ b/pkg/skillctl/install/install.go
@@ -20,7 +20,6 @@
 package install
 
 import (
-	"bufio"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -742,87 +741,25 @@ func extractTGZ(blob []byte, destDir string, maxBytes int64) error {
 	return skillbundle.ExtractTo(entries, destDir)
 }
 
-// validateChecksumsIfPresent reads the bundle's CHECKSUMS file (if it
-// exists) and verifies every entry's SHA-256 against the on-disk content.
+// validateChecksumsIfPresent verifies the bundle's own CHECKSUMS manifest.
 //
-// Format: each line is "<sha256-hex>  <relative-path>" (two spaces, per
-// the GNU coreutils sha256sum convention SPEC §3.1 follows). Lines with a
-// '#' prefix or empty lines are skipped.
+// The implementation moved to pkg/skillbundle on 2026-09-06 and this is now a
+// thin adapter. It moved because the OTHER installer, the trust-mode pull path in
+// pkg/skillctl/registry, could not call it: that package cannot import this one,
+// and the check was therefore simply absent there for as long as the path existed
+// (BUG-0217). A control that only one of two entry points can reach is a control
+// on one entry point.
 //
-// Missing CHECKSUMS file → success (some bundles may omit it). Mismatches
-// → ErrDigestMismatch (per SPEC §7 step 8).
+// The wrapping stays: callers here match on verify.ErrDigestMismatch, and the
+// bundle package has no reason to know about that sentinel.
 func validateChecksumsIfPresent(extractDir string) error {
-	// SPEC §3.1 puts CHECKSUMS at the bundle ROOT, but the tar has the
-	// bundle's <name>-<version>/ as its top-level dir. Walk one level
-	// down to find it.
-	root := extractDir
-	if entries, err := os.ReadDir(extractDir); err == nil && len(entries) == 1 && entries[0].IsDir() {
-		root = filepath.Join(extractDir, entries[0].Name())
-	}
-	checksumPath := filepath.Join(root, "CHECKSUMS")
-	f, err := os.Open(checksumPath)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("install: open CHECKSUMS: %w", err)
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
+	if err := skillbundle.ValidateChecksums(extractDir); err != nil {
+		if errors.Is(err, skillbundle.ErrChecksumMismatch) {
+			return fmt.Errorf("install: %w: %w", verify.ErrDigestMismatch, err)
 		}
-		// Accept "<hex>  <path>" or "<hex> <path>" (one or two spaces).
-		var wantHex, rel string
-		if i := strings.Index(line, "  "); i >= 0 {
-			wantHex = line[:i]
-			rel = strings.TrimSpace(line[i+2:])
-		} else if i := strings.Index(line, " "); i >= 0 {
-			wantHex = line[:i]
-			rel = strings.TrimSpace(line[i+1:])
-		} else {
-			return fmt.Errorf("install: CHECKSUMS malformed line %q: %w", line, verify.ErrDigestMismatch)
-		}
-		if rel == "" {
-			return fmt.Errorf("install: CHECKSUMS missing path on line %q: %w", line, verify.ErrDigestMismatch)
-		}
-		// Refuse path-traversal on relative paths inside CHECKSUMS too.
-		cleanRel := filepath.Clean(rel)
-		if strings.HasPrefix(cleanRel, "..") || filepath.IsAbs(cleanRel) {
-			return fmt.Errorf("install: CHECKSUMS entry %q escapes root: %w", rel, verify.ErrDigestMismatch)
-		}
-		if cleanRel == "CHECKSUMS" {
-			continue
-		}
-		fp := filepath.Join(root, cleanRel)
-		got, err := fileSHA256Hex(fp)
-		if err != nil {
-			return fmt.Errorf("install: hash %s: %w", fp, errors.Join(verify.ErrDigestMismatch, err))
-		}
-		if !strings.EqualFold(got, wantHex) {
-			return fmt.Errorf("install: CHECKSUMS mismatch for %s (got %s, want %s): %w", rel, got, wantHex, verify.ErrDigestMismatch)
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("install: read CHECKSUMS: %w", err)
+		return fmt.Errorf("install: %w", err)
 	}
 	return nil
-}
-
-func fileSHA256Hex(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // atomicInstall moves extractDir to ~/.claude/skills/<name>/. If a prior

--- a/pkg/skillctl/registry/install_trust_mode.go
+++ b/pkg/skillctl/registry/install_trust_mode.go
@@ -431,6 +431,25 @@ func installOne(b *StagedBundle, opts InstallOpts) (*InstallResult, error) {
 		return nil, fmt.Errorf("install: extract: %w", err)
 	}
 
+	// SPEC-0188 §7 step 8, and it was missing from this path entirely (BUG-0217).
+	//
+	// The outer chain proves the bytes are the ones that were signed and admitted.
+	// It says nothing about whether the bundle is internally consistent: a manifest
+	// that no longer describes the files beside it is a bundle that was altered
+	// before it was signed, and every gate upstream passes it happily. The other
+	// installer checked this from the day it existed; this one could not, because
+	// the function lived in a package this one cannot import. It now lives in
+	// pkg/skillbundle, where both reach it.
+	//
+	// Placed here on purpose: after extraction into the temp directory, before the
+	// provenance sidecar is written and long before the rename into place. §7 says
+	// any failure in steps 3 to 8 means NO WRITE, so the failure has to happen
+	// while the only thing on disk is a directory this function is about to delete.
+	if err := skillbundle.ValidateChecksums(tmp); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("install: %w", err)
+	}
+
 	// Write the sidecar inside the unpacked dir.
 	side := ProvenanceSidecar{
 		SchemaVersion:         ProvenanceSchemaVersion,

--- a/pkg/skillctl/sim/analytic.go
+++ b/pkg/skillctl/sim/analytic.go
@@ -186,17 +186,30 @@ func PredictHistogram(corpus []Scenario) map[string]int {
 			if !st.Expect.Claimed {
 				continue
 			}
-			accept, g := StateAt(sc.P, afterRevoke).Decide()
+			// The bin comes from the STEP EXPECTATION, not from a second derivation
+			// of the state vector.
+			//
+			// It used to call StateAt(...).Decide() again here, and that was a second
+			// oracle: the five-bit model knows the five gates and nothing else, so a
+			// requirement outside it, SPEC-0188 §7 step 8, was predicted as an accept
+			// while the expectation the comparison actually uses said refuse. The two
+			// disagreed by construction and the residual reported it as a finding
+			// about the product. The generator's expectation is the one oracle; this
+			// reads it.
+			_, g := StateAt(sc.P, afterRevoke).Decide()
 			// A waived disagreement is binned apart on BOTH sides, so it neither
 			// hides in the residual nor pretends to be agreement. The conflict count
 			// above still carries it; this bin only keeps it out of a number that
 			// means "the closed form reproduced the distribution".
-			if isWaivedPrediction(sc.P, g) {
+			switch {
+			case isWaivedPrediction(sc.P, g):
 				h[BinLabelOpen]++
-			} else if accept {
+			case st.Expect.Outcome == Accept:
 				h["accept"]++
-			} else {
-				h[g]++
+			case st.Expect.Gate != "":
+				h[st.Expect.Gate]++
+			default:
+				h["refused, no gate named"]++
 			}
 		}
 	}

--- a/pkg/skillctl/sim/generate.go
+++ b/pkg/skillctl/sim/generate.go
@@ -460,7 +460,14 @@ func build(p Params) Scenario {
 	})
 
 	// 7. Re-verification of what was installed.
-	if ok {
+	//
+	// The guard is whether the PULL accepted, not whether the five gates passed.
+	// Those came apart the moment SPEC-0188 §7 step 8 was implemented: a bundle can
+	// clear every gate and still be refused for an internal defect, and then there
+	// is nothing installed to re-verify. The old guard read `ok` and predicted a
+	// successful verify against an empty install target.
+	installed := pullExpect.Outcome == Accept
+	if installed {
 		if p.Adv == AdvTamperInstalled {
 			sc.Steps = append(sc.Steps,
 				Step{Action: Action{Kind: ActTamperInstalled, Actor: Adversary, Skill: skill},

--- a/pkg/skillctl/sim/waiver.go
+++ b/pkg/skillctl/sim/waiver.go
@@ -61,38 +61,28 @@ type Waiver struct {
 	Kind ActionKind
 }
 
-// Waivers is the register. Empty is the goal, and it now holds one entry, not two.
+// Waivers is the register, and it is EMPTY.
 //
-// The FR-0121 entry is GONE, and its removal is the substance of this change
-// rather than housekeeping. It waived the case "model says gate 3, binary says
-// accept" and described it as an unstable measurement owing one clean re-run.
-// The re-run happened on 2026-09-06 and found a cause: the adversary move edited
-// the detached "<bundle>.<digest>.author.sig" file, which the trust-mode pull
-// path never opens. Gate 3 was never reached, so the acceptance was correct behaviour
-// against a case that did not test it, and the disagreement was the MODEL's. With
-// a move that reaches the gate (see ForgeBundleSignatures) the prediction holds
-// and there is nothing left to waive.
+// It held two entries and both are gone for opposite reasons, which is the whole
+// argument for keeping a register rather than deleting tests.
 //
-// What remains is BUG-0217, and it is a different animal: a measured violation of
-// a written requirement, waived so the gate stays usable while the fix is decided.
-// Keeping the two apart is the point of the register. One was a defect in the
-// instrument, the other is a defect in the product, and a register that cannot
-// tell them apart will eventually be used to hide the second behind the first.
+// FR-0121 was withdrawn on 2026-09-06 because it was wrong: the adversary move it
+// covered edited a detached signature file the pull path never opens, so gate 3
+// was never reached and the acceptance it waived was correct behaviour against a
+// case that did not test it. The defect was in the instrument.
+//
+// BUG-0217 was a real defect in the PRODUCT, and it is fixed. The trust-mode pull
+// path now verifies the bundle's own CHECKSUMS manifest after extraction and
+// before any write, as SPEC-0188 §7 step 8 requires. The waiver stopped matching
+// by itself the first time the corpus ran against the fixed build, which is
+// exactly what it promised: "change what the binary does here and the waiver
+// stops matching, and the conflict fails the run again."
+//
+// The mechanism stays. An empty register is evidence that nothing needs waiving;
+// no register at all would force the next disagreement to be resolved by deleting
+// the test that found it.
 func Waivers() []Waiver {
-	return []Waiver{
-		{
-			Adv: AdvStaleChecksums, Kind: ActPull, Expected: "", Observed: "accept",
-			Finding:   "BUG-0217",
-			Invariant: InvAcceptDelivers,
-			Why: "A DEFECT, not an open question, and the line above is the measurement of it. " +
-				"SPEC-0188 §7 step 8 verifies " +
-				"the CHECKSUMS file inside the bundle and says any failure in steps 3 to 8 means " +
-				"no write. The trust-mode pull path extracts without that check (extractSkb does " +
-				"not validate; the other install path does), and a bundle whose internal manifest " +
-				"no longer describes its contents is installed. Waived so the gate stays usable " +
-				"while the fix is decided; it is a defect, not a naming question",
-		},
-	}
+	return nil
 }
 
 // waiverFor returns the waiver covering this disagreement, if any.

--- a/scripts/sim-calibrate.sh
+++ b/scripts/sim-calibrate.sh
@@ -65,9 +65,16 @@ MUTANTS=(
   "gate2-digest|pkg/skillctl/registry/backend_pull.go|s|if gotDigest != digest {|if false \&\& gotDigest != digest {|"
   "silent-noop-install|pkg/skillctl/registry/install_trust_mode.go|s|if err := os.Rename(tmp, target); err != nil {|if err := func() error { _ = tmp; _ = target; return nil }(); err != nil {|"
   "gate3-bundlesigs|pkg/skillctl/registry/backend_pull.go|s|if err := verifyBundleSignatures(event, pub, gotDigest); err != nil {|if err := verifyBundleSignatures(event, pub, gotDigest); false \&\& err != nil {|"
+  "step8-checksums|pkg/skillctl/registry/install_trust_mode.go|s|if err := skillbundle.ValidateChecksums(tmp); err != nil {|if err := skillbundle.ValidateChecksums(tmp); false \&\& err != nil {|"
   "early-fetch|pkg/skillctl/registry/backend_pull.go|s|if acc.IsRevoked(digest) {|if _, ferr := be.Fetch(ctx, artifact.ArtifactRef{Name: name, Version: ver, Digest: digest}); ferr != nil { res.Skipped = append(res.Skipped, \&PullSkip{Name: name, Version: ver, Digest: digest, Gate: ErrGateDigest, Detail: ferr.Error()}); continue } else if acc.IsRevoked(digest) {|"
 )
 
+# step8-checksums is the mutant for the control added on 2026-09-06 (BUG-0217).
+# It is here because of what gate 3 cost: a control with no mutant is a control
+# nobody has watched fail, and for two days the report described gate 3 in three
+# different wrong ways precisely because nothing had ever disabled it. A new check
+# arrives with its mutant or it arrives unverified.
+#
 # The last two are not disabled gates. They are the two SIDE-EFFECT requirements,
 # and each exists because the defect it models is invisible to everything that
 # reads an exit code or a gate name.


### PR DESCRIPTION
SPEC-0188 §7 Schritt 8 verlangt, das entpackte Bundle gegen sein eigenes CHECKSUMS-Manifest zu pruefen, und jeder Fehlschlag in den Schritten 3 bis 8 bedeutet KEIN Schreiben. Der Registry-Installationspfad tat das immer. Der Trust-Mode-Pull-Pfad tat es nie.

## Warum die Kontrolle fehlte

Die Funktion lag unexportiert in `pkg/skillctl/install`, und `pkg/skillctl/registry` kann dieses Paket nicht importieren, weil die Abhaengigkeit andersherum laeuft. Die Kontrolle war nicht vergessen, sie lag auf der falschen Seite einer Importkante, und von beiden Seiten aus sah alles vollstaendig aus. Sie liegt jetzt in `pkg/skillbundle`, wo beide Installationspfade sie erreichen.

Der Aufruf steht direkt nach dem Entpacken in das temporaere Verzeichnis, vor dem Provenance-Sidecar und lange vor dem Umbenennen an den Zielort: die Stelle, an der ein Fehlschlag noch nichts hinterlaesst.

## Wie der Fix belegt ist

Der Waiver fuer BUG-0217 hat beim ersten Lauf gegen den gefixten Build von selbst aufgehoert zu passen, genau wie sein eigener Text es versprochen hatte. Danach:

| Groesse | vorher | nachher |
|---|---|---|
| INV-7 (ein Accept liefert die signierten Bytes) | 1 Verletzung | 0 |
| INV-6 (eine Verweigerung schreibt nichts) | n/a | 63 Schritte, 0 Verletzungen |
| Waiver-Register | 1 Eintrag | leer |
| Basislinie der Kalibrierung | (1 Konflikt, 1 Verletzung) | (0, 0) |
| Erkennungsrate | 7 von 7 | **8 von 8**, Wilson [0,68, 1,00] |

Der achte Mutant ist neu und schaltet genau diese Pruefung ab. Ein Kontrollpunkt ohne Mutanten ist einer, den niemand hat scheitern sehen; das hat Tor 3 zwei Tage gekostet.

## Zwei Modellkorrekturen, beides Folgen des Fixes

Die Nachpruefung nach dem Pull haengt jetzt daran, ob der PULL angenommen hat, nicht daran, ob die fuenf Tore bestanden. Die beiden fielen auseinander, als Schritt 8 wirksam wurde: ein Bundle kann jedes Tor passieren und wegen eines inneren Defekts abgelehnt werden.

Und das Vorhersage-Histogramm las den Zustandsvektor ein zweites Mal, statt die Erwartung zu nehmen, die der Vergleich benutzt. Ein zweites Orakel: das Fuenf-Bit-Modell kennt Schritt 8 nicht, sagte "accept", waehrend die Erwartung "refuse" sagte.

Korpus danach: 51 Szenarien, 333 Schritte, 0 Konflikte, 0 Invariantenverletzungen, Residuum 0.