### PR TITLE
feat(trust): add-author und fingerprint, die Phase 0 von SPEC-0406

### DIFF
--- a/cmd/skillctl/trust_cmds.go
+++ b/cmd/skillctl/trust_cmds.go
@@ -19,9 +19,12 @@ package main
 // also surfaces them.
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
 	"io"
 	"os"
 	"strings"
@@ -43,6 +46,10 @@ func runTrust(args []string, stdout, stderr io.Writer) int {
 		return runTrustList(args[1:], stdout, stderr)
 	case "add":
 		return runTrustAdd(args[1:], stdout, stderr)
+	case "add-author":
+		return runTrustAddAuthor(args[1:], stdout, stderr)
+	case "fingerprint":
+		return runTrustFingerprint(args[1:], stdout, stderr)
 	case "remove", "rm":
 		return runTrustRemove(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
@@ -172,6 +179,101 @@ func runTrustAdd(args []string, stdout, stderr io.Writer) int {
 	return exitOK
 }
 
+// runTrustAddAuthor implements `skillctl trust add-author`.
+//
+// The Phase-0 command of SPEC-0406: it is what makes "the recipient need not
+// trust the transport" true instead of asserted.
+//
+// It is a SEPARATE verb rather than a flag on `trust add` because the two pin
+// different things and one of them requires an out-of-band step. `trust add`
+// pins the key that signs a registry's statements. This pins the key of a
+// PERSON, and it refuses without a fingerprint the operator confirmed over a
+// second channel. Folding that requirement into an existing verb as an optional
+// flag would make the strict path look like the variant of the loose one; it is
+// the other way round.
+func runTrustAddAuthor(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("trust add-author", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	registryURL := fs.String("registry", "", "Registry URL this author publishes under. Required. It is a NAME here, not an endpoint: the offline paths never call it.")
+	identityID := fs.String("identity", "", "The author identity id exactly as it appears in the bundle's author signature row (e.g. id:eric@kup). Required.")
+	pubkeyPath := fs.String("pubkey", "", "Path to the author's PEM SPKI ed25519 public key. Required.")
+	pin := fs.String("pin", "", "sha256:<hex> of the key, CONFIRMED OVER A SECOND CHANNEL. Required; there is no trust-on-first-use.")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl trust add-author --registry <url> --identity <id> --pubkey <path> --pin sha256:<hex>")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "Pin an AUTHOR's key so `verify --bundle` and `install --bundle` will accept")
+		fmt.Fprintln(stderr, "artifacts they signed. This is the step that has to happen BEFORE anything")
+		fmt.Fprintln(stderr, "arrives, and it is the reason the transport does not have to be trusted.")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "--pin is REQUIRED and is not a formality. Get the key by any convenient")
+		fmt.Fprintln(stderr, "means, then have the sender read the fingerprint to you on a call. A key")
+		fmt.Fprintln(stderr, "that arrives with its own fingerprint down one channel proves nothing.")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "Print a key's fingerprint with:  skillctl trust fingerprint <key.pub>")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *registryURL == "" || *identityID == "" || *pubkeyPath == "" || *pin == "" {
+		fs.Usage()
+		return exitUsage
+	}
+
+	path := trustConfigPath()
+	tr, err := verify.Load(path)
+	if errors.Is(err, os.ErrNotExist) {
+		// First time: Load returned an empty TrustRoots with Path set.
+	} else if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+
+	if err := tr.AddAuthor(*registryURL, *identityID, *pubkeyPath, *pin); err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	if err := tr.Save(); err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	fmt.Fprintf(stdout, "pinned author %s under %s in %s\n", *identityID, strings.TrimRight(*registryURL, "/"), tr.Path)
+	fmt.Fprintln(stdout, "You can now verify and install bundles this author signed, offline.")
+	return exitOK
+}
+
+// runTrustFingerprint prints the sha256 of a public key: the value one side
+// reads aloud and the other passes to `trust add-author --pin`.
+//
+// It exists so the fingerprint comes from the tool on BOTH ends rather than from
+// a human transcribing 64 hex characters out of a key file. The comparison is
+// the security step; making it easy is how it actually gets done.
+func runTrustFingerprint(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("trust fingerprint", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: skillctl trust fingerprint <key.pub>")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "Print sha256:<hex> of an ed25519 public key. Read this value aloud on a")
+		fmt.Fprintln(stderr, "call; the other side passes it to `trust add-author --pin`.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return exitUsage
+	}
+	pub, err := signing.LoadPublicKey(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return exitGeneric
+	}
+	sum := sha256.Sum256(pub)
+	fmt.Fprintf(stdout, "sha256:%s\n", hex.EncodeToString(sum[:]))
+	return exitOK
+}
+
 // runTrustRemove implements `skillctl trust remove --registry <url>`.
 // Deletes the entire entry (including all its keys). Convenience verb;
 // a future `skillctl trust retire --registry <url> --id <k>` would mark
@@ -225,6 +327,8 @@ func printTrustUsage(w io.Writer) {
 	fmt.Fprintln(w, "Verbs:")
 	fmt.Fprintln(w, "  list     Print configured registries and their pinned keys.")
 	fmt.Fprintln(w, "  add      Pin a registry public key.")
+	fmt.Fprintln(w, "  add-author   Pin an AUTHOR key, with a fingerprint confirmed out-of-band.")
+	fmt.Fprintln(w, "  fingerprint  Print sha256:<hex> of a public key, to read aloud on a call.")
 	fmt.Fprintln(w, "  remove   Unpin a registry (alias: rm).")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Trust roots config: ~/.claude/skill-trust-roots.yaml (per SPEC-0188 §4.4).")

--- a/docs/CLI-VERBS.md
+++ b/docs/CLI-VERBS.md
@@ -62,7 +62,7 @@ same way `cmd/docaudit` gates the flag surface.
 | `keygen` | SPEC-0188 §11 | 0/1/2 |
 | `sign` | SPEC-0188 §11 | 0/1/2 |
 | `verify-sig` | SPEC-0188 §11 | 0/1/2, 10, 11 |
-| `trust` | SPEC-0188 (S7) | 0/1/2 |
+| `trust` (`list`, `add`, `add-author`, `fingerprint`, `remove`) | SPEC-0188 (S7), `add-author`/`fingerprint` SPEC-0406 §3.2 | 0/1/2 |
 | `peer` | SPEC-0359 (D2) | 0/1/2 |
 | `cross-sign` | SPEC-0359 (D3) | 0/1/2 |
 | `attest` | SPEC-0188 (S9) | 0/1/2 |

--- a/pkg/skillctl/verify/addauthor_test.go
+++ b/pkg/skillctl/verify/addauthor_test.go
@@ -1,0 +1,171 @@
+package verify
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writePub writes an ed25519 public key in the PEM SPKI form `skillctl keygen`
+// produces, and returns its path plus the fingerprint an operator would read
+// aloud on a call.
+func writePub(t *testing.T, dir, name string) (path, fingerprint string) {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path = filepath.Join(dir, name+".pub")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	sum := sha256.Sum256(pub)
+	return path, "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func rootWithRegistry(t *testing.T, dir, url string) *TrustRoots {
+	t.Helper()
+	tr := &TrustRoots{Path: filepath.Join(dir, "roots.yaml")}
+	regPath, _ := writePub(t, dir, "registry")
+	if err := tr.AddRegistry(url, regPath, "reg-1"); err != nil {
+		t.Fatalf("AddRegistry: %v", err)
+	}
+	return tr
+}
+
+// THE test of this feature. A key that arrives with the artifact proves nothing,
+// because it came down the same untrusted channel. The fingerprint is what makes
+// SPEC-0406 AC-02 a fact instead of a claim, so a wrong one must be refused
+// rather than reported, and there is no trust-on-first-use to fall back to.
+func TestAddAuthorRefusesAKeyThatDoesNotMatchTheConfirmedFingerprint(t *testing.T) {
+	dir := t.TempDir()
+	const url = "https://eric.example/api/skills"
+	tr := rootWithRegistry(t, dir, url)
+
+	// The operator confirmed ONE key on the phone; a DIFFERENT key arrives.
+	_, confirmed := writePub(t, dir, "the-one-we-agreed")
+	arrived, _ := writePub(t, dir, "the-one-that-came")
+
+	err := tr.AddAuthor(url, "id:eric@kup", arrived, confirmed)
+	if err == nil {
+		t.Fatal("a key that does not match the confirmed fingerprint was pinned")
+	}
+	// The message has to show BOTH values: the operator's next move is to compare
+	// them, and a refusal that hides one of them cannot be acted on.
+	msg := err.Error()
+	for _, want := range []string{"confirmed:", "this key:", "second channel"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the refusal does not help the operator act: missing %q in %v", want, msg)
+		}
+	}
+	if len(tr.Roots[0].Authors) != 0 {
+		t.Error("a refused pin was written anyway")
+	}
+}
+
+// No fingerprint at all is the same refusal, not a lenient path. If this ever
+// becomes optional, trust-on-first-use is back and the whole Phase 0 is theatre.
+func TestAddAuthorRequiresAFingerprint(t *testing.T) {
+	dir := t.TempDir()
+	const url = "https://eric.example/api/skills"
+	tr := rootWithRegistry(t, dir, url)
+	pub, _ := writePub(t, dir, "eric")
+
+	if err := tr.AddAuthor(url, "id:eric@kup", pub, ""); err == nil {
+		t.Fatal("an author was pinned with no fingerprint at all")
+	} else if !strings.Contains(err.Error(), "SECOND channel") {
+		t.Errorf("the refusal does not say why a fingerprint is required: %v", err)
+	}
+}
+
+// The happy path, and the two side effects that matter: the key lands in
+// authors:, and the root flips to pinned. A root that carries a pinned author
+// key and still fetches identities from a registry would answer the author
+// question two ways.
+func TestAddAuthorPinsAndSwitchesTheRootToPinned(t *testing.T) {
+	dir := t.TempDir()
+	const url = "https://eric.example/api/skills"
+	tr := rootWithRegistry(t, dir, url)
+	if got := tr.Roots[0].IdentityKeysAuthorized; got != "from-registry" {
+		t.Fatalf("precondition: a fresh registry root should be %q, got %q", "from-registry", got)
+	}
+
+	pub, fp := writePub(t, dir, "eric")
+	if err := tr.AddAuthor(url, "id:eric@kup", pub, fp); err != nil {
+		t.Fatalf("AddAuthor: %v", err)
+	}
+	if n := len(tr.Roots[0].Authors); n != 1 {
+		t.Fatalf("authors = %d, want 1", n)
+	}
+	if got := tr.Roots[0].Authors[0].ID; got != "id:eric@kup" {
+		t.Errorf("identity = %q", got)
+	}
+	if got := tr.Roots[0].IdentityKeysAuthorized; got != "pinned" {
+		t.Errorf("identity_keys_authorized = %q, want pinned: the offline paths need it", got)
+	}
+	// The pin must survive a save/load round trip, or the second machine reads
+	// something different from what the first one wrote.
+	if err := tr.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	back, err := Load(tr.Path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(back.Roots) != 1 || len(back.Roots[0].Authors) != 1 || back.Roots[0].Authors[0].ID != "id:eric@kup" {
+		t.Fatalf("the pin did not survive the round trip: %+v", back.Roots)
+	}
+}
+
+// A second, different key under the SAME identity is either a rotation or a
+// substitution. Both are decisions; silently appending would make the second one
+// invisible, and the verifier would then accept either key.
+func TestAddAuthorRefusesASecondKeyForOneIdentity(t *testing.T) {
+	dir := t.TempDir()
+	const url = "https://eric.example/api/skills"
+	tr := rootWithRegistry(t, dir, url)
+
+	first, fp1 := writePub(t, dir, "eric-1")
+	if err := tr.AddAuthor(url, "id:eric@kup", first, fp1); err != nil {
+		t.Fatalf("first pin: %v", err)
+	}
+	second, fp2 := writePub(t, dir, "eric-2")
+	err := tr.AddAuthor(url, "id:eric@kup", second, fp2)
+	if err == nil {
+		t.Fatal("a second key for one identity was accepted silently")
+	}
+	if !strings.Contains(err.Error(), "DIFFERENT key") {
+		t.Errorf("the refusal does not name what happened: %v", err)
+	}
+	if n := len(tr.Roots[0].Authors); n != 1 {
+		t.Errorf("authors = %d after a refused second pin, want 1", n)
+	}
+}
+
+// An author key alone cannot create a root, because the chain also checks the
+// registry signature. The refusal has to name the fix, not the invariant: this
+// is the AC-08 lesson from verify-sig, applied before it could bite.
+func TestAddAuthorOnAnUnknownRegistryNamesTheFix(t *testing.T) {
+	dir := t.TempDir()
+	tr := &TrustRoots{Path: filepath.Join(dir, "roots.yaml")}
+	pub, fp := writePub(t, dir, "eric")
+
+	err := tr.AddAuthor("https://nobody.example/api/skills", "id:eric@kup", pub, fp)
+	if err == nil {
+		t.Fatal("an author key alone created a trust root")
+	}
+	if !strings.Contains(err.Error(), "skillctl trust add --registry") {
+		t.Errorf("the refusal does not tell the operator what to run: %v", err)
+	}
+}

--- a/pkg/skillctl/verify/trustroots.go
+++ b/pkg/skillctl/verify/trustroots.go
@@ -19,7 +19,9 @@ package verify
 // The verifier accepts ANY non-retired key during overlap.
 
 import (
+	"crypto/subtle"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -1233,4 +1235,114 @@ func deriveKeyID(rawPub []byte) string {
 // data-model file's hot path.
 var todayISO = func() string {
 	return nowISO()
+}
+
+// AddAuthor pins an AUTHOR key into a trust root's `authors:` list, refusing
+// unless the caller's out-of-band fingerprint matches the key.
+//
+// WHY IT EXISTS. `AddRegistry` pins the key that signs the registry's
+// statements; the offline paths (`verify --bundle`, `install --bundle`) check
+// the AUTHOR signature against `authors:`, and nothing wrote that list. Until
+// now the file had to be hand-written, which is the one place in this system
+// where a typo becomes a wrong pin that nobody notices, because a wrong pin
+// looks exactly like a correct one until the day it matters.
+//
+// THE FINGERPRINT IS REQUIRED, and that is the whole design. A key that arrives
+// with the artifact proves nothing: it came down the same untrusted channel. The
+// caller confirms sha256(pubkey) over a SECOND channel (a phone call, a video
+// call, in person) and passes it here; a mismatch is refused rather than
+// reported, because a fingerprint the operator did not actually compare is worse
+// than none at all. This is SPEC-0406 §3.2, and it is what makes AC-02 ("the
+// recipient need not trust the transport") a fact rather than a claim.
+//
+// The root is created with identity_keys_authorized: pinned, because a root that
+// carries a pinned author key and then fetches identities from a registry would
+// answer the author question two ways.
+func (t *TrustRoots) AddAuthor(registryURL, identityID, pubkeyPath, fingerprint string) error {
+	if t == nil {
+		return errors.New("trust-roots: AddAuthor called on nil")
+	}
+	registryURL = strings.TrimRight(strings.TrimSpace(registryURL), "/")
+	switch {
+	case registryURL == "":
+		return errors.New("trust-roots: --registry is required")
+	case strings.TrimSpace(identityID) == "":
+		return errors.New("trust-roots: --identity is required (the id in the bundle's author signature row)")
+	case pubkeyPath == "":
+		return errors.New("trust-roots: --pubkey is required")
+	case strings.TrimSpace(fingerprint) == "":
+		return errors.New("trust-roots: --pin is required; confirm sha256(pubkey) over a SECOND channel first (no trust-on-first-use)")
+	}
+	if err := validateRegistryURL(registryURL); err != nil {
+		return fmt.Errorf("trust-roots: %w", err)
+	}
+
+	pub, err := signing.LoadPublicKey(pubkeyPath)
+	if err != nil {
+		return fmt.Errorf("trust-roots: load pubkey %s: %w", pubkeyPath, err)
+	}
+	if len(pub) != pubkeyRawSize {
+		return fmt.Errorf("trust-roots: pubkey %s is %d bytes, want %d", pubkeyPath, len(pub), pubkeyRawSize)
+	}
+	raw := make([]byte, len(pub))
+	copy(raw, pub)
+
+	sum := sha256.Sum256(raw)
+	want := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(fingerprint, "sha256:")))
+	got := hex.EncodeToString(sum[:])
+	if subtle.ConstantTimeCompare([]byte(got), []byte(want)) != 1 {
+		return fmt.Errorf(
+			"trust-roots: the key in %s does not match the fingerprint you confirmed.\n"+
+				"  confirmed: sha256:%s\n"+
+				"  this key:  sha256:%s\n"+
+				"  Refusing. Do not re-send the key over the same channel: go back to the second "+
+				"channel and read the fingerprint again, because a mismatch here is either a typo "+
+				"or the one case this check exists for",
+			pubkeyPath, want, got)
+	}
+
+	ak := AuthorKey{ID: strings.TrimSpace(identityID), Pubkey: raw, PubkeyB64: base64.StdEncoding.EncodeToString(raw)}
+
+	if existing := t.findRegistry(registryURL); existing != nil {
+		for _, a := range existing.Authors {
+			if a.ID == ak.ID {
+				if a.PubkeyB64 == ak.PubkeyB64 {
+					return fmt.Errorf("trust-roots: author %s is already pinned with this exact key", ak.ID)
+				}
+				// A DIFFERENT key under the same identity is the interesting case:
+				// either a legitimate rotation or someone substituting an identity.
+				// Both are decisions, and neither is ours to make silently.
+				return fmt.Errorf(
+					"trust-roots: author %s is already pinned with a DIFFERENT key under %s.\n"+
+						"  Refusing to overwrite. If this is a key rotation, remove the old entry "+
+						"deliberately; if it is not, you have just been handed a second key for one identity",
+					ak.ID, registryURL)
+			}
+		}
+		existing.Authors = append(existing.Authors, ak)
+		if existing.IdentityKeysAuthorized != "pinned" {
+			existing.IdentityKeysAuthorized = "pinned"
+		}
+		return nil
+	}
+
+	// No entry for this registry yet, and an author key alone cannot make one.
+	//
+	// The chain checks the REGISTRY signature as well as the author's, so a root
+	// with only an author key would be refused later, during a verification, with
+	// a message about the chain. Saying it here instead costs the operator one
+	// command and saves them a failure they would have to trace backwards.
+	//
+	// The first version of this function created the entry anyway and let the
+	// schema validator reject it. The validator was right, but it answered with
+	// "registry_keys is empty (a registry with no keys is useless)", which names
+	// an invariant rather than an action. That is precisely the AC-08 failure this
+	// project has already corrected once, in verify-sig.
+	return fmt.Errorf(
+		"trust-roots: no entry for %s yet, and an author key alone is not enough.\n"+
+			"  why: the chain checks the REGISTRY signature too, so a root with only an\n"+
+			"       author key would be refused later, when you verify something.\n"+
+			"  fix: pin the registry key first, then re-run this command:\n"+
+			"       skillctl trust add --registry %s --pubkey <registry-key.pub>",
+		registryURL, registryURL)
 }


### PR DESCRIPTION
Gefunden durch eine Frage des Nutzers: er wollte den `peer add`-Locator fuer Schritt B3 der Runbooks wissen. **Es gibt keinen, weil `peer add` dort das falsche Kommando ist.**

## Der Befund

`install --bundle` und `verify --bundle` lesen die Trust-Roots ([install_bundle_cmds.go:74](../blob/master/cmd/skillctl/install_bundle_cmds.go#L74)) und pruefen dort den `authors:`-Block. `peer add` pinnt eine Peer-**Registry** fuer `pull` und macht nicht, dass der Bundle-Pfad dem Autorenschluessel der Gegenseite traut.

Und `trust add` pinnt nur Registry-Schluessel. Fuer `authors:` gab es **kein Kommando**: die Datei musste von Hand geschrieben werden. Das ist die eine Stelle im System, an der ein Tippfehler still zu einem falschen Pin wird, denn ein falscher Pin sieht aus wie ein richtiger, bis zu dem Tag, an dem es darauf ankommt.

Damit ist auch **Entscheidung D3 in SPEC-0406 falsch**, und sie fiel auf meine Empfehlung. Geprueft hatte ich „verweigert `peer add` Trust-on-First-Use?" (ja), nicht „pinnt es das, worauf der Bundle-Pfad schaut?" (nein). Die richtige Pruefung am falschen Gegenstand.

## Neu

```
skillctl trust fingerprint <key.pub>
skillctl trust add-author --registry <url> --identity <id> --pubkey <key.pub> --pin sha256:<hex>
```

`--pin` ist **Pflicht** und kein Formalismus. Ein Schluessel, der mit dem Artefakt kommt, beweist nichts: er kam denselben unsicheren Kanal herunter. Der Abgleich ueber einen zweiten Kanal ist das, was AC-02 von einer Behauptung zu einer Tatsache macht, und eine Abweichung wird **abgelehnt statt gemeldet**.

Ein eigenes Verb statt eines Flags an `trust add`, weil die beiden Verschiedenes pinnen und nur eines einen Schritt ausserhalb des Rechners verlangt. Als optionales Flag saehe der strenge Pfad wie die Variante des losen aus; es ist umgekehrt.

## Zwei Ablehnungen ohne Bequemlichkeit

Ein zweiter, **anderer** Schluessel unter derselben Identitaet wird abgelehnt statt angehaengt: Rotation oder Unterschiebung, beides Entscheidungen, keine davon unsere.

Ein Autorenschluessel allein kann keinen Trust-Root anlegen, weil die Kette auch die Registry-Signatur prueft. **Dieser Fall kam aus dem Lauf des echten Binaries:** die erste Fassung legte den Eintrag an und liess den Schema-Validator ablehnen, mit `registry_keys is empty (a registry with no keys is useless)`. Das benennt eine Invariante statt einer Handlung, genau der AC-08-Fehler, den dieses Projekt in `verify-sig` schon einmal korrigiert hat. Jetzt nennt die Meldung das Kommando, das fehlt.

## Nicht behauptet, mutiert

```
Pin-Pruefung abgeschaltet:  --- FAIL  a key that does not match the confirmed fingerprint was pinned
wiederhergestellt:          ok
```

Fuenf Tests: der falsche Pin, der fehlende Pin, der Happy Path samt Round-Trip und dem Umschalten auf `identity_keys_authorized: pinned`, der zweite Schluessel je Identitaet, und die unbekannte Registry.

Beide Runbooks sind korrigiert, `peer add` ist dort raus. Verb im Register.

Refs: SPEC-0406 §3.2 (Phase 0), AC-02, D3 (Korrektur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)