### PR TITLE
fix(installer): RELEASE_BASE-Default auf v0.4.0, ed25519-Fallback-Fetch diagnostizierbar

### DIFF
--- a/tools/skillctl-install.ps1
+++ b/tools/skillctl-install.ps1
@@ -22,7 +22,7 @@
 
 .PARAMETER ReleaseBase
   Base URL of the release assets. Env fallback: $env:RELEASE_BASE. Default:
-  https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.3.1
+  https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.4.0
 
 .PARAMETER InstallDir
   Install directory. Env fallback: $env:INSTALL_DIR. Default:
@@ -98,7 +98,7 @@ $ASSET = 'skillctl-windows-amd64.exe'
 # ============================================================================
 if (-not $ReleaseBase) {
     $ReleaseBase = if ($env:RELEASE_BASE) { $env:RELEASE_BASE }
-                   else { 'https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.3.1' }
+                   else { 'https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.4.0' }
 }
 if (-not $InstallDir) {
     $InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR }

--- a/tools/skillctl-install.sh
+++ b/tools/skillctl-install.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 # SEC: an env-supplied release base relaxes the trust anchor. Honor it (legitimate
 # for testing) but warn loudly so a poisoned environment can't silently repoint us.
 [ -n "${RELEASE_BASE:-}" ] && echo "WARNING: RELEASE_BASE overrides the default release origin (${RELEASE_BASE})" >&2
-RELEASE_BASE="${RELEASE_BASE:-https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.3.1}"
+RELEASE_BASE="${RELEASE_BASE:-https://github.com/kamir/m3c-tools/releases/download/skillctl/v0.4.0}"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 
 # SEC-M2: pin the release-key fingerprint. The signature alone proves only that
@@ -102,7 +102,22 @@ fi
 # === Provenance track 2 (fallback / current default): pinned ed25519 (SEC-M2). ===
 # Reached when cosign is absent or the release carries no cosign bundle.
 if [ "$verified" != "1" ]; then
-  fetch SHA256SUMS.sig
+  # Attaching SHA256SUMS.sig to a release is a manual operator step with the
+  # private key, and it has been missed before. Unguarded, this fetch would die
+  # under `set -e` with a bare curl 404 and no hint what went wrong; guard it
+  # like the manifest fetch above and say what is missing and what to do.
+  if ! fetch SHA256SUMS.sig; then
+    echo "Could not fetch the fallback signature (SHA256SUMS.sig) from:" >&2
+    echo "  $RELEASE_BASE" >&2
+    echo "The cosign track did not verify here (cosign missing, or no bundle fetched) and" >&2
+    echo "this release does not (yet) carry the ed25519 fallback asset SHA256SUMS.sig," >&2
+    echo "so neither provenance track can verify." >&2
+    echo "Two ways out:" >&2
+    echo "  1. install cosign and re-run; track 1 verifies the keyless cosign bundle, or" >&2
+    echo "  2. ask the release operator to attach SHA256SUMS.sig to this release." >&2
+    echo "Refusing to install unverified binaries." >&2
+    exit 1
+  fi
   fetch skillctl-release.pub
 
   # SEC-M2: prefer the in-repo, version-controlled release key when this script


### PR DESCRIPTION
## Befunde (Enterprise-Audit Welle 1, adversarial nachgemessen)

**1.7 (mittel):** `tools/skillctl-install.sh:16` und `tools/skillctl-install.ps1:101` defaulten auf `releases/download/skillctl/v0.3.1`; `skillctl/v0.4.0` ist seit 2026-09-03 publiziert (gemessen: `gh release view skillctl/v0.4.0` liefert `isDraft:false, publishedAt 2026-09-03T11:23:07Z`). Der Einzeiler ohne Override installierte still die Vorversion.

**1.6, Code-Anteil (hoch):** Track 2 (ed25519-Fallback ohne cosign) fetcht `SHA256SUMS.sig` ungeguardet unter `set -euo pipefail`. Das Asset fehlt an 2 von 2 signierten Releases (gemessen: Asset-Listen von v0.3.1 und v0.4.0 enthalten `SHA256SUMS.cosign.bundle` und `skillctl-release.pub`, aber kein `SHA256SUMS.sig`); der Einzeiler starb mit nacktem curl-404 ohne Diagnose.

