### PR TITLE
fix(ci): der Windows-Zwilling ist nie gelaufen, zwei Ursachen

### DIFF
--- a/.github/workflows/skillctl-windows-smoke.yml
+++ b/.github/workflows/skillctl-windows-smoke.yml
@@ -59,6 +59,7 @@ jobs:
         run: |
           powershell -ExecutionPolicy Bypass -File scripts\skillctl-quickstart-windows.ps1
           if ($LASTEXITCODE -ne 0) { Write-Error "quickstart smoke failed (exit $LASTEXITCODE)"; exit $LASTEXITCODE }
+        shell: pwsh
 
       # SPEC-0406: the acceptance REHEARSAL, the Windows half of the twin pair.
       # Its Unix twin is scripts/skillctl-acceptance.sh; the two carry the same
@@ -71,7 +72,6 @@ jobs:
         run: |
           powershell -ExecutionPolicy Bypass -File scripts\skillctl-acceptance.ps1 -Skillctl $env:SKILLCTL
           if ($LASTEXITCODE -ne 0) { Write-Error "acceptance rehearsal failed (exit $LASTEXITCODE)"; exit $LASTEXITCODE }
-        shell: pwsh
         shell: pwsh
 
   # BUG-0193 regression guard: reproduce the FIELD environment, Windows PowerShell

