### PR TITLE
feat(pull): FR-0122, jede Ablehnung nennt ihre Ursache im Exit-Code

### DIFF
--- a/cmd/skillctl/pull_cmds.go
+++ b/cmd/skillctl/pull_cmds.go
@@ -26,8 +26,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kamir/m3c-tools/pkg/skillbundle"
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
 	"github.com/kamir/m3c-tools/pkg/skillctl/artifactauth"
+	"github.com/kamir/m3c-tools/pkg/skillctl/exitcode"
 	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
 	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
 )
@@ -155,7 +157,7 @@ func runPull(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, "       install aborts on ANY skip so a broken or revoked bundle can't ride in next to the good ones.")
 			fmt.Fprintln(stderr, "  fix: install a known-good subset with --skill <name> or --digest <sha256:…>, or remove/replace the skipped bundles.")
 		}
-		return 1
+		return skipExitCode(res.Skipped, stderr)
 	}
 
 	// ── P3 install path ──────────────────────────────────────────────────
@@ -227,6 +229,16 @@ func runPull(args []string, stdout, stderr io.Writer) int {
 		case errors.Is(err, registry.ErrUnsafeBundleName):
 			fmt.Fprintf(stderr, "pull --install: REFUSED: a staged bundle has an unsafe name.\n  detail: %v\n", err)
 			return 2
+		case errors.Is(err, skillbundle.ErrChecksumMismatch):
+			// SPEC-0188 §7 step 8. The chain verified and the bytes are the signed
+			// ones; the bundle's own manifest no longer describes them, which is an
+			// integrity failure and reported as one. Leaving it at a bare 1 would
+			// have reintroduced FR-0122 at the last step of the very path that
+			// motivated it: one refusal a caller still could not attribute.
+			fmt.Fprintf(stderr, "pull --install: REFUSED: the bundle's CHECKSUMS manifest does not describe its contents.\n  detail: %v\n", err)
+			fmt.Fprintln(stderr, "  why: SPEC-0188 §7 step 8 verifies the manifest after extraction; any failure in steps 3 to 8 means no write.")
+			fmt.Fprintln(stderr, "  fix: this is not a transport problem and retrying will not help. Ask the publisher to repack and re-sign.")
+			return exitcode.VerifyDigestMismatch.Number
 		default:
 			fmt.Fprintf(stderr, "pull --install: %v\n", err)
 			return 1
@@ -424,4 +436,57 @@ func resolvePullTrustRoots(registryName, trustPath string) (*registry.SelfTrustR
 	}
 	tr, lerr := registry.LoadSelfTrustRoots(trustPath)
 	return tr, "", lerr
+}
+
+// skipExitCode turns the gates that refused into a process exit code (FR-0122).
+//
+// The path used to return a bare 1 for every refusal. A caller, an audit record
+// and any automated policy see the SIGNAL, not the cause, so a revoked bundle and
+// an unsigned one were the same event to everything downstream. That matters most
+// for the case it matters most in: a revocation is never retried, and a transient
+// fetch failure always is.
+//
+// Four gates map onto the numbers SPEC-0188 §11 already assigns. The fifth had no
+// number at all: the specification named 15 for bundle_revoked, but 15 has meant
+// blob_missing in every shipped build (BUG-0216). Decided 2026-09-06: revocation
+// takes 20, the specification is corrected, and 15 keeps the meaning callers have.
+//
+// MIXED refusals stay 1, deliberately. One number cannot describe two causes, and
+// picking the "worst" would invent a ranking nothing else in this tool uses. The
+// caller is told, in words, that the rows differ and that the codes are per-gate.
+func skipExitCode(skipped []*registry.PullSkip, stderr io.Writer) int {
+	codes := map[int]bool{}
+	for _, k := range skipped {
+		codes[gateExit(k.Gate)] = true
+	}
+	if len(codes) == 1 {
+		for c := range codes {
+			return c
+		}
+	}
+	fmt.Fprintf(stderr, "\npull: %d bundle(s) were skipped for DIFFERENT reasons, so no single exit code describes the run.\n", len(skipped))
+	fmt.Fprintln(stderr, "  exit 1 here means \"more than one cause\"; the per-bundle gate is on each ❌ row above.")
+	return 1
+}
+
+// gateExit maps one gate to its code. An unrecognised or absent gate is 1: a
+// refusal whose cause this function does not know must not borrow a number that
+// promises a specific one.
+func gateExit(gate error) int {
+	switch {
+	case gate == nil:
+		return 1
+	case errors.Is(gate, registry.ErrGateEnvelope):
+		return exitcode.VerifyRegistryNotTrusted.Number
+	case errors.Is(gate, registry.ErrGateDigest):
+		return exitcode.VerifyDigestMismatch.Number
+	case errors.Is(gate, registry.ErrGateBundleSigs):
+		return exitcode.VerifyAuthorSigInvalid.Number
+	case errors.Is(gate, registry.ErrGateGovernance):
+		return exitcode.VerifyGovernanceBelowMin.Number
+	case errors.Is(gate, registry.ErrGateRevoked):
+		return exitcode.RevokedBundle.Number
+	default:
+		return 1
+	}
 }

