### PR TITLE
fix(ci): ein Tor gegen Workflow-Dateien, die GitHub gar nicht erst annimmt

### DIFF
--- a/.github/workflows/pin-guard.yml
+++ b/.github/workflows/pin-guard.yml
@@ -47,6 +47,62 @@ jobs:
       # this is not a "mutable tag" hole. The exception is scoped to that exact
       # repo + workflows dir + a full 3-part semver tag; everything else (incl.
       # slsa-verifier's own installer action) must still be a 40-hex SHA.
+      # (0) A workflow file GitHub will not even parse is worse than a failing
+      #     job: no job is created, the run dies before any step, and the only
+      #     message is "This run likely failed because of a workflow file issue".
+      #
+      #     This gate exists because that happened on 2026-09-06: a duplicated
+      #     `shell:` key slipped into skillctl-windows-smoke.yml, GitHub rejected
+      #     the file, and 14 runs failed across every branch for three and a half
+      #     hours while nine PRs were merged. Nobody noticed, for two reasons
+      #     worth writing down.
+      #
+      #     FIRST, the author validated with `yaml.safe_load`, which ACCEPTS
+      #     duplicate keys and silently keeps the last one. The check reported
+      #     "YAML OK" and could not have said anything else: it was the right
+      #     tool answering a different question. Only a parser that REFUSES
+      #     duplicates can see this class, which is why the one below refuses.
+      #
+      #     SECOND, the affected run is not a required check, so a red workflow
+      #     blocked nothing. A gate nobody has to pass is a report.
+      - name: "Guard: every workflow parses, with NO duplicate keys"
+        run: |
+          python3 - <<'PY'
+          import glob, sys, yaml
+
+          class Strict(yaml.SafeLoader):
+              pass
+
+          def no_duplicate_keys(loader, node, deep=False):
+              seen, out = set(), {}
+              for k, v in node.value:
+                  key = loader.construct_object(k, deep=deep)
+                  if key in seen:
+                      raise ValueError(
+                          f"duplicate key {key!r} at line {k.start_mark.line + 1}")
+                  seen.add(key)
+                  out[key] = loader.construct_object(v, deep=deep)
+              return out
+
+          Strict.add_constructor(
+              yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_duplicate_keys)
+
+          bad = 0
+          for f in sorted(glob.glob(".github/workflows/*.yml")):
+              try:
+                  yaml.load(open(f), Strict)
+              except Exception as e:
+                  print(f"FAIL {f}: {e}")
+                  bad += 1
+          if bad:
+              print("")
+              print("A duplicate key is silently accepted by most YAML readers and")
+              print("rejected by GitHub. Fix the file; do not re-check with a loader")
+              print("that tolerates it.")
+              sys.exit(1)
+          print("OK: every workflow parses and carries no duplicate key.")
+          PY
+
       - name: "Guard: all `uses:` refs are pinned to a 40-hex SHA"
         run: |
           set -euo pipefail


### PR DESCRIPTION
Aus meinem eigenen Fehler von heute, und er hat dreieinhalb Stunden lang nichts gemeldet.

## Was passiert ist

Beim Einhaengen des Zwillingsskripts in `skillctl-windows-smoke.yml` (PR #218) ist ein **zweites `shell: pwsh`** in denselben Schritt geraten. GitHub weist die Datei ab, es entsteht **kein Job**, und die einzige Meldung lautet „This run likely failed because of a workflow file issue".

```
2026-09-04 07:39 .. 2026-09-06 12:38   16x success
2026-09-06 12:39 .. 2026-09-06 14:00   14x failure, auf JEDEM Zweig
```

Mein eigener Release-Tor-Merge (`0b8dacc`) liegt mitten in diesem Fenster.

## Zwei Gruende, warum es niemand sah

**Erstens: ich habe mit `yaml.safe_load` geprueft und dreimal „YAML OK" gemeldet.** Der Loader akzeptiert doppelte Schluessel und behaelt still den letzten. Die Pruefung konnte gar nichts anderes sagen. Das richtige Werkzeug, auf eine andere Frage angewendet, und damit dieselbe Fehlerform wie beim Slot-Register und bei `peer add` heute.

**Zweitens: der betroffene Lauf ist kein erforderlicher Check.** Ein rotes Workflow blockierte nichts. Ein Tor, das niemand bestehen muss, ist ein Bericht.

## Der Fix

Eingehaengt im `pin-guard`, weil der ohnehin ueber alle Workflows laeuft **und ein erforderlicher Check ist**. Er prueft ab jetzt zuerst, ob die Datei ueberhaupt parst, bevor er ihre Inhalte beurteilt: eine Datei, die GitHub ablehnt, kann keine gepinnten Refs haben, die etwas bedeuten.

## Selbstprobe statt Behauptung

```
doppelter Schluessel wiederhergestellt:  FAIL <datei>: duplicate key ... at line N   exit 1
sauberer Baum:                           OK: every workflow parses and carries no duplicate key
```

## Der zweite Fehler desselben Vorgangs

`$home` ist in PowerShell eine schreibgeschuetzte automatische Variable; die Zuweisung im Zwillingsskript scheiterte still und jeder Pfad verliess die Sandbox. Bereits von einer Nachbarsitzung behoben (PR #225, `$partyHome`).

Er war nur deshalb so lange unsichtbar, weil die Datei, die ihn haette finden muessen, gar nicht ausgefuehrt wurde. Mein eigener Kommentar an diesem Schritt hatte es vorweggenommen: *„ein Zwilling, der nur auf der Maschine seines Autors laeuft, ist eine Behauptung ueber die andere Plattform und keine Pruefung."* Genau das war eingetreten.

Refs: PR #218 (Ursache), PR #225 (der zweite Fehler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)