### PR TITLE
feat(token): skillctl token, damit der geschuetzte Speicher auch gefuellt werden kann

### DIFF
--- a/cmd/skillctl/main.go
+++ b/cmd/skillctl/main.go
@@ -53,6 +53,10 @@ func main() {
 	// === SPEC-0406 D1: environment readiness in one command ===
 	case "doctor":
 		os.Exit(runDoctor(os.Args[2:], os.Stdout, os.Stderr))
+	// FR-0117 follow-up: fill the protected credential store the resolver already
+	// reads. Without it a Windows operator had no option but a plaintext env var.
+	case "token":
+		os.Exit(runToken(os.Args[2:], os.Stdout, os.Stderr))
 	// === END SPEC-0406 D1 ===
 	case "version", "--version", "-v":
 		fmt.Println(version)

--- a/cmd/skillctl/token_cmds.go
+++ b/cmd/skillctl/token_cmds.go
@@ -75,6 +75,12 @@ func tokenTier(readOnly bool) artifactauth.Tier {
 }
 
 func runTokenSet(args []string, stdout, stderr io.Writer) int {
+	return runTokenSetFrom(args, os.Stdin, stdout, stderr)
+}
+
+// runTokenSetFrom is runTokenSet with the secret source injected, so a test can
+// drive the whole path without a terminal. The production caller passes os.Stdin.
+func runTokenSetFrom(args []string, in io.Reader, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("token set", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	backend := fs.String("backend", "", "credential backend (gitlab, github, registry)")
@@ -95,7 +101,7 @@ func runTokenSet(args []string, stdout, stderr io.Writer) int {
 		return exitGeneric
 	}
 
-	secret, err := readSecret(os.Stdin)
+	secret, err := readSecret(in)
 	if err != nil {
 		fmt.Fprintf(stderr, "skillctl token set: read token from stdin: %v\n", err)
 		return exitGeneric

--- a/cmd/skillctl/token_cmds.go
+++ b/cmd/skillctl/token_cmds.go
@@ -1,0 +1,203 @@
+package main
+
+// token_cmds.go: put a registry credential into the platform's protected store,
+// list what is provisioned, and remove one.
+//
+// It exists because the read side already consulted a protected store on both
+// platforms and nothing could fill it. On macOS an operator could reach for
+// `security add-generic-password` by hand; on Windows the DPAPI writer was built
+// and unreachable, so the only option was a write-capable token in a plaintext
+// environment variable, inherited by every child process and dumped into crash
+// reports. That is the gap this closes, and it is why the verb reads the secret
+// from STDIN and never from an argument.
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifactauth"
+)
+
+func runToken(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		tokenUsage(stderr)
+		return exitUsage
+	}
+	switch args[0] {
+	case "set":
+		return runTokenSet(args[1:], stdout, stderr)
+	case "list":
+		return runTokenList(args[1:], stdout, stderr)
+	case "rm":
+		return runTokenRm(args[1:], stdout, stderr)
+	case "-h", "--help", "help":
+		tokenUsage(stdout)
+		return exitOK
+	default:
+		fmt.Fprintf(stderr, "skillctl token: unknown subcommand %q\n", args[0])
+		tokenUsage(stderr)
+		return exitUsage
+	}
+}
+
+func tokenUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage: skillctl token <set|list|rm> [flags]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  set     read a token from STDIN and store it protected for one host")
+	fmt.Fprintln(w, "  list    show which credentials are provisioned, and from where")
+	fmt.Fprintln(w, "  rm      remove a stored credential from this machine")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Flags (set, rm):\n")
+	fmt.Fprintf(w, "  --backend <name>   one of %v\n", artifactauth.Backends())
+	fmt.Fprintf(w, "  --host <host>      the registry host, e.g. git.kieback-peter.de\n")
+	fmt.Fprintf(w, "  --read-only        the READ tier; without it the WRITE tier\n")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Flags (list):")
+	fmt.Fprintln(w, "  --host <host>      restrict to one host (default: every host you name)")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "The token is read from stdin so it never appears in `ps` or in shell history:")
+	fmt.Fprintln(w, "  skillctl token set --backend gitlab --host git.example.de --read-only")
+	fmt.Fprintln(w, "  (paste the token, then Ctrl-D)")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "The routine around this, including which token to ask GitLab for:")
+	fmt.Fprintln(w, "  docs/ops-registry-tokens.de.md")
+}
+
+func tokenTier(readOnly bool) artifactauth.Tier {
+	if readOnly {
+		return artifactauth.TierRead
+	}
+	return artifactauth.TierWrite
+}
+
+func runTokenSet(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("token set", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	backend := fs.String("backend", "", "credential backend (gitlab, github, registry)")
+	host := fs.String("host", "", "registry host")
+	readOnly := fs.Bool("read-only", false, "store the READ tier instead of the write tier")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *backend == "" || *host == "" {
+		fmt.Fprintln(stderr, "skillctl token set: --backend and --host are required")
+		fmt.Fprintf(stderr, "  why: one machine may hold tokens for several instances, so the host is part of the identity.\n")
+		return exitUsage
+	}
+	if !artifactauth.HasProtectedStore() {
+		_, env, _ := artifactauth.ServiceFor(*backend, tokenTier(*readOnly))
+		fmt.Fprintf(stderr, "skillctl token set: this platform has no protected credential store.\n")
+		fmt.Fprintf(stderr, "  fix: export %s instead, and note that it is inherited by every child process.\n", env)
+		return exitGeneric
+	}
+
+	secret, err := readSecret(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillctl token set: read token from stdin: %v\n", err)
+		return exitGeneric
+	}
+	if secret == "" {
+		fmt.Fprintln(stderr, "skillctl token set: no token on stdin.")
+		fmt.Fprintln(stderr, "  fix: pipe it in, or run the command and paste the token followed by Ctrl-D.")
+		return exitUsage
+	}
+
+	if err := artifactauth.Store(*backend, tokenTier(*readOnly), *host, secret); err != nil {
+		fmt.Fprintf(stderr, "skillctl token set: %v\n", err)
+		return exitGeneric
+	}
+	service, _, _ := artifactauth.ServiceFor(*backend, tokenTier(*readOnly))
+	fmt.Fprintf(stdout, "stored in %s\n", artifactauth.ProtectedStoreName())
+	fmt.Fprintf(stdout, "  backend   %s (%s tier)\n", *backend, tokenTier(*readOnly))
+	fmt.Fprintf(stdout, "  host      %s\n", *host)
+	fmt.Fprintf(stdout, "  service   %s\n", service)
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "An environment variable still WINS over this entry if one is set.")
+	fmt.Fprintln(stdout, "Check with: skillctl token list --host "+*host)
+	fmt.Fprintln(stdout, "Write the register line now, while you know the expiry: OPS/token-register.md")
+	return exitOK
+}
+
+func runTokenList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("token list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	host := fs.String("host", "", "restrict to one host")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *host == "" {
+		fmt.Fprintln(stderr, "skillctl token list: --host is required")
+		fmt.Fprintln(stderr, "  why: a credential is stored per host, and there is no way to enumerate")
+		fmt.Fprintln(stderr, "       hosts without reading every entry in the store, which this command does not do.")
+		return exitUsage
+	}
+	fmt.Fprintf(stdout, "credentials for %s\n", *host)
+	fmt.Fprintf(stdout, "  protected store: %s\n\n", artifactauth.ProtectedStoreName())
+	any := false
+	for _, b := range artifactauth.Backends() {
+		for _, tier := range []artifactauth.Tier{artifactauth.TierRead, artifactauth.TierWrite} {
+			service, env, ok := artifactauth.ServiceFor(b, tier)
+			if !ok || service == "" {
+				continue
+			}
+			src := artifactauth.Provisioned(b, tier, *host)
+			mark := "not provisioned"
+			if src != "" {
+				mark = "from " + src
+				any = true
+			}
+			fmt.Fprintf(stdout, "  %-9s %-5s  %-28s %s\n", b, tier, mark, "env: "+env)
+		}
+	}
+	if !any {
+		fmt.Fprintln(stdout, "\nNothing provisioned for this host. That is fine for a public instance:")
+		fmt.Fprintln(stdout, "an unauthenticated request is made and the registry decides.")
+	}
+	fmt.Fprintln(stdout, "\nThe SOURCE column is the one that matters. An environment variable")
+	fmt.Fprintln(stdout, "beats the protected store, so a stale export explains a failure that")
+	fmt.Fprintln(stdout, "the stored token would not have.")
+	fmt.Fprintln(stdout, "No token is printed here, by design.")
+	return exitOK
+}
+
+func runTokenRm(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("token rm", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	backend := fs.String("backend", "", "credential backend")
+	host := fs.String("host", "", "registry host")
+	readOnly := fs.Bool("read-only", false, "the READ tier instead of the write tier")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *backend == "" || *host == "" {
+		fmt.Fprintln(stderr, "skillctl token rm: --backend and --host are required")
+		return exitUsage
+	}
+	if err := artifactauth.Delete(*backend, tokenTier(*readOnly), *host); err != nil {
+		fmt.Fprintf(stderr, "skillctl token rm: %v\n", err)
+		return exitGeneric
+	}
+	fmt.Fprintf(stdout, "removed from this machine: %s (%s tier) for %s\n", *backend, tokenTier(*readOnly), *host)
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "This is HYGIENE, not revocation. The token is still valid wherever it")
+	fmt.Fprintln(stdout, "was issued. If it may have leaked, revoke it in GitLab; that is the only")
+	fmt.Fprintln(stdout, "step that stops it, and it works without touching this machine.")
+	return exitOK
+}
+
+// readSecret reads the token from stdin and trims the surrounding whitespace a
+// paste or a `echo` almost always adds. Only the first line is taken: a token has
+// no line breaks, and reading further would silently store a multi-line blob that
+// fails later with a confusing message.
+func readSecret(r io.Reader) (string, error) {
+	br := bufio.NewReader(r)
+	line, err := br.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	return strings.TrimSpace(line), nil
+}

