### PR TITLE
feat(release): der Akzeptanztest wird ein blockierendes Tor (SPEC-0406 REQ-9.2)

### DIFF
--- a/.github/workflows/skillctl-release.yml
+++ b/.github/workflows/skillctl-release.yml
@@ -87,6 +87,67 @@ jobs:
       - name: No U+2014 EM DASH in the tracked tree (CODESTYLE.md)
         run: ./scripts/check-no-emdash.sh
 
+  # 0b) ACCEPTANCE GATE (SPEC-0406 REQ-9.1 / REQ-9.2). BLOCKING, and placed
+  #     BEFORE the build on purpose: a failure has to stop the release, not be
+  #     reported next to a finished artifact. A gate that runs last is a report.
+  #
+  #     REQ-9.1 requires green on macOS AND Windows with the SAME build, so this
+  #     is a matrix over both and not a single runner. "The same version on both"
+  #     is only half the claim when one side is Windows and the other macOS: the
+  #     refusal paths are where the platforms actually differ (mode bits, path
+  #     handling, the WIN-09 home confinement).
+  #
+  #     Two things run, and they answer different questions. The Go test is the
+  #     two-party exchange with separate homes, keys and trust-roots, including
+  #     the tampering and the audit record (T01..T15). The twin script is what a
+  #     human runs by hand; running it here is what keeps the pair honest, since
+  #     a twin that only ever runs on the author's machine is a claim about the
+  #     other platform rather than a check of it.
+  #
+  #     Holds no signing identity (contents: read), so it does not touch the
+  #     SLSA L3 isolation argument below.
+  acceptance-gate:
+    name: "SPEC-0406 acceptance gate (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # report BOTH platforms: which one failed is the finding
+      matrix:
+        os: [macos-latest, windows-latest]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.6"
+
+      # The matrix rows must exercise the same code, so the binary is built the
+      # same way on both and the scripts are pointed at it explicitly rather
+      # than at whatever happens to be on PATH.
+      - name: Build skillctl
+        shell: bash
+        run: go build -o build/skillctl ./cmd/skillctl
+
+      - name: "T01..T15: the two-party exchange, hermetic"
+        shell: bash
+        run: go test -count=1 -run TestAcceptance_TwoParty ./cmd/skillctl/
+
+      - name: "Both install paths refuse the same artifact (BUG-0217)"
+        shell: bash
+        run: go test -count=1 -run TestBothInstallPaths ./pkg/skillctl/install/
+
+      - name: "Acceptance rehearsal, Unix twin"
+        if: runner.os != 'Windows'
+        run: bash scripts/skillctl-acceptance.sh --skillctl ./build/skillctl
+
+      - name: "Acceptance rehearsal, Windows twin"
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          powershell -ExecutionPolicy Bypass -File scripts\skillctl-acceptance.ps1 -Skillctl .\build\skillctl.exe
+          if ($LASTEXITCODE -ne 0) { Write-Error "acceptance rehearsal failed (exit $LASTEXITCODE)"; exit $LASTEXITCODE }
+
   # 1) BUILD: compiles the 5 arches and emits their digests. Holds NO signing
   #    identity (contents: read only): it CANNOT sign provenance, an attestation,
   #    or a blob. The only thing it hands the trusted generator is a base64 string
@@ -94,7 +155,7 @@ jobs:
   build:
     name: Build 5 arches + digests
     runs-on: ubuntu-latest
-    needs: [docs-gate]
+    needs: [docs-gate, acceptance-gate]
     permissions:
       contents: read
     outputs:
@@ -419,7 +480,7 @@ jobs:
   #    consumer recomputes it again. This job never trusts a stored bool.
   evidence:
     name: Assemble release-evidence bundle (Trust Binder)
-    needs: [docs-gate, build, provenance, cosign, verify, release, smoke]
+    needs: [docs-gate, acceptance-gate, build, provenance, cosign, verify, release, smoke]
     # Run whenever the draft was cut (release succeeded) EVEN IF the post-draft
     # smoke gate failed: a red smoke must be recorded as platform-smoke:fail /
     # enterprise_ready:false, not suppress the evidence entirely.