--- a/pkg/skillctl/exitcode/registry.go
+++ b/pkg/skillctl/exitcode/registry.go
@@ -60,6 +60,27 @@ var (
 	VerifyDataSourceDenied   = Code{17, "data-source / source-policy", "verify", "data_source_denied"}
 	VerifyIntentInconsistent = Code{18, "intent contradiction", "verify", "intent_inconsistent"}
 	VerifyIdentityMismatch   = Code{19, "identity / source-block", "verify", "identity_mismatch"}
+
+	// RevokedBundle is the code SPEC-0188 §7 describes and the register did not
+	// have (BUG-0216). The specification named 15 for it, but 15 has meant
+	// blob_missing in shipped builds since the ladder existed, and a number whose
+	// meaning changes silently is worse than a number that was never allocated:
+	// a caller that reads 15 as "revoked" would treat a transport failure as a
+	// security verdict, and one that reads it as "blob missing" would retry a
+	// revocation. Decided 2026-09-06: bundle_revoked takes 20, the specification
+	// is corrected, and 15 keeps the meaning every existing caller already has.
+	//
+	// It sits outside the 10-19 verify ladder deliberately, and its family is
+	// "pull", not "verify". TestExitCode_VerifyFamilyCompleteness pins the verify
+	// family to exactly those ten numbers, and that pin is worth more than the
+	// convenience of reusing the name: the code is emitted by `pull --trust-mode`,
+	// which is the surface FR-0122 is about, so "pull" is also simply what is
+	// true. 20 is free, and below the skillgate band at 30-39.
+	//
+	// Its theme is its own because a revocation is not a failed check. The chain
+	// verified. Someone withdrew the bundle afterwards, and a caller has to be
+	// able to tell those two apart: one is retried, the other never is.
+	RevokedBundle = Code{20, "trust-chain revocation", "pull", "bundle_revoked"}
 )
 
 // ---------------------------------------------------------------------------
@@ -155,7 +176,7 @@ func AllCodes() []Code {
 		VerifyDigestMismatch, VerifyAuthorSigInvalid, VerifyRegistryNotTrusted,
 		VerifyGovernanceBelowMin, VerifyDepsUnsatisfied, VerifyBlobMissing,
 		VerifyTenantBlocked, VerifyDataSourceDenied, VerifyIntentInconsistent,
-		VerifyIdentityMismatch,
+		VerifyIdentityMismatch, RevokedBundle,
 		// Tier 2 (import-public
 		ImportPinRequired, ImportScannerRefuse, ImportNoSourcePolicy,
 		ImportIntentCapped, ImportSourceBlocked,

--- a/pkg/skillctl/sim/discrimination.go
+++ b/pkg/skillctl/sim/discrimination.go
@@ -215,9 +215,12 @@ func (rep Report) WriteDiscrimination(w io.Writer) {
 	}
 	fmt.Fprintf(w, "  A caller, an audit record and any automated policy see the SIGNAL, not the\n")
 	fmt.Fprintf(w, "  cause. Where one signal stands for several causes, they cannot tell them\n")
-	fmt.Fprintf(w, "  apart. pkg/skillctl/exitcode defines typed codes for exactly this and the\n")
-	fmt.Fprintf(w, "  pull path does not use them yet; its own header calls that an unfinished\n")
-	fmt.Fprintf(w, "  migration. Tracked as FR-0122.\n")
+	fmt.Fprintf(w, "  apart. Since FR-0122 was implemented on 2026-09-06 the pull path reports a\n")
+	fmt.Fprintf(w, "  typed code per gate (12, 10, 11, 13, 20), so an overload left here is no\n")
+	fmt.Fprintf(w, "  longer a missing code. Read the remaining ones as questions about the\n")
+	fmt.Fprintf(w, "  THREAT MODEL: a suppressed revoke makes a bundle ungoverned, and gate 4 is\n")
+	fmt.Fprintf(w, "  then the honest answer, because nothing in a plain git registry can tell a\n")
+	fmt.Fprintf(w, "  deleted event from one that was never written.\n")
 	fmt.Fprintf(w, "  This is a measurement of the OUTPUT CONTRACT. It says nothing about whether\n")
 	fmt.Fprintf(w, "  a human understands the message, which is not measured anywhere here.\n")
 }