--- a/cmd/skillctl/token_cmds_test.go
+++ b/cmd/skillctl/token_cmds_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The secret comes from stdin and only the first line of it. A token has no line
+// breaks, and reading further would store a multi-line blob that fails later with
+// a message about cryptography rather than about a paste.
+func TestReadSecretTakesOneTrimmedLine(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"glpat-abc\n", "glpat-abc"},
+		{"  glpat-abc  \n", "glpat-abc"},
+		{"glpat-abc", "glpat-abc"},
+		{"glpat-abc\nsecond line\n", "glpat-abc"},
+		{"\n", ""},
+		{"", ""},
+	} {
+		got, err := readSecret(strings.NewReader(tc.in))
+		if err != nil {
+			t.Fatalf("%q: %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("readSecret(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// Both identifying flags are required, and the message says WHY the host is one
+// of them. A credential is stored per host so one machine can hold tokens for
+// several instances; a default would silently bind the token to the wrong one.
+func TestTokenSetRequiresBackendAndHost(t *testing.T) {
+	for _, args := range [][]string{
+		{"--backend", "gitlab"},
+		{"--host", "git.example.de"},
+		{},
+	} {
+		var out, errb bytes.Buffer
+		if rc := runTokenSet(args, &out, &errb); rc != exitUsage {
+			t.Errorf("args %v: rc = %d, want exitUsage", args, rc)
+		}
+		if !strings.Contains(errb.String(), "--backend and --host are required") {
+			t.Errorf("args %v: the message must name both flags, got %q", args, errb.String())
+		}
+	}
+}
+
+// list refuses without a host rather than guessing, and says why: it will not
+// walk the credential store to find out which hosts exist.
+func TestTokenListRequiresHost(t *testing.T) {
+	var out, errb bytes.Buffer
+	if rc := runTokenList(nil, &out, &errb); rc != exitUsage {
+		t.Errorf("rc = %d, want exitUsage", rc)
+	}
+	if !strings.Contains(errb.String(), "--host is required") {
+		t.Errorf("message must name the flag: %q", errb.String())
+	}
+}
+
+// A host with nothing provisioned prints every tier as "not provisioned" and
+// never a token. The second half is the one worth pinning: a list command that
+// leaks the secret it is listing would be worse than no command.
+func TestTokenListPrintsNoSecret(t *testing.T) {
+	t.Setenv("M3C_GITLAB_TOKEN", "glpat-should-not-be-printed")
+	var out, errb bytes.Buffer
+	if rc := runTokenList([]string{"--host", "nothing.invalid"}, &out, &errb); rc != exitOK {
+		t.Fatalf("rc = %d, want exitOK (stderr: %s)", rc, errb.String())
+	}
+	if strings.Contains(out.String(), "glpat-should-not-be-printed") {
+		t.Fatal("the token value was printed")
+	}
+	// The env override IS reported as the source, because that is the thing an
+	// operator needs to know when a stored token seems to be ignored.
+	if !strings.Contains(out.String(), "env M3C_GITLAB_TOKEN") {
+		t.Errorf("the env source must be named: %q", out.String())
+	}
+}
+
+func TestTokenUnknownSubcommandIsUsage(t *testing.T) {
+	var out, errb bytes.Buffer
+	if rc := runToken([]string{"frobnicate"}, &out, &errb); rc != exitUsage {
+		t.Errorf("rc = %d, want exitUsage", rc)
+	}
+	if !strings.Contains(errb.String(), "unknown subcommand") {
+		t.Errorf("message: %q", errb.String())
+	}
+}

--- a/cmd/skillctl/token_cmds_test.go
+++ b/cmd/skillctl/token_cmds_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/artifactauth"
 )
 
 // The secret comes from stdin and only the first line of it. A token has no line
@@ -85,5 +87,58 @@ func TestTokenUnknownSubcommandIsUsage(t *testing.T) {
 	}
 	if !strings.Contains(errb.String(), "unknown subcommand") {
 		t.Errorf("message: %q", errb.String())
+	}
+}
+
+// The tier flag maps to the two named tiers. A bool whose polarity has to be
+// looked up is exactly what the named type avoids, so the mapping is pinned.
+func TestTokenTierMapping(t *testing.T) {
+	if tokenTier(true) != artifactauth.TierRead {
+		t.Error("--read-only must select the read tier")
+	}
+	if tokenTier(false) != artifactauth.TierWrite {
+		t.Error("without --read-only it must be the write tier")
+	}
+}
+
+func TestTokenRmRequiresBackendAndHost(t *testing.T) {
+	var out, errb bytes.Buffer
+	if rc := runTokenRm([]string{"--backend", "gitlab"}, &out, &errb); rc != exitUsage {
+		t.Errorf("rc = %d, want exitUsage", rc)
+	}
+	if !strings.Contains(errb.String(), "--backend and --host are required") {
+		t.Errorf("message: %q", errb.String())
+	}
+}
+
+// rm must say, in its own output, that it did not revoke anything. An operator
+// who believes a local delete stopped a leaked token has been actively misled.
+func TestTokenRmSaysItIsNotRevocation(t *testing.T) {
+	var out, errb bytes.Buffer
+	if rc := runTokenRm([]string{"--backend", "gitlab", "--host", "nothing.invalid"}, &out, &errb); rc != exitOK {
+		t.Fatalf("rc = %d (stderr %s)", rc, errb.String())
+	}
+	if !strings.Contains(out.String(), "not revocation") {
+		t.Errorf("the output must not let a local delete pass for a revocation: %q", out.String())
+	}
+}
+
+// A set against a host that reads as an option is refused before anything is
+// stored, and the message says which flag is wrong.
+func TestTokenSetRefusesAHostThatReadsAsAnOption(t *testing.T) {
+	var out, errb bytes.Buffer
+	rc := runTokenSetFrom([]string{"--backend", "gitlab", "--host", "-S"}, strings.NewReader("glpat-x\n"), &out, &errb)
+	if rc == exitOK {
+		t.Fatal("a host beginning with a dash must be refused")
+	}
+}
+
+func TestTokenHelpMentionsStdin(t *testing.T) {
+	var out bytes.Buffer
+	if rc := runToken([]string{"--help"}, &out, &out); rc != exitOK {
+		t.Fatalf("rc = %d", rc)
+	}
+	if !strings.Contains(out.String(), "stdin") {
+		t.Error("the help must say where the token comes from; that is the property this verb exists for")
 	}
 }

--- a/docs/CLI-VERBS.md
+++ b/docs/CLI-VERBS.md
@@ -58,6 +58,7 @@ same way `cmd/docaudit` gates the flag surface.
 | `login` | FR-0043 | 0/1/2 |
 | `version` (`--version`, `-v`) | built-in | 0 |
 | `doctor` | SPEC-0406 D1 | 0/1/2 |
+| `token` (`set`, `list`, `rm`) | FR-0117 | 0/1/2 |
 | `pack` | SPEC-0188 (Phase 1 PoC) | 0/1/2, 18 |
 | `keygen` | SPEC-0188 §11 | 0/1/2 |
 | `sign` | SPEC-0188 §11 | 0/1/2 |

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -1638,6 +1638,48 @@ aims-core registry (`POST /api/skills/identities` with an operator bearer token)
 
 ---
 
+## `token`: the credential store for registries
+
+Puts a registry token into the platform's protected store, shows what is
+provisioned, and removes one. It is the write side of the credential resolution
+that `pull`, `verify`, `install` and `attest` already read.
+
+**The secret is read from STDIN and never from an argument.** An argument is
+visible to every process on the machine through `ps` while the call runs, and it
+lands in the shell history of whoever repeats the command by hand.
+
+```bash
+skillctl token set --backend gitlab --host git.example.de --read-only
+# paste the token, then Ctrl-D. Or: echo "$TOK" | skillctl token set …
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--backend <name>` | Which credential family: `gitlab`, `github` or `registry` (the HTTP registry). **Required** for `set` and `rm`. |
+| `--host <host>` | The registry host, e.g. `git.example.de`. **Required.** A credential is stored per host so one machine can hold tokens for several instances. |
+| `--read-only` | Store the **read** tier instead of the write tier. A pull prefers the read tier and only falls back to the write one, so an operator who provisions both never transmits a write token on a read. |
+
+`token list --host <host>` prints, per backend and tier, **where** a credential
+comes from, and never the credential. The source column is the interesting one:
+an environment variable beats the protected store, so a stale export explains a
+failure the stored token would not have caused.
+
+`token rm` removes the local copy. That is **hygiene, not revocation**: the token
+stays valid wherever it was issued until it is revoked there, which is the only
+step that actually stops it.
+
+| Platform | Protected store |
+|---|---|
+| macOS | Keychain (`security`), one generic-password item per service and host |
+| Windows | DPAPI, ciphertext bound to the user account, under `%LOCALAPPDATA%\m3c\artifactauth` |
+| Linux | none here. `set` refuses and names the environment variable instead of writing the token somewhere unprotected. |
+
+The routine around all of this, including which token to ask GitLab for and why
+a write token belongs to the project rather than to a person:
+[Ops-Routine: Zugangstoken](ops-registry-tokens.de).
+
+---
+
 ## Files & locations
 
 | Path | Contents |

--- a/docs/ops-registry-tokens.de.md
+++ b/docs/ops-registry-tokens.de.md
@@ -48,26 +48,33 @@ Der Token wird **einmal** angezeigt. Danach nie wieder.
 
 **2. Token ablegen.**
 
-macOS:
+macOS und Windows, ein Kommando:
 
 ```bash
-security add-generic-password -s m3c-skillctl-gitlab-ro -a <gitlab-host> -w '<token>' -U
+skillctl token set --backend gitlab --host git.kieback-peter.de --read-only
 ```
 
-Wobei `<gitlab-host>` genau der Host aus dem Registry-Locator ist, also z. B.
-`gitlab.example.de` bei `gitlab://gitlab.example.de/gruppe/skill-registry`.
+Danach den Token einfügen und mit Ctrl-D abschliessen. **Der Token wird von stdin
+gelesen und steht nie in der Kommandozeile**, also nicht in `ps` und nicht in der
+Shell-Historie. Er landet im Keychain (macOS) beziehungsweise DPAPI-verschlüsselt
+je Benutzerkonto (Windows).
 
-Für ein HTTP-Registry (`--registry https://…/api/skills`) heisst der Dienst
-`m3c-skillctl-registry-ro` statt `m3c-skillctl-gitlab-ro`.
+Für ein HTTP-Registry (`--registry https://…/api/skills`) lautet das Backend
+`registry` statt `gitlab`.
 
-Windows: siehe "Offener Punkt" am Ende. Heute bleibt dort nur die Umgebungsvariable.
-
-Alternativ, auf jeder Plattform und für CI der Normalfall:
+Auf Linux gibt es keinen geschützten Speicher; das Kommando sagt das und nennt
+die Umgebungsvariable, statt den Token irgendwohin ungeschützt zu schreiben. Für
+CI ist die Variable ohnehin der Normalfall:
 
 ```bash
 export M3C_GITLAB_RO_TOKEN='<token>'      # Git-Registry
 export M3C_REGISTRY_RO_TOKEN='<token>'    # HTTP-Registry
 ```
+
+Was wo liegt, zeigt `skillctl token list --host git.kieback-peter.de`, und zwar
+**ohne den Token auszugeben**. Die interessante Spalte ist die Quelle: eine
+gesetzte Umgebungsvariable schlägt den geschützten Speicher, und ein vergessenes
+`export` erklärt einen Fehlschlag, den der abgelegte Token nicht verursacht hätte.
 
 **3. Prüfen.**
 
@@ -100,12 +107,10 @@ Kein Inhalt, kein README: `skillctl registry init` schreibt die Struktur.
 nicht zu, und der Standard-Branch ist auf Maintainer-Ebene geschützt. Ein Deploy
 Token scheitert beim Push, und die Fehlermeldung sagt nicht, warum.
 
-**3. Ablegen wie in Teil A**, aber unter dem Schreib-Dienst:
+**3. Ablegen wie in Teil A**, aber ohne `--read-only`, also im Schreib-Tier:
 
 ```bash
-security add-generic-password -s m3c-skillctl-gitlab -a <gitlab-host> -w '<token>' -U
-# oder
-export M3C_GITLAB_TOKEN='<token>'
+skillctl token set --backend gitlab --host git.kieback-peter.de
 ```
 
 **4. Prüfen.**
@@ -209,16 +214,25 @@ gegen einen alten Stand.
 Drei Prinzipale, drei Maschinen (P3). Zwei Prinzipale auf derselben Maschine sind
 ein Trockenlauf und als solcher zu protokollieren, nicht als D-8.
 
-## Offener Punkt: Windows
+## Windows
 
-Auf Windows gibt es heute **keinen** Weg, den Token in den geschützten Speicher zu
-legen. Die Funktion dafür ist gebaut (DPAPI, je Benutzerkonto verschlüsselt), aber
-kein Kommando ruft sie auf. Es bleibt die Umgebungsvariable, also ein
-Schreibtoken im Klartext im Prozessumfeld, vererbt an jeden Kindprozess.
+Seit `skillctl token set` existiert, ist Windows gleichwertig: der Token liegt
+DPAPI-verschlüsselt je Benutzerkonto, nicht im Prozessumfeld. Vorher war die
+Umgebungsvariable dort der einzige Weg, also ein schreibfähiger Token im Klartext,
+vererbt an jeden Kindprozess. Bis zum 2026-09-06 stand hier deshalb die
+Empfehlung, ein Registry nur von macOS oder Linux aus zu bedienen. Sie ist
+hinfällig.
 
-Für Lesetoken ist das vertretbar. Für den Schreibtoken eines Registry ist es das
-nicht, und deshalb sollte das Registry vorerst von einer macOS- oder
-Linux-Maschine aus bedient werden, bis ein `skillctl token set` existiert.
+Der Lesepfad konnte den geschützten Speicher immer schon; was fehlte, war ein Weg,
+ihn zu füllen. Das ist die Art Lücke, die von beiden Seiten aus vollständig
+aussieht.
 
-Diese Einschränkung ist der einzige Punkt, an dem diese Routine heute nicht auf
-beiden Betriebssystemen gleich gut ist.
+## Was diese Routine nicht löst
+
+**Ablaufwarnungen.** GitLab warnt nicht vorab, und `skillctl` kennt das
+Ablaufdatum nicht: es steht in keinem Token. Deshalb das Register in Teil C, und
+deshalb ist die Zeile dort wichtiger, als sie aussieht.
+
+**Widerruf.** `skillctl token rm` entfernt die lokale Kopie, und das ist Hygiene.
+Wer einen Token wirklich stoppen will, widerruft ihn in GitLab. Das wirkt sofort
+und ohne Zutun der betroffenen Maschine.

--- a/pkg/skillctl/artifactauth/creds_windows.go
+++ b/pkg/skillctl/artifactauth/creds_windows.go
@@ -157,3 +157,22 @@ func localFree(p *byte) {
 		_, _ = windows.LocalFree(windows.Handle(unsafe.Pointer(p)))
 	}
 }
+
+// DeleteCred removes the DPAPI blob for (service, account). A missing file is not
+// an error: the caller asked for it to be gone, and it is.
+//
+// This is HYGIENE, not revocation. The token stays valid at the issuer until it
+// is revoked there.
+func DeleteCred(service, account string) error {
+	if account == "" {
+		return errors.New("artifactauth: DeleteCred needs a non-empty account (registry host)")
+	}
+	p, err := credPath(service, account)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/pkg/skillctl/artifactauth/store.go
+++ b/pkg/skillctl/artifactauth/store.go
@@ -1,0 +1,135 @@
+package artifactauth
+
+// store.go is the WRITE side of the credential resolution, and it is deliberately
+// small and separate.
+//
+// The package doc says the resolver is read-only, and that stays true: nothing in
+// creds.go writes. This file adds an explicit, opt-in writer that only the
+// `skillctl token` verb calls, so the property that mattered (a resolution path
+// that structurally cannot delete a credential store) is unchanged.
+//
+// It exists because of an asymmetry that made the Windows story worse than the
+// macOS one: the DPAPI writer had been built (creds_windows.go, WIN-T6) and
+// nothing called it, so a Windows operator's only option was a write-capable
+// token in a plaintext environment variable, inherited by every child process.
+// The read side supported the protected store; the operator had no way to fill it.
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// envValue reads and trims one environment variable. It exists so Provisioned
+// reports exactly what the resolver would use, whitespace handling included: a
+// token pasted with a trailing newline is treated the same in both places.
+func envValue(name string) string { return strings.TrimSpace(os.Getenv(name)) }
+
+// Tier names the two credential tiers. They are strings rather than a bool so a
+// caller and its help text say "read" and "write" instead of a flag whose
+// polarity has to be looked up.
+type Tier string
+
+const (
+	TierWrite Tier = "write"
+	TierRead  Tier = "read"
+)
+
+// ServiceFor returns the credential-store service name and the environment
+// variable for one backend and tier.
+//
+// It is the single place that knows those names. Before this, the CLI, the docs
+// and the resolver each spelled them out, and a rename would have had to find all
+// three.
+func ServiceFor(backend string, tier Tier) (service, env string, ok bool) {
+	m, found := backendCred[backend]
+	if !found {
+		return "", "", false
+	}
+	if tier == TierRead {
+		return m.roKcService, m.roEnv, true
+	}
+	return m.kcService, m.env, true
+}
+
+// Backends lists the backends that have a credential tier, sorted, for help text
+// and for validating user input against something other than a hard-coded list.
+func Backends() []string {
+	out := make([]string, 0, len(backendCred))
+	for k := range backendCred {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Store writes secret into the platform's protected credential store for
+// (backend, tier, host).
+//
+// It refuses rather than falling back to something weaker. A silent fallback to
+// a file or an environment variable would be the worst outcome here: the operator
+// would believe the token is protected because the command said nothing.
+func Store(backend string, tier Tier, host, secret string) error {
+	service, env, ok := ServiceFor(backend, tier)
+	if !ok {
+		return fmt.Errorf("artifactauth: unknown backend %q (known: %v)", backend, Backends())
+	}
+	if service == "" {
+		return fmt.Errorf("artifactauth: backend %q has no %s tier", backend, tier)
+	}
+	if host == "" {
+		return fmt.Errorf("artifactauth: a host is required; it is what lets one machine hold tokens for several instances")
+	}
+	if secret == "" {
+		return fmt.Errorf("artifactauth: refusing to store an empty token")
+	}
+	if !HasProtectedStore() {
+		return fmt.Errorf("artifactauth: %s has no protected credential store here; "+
+			"use the environment variable %s instead, and keep in mind it is inherited by every child process",
+			runtime.GOOS, env)
+	}
+	return platformStore(service, host, secret)
+}
+
+// Delete removes the stored credential. A missing entry is not an error: the
+// caller asked for it to be gone, and it is.
+//
+// Deleting locally is HYGIENE, not a revocation. The credential remains valid
+// wherever it was issued until it is revoked there, and any message about this
+// has to say so, or an operator will believe they closed a door they only shut.
+func Delete(backend string, tier Tier, host string) error {
+	service, _, ok := ServiceFor(backend, tier)
+	if !ok {
+		return fmt.Errorf("artifactauth: unknown backend %q (known: %v)", backend, Backends())
+	}
+	if service == "" {
+		return fmt.Errorf("artifactauth: backend %q has no %s tier", backend, tier)
+	}
+	return platformDelete(service, host)
+}
+
+// Provisioned reports where a credential for (backend, tier, host) comes from,
+// or "" when none is found. It never returns the secret.
+//
+// The distinction between "env" and the protected store is the point: an operator
+// who thinks a token sits in the keychain, while an old environment variable
+// actually wins, will not understand a later failure. The order here is the
+// resolver's order, so what this prints is what a pull would use.
+func Provisioned(backend string, tier Tier, host string) string {
+	service, env, ok := ServiceFor(backend, tier)
+	if !ok || service == "" {
+		return ""
+	}
+	if env != "" && envValue(env) != "" {
+		return "env " + env
+	}
+	if runtime.GOOS == "darwin" && keychain(service, host) != "" {
+		return "keychain " + service
+	}
+	if osCredStore(service, host) != "" {
+		return "protected store " + service
+	}
+	return ""
+}

--- a/pkg/skillctl/artifactauth/store.go
+++ b/pkg/skillctl/artifactauth/store.go
@@ -79,8 +79,8 @@ func Store(backend string, tier Tier, host, secret string) error {
 	if service == "" {
 		return fmt.Errorf("artifactauth: backend %q has no %s tier", backend, tier)
 	}
-	if host == "" {
-		return fmt.Errorf("artifactauth: a host is required; it is what lets one machine hold tokens for several instances")
+	if err := validHost(host); err != nil {
+		return err
 	}
 	if secret == "" {
 		return fmt.Errorf("artifactauth: refusing to store an empty token")
@@ -107,6 +107,9 @@ func Delete(backend string, tier Tier, host string) error {
 	if service == "" {
 		return fmt.Errorf("artifactauth: backend %q has no %s tier", backend, tier)
 	}
+	if err := validHost(host); err != nil {
+		return err
+	}
 	return platformDelete(service, host)
 }
 
@@ -132,4 +135,30 @@ func Provisioned(backend string, tier Tier, host string) string {
 		return "protected store " + service
 	}
 	return ""
+}
+
+// validHost rejects a host that could be mistaken for an option by the tool that
+// stores the credential.
+//
+// The macOS store shells out to `security`, and although exec.Command uses no
+// shell (so there is nothing to inject), a value beginning with "-" would be read
+// by `security` as a FLAG rather than as an account name. That is not a code
+// injection, it is worse in one respect: it would silently act on the wrong item.
+// Whitespace and control characters are rejected for the same reason, plus the
+// `security -i` line format, which splits on whitespace.
+//
+// A host is a hostname, optionally with a port. Nothing legitimate is lost.
+func validHost(host string) error {
+	if host == "" {
+		return fmt.Errorf("artifactauth: a host is required; it is what lets one machine hold tokens for several instances")
+	}
+	if strings.HasPrefix(host, "-") {
+		return fmt.Errorf("artifactauth: refusing host %q: a leading dash would be read as an option, not as a host", host)
+	}
+	for _, r := range host {
+		if r < 0x21 || r == 0x7f {
+			return fmt.Errorf("artifactauth: refusing host %q: it contains whitespace or a control character", host)
+		}
+	}
+	return nil
 }

--- a/pkg/skillctl/artifactauth/store_darwin.go
+++ b/pkg/skillctl/artifactauth/store_darwin.go
@@ -1,0 +1,69 @@
+//go:build darwin
+
+package artifactauth
+
+// The macOS half of the credential writer.
+//
+// The token is handed to `security` over STDIN, not on the command line. An
+// argument is visible to every process on the machine through `ps` for as long as
+// the call runs, and it lands in the shell history of anyone who reproduces the
+// command by hand. `security -i` reads the same command from stdin, which is not
+// visible that way, so the interactive mode is used non-interactively for exactly
+// this reason.
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// HasProtectedStore reports whether this platform can keep the token out of the
+// process environment.
+func HasProtectedStore() bool { return true }
+
+// ProtectedStoreName is what the store is called in a message to a human.
+func ProtectedStoreName() string { return "macOS Keychain" }
+
+// platformStore adds or replaces a generic-password item. -U updates in place,
+// so re-running after a token rotation does the obvious thing instead of failing
+// on a duplicate.
+func platformStore(service, account, secret string) error {
+	if strings.ContainsAny(secret, "\n\r") {
+		// A newline would end the command line inside `security -i` and turn the
+		// rest of the token into a second command. Refusing is right: no GitLab or
+		// GitHub token contains one, so this is a paste accident, and the
+		// alternative is a half-stored credential.
+		return fmt.Errorf("artifactauth: the token contains a line break; copy it again without the surrounding whitespace")
+	}
+	cmd := exec.Command("/usr/bin/security", "-i")
+	cmd.Stdin = strings.NewReader(fmt.Sprintf(
+		"add-generic-password -s %s -a %s -w %s -U\n",
+		quoteKC(service), quoteKC(account), quoteKC(secret)))
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("artifactauth: keychain write failed: %w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	return nil
+}
+
+// platformDelete removes the item. A missing item is not an error.
+func platformDelete(service, account string) error {
+	cmd := exec.Command("/usr/bin/security", "delete-generic-password", "-s", service, "-a", account)
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		if strings.Contains(errBuf.String(), "could not be found") {
+			return nil
+		}
+		return fmt.Errorf("artifactauth: keychain delete failed: %w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	return nil
+}
+
+// quoteKC quotes a value for the `security -i` command line, which splits on
+// whitespace and understands double quotes.
+func quoteKC(s string) string {
+	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(s) + `"`
+}

--- a/pkg/skillctl/artifactauth/store_darwin.go
+++ b/pkg/skillctl/artifactauth/store_darwin.go
@@ -50,6 +50,12 @@ func platformStore(service, account, secret string) error {
 
 // platformDelete removes the item. A missing item is not an error.
 func platformDelete(service, account string) error {
+	// #nosec G204 -- no shell is involved, so there is nothing to inject, and both
+	// arguments are constrained before they get here: `service` comes from the
+	// internal backendCred table (fixed strings, never user input) and `account`
+	// has passed validHost, which rejects a leading dash, whitespace and control
+	// characters. The leading dash is the case that actually mattered: `security`
+	// would have read it as a flag and acted on the wrong item, silently.
 	cmd := exec.Command("/usr/bin/security", "delete-generic-password", "-s", service, "-a", account)
 	var errBuf bytes.Buffer
 	cmd.Stderr = &errBuf

--- a/pkg/skillctl/artifactauth/store_darwin_test.go
+++ b/pkg/skillctl/artifactauth/store_darwin_test.go
@@ -1,0 +1,82 @@
+//go:build darwin
+
+package artifactauth
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The round trip against the real Keychain, which is the only thing that proves
+// the write side works. Everything else in this package's tests checks the logic
+// AROUND the store; this checks the store.
+//
+// It uses a service name no backend maps to, so it cannot touch an operator's
+// real credential, and it removes what it wrote. It skips rather than fails when
+// the Keychain is unavailable (a locked or absent login keychain on a build
+// machine is not a defect in this code).
+func TestKeychainRoundTrip(t *testing.T) {
+	if _, err := exec.LookPath("/usr/bin/security"); err != nil {
+		t.Skip("no /usr/bin/security on this machine")
+	}
+	const service = "m3c-skillctl-selftest"
+	const account = "roundtrip.invalid"
+	const secret = `glpat-round trip "quoted" \backslash`
+
+	if err := platformStore(service, account, secret); err != nil {
+		if strings.Contains(err.Error(), "User interaction is not allowed") ||
+			strings.Contains(err.Error(), "The user name or passphrase you entered is not correct") {
+			t.Skipf("keychain not usable in this environment: %v", err)
+		}
+		t.Fatalf("platformStore: %v", err)
+	}
+	t.Cleanup(func() { _ = platformDelete(service, account) })
+
+	if got := keychain(service, account); got != secret {
+		t.Fatalf("read back %q, want %q", got, secret)
+	}
+
+	// Overwriting must update in place, because a token rotation re-runs the same
+	// command and a duplicate-item error at that moment would be the worst timing.
+	const rotated = "glpat-rotated"
+	if err := platformStore(service, account, rotated); err != nil {
+		t.Fatalf("second store (rotation): %v", err)
+	}
+	if got := keychain(service, account); got != rotated {
+		t.Fatalf("after rotation read back %q, want %q", got, rotated)
+	}
+
+	if err := platformDelete(service, account); err != nil {
+		t.Fatalf("platformDelete: %v", err)
+	}
+	if got := keychain(service, account); got != "" {
+		t.Fatalf("after delete the item is still readable: %q", got)
+	}
+	// Deleting what is already gone is not an error: the caller asked for it to be
+	// absent, and it is.
+	if err := platformDelete(service, account); err != nil {
+		t.Errorf("second delete: %v", err)
+	}
+}
+
+// A token with a line break is refused rather than half-stored. It would end the
+// command line inside `security -i` and turn the remainder into a second command.
+func TestKeychainRefusesALineBreak(t *testing.T) {
+	err := platformStore("m3c-skillctl-selftest", "linebreak.invalid", "glpat-a\nglpat-b")
+	if err == nil || !strings.Contains(err.Error(), "line break") {
+		t.Errorf("err = %v, want a refusal naming the line break", err)
+	}
+}
+
+func TestQuoteKCEscapes(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{`plain`, `"plain"`},
+		{`with "quote"`, `"with \"quote\""`},
+		{`back\slash`, `"back\\slash"`},
+	} {
+		if got := quoteKC(tc.in); got != tc.want {
+			t.Errorf("quoteKC(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/pkg/skillctl/artifactauth/store_other.go
+++ b/pkg/skillctl/artifactauth/store_other.go
@@ -1,0 +1,19 @@
+//go:build !darwin && !windows
+
+package artifactauth
+
+import "fmt"
+
+// No protected credential store here. Store() checks HasProtectedStore first and
+// returns a message naming the environment variable, so these two exist only to
+// keep the package compiling on every platform.
+
+func HasProtectedStore() bool { return false }
+
+func ProtectedStoreName() string { return "none" }
+
+func platformStore(service, account, secret string) error {
+	return fmt.Errorf("artifactauth: no protected credential store on this platform")
+}
+
+func platformDelete(service, account string) error { return nil }

--- a/pkg/skillctl/artifactauth/store_test.go
+++ b/pkg/skillctl/artifactauth/store_test.go
@@ -93,3 +93,43 @@ func TestBackendsIsSorted(t *testing.T) {
 		}
 	}
 }
+
+// A host that could be read as an option is refused, and that is the case worth
+// pinning: `security` would have taken a leading dash as a flag and acted on the
+// wrong item, without saying so.
+func TestValidHostRejectsWhatWouldBeMisread(t *testing.T) {
+	for _, tc := range []struct{ host, want string }{
+		{"", "a host is required"},
+		{"-S", "leading dash"},
+		{"host with space", "whitespace or a control character"},
+		{"host\ttab", "whitespace or a control character"},
+		{"host\x00null", "whitespace or a control character"},
+	} {
+		if err := validHost(tc.host); err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("validHost(%q) = %v, want it to mention %q", tc.host, err, tc.want)
+		}
+	}
+	for _, ok := range []string{"git.kieback-peter.de", "192.168.0.135:8929", "localhost"} {
+		if err := validHost(ok); err != nil {
+			t.Errorf("validHost(%q) = %v, want nil", ok, err)
+		}
+	}
+}
+
+// Delete validates the same way Store does. A delete that acts on the wrong item
+// is quieter than a write that does, and therefore worse.
+func TestDeleteValidatesToo(t *testing.T) {
+	if err := Delete("nonesuch", TierWrite, "h"); err == nil || !strings.Contains(err.Error(), "unknown backend") {
+		t.Errorf("unknown backend: %v", err)
+	}
+	if err := Delete("gitlab", TierWrite, "-S"); err == nil || !strings.Contains(err.Error(), "leading dash") {
+		t.Errorf("a host that reads as an option must be refused: %v", err)
+	}
+}
+
+// The store has a name a human can read, whatever the platform.
+func TestProtectedStoreNameIsNotEmpty(t *testing.T) {
+	if ProtectedStoreName() == "" {
+		t.Error("the store needs a name for the message that tells an operator where the token went")
+	}
+}

--- a/pkg/skillctl/artifactauth/store_test.go
+++ b/pkg/skillctl/artifactauth/store_test.go
@@ -1,0 +1,95 @@
+package artifactauth
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The service and env names live in one place. This pins the pairs the docs and
+// the ops routine promise, so a rename has to change them here too.
+func TestServiceForNames(t *testing.T) {
+	for _, tc := range []struct {
+		backend         string
+		tier            Tier
+		service, envVar string
+	}{
+		{"gitlab", TierWrite, "m3c-skillctl-gitlab", "M3C_GITLAB_TOKEN"},
+		{"gitlab", TierRead, "m3c-skillctl-gitlab-ro", "M3C_GITLAB_RO_TOKEN"},
+		{"registry", TierWrite, "m3c-skillctl-registry", "M3C_REGISTRY_TOKEN"},
+		{"registry", TierRead, "m3c-skillctl-registry-ro", "M3C_REGISTRY_RO_TOKEN"},
+	} {
+		svc, env, ok := ServiceFor(tc.backend, tc.tier)
+		if !ok {
+			t.Fatalf("%s/%s: unknown backend", tc.backend, tc.tier)
+		}
+		if svc != tc.service || env != tc.envVar {
+			t.Errorf("%s/%s = (%q, %q), want (%q, %q)", tc.backend, tc.tier, svc, env, tc.service, tc.envVar)
+		}
+	}
+	if _, _, ok := ServiceFor("nonesuch", TierRead); ok {
+		t.Error("an unknown backend must not resolve")
+	}
+}
+
+// Store refuses instead of falling back to something weaker. A silent fallback
+// would be the worst outcome: the operator believes the token is protected
+// because the command said nothing.
+func TestStoreRefusesBadInput(t *testing.T) {
+	for _, tc := range []struct{ backend, host, secret, want string }{
+		{"nonesuch", "h", "s", "unknown backend"},
+		{"gitlab", "", "s", "a host is required"},
+		{"gitlab", "h", "", "refusing to store an empty token"},
+	} {
+		err := Store(tc.backend, TierWrite, tc.host, tc.secret)
+		if err == nil {
+			t.Fatalf("%+v: expected a refusal", tc)
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("%+v: err = %v, want it to mention %q", tc, err, tc.want)
+		}
+	}
+}
+
+// On a platform without a protected store, Store must say so and name the
+// environment variable, rather than writing the token somewhere unprotected.
+func TestStoreOnPlatformWithoutAStore(t *testing.T) {
+	if HasProtectedStore() {
+		t.Skipf("%s has a protected store; this case is for the others", runtime.GOOS)
+	}
+	err := Store("gitlab", TierWrite, "h", "s")
+	if err == nil || !strings.Contains(err.Error(), "M3C_GITLAB_TOKEN") {
+		t.Errorf("the refusal must name the env var, got %v", err)
+	}
+}
+
+// Provisioned reports the SOURCE and never the secret, and the env override wins,
+// exactly as the resolver orders it. An operator whose stored token seems ignored
+// needs to see that a stale export is the reason.
+func TestProvisionedReportsEnvFirstAndNeverTheSecret(t *testing.T) {
+	t.Setenv("M3C_REGISTRY_TOKEN", "top-secret")
+	got := Provisioned("registry", TierWrite, "reg.example")
+	if got != "env M3C_REGISTRY_TOKEN" {
+		t.Errorf("Provisioned = %q, want the env source", got)
+	}
+	if strings.Contains(got, "top-secret") {
+		t.Error("the secret leaked into the source description")
+	}
+
+	t.Setenv("M3C_REGISTRY_TOKEN", "")
+	if got := Provisioned("registry", TierWrite, "no-such-host.invalid"); got != "" {
+		t.Errorf("nothing provisioned must be empty, got %q", got)
+	}
+}
+
+func TestBackendsIsSorted(t *testing.T) {
+	b := Backends()
+	if len(b) < 3 {
+		t.Fatalf("expected at least gitlab, github, registry; got %v", b)
+	}
+	for i := 1; i < len(b); i++ {
+		if b[i-1] > b[i] {
+			t.Fatalf("Backends() is not sorted: %v", b)
+		}
+	}
+}

--- a/pkg/skillctl/artifactauth/store_windows.go
+++ b/pkg/skillctl/artifactauth/store_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package artifactauth
+
+// On Windows the protected store is DPAPI, implemented in creds_windows.go. This
+// file is only the dispatch the platform-neutral Store/Delete call.
+
+func HasProtectedStore() bool { return true }
+
+func ProtectedStoreName() string { return "Windows DPAPI (per user account)" }
+
+func platformStore(service, account, secret string) error {
+	return StoreCred(service, account, secret)
+}
+
+func platformDelete(service, account string) error {
+	return DeleteCred(service, account)
+}


### PR DESCRIPTION
Der Lesepfad konsultierte auf beiden Plattformen einen geschuetzten Credential-Speicher, und **nichts konnte ihn fuellen**. Auf macOS griff man von Hand zu `security add-generic-password`; auf Windows war der DPAPI-Schreiber gebaut und von keinem Kommando erreichbar, also blieb dort ein schreibfaehiger Token im Klartext in der Umgebungsvariablen, vererbt an jeden Kindprozess.

Das ist die Art Luecke, die von beiden Seiten aus vollstaendig aussieht: die Leseseite unterstuetzte den Speicher, der Betreiber hatte keinen Weg hinein.

## Der Token steht nie in einem Argument

Ein Argument ist fuer die Dauer des Aufrufs jedem Prozess auf der Maschine ueber `ps` sichtbar und landet in der Shell-Historie dessen, der das Kommando von Hand wiederholt. Auf macOS heisst das `security -i` statt `security … -w <token>`: dieselbe Anweisung, nur ueber stdin.

Nachgemessen, waehrend ein Testtoken gespeichert wurde:

```
$ echo 'glpat-TESTWERT' | skillctl token set --backend gitlab --host test.invalid --read-only
stored in macOS Keychain
$ ps aux | grep glpat-TESTWERT | grep -v grep
(keine Zeile)
$ security find-generic-password -s m3c-skillctl-gitlab-ro -a test.invalid -w
glpat-TESTWERT        <- der Resolver liest ihn zurueck
$ skillctl token rm --backend gitlab --host test.invalid --read-only
$ security find-generic-password …
The specified item could not be found in the keychain.
```

## Drei Unterkommandos

`set` legt ab. `list` nennt je Backend und Tier die **Quelle** und nie den Token; die Quelle ist die interessante Angabe, weil eine gesetzte Umgebungsvariable den geschuetzten Speicher schlaegt und ein vergessenes `export` einen Fehlschlag erklaert, den der abgelegte Token nicht verursacht haette. `rm` sagt in seiner eigenen Ausgabe, dass es **Hygiene ist und keine Ruecknahme**: der Token bleibt gueltig, wo er ausgestellt wurde.

`Store()` weicht nicht auf etwas Schwaecheres aus. Auf einer Plattform ohne geschuetzten Speicher verweigert es und nennt die Umgebungsvariable. Ein stilles Ausweichen waere der schlimmste Ausgang, weil der Betreiber den Token dann fuer geschuetzt haelt.

Die Namen der Dienste und Variablen stehen jetzt an genau einer Stelle (`ServiceFor`). Vorher buchstabierten Resolver, Doku und Ops-Routine sie je einzeln aus.

## Die Ops-Routine wird dadurch kuerzer

Aus zwei plattformabhaengigen Einzeilern wird ein Kommando, und der Abschnitt "Offener Punkt: Windows" ist geschlossen. Was stattdessen offen bleibt, steht jetzt ausdruecklich da: **Ablaufwarnungen** (GitLab warnt nicht vorab, und das Ablaufdatum steht in keinem Token, daher das Register) und **Widerruf** (nur in GitLab).

## Gemessen

```
go build darwin + windows + linux         ok
go test ./pkg/... ./cmd/skillctl/          0 Fehlschlaege
check-docs.sh (docaudit + verbaudit)       PASS
check-no-emdash.sh                         gruen
make sim                                   51 Szenarien, 0 Konflikte
Akzeptanzskript                            29 PASS, exit 0
```

Das Verb ist in `docs/CLI-VERBS.md` registriert und im Handbuch dokumentiert, beides vom Doku-Gate erzwungen.