### PR TITLE
feat(registry): FR-0117, der HTTP-Client authentifiziert sich (Bearer)

### DIFF
--- a/cmd/skillctl/attest_cmds.go
+++ b/cmd/skillctl/attest_cmds.go
@@ -39,6 +39,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
 	"github.com/kamir/m3c-tools/pkg/skillctl/signing"
 )
 
@@ -249,6 +250,14 @@ func runAttestWithClient(
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "skillctl/spec-0188")
 
+	// FR-0117. attest is the WRITE surface of the HTTP registry, so it asks for
+	// the write tier. Empty stays anonymous, which is what a public instance
+	// wants and what every existing test drives.
+	tok := registryToken(*registry, artifact.ModeWrite)
+	if tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: *timeoutFlag}
 	}
@@ -265,6 +274,13 @@ func runAttestWithClient(
 		return exitGeneric
 	}
 
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		// Say which of the two it is. "401" alone cannot distinguish a machine
+		// with no credential from a credential that was refused, and the two
+		// have different next actions.
+		_ = explainUnauthorized(stderr, *registry, tok != "", fmt.Errorf("%s: %w", resp.Status, errRegistryUnauthorized))
+		return exitGeneric
+	}
 	if resp.StatusCode != http.StatusCreated {
 		fmt.Fprintf(stderr, "skillctl attest: registry returned %s\n", resp.Status)
 		if len(respBody) > 0 {

--- a/cmd/skillctl/export_bundle_cmds.go
+++ b/cmd/skillctl/export_bundle_cmds.go
@@ -96,7 +96,7 @@ func runExportBundle(args []string, stdout, stderr io.Writer) int {
 	}
 
 	ctx := context.Background()
-	c := registry.New(root.RegistryURL, install.HTTPClientOf(*timeout))
+	c := newRegistryClient(root.RegistryURL, install.HTTPClientOf(*timeout))
 
 	digest, resolvedVersion, err := resolveExportDigest(ctx, c, name, wantVersion)
 	if err != nil {

--- a/cmd/skillctl/install_cmds.go
+++ b/cmd/skillctl/install_cmds.go
@@ -153,7 +153,7 @@ func runInstall(args []string, stdout, stderr io.Writer) (code int) {
 
 	// Build a registry HTTP client targeting the matched trust root.
 	httpClient := install.HTTPClientOf(*timeout)
-	c := registry.New(root.RegistryURL, httpClient)
+	c := newRegistryClient(root.RegistryURL, httpClient)
 
 	// Audit poster targets the same registry. The CLI does NOT carry a
 	// separate audit URL: keeping the configuration surface narrow.
@@ -357,7 +357,7 @@ func runVerify(args []string, stdout, stderr io.Writer) (code int) {
 	}
 
 	httpClient := install.HTTPClientOf(*timeout)
-	c := registry.New(root.RegistryURL, httpClient)
+	c := newRegistryClient(root.RegistryURL, httpClient)
 
 	res, err := install.VerifyInstalled(install.Opts{
 		Name:          name,

--- a/cmd/skillctl/intent_cmds.go
+++ b/cmd/skillctl/intent_cmds.go
@@ -293,7 +293,7 @@ func runIntentDeclareWithClient(opts intentDeclareOpts, stdout, stderr io.Writer
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: opts.timeout}
 	}
-	c := registry.New(opts.registryURL, httpClient)
+	c := newRegistryClient(opts.registryURL, httpClient)
 
 	// Resolve digest. `@sha256:...` short-circuits; otherwise call the
 	// resolver (default = ResolveByName, picks newest admitted).
@@ -422,7 +422,7 @@ func runIntentShow(args []string, stdout, stderr io.Writer) int {
 	}
 
 	httpClient := &http.Client{Timeout: *timeout}
-	c := registry.New(*registryURL, httpClient)
+	c := newRegistryClient(*registryURL, httpClient)
 	ctx := context.Background()
 	digest, err := resolveSkillDigest(ctx, c, skill, nil)
 	if err != nil {

--- a/cmd/skillctl/registry_client.go
+++ b/cmd/skillctl/registry_client.go
@@ -1,0 +1,101 @@
+package main
+
+// registry_client.go resolves the credential for the HTTP registry and hands
+// back a client that carries it (FR-0117).
+//
+// The resolution lives here, at the command layer, and not in pkg/skillctl/registry.
+// That package is the transport: it should be drivable from a test without an
+// environment, a keychain or a home directory, and a future credential source
+// should be changeable without touching it. The git backends already work this
+// way, with credentials injected through artifact.OpenOptions, and this is the
+// same seam for the third backend.
+//
+// Anonymous stays the default. A registry that serves its endpoints without
+// authentication keeps working for someone who provisioned nothing, which is how
+// the public path and every existing test behave.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifactauth"
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+)
+
+// errRegistryUnauthorized is registry.ErrUnauthorized under a local name.
+//
+// attest_cmds.go has a flag variable called `registry`, which shadows the
+// package name in that file, so it cannot write registry.ErrUnauthorized. Naming
+// it once here is cheaper than renaming a flag that appears in documented output.
+var errRegistryUnauthorized = registry.ErrUnauthorized
+
+// registryCredScheme is the key artifactauth uses for the HTTP registry tier.
+const registryCredScheme = "registry"
+
+// newRegistryClient builds a registry client for baseURL with whatever token is
+// provisioned for its host, or none.
+//
+// The tier matters: an operator who provisioned only a write token gets it for
+// both, which is the existing single-token behaviour; one who also provisioned a
+// read-only token never transmits the write token on a read.
+// newRegistryClient builds a READ client. Every registry.Client in this binary
+// reads: pull, verify, export. The write surface is `attest`, which posts a raw
+// request and takes its token from registryToken directly.
+func newRegistryClient(baseURL string, httpClient *http.Client) *registry.Client {
+	c := registry.New(baseURL, httpClient)
+	c.Token = registryToken(baseURL, artifact.ModeRead)
+	return c
+}
+
+// registryToken resolves the token for baseURL's host, or "" for anonymous.
+//
+// Every failure path is silent and yields anonymous on purpose: a missing
+// keychain entry, an unparsable URL or a locked store must not stop a command
+// that may not need a credential at all. What must NOT be silent is the refusal
+// that follows, and that is what explainUnauthorized is for.
+func registryToken(baseURL string, mode artifact.AccessMode) string {
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	cred, err := artifactauth.New().Credential(context.Background(), registryCredScheme, u.Host, mode)
+	if err != nil {
+		return ""
+	}
+	return cred.Token
+}
+
+// explainUnauthorized turns a 401 or 403 into a message that names the next
+// action, and returns err unchanged for anything else.
+//
+// The point is the distinction a bare status code cannot make: whether no
+// credential was sent (provision one) or the one sent was rejected (it is wrong,
+// expired or lacks the scope). The client knows which, because it knows whether
+// it set the header.
+func explainUnauthorized(w io.Writer, baseURL string, sent bool, err error) error {
+	if !errors.Is(err, registry.ErrUnauthorized) {
+		return err
+	}
+	host := baseURL
+	if u, perr := url.Parse(baseURL); perr == nil && u.Host != "" {
+		host = u.Host
+	}
+	if sent {
+		fmt.Fprintf(w, "registry %s: the token was REJECTED.\n", host)
+		fmt.Fprintln(w, "  why: it is wrong, expired, or lacks the scope this endpoint needs.")
+		fmt.Fprintf(w, "  fix: issue a new token and replace it, then re-run. See docs/ops-registry-tokens.de.md\n")
+		return err
+	}
+	fmt.Fprintf(w, "registry %s: this instance requires authentication and NO token was sent.\n", host)
+	fmt.Fprintln(w, "  why: no credential is provisioned on this machine for that host.")
+	fmt.Fprintf(w, "  fix: provide one of, in this order of precedence:\n")
+	fmt.Fprintf(w, "         env   M3C_REGISTRY_TOKEN (read-only: M3C_REGISTRY_RO_TOKEN)\n")
+	fmt.Fprintf(w, "         macOS security add-generic-password -s m3c-skillctl-registry -a %s -w '<token>' -U\n", host)
+	fmt.Fprintln(w, "  The full routine, including how a KuP account issues the token: docs/ops-registry-tokens.de.md")
+	return err
+}

--- a/cmd/skillctl/verify_all_cmds.go
+++ b/cmd/skillctl/verify_all_cmds.go
@@ -134,7 +134,7 @@ func runVerifyAll(args []string, stdout, stderr io.Writer) int {
 	var sc sweepCtx
 	if rootErr == nil {
 		sc = sweepCtx{
-			client: registry.New(root.RegistryURL, install.HTTPClientOf(verifyHookTimeout)),
+			client: newRegistryClient(root.RegistryURL, install.HTTPClientOf(verifyHookTimeout)),
 			root:   root,
 			tenant: resolveTenant("", tr),
 			govMin: *governanceMin,

--- a/cmd/skillctl/verify_hook_cmds.go
+++ b/cmd/skillctl/verify_hook_cmds.go
@@ -673,7 +673,7 @@ func verifyManagedSkill(name string, pol gatePolicy) (int, string) {
 	}
 	tenant := resolveTenant("", tr)
 	httpClient := install.HTTPClientOf(verifyHookTimeout)
-	c := registry.New(root.RegistryURL, httpClient)
+	c := newRegistryClient(root.RegistryURL, httpClient)
 
 	_, err = install.VerifyInstalled(install.Opts{
 		Name:          name,

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,7 @@ agent skills that act on it (sign, admit, verify, revoke: offline-verifiable).
 - [Tutorial, Szenario 01 (Deutsch)](tutorial-szenario-01-eigene-skills-mehrere-maschinen.de): eigene Skills auf mehreren Maschinen, plus fremde signierte Skills
 - [Tutorial, Szenario 02 (Deutsch)](tutorial-szenario-02-erster-signierter-skill.de): der erste signierte Skill, mit Prüfung durch einen Zweiten
 - [Tutorial, Katas und Test Ride (Deutsch)](tutorial-katas-und-test-ride.de): üben statt zusehen, jeder Beat ein echter Exit-Code
+- [Ops-Routine: Zugangstoken (Deutsch)](ops-registry-tokens.de): wer welchen Token besorgt, wo er liegt, und was beim Ausscheiden passiert
 - [CISO onboarding deck](skillctl-ciso-deck.html): sharp, honest arguments to defend skillctl to a security expert + a CTO (infographic)
 - [CISO-Onboarding-Deck (Deutsch)](skillctl-ciso-deck.de.html): dieselben Argumente auf Deutsch
 - [Menu Bar App](menubar-app): channels, Observation Window, menu items

--- a/docs/ops-registry-tokens.de.md
+++ b/docs/ops-registry-tokens.de.md
@@ -1,0 +1,181 @@
+# Ops-Routine: Zugangstoken für Registry und Skill-Repository
+
+Wer welchen Token besorgt, woher, wo er liegt, und was beim Ausscheiden passiert.
+Gedacht für den echten Betrieb bei einem Kunden mit eigener GitLab-Instanz.
+
+Zielgruppe: die Person, die eine Maschine einrichtet, und die Person, die das
+Registry betreibt. Beide brauchen jeweils nur ihren eigenen Abschnitt.
+
+## Die Grundregel in einem Satz
+
+**Der Token entscheidet, wer die Bytes bewegen darf. Der Schlüssel entscheidet,
+wem sie zugerechnet werden.** Die beiden sind getrennt, und deshalb ist es keine
+Schwächung, wenn ein Token einem Projekt gehört statt einer Person.
+
+Daraus folgt die ganze Routine:
+
+| | Woher | Wem gehört er | Warum |
+|---|---|---|---|
+| **Lesen** (`pull`, `verify`, `install`) | GitLab-Konto der Mitarbeiterin | der Person | Beim Ausscheiden endet der Zugang von selbst |
+| **Schreiben** (`publish`, `attest`) | Projekt-Einstellungen des Registry | dem Projekt | Das Registry überlebt einen Personalwechsel |
+
+Die zweite Zeile ist die einzige Stelle, an der diese Routine von der nächstliegenden
+Lösung abweicht, und der Grund steht unten unter "Warum Schreibtoken nicht persönlich sind".
+
+## Teil A: eine Mitarbeiterin richtet ihre Maschine ein (Lesen)
+
+Dauer: zwei Minuten. Kein Adminrecht nötig.
+
+**1. Token im eigenen GitLab-Konto erzeugen.**
+
+> Profil → Zugriffstoken (Access Tokens) → Neuen Token hinzufügen
+> Name: `skillctl-lesen-<maschinenname>`
+> Ablaufdatum: setzen, höchstens 12 Monate
+> Bereiche (Scopes): **`read_api`** und **`read_repository`**, sonst nichts
+
+Der Token wird **einmal** angezeigt. Danach nie wieder.
+
+**2. Token ablegen.**
+
+macOS:
+
+```bash
+security add-generic-password -s m3c-skillctl-gitlab-ro -a <gitlab-host> -w '<token>' -U
+```
+
+Wobei `<gitlab-host>` genau der Host aus dem Registry-Locator ist, also z. B.
+`gitlab.example.de` bei `gitlab://gitlab.example.de/gruppe/skill-registry`.
+
+Für ein HTTP-Registry (`--registry https://…/api/skills`) heisst der Dienst
+`m3c-skillctl-registry-ro` statt `m3c-skillctl-gitlab-ro`.
+
+Windows: siehe "Offener Punkt" am Ende. Heute bleibt dort nur die Umgebungsvariable.
+
+Alternativ, auf jeder Plattform und für CI der Normalfall:
+
+```bash
+export M3C_GITLAB_RO_TOKEN='<token>'      # Git-Registry
+export M3C_REGISTRY_RO_TOKEN='<token>'    # HTTP-Registry
+```
+
+**3. Prüfen.**
+
+```bash
+skillctl pull --registry gitlab://<host>/<gruppe>/<projekt> --skill <name> --dry-run-install
+```
+
+Erwartet: die Tore laufen durch. Bei `401` sagt das Werkzeug seit FR-0117
+ausdrücklich, ob **kein** Token gesendet wurde oder ob der gesendete **abgelehnt**
+wurde. Das sind zwei verschiedene Fehler mit zwei verschiedenen nächsten Schritten.
+
+**4. Eintrag ins Token-Register.** Eine Zeile, siehe Teil C.
+
+## Teil B: das Registry wird eingerichtet (Schreiben)
+
+Macht die Person, die das Registry betreibt. Einmal je Registry, nicht je Mensch.
+
+**1. Projekt anlegen.** Ein leeres GitLab-Projekt, z. B. `<gruppe>/skill-registry`.
+Kein Inhalt, kein README: `skillctl registry init` schreibt die Struktur.
+
+**2. Project Access Token erzeugen.**
+
+> Projekt → Einstellungen → Zugriffstoken → Neuen Token hinzufügen
+> Name: `skillctl-publish`
+> Rolle: **Maintainer**
+> Bereiche: **`write_repository`**
+> Ablaufdatum: setzen, höchstens 12 Monate
+
+**Kein Deploy Token.** GitLab lässt `write_repository` als Deploy-Token-Bereich
+nicht zu, und der Standard-Branch ist auf Maintainer-Ebene geschützt. Ein Deploy
+Token scheitert beim Push, und die Fehlermeldung sagt nicht, warum.
+
+**3. Ablegen wie in Teil A**, aber unter dem Schreib-Dienst:
+
+```bash
+security add-generic-password -s m3c-skillctl-gitlab -a <gitlab-host> -w '<token>' -U
+# oder
+export M3C_GITLAB_TOKEN='<token>'
+```
+
+**4. Prüfen.**
+
+```bash
+skillctl registry init --registry gitlab://<host>/<gruppe>/skill-registry
+skillctl publish <name>@<version> --bundle <datei>.skb --registry gitlab://… --yes
+```
+
+## Warum Schreibtoken nicht persönlich sind
+
+Der naheliegende Weg wäre, auch das Schreiben über das persönliche Konto laufen
+zu lassen. Er hat zwei Folgen, die erst später auffallen:
+
+1. **Das Registry stirbt mit dem Konto.** Scheidet die Person aus, kann niemand
+   mehr aufnehmen, bis jemand merkt, woran es liegt. Beim Lesen ist genau das
+   erwünscht, beim Schreiben ist es ein Ausfall.
+2. **Es sieht nach Zurechenbarkeit aus, ist aber keine.** Wer aufgenommen hat,
+   steht in der **Signatur** des Admit-Ereignisses, nicht im Token. Ein
+   persönlicher Schreibtoken fügt der Zurechnung nichts hinzu und nimmt der
+   Verfügbarkeit etwas weg.
+
+Die Trennung kostet nichts: die Aufnahme wird weiterhin mit dem persönlichen
+Schlüssel signiert, und der Pull prüft genau diese Signatur.
+
+## Was bei einem Personalwechsel passiert
+
+| Fall | Zu tun |
+|---|---|
+| Mitarbeiterin scheidet aus | Nichts. Ihr Lesetoken endet mit ihrem Konto. |
+| Maschine wird ersetzt | Neuen Lesetoken erzeugen, alten in GitLab widerrufen, Registerzeile ersetzen. |
+| Registry-Betreiber wechselt | Project Access Token rotieren; das Projekt und alle Lesetoken bleiben. |
+| Token abgelaufen | GitLab meldet es nicht vorab. Deshalb Teil C. |
+| Token kompromittiert | In GitLab widerrufen. Das ist die einzige Stelle, die wirklich zählt; der lokale Eintrag ist danach nur noch Müll. |
+
+Ein Widerruf in GitLab wirkt sofort und ohne Zutun der Maschine. Das lokale
+Löschen (Keychain-Eintrag entfernen) ist Hygiene, keine Sicherheitsmassnahme.
+
+## Teil C: das Token-Register
+
+Ohne Register läuft ein Token ab, und niemand weiss, welcher es war. Eine Zeile
+je ausgestelltem Token, im Wartungsrepo unter `OPS/token-register.md`:
+
+| Registry | Zweck | Inhaber | Ausgestellt | Läuft ab | Widerrufen am |
+|---|---|---|---|---|---|
+| `gitlab://…/skill-registry` | lesen, Laptop Anna | Anna | 2026-09-06 | 2027-09-01 | n/a |
+| `gitlab://…/skill-registry` | schreiben, publish | Projekt | 2026-09-06 | 2027-09-01 | n/a |
+
+Kein Token im Register, nur die Tatsache seiner Existenz. Wer das Register liest,
+soll wissen, **was abläuft**, nicht **womit man sich anmeldet**.
+
+Erfüllt AC-14 aus SPEC-0407 und REQ-3.15.
+
+## Reihenfolge, in der gesucht wird
+
+Findet `skillctl` nichts, arbeitet es anonym weiter. Das ist Absicht: eine
+öffentliche Instanz soll ohne Einrichtung funktionieren.
+
+```
+1. Umgebungsvariable      M3C_GITLAB_RO_TOKEN → M3C_GITLAB_TOKEN
+                          M3C_REGISTRY_RO_TOKEN → M3C_REGISTRY_TOKEN
+2. macOS-Keychain         m3c-skillctl-gitlab-ro → m3c-skillctl-gitlab
+                          m3c-skillctl-registry-ro → m3c-skillctl-registry
+3. Windows-Speicher       DPAPI, je Benutzerkonto
+4. sonst                  anonym
+```
+
+Auf einem Lesepfad wird zuerst der Lesetoken gesucht und nur ersatzweise der
+Schreibtoken genommen. Wer beide hinterlegt hat, schickt auf einem `pull` nie den
+Schreibtoken über die Leitung.
+
+## Offener Punkt: Windows
+
+Auf Windows gibt es heute **keinen** Weg, den Token in den geschützten Speicher zu
+legen. Die Funktion dafür ist gebaut (DPAPI, je Benutzerkonto verschlüsselt), aber
+kein Kommando ruft sie auf. Es bleibt die Umgebungsvariable, also ein
+Schreibtoken im Klartext im Prozessumfeld, vererbt an jeden Kindprozess.
+
+Für Lesetoken ist das vertretbar. Für den Schreibtoken eines Registry ist es das
+nicht, und deshalb sollte das Registry vorerst von einer macOS- oder
+Linux-Maschine aus bedient werden, bis ein `skillctl token set` existiert.
+
+Diese Einschränkung ist der einzige Punkt, an dem diese Routine heute nicht auf
+beiden Betriebssystemen gleich gut ist.

--- a/pkg/skillctl/artifactauth/creds.go
+++ b/pkg/skillctl/artifactauth/creds.go
@@ -42,6 +42,13 @@ var _ artifact.CredentialSource = (*Resolver)(nil)
 var backendCred = map[string]struct{ env, roEnv, kcService, roKcService, user string }{
 	"gitlab": {"M3C_GITLAB_TOKEN", "M3C_GITLAB_RO_TOKEN", "m3c-skillctl-gitlab", "m3c-skillctl-gitlab-ro", "oauth2"},
 	"github": {"M3C_GITHUB_TOKEN", "M3C_GITHUB_RO_TOKEN", "m3c-skillctl-github", "m3c-skillctl-github-ro", "oauth2"},
+
+	// The HTTP registry (SPEC-0188 /api/skills), added 2026-09-06 for FR-0117.
+	// It is not a git remote, so it carries no git username: the token rides in
+	// an `Authorization: Bearer` header, not in a URL. Same two tiers as the git
+	// backends, and the same anonymous fallback, so a public instance keeps
+	// working for someone who provisioned nothing.
+	"registry": {"M3C_REGISTRY_TOKEN", "M3C_REGISTRY_RO_TOKEN", "m3c-skillctl-registry", "m3c-skillctl-registry-ro", ""},
 }
 
 // Credential resolves the token for (scheme, host, mode). host lets one machine

--- a/pkg/skillctl/artifactauth/registry_tier_test.go
+++ b/pkg/skillctl/artifactauth/registry_tier_test.go
@@ -1,0 +1,60 @@
+package artifactauth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifact"
+)
+
+// The read tier is preferred on a read, and the write tier is the fallback. An
+// operator who provisioned both must never transmit the write token on a pull;
+// one who provisioned only the write token must keep working.
+func TestRegistryTierPrecedence(t *testing.T) {
+	t.Setenv("M3C_REGISTRY_TOKEN", "write-token")
+	t.Setenv("M3C_REGISTRY_RO_TOKEN", "read-token")
+
+	got, err := New().Credential(context.Background(), "registry", "reg.example", artifact.ModeRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Token != "read-token" {
+		t.Errorf("read mode took %q, want the read tier", got.Token)
+	}
+
+	got, err = New().Credential(context.Background(), "registry", "reg.example", artifact.ModeWrite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Token != "write-token" {
+		t.Errorf("write mode took %q, want the write tier", got.Token)
+	}
+}
+
+func TestRegistryReadFallsBackToTheWriteTier(t *testing.T) {
+	t.Setenv("M3C_REGISTRY_TOKEN", "write-token")
+	t.Setenv("M3C_REGISTRY_RO_TOKEN", "")
+
+	got, err := New().Credential(context.Background(), "registry", "reg.example", artifact.ModeRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Token != "write-token" {
+		t.Errorf("a single-token setup must keep working; got %q", got.Token)
+	}
+}
+
+// Nothing provisioned is anonymous with a nil error, not a failure: a public
+// instance has to keep working for someone who set nothing up.
+func TestRegistryWithoutCredentialIsAnonymous(t *testing.T) {
+	t.Setenv("M3C_REGISTRY_TOKEN", "")
+	t.Setenv("M3C_REGISTRY_RO_TOKEN", "")
+
+	got, err := New().Credential(context.Background(), "registry", "", artifact.ModeRead)
+	if err != nil {
+		t.Fatalf("a missing credential must not be an error: %v", err)
+	}
+	if got.Token != "" {
+		t.Errorf("expected anonymous, got a token")
+	}
+}

--- a/pkg/skillctl/registry/client.go
+++ b/pkg/skillctl/registry/client.go
@@ -42,6 +42,15 @@ const MaxBlobSize int64 = 256 << 20 // 256 MiB
 // a generic install failure. Translation lives in S8, not here.
 var ErrNotFound = errors.New("registry: not found")
 
+// ErrUnauthorized marks an HTTP 401 or 403 from the registry, so a caller can
+// say what is missing instead of printing a bare status code.
+//
+// It exists because "HTTP 401" is a true statement that helps nobody: the person
+// at the terminal may be perfectly entitled and simply have no token provisioned
+// on this machine. The gate is real; what was missing was a message that names
+// the next action (FR-0117).
+var ErrUnauthorized = errors.New("registry: not authorized")
+
 // Client is the HTTP client for the aims-core skill-registry endpoints.
 // Construct via New(); zero-value Client is not usable (BaseURL would be
 // empty).
@@ -61,6 +70,15 @@ type Client struct {
 	// UserAgent is sent on every request. Defaults to "skillctl/<version>"
 	// per stream S7 brief; callers can override for diagnostic tags.
 	UserAgent string
+
+	// Token, when set, is sent as `Authorization: Bearer <token>` (FR-0117).
+	//
+	// Empty means anonymous, which is the previous behaviour and the correct one
+	// for a public instance. The field is deliberately plain and the RESOLUTION
+	// lives with the caller: this package does not read environments, keychains
+	// or config files, so a test can drive it and a future credential source can
+	// change without touching the transport.
+	Token string
 }
 
 // New constructs a Client with sane defaults. Pass nil for httpClient to
@@ -119,6 +137,9 @@ func (c *Client) ResolveByName(ctx context.Context, name string) ([]BundleVersio
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("registry: by-name %q: %w", name, ErrNotFound)
 	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("registry: GET %s: HTTP %d: %w", u, resp.StatusCode, ErrUnauthorized)
+	}
 	if resp.StatusCode/100 != 2 {
 		return nil, fmt.Errorf("registry: GET %s: HTTP %d", u, resp.StatusCode)
 	}
@@ -161,6 +182,9 @@ func (c *Client) GetBundle(ctx context.Context, digest string) ([]byte, error) {
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("registry: bundle %s: %w", digest, ErrNotFound)
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("registry: GET %s: HTTP %d: %w", u, resp.StatusCode, ErrUnauthorized)
 	}
 	if resp.StatusCode/100 != 2 {
 		return nil, fmt.Errorf("registry: GET %s: HTTP %d", u, resp.StatusCode)
@@ -208,6 +232,9 @@ func (c *Client) GetBundleMeta(ctx context.Context, digest string) (*BundleMeta,
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("registry: bundle %s meta: %w", digest, ErrNotFound)
 	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("registry: GET %s: HTTP %d: %w", u, resp.StatusCode, ErrUnauthorized)
+	}
 	if resp.StatusCode/100 != 2 {
 		return nil, fmt.Errorf("registry: GET %s: HTTP %d", u, resp.StatusCode)
 	}
@@ -244,6 +271,9 @@ func (c *Client) GetIdentity(ctx context.Context, id string) (*Identity, error) 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("registry: identity %s: %w", id, ErrNotFound)
 	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("registry: GET %s: HTTP %d: %w", u, resp.StatusCode, ErrUnauthorized)
+	}
 	if resp.StatusCode/100 != 2 {
 		return nil, fmt.Errorf("registry: GET %s: HTTP %d", u, resp.StatusCode)
 	}
@@ -269,6 +299,9 @@ func (c *Client) setHeaders(req *http.Request, accept string) {
 	}
 	if accept != "" {
 		req.Header.Set("Accept", accept)
+	}
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
 	}
 }
 

--- a/pkg/skillctl/registry/client_auth_test.go
+++ b/pkg/skillctl/registry/client_auth_test.go
@@ -1,0 +1,78 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The header is sent when a token is set, and NOT sent when it is not. The
+// second half matters as much as the first: a public instance must keep seeing
+// an anonymous request, and an empty Bearer would be a lie about the caller.
+func TestClientSendsBearerOnlyWhenTokenIsSet(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{"with a token", "s3cr3t", "Bearer s3cr3t"},
+		{"without one", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			var seen bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get("Authorization")
+				seen = true
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer srv.Close()
+
+			c := New(srv.URL, srv.Client())
+			c.Token = tc.token
+			_, _ = c.ResolveByName(context.Background(), "demo")
+
+			if !seen {
+				t.Fatal("the server was never called; the test proves nothing")
+			}
+			if got != tc.want {
+				t.Errorf("Authorization = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A 401 and a 403 must be distinguishable from every other refusal, because the
+// operator's next action is different: provision or fix a credential, rather
+// than look for the bundle.
+func TestUnauthorizedIsItsOwnError(t *testing.T) {
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(code)
+		}))
+		_, err := New(srv.URL, srv.Client()).ResolveByName(context.Background(), "demo")
+		srv.Close()
+		if !errors.Is(err, ErrUnauthorized) {
+			t.Errorf("HTTP %d: err = %v, want ErrUnauthorized", code, err)
+		}
+	}
+}
+
+// A 500 must NOT be reported as an authorization problem. Without this the
+// mapping above could swallow every failure and send an operator hunting for a
+// token that was never the issue.
+func TestServerErrorIsNotUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	_, err := New(srv.URL, srv.Client()).ResolveByName(context.Background(), "demo")
+	if err == nil {
+		t.Fatal("a 500 must be an error")
+	}
+	if errors.Is(err, ErrUnauthorized) {
+		t.Errorf("a 500 was reported as ErrUnauthorized: %v", err)
+	}
+}


### PR DESCRIPTION
Der HTTP-Registry-Client setzte `User-Agent` und `Accept`, sonst nichts. Eine Instanz, die ihre Endpunkte authentifiziert, antwortete mit 401, unabhaengig davon, wozu der Mensch am Terminal berechtigt war. `install` und `attest` waren gegen eine geschuetzte Instanz unbenutzbar.

## Umgesetzt

`Authorization: Bearer`, zwei Tiers wie bei den Git-Backends:

```
M3C_REGISTRY_TOKEN / M3C_REGISTRY_RO_TOKEN
Keychain m3c-skillctl-registry / m3c-skillctl-registry-ro
```

Die Aufloesung liegt bei den Kommandos (`cmd/skillctl/registry_client.go`), nicht im Transportpaket: `registry` bleibt ohne Umgebung, Keychain und Home-Verzeichnis testbar, und eine kuenftige Credential-Quelle kann sich aendern, ohne den Transport anzufassen. Genau aus diesem Grund bekommen die Git-Backends ihre Zugangsdaten ueber `artifact.OpenOptions` hereingereicht.

Ohne gefundene Credential bleibt alles **anonym**: eine oeffentliche Instanz und jeder bestehende Test verhalten sich unveraendert.

401 und 403 sind jetzt `ErrUnauthorized`. Die Meldung unterscheidet die beiden Faelle mit verschiedenen naechsten Schritten: **kein** Token gesendet (einen besorgen) oder der gesendete **abgelehnt** (falsch, abgelaufen, falscher Bereich).

## Die Ops-Routine

`docs/ops-registry-tokens.de.md`, fuer den echten Betrieb bei einem Kunden mit eigener GitLab-Instanz. Ihr Kern ist eine Trennung, die von der naheliegenden Loesung abweicht:

| | Woher | Wem gehoert er |
|---|---|---|
| **Lesen** (`pull`, `verify`, `install`) | GitLab-Konto der Mitarbeiterin | der Person |
| **Schreiben** (`publish`, `attest`) | Projekt-Einstellungen des Registry | dem Projekt |

Ein persoenlicher **Lesetoken** laesst das Offboarding von selbst funktionieren: das Konto endet, der Zugang endet. Ein persoenlicher **Schreibtoken** dagegen laesst das Registry mit dem Konto sterben und fuegt der Zurechenbarkeit nichts hinzu, denn wer aufgenommen hat, steht in der SIGNATUR des Admit-Ereignisses und nicht im Token. Der Token bewegt Bytes, der Schluessel rechnet sie zu.

Dazu: Ablage je Plattform, Ablauf und Rotation, Personalwechsel, und das Token-Register nach AC-14 / REQ-3.15.

## Ein offener Punkt, im Dokument benannt

Auf **Windows** gibt es heute keinen Weg, den Token in den geschuetzten Speicher zu legen. Die DPAPI-Funktion (`artifactauth.StoreCred`) ist gebaut, aber **kein Kommando ruft sie auf**, also bleibt die Umgebungsvariable im Klartext. Fuer Lesetoken vertretbar, fuer den Schreibtoken eines Registry nicht. Ein `skillctl token set` waere der Fix.

## Gemessen

```
go test ./pkg/skillctl/... ./cmd/skillctl/   0 Fehlschlaege
check-docs.sh                                 PASS
make sim                                      51 Szenarien, 0 Konflikte
check-no-emdash.sh                            gruen
```

Neue Tests: Bearer wird gesendet wenn ein Token da ist und NICHT wenn keiner da ist; 401 und 403 sind `ErrUnauthorized`; ein 500 ist es ausdruecklich nicht; die Tier-Reihenfolge und der anonyme Fall.