## Fix

1. `RELEASE_BASE`-Default in beiden Skripten auf `skillctl/v0.4.0` (sh Zeile 16; ps1 Hilfetext und Default-Aufloesung). Die `.ps1` ist sonst unangetastet (sie laedt gepinntes cosign selbst, Befund 1.6 betrifft sie nicht).
2. Der `.sig`-Fetch ist jetzt wie der Manifest-Fetch geguardet: bei 404 benennt die Meldung das fehlende Asset, dass das Release den ed25519-Fallback (noch) nicht traegt, und die zwei Auswege (cosign installieren; `SHA256SUMS.sig` beim Release-Operator nachfordern). Fail-closed bleibt: Exit 1, nichts wird installiert.

## Messung vorher/nachher

404-Pfad hermetisch simuliert (lokaler HTTP-Server mit `SHA256SUMS`, aber 404 fuer `SHA256SUMS.sig`; `PATH=/usr/bin:/bin`, also ohne cosign):

| n/a | Exit | stderr |
|---|---|---|
| vorher (origin/master) | 22 | `curl: (22) The requested URL returned error: 404` (sonst nichts) |
| nachher | 1 | volle Diagnose: fehlendes Asset, Ursache, zwei Auswege, "Refusing to install unverified binaries." |

Gegenproben:
- `.sig` vorhanden (Dummy): der Guard ist transparent, das Skript laeuft in die Signaturpruefung und lehnt die Dummy-Signatur ab (`SIGNATURE VERIFICATION FAILED`, Exit 1).
- Realer Lauf ohne `RELEASE_BASE` gegen das Netz: Manifest kommt vom neuen v0.4.0-Default, danach die neue Diagnose (das echte v0.4.0 traegt die `.sig` tatsaechlich nicht), Exit 1.
- `bash -n` beider... der `.ps1`-Anteil ist ein reiner String-Tausch; `bash -n tools/skillctl-install.sh` OK, `./scripts/check-install-pins.sh` gruen (3 Pins, Digests passen), `./scripts/check-no-emdash.sh` PASS, `go build ./... && go vet ./...` OK.

## Doku-Pins: warum dieser PR sie NICHT anfasst (Henne-Ei, gemessen)

`scripts/bump-install-pins.sh` + `.github/workflows/pin-bump.yml` loesen das Henne-Ei so: Pins zeigen immer auf einen PUBLIZIERTEN Commit (`check-install-pins.sh` verlangt `merge-base --is-ancestor origin/master`), und der Doku-Bump ist ein EIGENER Post-Merge-PR des Workflows. Gemessen: `git rev-parse "skillctl/v0.4.0^{commit}"` = `f43eb49...`, exakt der Commit, den README/quickstart/acceptance heute pinnen. Die Pins sind also nach diesem Design aktuell; haette dieser PR sie auf den eigenen (unpublizierten) Commit gehoben, waere `check-install-pins.sh` rot und die Raw-URLs 404.

**Nach dem Merge:** `pin-bump` per `workflow_dispatch` mit `ref` = Merge-Commit (oder `origin/master`) ausloesen; der Bot-PR hebt Pins + Digests, `check-install-pins.sh` gatet ihn.

## pin-bump.yml: kein Aenderungsbedarf

Der geforderte `workflow_dispatch` existiert bereits auf `origin/master` (Commit `5e8df21`), mit Input `ref` ("tag, branch or commit to pin"); ein Tag ist dort zulaessig, der Resolve-Schritt macht `${ref}^{commit}`. Gemessen mit einem Duplikatschluessel-verweigernden YAML-Parser: Datei parst sauber, `workflow_dispatch.inputs = ['ref']`. Ein zusaetzlicher `tag`-Input waere ein Duplikat desselben Wegs.

## Offen (Operator, nicht dieser PR)

- `SHA256SUMS.sig` an v0.3.1/v0.4.0 anheften: manueller Schritt mit dem privaten Release-Schluessel.
- Nach Merge: pin-bump per workflow_dispatch ausloesen (s.o.).
- Kommentar in `.github/workflows/skillctl-windows-smoke.yml:95` nennt noch v0.3.1 als Default (nur Kommentar; Workflow-Push braucht SSH, hier bewusst nicht angefasst).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