--- a/pkg/skillctl/sim/generate.go
+++ b/pkg/skillctl/sim/generate.go
@@ -261,6 +261,36 @@ func whyGate(gate string, p Params) string {
 	return "SPEC-0188 §7"
 }
 
+// gateExit is the exit code the pull surface reports for each gate, decided on
+// 2026-09-06 under FR-0122 and pinned here.
+//
+// It is a DECISION carried into the model, not a reading taken off the binary.
+// The distinction is the one this package exists to keep: when the mapping landed,
+// the corpus went red with 59 conflicts, every one of them an exit code that had
+// changed from 1. That is what a pinned expectation is for. The numbers below were
+// then written from the decision record, and the conflicts cleared because the
+// binary agrees with the decision, not because the model was fitted to it.
+//
+// Gate 5 is 20 rather than the 15 SPEC-0188 named, because 15 has meant
+// blob_missing in every shipped build (BUG-0216) and a number whose meaning
+// changes silently is worse than one that was never allocated.
+func gateExit(gate string) int {
+	switch gate {
+	case "gate 1":
+		return 12 // registry_not_trusted
+	case "gate 2":
+		return 10 // digest_mismatch
+	case "gate 3":
+		return 11 // author_sig_invalid
+	case "gate 4":
+		return 13 // governance_below_min
+	case "gate 5":
+		return 20 // bundle_revoked
+	default:
+		return 1
+	}
+}
+
 func build(p Params) Scenario {
 	id := fmt.Sprintf("S-%s-%s-%s-%s%s", p.Cast, p.Key, p.Gov, p.Adv, map[bool]string{true: "-rev", false: ""}[p.Revoke])
 	sc := Scenario{
@@ -443,12 +473,14 @@ func build(p Params) Scenario {
 	// matrix says so. A specified check with no representation in the abstract
 	// model is exactly what the backwards pass exists to surface.
 	if p.Adv == AdvStaleChecksums && ok {
-		pullExpect = Expectation{Outcome: Refuse, Exit: 1, Claimed: true,
+		pullExpect = Expectation{Outcome: Refuse, Exit: 10, Claimed: true,
 			Why: "SPEC-0188 §7 step 8: the CHECKSUMS file inside the bundle is verified " +
-				"after extraction, and any failure in steps 3 to 8 means no write"}
+				"after extraction, and any failure in steps 3 to 8 means no write. Exit 10 " +
+				"(digest_mismatch) because it is an integrity failure, and because the other " +
+				"install path already reports it that way"}
 	}
 	if !ok {
-		pullExpect = Expectation{Outcome: Refuse, Gate: gate, Exit: 1, Claimed: true, Why: why}
+		pullExpect = Expectation{Outcome: Refuse, Gate: gate, Exit: gateExit(gate), Claimed: true, Why: why}
 	}
 	if p.Adv == AdvStolenKey && ok {
 		pullExpect.Claimed = false
@@ -521,7 +553,7 @@ func build(p Params) Scenario {
 					Expect: Expectation{Outcome: NoEffect, Exit: -1, Claimed: true,
 						Why: "the filename is an unsigned projection the store controls"}},
 				Step{Action: Action{Kind: ActPull, Actor: Consumer, Skill: skill},
-					Expect: Expectation{Outcome: Refuse, Gate: "gate 5", Exit: 1, Claimed: true,
+					Expect: Expectation{Outcome: Refuse, Gate: "gate 5", Exit: gateExit("gate 5"), Claimed: true,
 						Why: "FR-0090 IS-T1: identity comes from the SIGNED envelope, never from the path, so a relabelled revoke still revokes"}},
 			)
 		default:
@@ -534,7 +566,7 @@ func build(p Params) Scenario {
 			claimed2 := true
 			sc.Steps = append(sc.Steps, Step{
 				Action: Action{Kind: ActPull, Actor: Consumer, Skill: skill},
-				Expect: Expectation{Outcome: Refuse, Gate: gate2, Exit: 1, Claimed: claimed2,
+				Expect: Expectation{Outcome: Refuse, Gate: gate2, Exit: gateExit(gate2), Claimed: claimed2,
 					Why: why2},
 			})
 		}
@@ -555,7 +587,7 @@ func build(p Params) Scenario {
 					Expect: Expectation{Outcome: Accept, Exit: 0, Claimed: true,
 						Why: "posting an attestation is never gated; it is worth what the pull says it is worth"}},
 				Step{Action: Action{Kind: ActPull, Actor: Consumer, Skill: skill},
-					Expect: Expectation{Outcome: Refuse, Gate: "gate 5", Exit: 1, Claimed: true,
+					Expect: Expectation{Outcome: Refuse, Gate: "gate 5", Exit: gateExit("gate 5"), Claimed: true,
 						Why: "SPEC-0188 §7: a revoke is bound to a digest and outlives any later attestation; " +
 							"governance is not even consulted"}},
 			)

--- a/pkg/skillctl/sim/traceability.go
+++ b/pkg/skillctl/sim/traceability.go
@@ -158,7 +158,7 @@ func TraceMatrix() []TraceItem {
 			Note: "NEVER EVALUATED. Declared here and in model.go, checked by nothing. It " +
 				"needs a pair of runs, with and without the move, and the harness runs each " +
 				"scenario once. Reported as 0 evaluations rather than as a silent pass " +
-				"(FR-0125); a monotonicity property of the model, not a product requirement",
+				"(FR-0140); a monotonicity property of the model, not a product requirement",
 		},
 		{
 			ID: "INV-6", What: "a refusal leaves the install target byte-identical",


### PR DESCRIPTION
Die zweite Haelfte der Arbeit aus PR #221. Der wurde gemergt, waehrend hier noch zwei Commits nachkamen, also stehen sie in einem eigenen PR auf dem aktuellen master, statt still auf einem gemergten Zweig liegenzubleiben.

Der Pull-Pfad verliess jede Ablehnung mit einer nackten 1. Ein Aufrufer, ein Audit-Eintrag und jede automatische Richtlinie sehen das SIGNAL, nicht die Ursache, also waren ein widerrufenes Bundle und ein unsigniertes fuer alles Nachgelagerte dasselbe Ereignis. Das wiegt genau dort am schwersten, wo es am meisten zaehlt: einen Widerruf versucht man nie erneut, einen fehlenden Blob immer.

| Tor | Code | Bedeutung |
|---|---|---|
| 1 | 12 | registry_not_trusted |
| 2 | 10 | digest_mismatch |
| 3 | 11 | author_sig_invalid |
| 4 | 13 | governance_below_min |
| 5 | **20** | bundle_revoked (neu) |
| §7 Schritt 8 | 10 | CHECKSUMS im Bundle, als Integritaetsfehler |

Das fuenfte Tor hatte gar keine Nummer. Die Spezifikation nannte 15, aber 15 heisst in jedem ausgelieferten Build `blob_missing` (BUG-0216). Entschieden am 2026-09-06: der Widerruf bekommt die 20, die Spezifikation wird korrigiert, und 15 behaelt die Bedeutung, die jeder bestehende Aufrufer hat. Die 20 traegt die Familie `pull`, weil `TestExitCode_VerifyFamilyCompleteness` die Verify-Familie auf genau zehn Nummern pinnt und dieser Pin mehr wert ist als der Name.

Gemischte Ablehnungen bleiben absichtlich 1: eine Zahl kann nicht zwei Ursachen beschreiben. Der Aufrufer bekommt stattdessen einen Satz.

## Was die Simulation beigetragen hat

Als die Abbildung landete, ging der Korpus mit **59 Konflikten** rot, jeder davon ein Exit-Code, der sich von 1 geaendert hatte. Kein Unit-Test haette das gemeldet, weil jeder Teil fuer sich stimmte. Die Erwartungen wurden danach aus dem Entscheidungsprotokoll geschrieben, nicht aus der Messung, und der Unterschied steht als Kommentar an der Abbildungsfunktion.

Ursachen-Unterscheidbarkeit: von 5 Ursachen auf 4 Signale auf **6 auf 6**. Die eine verbleibende Ueberladung ist keine fehlende Nummer, sondern eine Grenze des Bedrohungsmodells.

Gegen den aktuellen master nachgemessen: 51 Szenarien, 333 Schritte, 0 Konflikte, Residuum 0.

Begleitendes Wartungs-PR: kamir/m3c-tools-maintenance#82.