@@ -447,6 +508,7 @@ jobs:
           PROV_NAME: ${{ needs.provenance.outputs.provenance-name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           DOCAUDIT_RESULT: ${{ needs['docs-gate'].result }}
+          ACCEPTANCE_RESULT: ${{ needs['acceptance-gate'].result }}
           SBOM_RESULT: ${{ needs.build.result }}
           SLSA_RESULT: ${{ needs.verify.result }}
           COSIGN_RESULT: ${{ needs.cosign.result }}
@@ -486,6 +548,7 @@ jobs:
             -gate "govulncheck-cve=$(resolve 'govulncheck (reachable CVEs)')"
             -gate "gitleaks-secret=$(resolve 'gitleaks (secret scan)')"
             -gate "docaudit=${DOCAUDIT_RESULT}"
+            -gate "two-party-acceptance=${ACCEPTANCE_RESULT},note=SPEC-0406 T01..T15 on macOS AND Windows, blocking before the build (REQ-9.1/9.2). Covers the machine half only: whether two people on two machines compared a fingerprint out-of-band is Phase 0 and stays human"
             -gate "sbom=${SBOM_RESULT},note=CycloneDX SBOM is a blocking step of the build job"
             -gate "slsa-provenance=${SLSA_RESULT},note=slsa-verifier verify-artifact gate over the isolated L3 generator provenance"
             -gate "cosign-signature=${COSIGN_RESULT}"

--- a/scripts/tutorial-smoke.sh
+++ b/scripts/tutorial-smoke.sh
@@ -350,11 +350,12 @@ pause
 step "NEGATIVPROBE A: derselbe Pull ohne den gepinnten Reviewer"
 why "Die Attestierung liegt weiter im Repository, sie ist gueltig, und sie zaehlt
    trotzdem nicht. Vertrauen entsteht beim Empfaenger, nicht beim Sender.
-   Erwartet: gate 4 und Prozess-Exit 1."
+   Erwartet: gate 4 und Prozess-Exit 13 (FR-0122: der Pull-Pfad sendet seit dem
+   2026-09-06 typisierte Codes je Tor, statt jede Ablehnung als 1 zu melden)."
 
 write_trust_roots without-signers
 rm -rf "$CONSUMER_HOME/.claude/skills/hello-kup"
-run "pull ohne signers" 1 env HOME="$CONSUMER_HOME" "$SKILLCTL" pull \
+run "pull ohne signers" 13 env HOME="$CONSUMER_HOME" "$SKILLCTL" pull \
   --registry "local://$WS/registry.git" --skill hello-kup \
   --install --trust-mode --dry-run-install --no-checkpoint
 expect_in "die Ablehnung nennt das Governance-Tor" "gate 4"


### PR DESCRIPTION
Der letzte Bauschritt vor der Abnahme.

## Vor dem Build, nicht danach

`build.needs` nennt jetzt `acceptance-gate`. Das ist die eigentliche Entscheidung: ein Fehlschlag **stoppt** das Release, statt neben einem fertigen Artefakt berichtet zu werden. Ein Tor, das zuletzt laeuft, ist ein Bericht.

## Matrix ueber beide Plattformen

REQ-9.1 verlangt gruen auf macOS **und** Windows. „Dieselbe Version auf beiden Seiten" ist nur die halbe Aussage, wenn eine Seite Windows ist: die Ablehnungspfade sind genau die Stelle, an der sich die Plattformen unterscheiden (Rechtebits, Pfadbehandlung, die HOME-Confinement-Regel WIN-09). `fail-fast: false`, denn **welche** der beiden scheitert, ist der Befund.

Drei Dinge laufen, und sie beantworten Verschiedenes:

| | |
|---|---|
| `TestAcceptance_TwoParty` | der Austausch mit getrennten Homes, Schluesseln und Trust-Roots, Manipulation und Audit-Eintrag (T01..T15) |
| `TestBothInstallPaths` | beide Installationspfade lehnen dasselbe Artefakt ab (BUG-0217) |
| das Zwillingsskript | was ein Mensch von Hand faehrt |

Den Zwilling hier zu fahren ist das, was das Paar ehrlich haelt: ein Zwilling, der nur auf der Maschine seines Autors laeuft, ist eine Behauptung ueber die andere Plattform und keine Pruefung.

Das Tor haelt keine Signaturidentitaet (`contents: read`) und beruehrt das SLSA-L3-Isolationsargument nicht.

## Und im Trust Binder

Als Tor `two-party-acceptance` im Evidenz-Bundle, mit der Notiz, dass es die **maschinelle** Haelfte abdeckt. Ob zwei Menschen an zwei Maschinen einen Fingerabdruck ueber einen zweiten Kanal verglichen haben, ist Phase 0 und bleibt menschlich.

Ein Trust Binder, der seine Tore aufzaehlt und ausgerechnet das auslaesst, das die Spezifikation blockierend macht, behauptet mehr als er belegt.

## Gegengeprobt

```
Erwartung im Akzeptanztest absichtlich gebrochen:  4 FAIL-Zeilen
wiederhergestellt:                                 ok
```

Das Tor wuerde also greifen, statt gruen zu bleiben, waehrend der Test nichts mehr prueft.

Refs: SPEC-0406 REQ-9.1, REQ-9.2, S7

🤖 Generated with [Claude Code](https://claude.com/claude-code)