--- a/scripts/skillctl-acceptance.ps1
+++ b/scripts/skillctl-acceptance.ps1
@@ -173,16 +173,23 @@ Says -Id "R2" -Needle $Version -Label "the build under test is named in the repo
 # checks it, then a tampered copy is checked too.
 function Exchange {
   param([string]$Who, [string]$Skill, [string]$Px)
-  $home = Join-Path $Work $Who
+  # NOT $home. That is a PowerShell AUTOMATIC variable and it is read-only: the
+  # assignment fails with VariableNotWritable, the variable keeps pointing at the
+  # real user profile, and every path built from it silently leaves the sandbox.
+  # The failure looked like a missing SKILL.md in C:\Users\runneradmin, four steps
+  # later. The Unix twin has no such collision, which is why only a Windows run
+  # could find it, and no Windows run had ever happened (the workflow file was
+  # rejected for a duplicate key).
+  $partyHome = Join-Path $Work $Who
   $key  = Join-Path $Work "$Who\keys\$Who"
-  $skb  = Join-Path $home "$Skill@1.0.0.skb"
-  $src  = Join-Path $home "src\$Skill"
+  $skb  = Join-Path $partyHome "$Skill@1.0.0.skb"
+  $src  = Join-Path $partyHome "src\$Skill"
 
-  Step -Id "$($Px)a" -Want 0 -Label "$Who`: packs the skill" -HomeDir $home `
+  Step -Id "$($Px)a" -Want 0 -Label "$Who`: packs the skill" -HomeDir $partyHome `
     -ArgList @("pack","--skill",$src,"-o",$skb,"--name",$Skill,"--version","1.0.0")
-  Step -Id "$($Px)b" -Want 0 -Label "$Who`: signs it" -HomeDir $home `
+  Step -Id "$($Px)b" -Want 0 -Label "$Who`: signs it" -HomeDir $partyHome `
     -ArgList @("sign","--key","$key.priv",$skb)
-  Step -Id "$($Px)c" -Want 0 -Label "$Who`: checks their OWN work before sending" -HomeDir $home `
+  Step -Id "$($Px)c" -Want 0 -Label "$Who`: checks their OWN work before sending" -HomeDir $partyHome `
     -ArgList @("verify-sig","--pubkey","$key.pub",$skb)
 
   # The artifact travels. Its signature travels with it, which is what actually
@@ -192,7 +199,7 @@ function Exchange {
     ForEach-Object { Copy-Item $_.FullName (Join-Path $Transport $_.Name) }
   $arrived = Join-Path $Transport (Split-Path $skb -Leaf)
 
-  Step -Id "$($Px)d" -Want 0 -Label "the unaltered artifact still verifies after transport" -HomeDir $home `
+  Step -Id "$($Px)d" -Want 0 -Label "the unaltered artifact still verifies after transport" -HomeDir $partyHome `
     -ArgList @("verify-sig","--pubkey","$key.pub",$arrived)
 
   # Now the tamper: a copy, altered, with the signature NOT re-made.
@@ -207,7 +214,7 @@ function Exchange {
   $bytes[200] = $bytes[200] -bxor 0xFF
   [System.IO.File]::WriteAllBytes($bad, $bytes)
 
-  Step -Id "$($Px)e" -Want 10 -Label "the altered artifact is REFUSED" -HomeDir $home `
+  Step -Id "$($Px)e" -Want 10 -Label "the altered artifact is REFUSED" -HomeDir $partyHome `
     -ArgList @("verify-sig","--pubkey","$key.pub",$bad)
   Says -Id "$($Px)f" -Needle "changed after signing" -Label "the refusal names the cause, not a missing file"
 }


### PR DESCRIPTION
Zwei Fehler, die einander verdeckt haben. Der zweite war unsichtbar, solange der erste bestand.

## 1. Die Workflow-Datei wurde abgewiesen

`skillctl-windows-smoke.yml` hatte im Schritt "Run acceptance rehearsal" zweimal `shell: pwsh`: beim Einfuegen des neuen Schrittes ist das `shell` des VORHERGEHENDEN an den neuen gerutscht. GitHub weist die Datei ab, der Lauf scheitert, bevor ein Job entsteht.

`yaml.safe_load` akzeptiert doppelte Schluessel und nimmt den letzten, eine lokale Syntaxpruefung sagt also "in Ordnung". Sichtbar erst mit einem Parser, der Duplikate zurueckweist.

```
2026-09-04 07:39 .. 2026-09-06 12:38   16x success
2026-09-06 12:39 .. 2026-09-06 14:00   14x failure, auf JEDEM Zweig
```

Der Lauf ist kein erforderlicher Check, deshalb hat es niemandem wehgetan. In diesen dreieinhalb Stunden sind neun PRs gemergt worden. Ein rotes Tor, das nichts blockiert, ist ein Tor, das niemand liest.

## 2. Der PowerShell-Zwilling schrieb in `$home`

Erst nachdem der Workflow ueberhaupt startete, wurde der eigentliche Fehler sichtbar. `Exchange` in `scripts/skillctl-acceptance.ps1` setzte `$home` auf das Sandbox-Verzeichnis der Partei. `$home` ist eine AUTOMATISCHE Variable von PowerShell und schreibgeschuetzt: die Zuweisung scheitert mit `VariableNotWritable`, die Variable zeigt weiter auf das echte Benutzerprofil, und jeder daraus gebaute Pfad verlaesst die Sandbox.

Gemeldet wurde es vier Schritte spaeter als etwas ganz anderes:

```
R3a FAIL  eric: packs the skill: wanted exit 0, got 1
          pack failed: skill dir "C:\Users\runneradmin\src\eric-demo-skill"
          must contain SKILL.md
```

Der Unix-Zwilling hat diese Kollision nicht, weil `home` dort eine gewoehnliche Shell-Variable ist. **Nur ein Windows-Lauf konnte es finden, und es hat nie einer stattgefunden.** Ein Zwilling, der nie laeuft, ist eine Behauptung ueber Windows und keine Pruefung, und genau das sollte er verhindern.

## Nachgewiesen

Per `workflow_dispatch` gegen diesen Zweig, weil der Push-Ausloeser nur bestimmte Zweige kennt:

```
vor Fix 2:   Quickstart Smoke (windows-latest)   failure    R3a..R4f FAIL
nach Fix 2:  Quickstart Smoke (windows-latest)   success
             Installer under Windows PowerShell 5.1        success
             R1 bis R4f  alle PASS
```

Der Zwei-Parteien-Akzeptanztest laeuft damit zum ersten Mal auf Windows durch, und das ist die Voraussetzung dafuer, dass das blockierende Release-Tor aus PR #223 auf beiden Betriebssystemen etwas aussagt.