### PR TITLE
fix(skillbundle): Eingabe-Budgets fuer CHECKSUMS-Verifier und Tar-Headernamen (AUDIT-0001, 1.8 + 1.9)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,8 +1,8 @@
 name: Nightly Fuzz (trust-layer parsers)
 
 # Nightly Go native-fuzzing sweep over the untrusted-input surfaces of the
-# skillctl trust layer (archive readers, semver comparator, event envelope,
-# revocation list, trust-roots + SKILL.md parsers). Each target runs for a bounded
+# skillctl trust layer (archive readers, CHECKSUMS verifier, semver comparator,
+# event envelope, revocation list, trust-roots + SKILL.md parsers). Each target runs for a bounded
 # time and FAILS the job on any NEW crasher. An input that panics or violates the
 # target's invariant oracle (a path escape, a fail-open verify, an ordering
 # inconsistency).
@@ -39,6 +39,8 @@ jobs:
           - target: FuzzUnpack
             dir: pkg/skillbundle
           - target: FuzzExtractTo
+            dir: pkg/skillbundle
+          - target: FuzzValidateChecksums
             dir: pkg/skillbundle
           - target: FuzzCompare
             dir: pkg/skillctl/semver

--- a/pkg/skillbundle/checksums.go
+++ b/pkg/skillbundle/checksums.go
@@ -37,7 +37,20 @@ var ErrChecksumMismatch = errors.New("bundle CHECKSUMS does not describe the ext
 // Two layouts are accepted because two producers exist: the flat archive that
 // skillbundle.Pack emits, and the one wrapped in a single <name>-<version>/
 // directory. The single-entry directory heuristic is what tells them apart.
+//
+// The manifest is attacker-influenced input, so the work it can demand is
+// budgeted (AUDIT-0001 finding 1.8): the entry count is capped by
+// DefaultMaxExtractedFiles, the total bytes hashed by DefaultMaxExtractedBytes,
+// the same limits the extraction path already enforces, and a path named twice
+// is refused outright. Without those caps a small bundle could demand gigabytes
+// of hashing through sheer line repetition.
 func ValidateChecksums(extractDir string) error {
+	return validateChecksums(extractDir, DefaultMaxExtractedBytes, DefaultMaxExtractedFiles)
+}
+
+// validateChecksums is the budget-parameterised body; tests override the limits
+// so the budget branches are reachable without gigabyte fixtures.
+func validateChecksums(extractDir string, maxBytes int64, maxEntries int) error {
 	root := extractDir
 	if entries, err := os.ReadDir(extractDir); err == nil && len(entries) == 1 && entries[0].IsDir() {
 		root = filepath.Join(extractDir, entries[0].Name())
@@ -54,10 +67,18 @@ func ValidateChecksums(extractDir string) error {
 	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
+	seen := make(map[string]struct{})
+	var lineCount int
+	var hashedBytes int64
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
+		}
+		lineCount++
+		if lineCount > maxEntries {
+			return fmt.Errorf("CHECKSUMS lists more than %d entries: %w",
+				maxEntries, ErrChecksumMismatch)
 		}
 		// Accept "<hex>  <path>" or "<hex> <path>" (one or two spaces).
 		var wantHex, rel string
@@ -80,11 +101,23 @@ func ValidateChecksums(extractDir string) error {
 		if strings.HasPrefix(cleanRel, "..") || filepath.IsAbs(cleanRel) {
 			return fmt.Errorf("CHECKSUMS entry %q escapes root: %w", rel, ErrChecksumMismatch)
 		}
+		// A manifest that names the same file twice is not a valid manifest: the
+		// second line either repeats the first (wasted work an attacker can
+		// multiply) or contradicts it. Either way, refuse.
+		if _, dup := seen[cleanRel]; dup {
+			return fmt.Errorf("CHECKSUMS names %q twice: %w", cleanRel, ErrChecksumMismatch)
+		}
+		seen[cleanRel] = struct{}{}
 		if cleanRel == "CHECKSUMS" {
 			continue
 		}
 		fp := filepath.Join(root, cleanRel)
-		got, err := fileSHA256Hex(fp)
+		got, n, err := fileSHA256Hex(fp, maxBytes-hashedBytes)
+		hashedBytes += n
+		if errors.Is(err, errHashBudgetExceeded) {
+			return fmt.Errorf("CHECKSUMS verification exceeds the %d byte hashing budget at %q: %w",
+				maxBytes, rel, ErrChecksumMismatch)
+		}
 		if err != nil {
 			return fmt.Errorf("hash %s: %w", fp, errors.Join(ErrChecksumMismatch, err))
 		}
@@ -99,17 +132,30 @@ func ValidateChecksums(extractDir string) error {
 	return nil
 }
 
-func fileSHA256Hex(path string) (string, error) {
+// errHashBudgetExceeded is the internal signal that a hash run hit the byte
+// budget; the caller maps it onto ErrChecksumMismatch with the limit named.
+var errHashBudgetExceeded = errors.New("hash byte budget exceeded")
+
+// fileSHA256Hex hashes at most budget bytes of path and reports how many bytes
+// it consumed. Reading past the budget aborts with errHashBudgetExceeded
+// instead of finishing the file: the budget bounds work, not just output.
+func fileSHA256Hex(path string, budget int64) (string, int64, error) {
 	// #nosec G304 -- a path inside the caller's extraction directory, cleaned and
 	// checked for escape above.
 	f, err := os.Open(path)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	defer func() { _ = f.Close() }()
 	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
+	// budget+1 so a file that is exactly one byte over is detected, not
+	// silently truncated into a wrong (and then "mismatching") hash.
+	n, err := io.Copy(h, io.LimitReader(f, budget+1))
+	if err != nil {
+		return "", n, err
 	}
-	return hex.EncodeToString(h.Sum(nil)), nil
+	if n > budget {
+		return "", n, errHashBudgetExceeded
+	}
+	return hex.EncodeToString(h.Sum(nil)), n, nil
 }

--- a/pkg/skillbundle/checksums_test.go
+++ b/pkg/skillbundle/checksums_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -105,5 +106,67 @@ func TestValidateChecksumsHandlesTheWrappedLayout(t *testing.T) {
 	}
 	if err := ValidateChecksums(outer); !errors.Is(err, ErrChecksumMismatch) {
 		t.Fatalf("the wrapped layout must be checked, not skipped: %v", err)
+	}
+}
+
+// AUDIT-0001 finding 1.8: a manifest that names the same file twice is refused,
+// not re-hashed. Before the budget fix, 2000 duplicate VALID lines on a 10MiB
+// file made ValidateChecksums hash 19.5GiB and return nil; the small-scale
+// probe here (50 duplicates) must die on line two instead.
+func TestValidateChecksumsRefusesADuplicateEntry(t *testing.T) {
+	line := hashOf("body") + "  SKILL.md\n"
+	dir := write(t, map[string]string{"SKILL.md": "body"}, strings.Repeat(line, 50))
+	err := ValidateChecksums(dir)
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("a duplicated entry must be refused with ErrChecksumMismatch: %v", err)
+	}
+	if !strings.Contains(err.Error(), "twice") {
+		t.Fatalf("the refusal must say the path was named twice: %v", err)
+	}
+}
+
+// AUDIT-0001 finding 1.8: the total bytes hashed are capped by the same byte
+// budget the extraction path enforces. Three distinct 8-byte files against a
+// 16-byte override must refuse (24 > 16) and name the limit; the same layout
+// within a 32-byte budget must pass.
+func TestValidateChecksumsCapsTotalHashedBytes(t *testing.T) {
+	files := map[string]string{"a.md": "AAAAAAAA", "b.md": "BBBBBBBB", "c.md": "CCCCCCCC"}
+	manifest := hashOf("AAAAAAAA") + "  a.md\n" +
+		hashOf("BBBBBBBB") + "  b.md\n" +
+		hashOf("CCCCCCCC") + "  c.md\n"
+	dir := write(t, files, manifest)
+	err := validateChecksums(dir, 16, DefaultMaxExtractedFiles)
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("exceeding the hashing byte budget must carry ErrChecksumMismatch: %v", err)
+	}
+	if !strings.Contains(err.Error(), "16 byte") {
+		t.Fatalf("the refusal must name the budget: %v", err)
+	}
+	if err := validateChecksums(dir, 32, DefaultMaxExtractedFiles); err != nil {
+		t.Fatalf("the same manifest within the budget must pass: %v", err)
+	}
+}
+
+// AUDIT-0001 finding 1.8: the entry-line count is capped by the same file limit
+// the extraction path enforces. Five entries against a cap of three refuse and
+// name the limit; blank and comment lines do not count against it.
+func TestValidateChecksumsCapsEntryCount(t *testing.T) {
+	files := map[string]string{"a.md": "A", "b.md": "B", "c.md": "C", "d.md": "D", "e.md": "E"}
+	manifest := "# header comment\n\n" +
+		hashOf("A") + "  a.md\n" +
+		hashOf("B") + "  b.md\n" +
+		hashOf("C") + "  c.md\n"
+	dir := write(t, files, manifest)
+	if err := validateChecksums(dir, DefaultMaxExtractedBytes, 3); err != nil {
+		t.Fatalf("three entries plus comments within a cap of three must pass: %v", err)
+	}
+	longer := manifest + hashOf("D") + "  d.md\n" + hashOf("E") + "  e.md\n"
+	dir2 := write(t, files, longer)
+	err := validateChecksums(dir2, DefaultMaxExtractedBytes, 3)
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("exceeding the entry cap must carry ErrChecksumMismatch: %v", err)
+	}
+	if !strings.Contains(err.Error(), "more than 3 entries") {
+		t.Fatalf("the refusal must name the cap: %v", err)
 	}
 }

--- a/pkg/skillbundle/fuzz_test.go
+++ b/pkg/skillbundle/fuzz_test.go
@@ -16,6 +16,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -66,17 +67,17 @@ func FuzzUnpack(f *testing.F) {
 	seeds := [][]titem{
 		{reg("SKILL.md", "# s"), reg("scripts/run.sh", "echo hi"), reg("references/doc.md", "ref")},
 		{dir("bundle"), reg("bundle/SKILL.md", "# s"), reg("bundle/scripts/run.sh", "x")}, // wrapped
-		{reg("mybundle/Skill.md", "# s")},                                                 // canonicalize
-		{reg("../evil", "x")},                                                             // traversal
-		{reg("a/../../b", "x")},                                                           // deep escape
-		{reg("/etc/passwd", "x")},                                                         // absolute
-		{reg("..", "x")},                                                                  // bare dotdot
-		{reg(`a\..\..\evil`, "x")},                                                        // backslash
-		{sym("link", "/etc/passwd")},                                                      // symlink refused
-		{hard("hl", "/etc/passwd")},                                                       // hardlink refused
-		{chardev("dev")},                                                                  // device refused
-		{reg("big", strings.Repeat("A", 4096))},                                           // exercises the byte ceiling when opt bit set
-		{reg("a", "1"), reg("b", "2"), reg("c", "3")},                                     // exercises the file-count cap when opt bit set
+		{reg("mybundle/Skill.md", "# s")},             // canonicalize
+		{reg("../evil", "x")},                         // traversal
+		{reg("a/../../b", "x")},                       // deep escape
+		{reg("/etc/passwd", "x")},                     // absolute
+		{reg("..", "x")},                              // bare dotdot
+		{reg(`a\..\..\evil`, "x")},                    // backslash
+		{sym("link", "/etc/passwd")},                  // symlink refused
+		{hard("hl", "/etc/passwd")},                   // hardlink refused
+		{chardev("dev")},                              // device refused
+		{reg("big", strings.Repeat("A", 4096))},       // exercises the byte ceiling when opt bit set
+		{reg("a", "1"), reg("b", "2"), reg("c", "3")}, // exercises the file-count cap when opt bit set
 	}
 	// optBits: bit0 StripWrapper, bit1 CanonicalizeMD, bit2 tiny MaxBytes, bit3 tiny MaxFiles.
 	optCombos := []uint8{0, 1, 2, 3, 4, 8, 12}
@@ -179,5 +180,46 @@ func FuzzExtractTo(f *testing.F) {
 			t.Fatalf("ExtractTo wrote outside destDir: rel=%q created %q (dest=%q)", rel, p, absDest)
 			return nil
 		})
+	})
+}
+
+// FuzzValidateChecksums drives the CHECKSUMS verifier with an untrusted
+// manifest laid over a tiny fixed bundle (the manifest arrives inside the
+// attacker's archive, so it is as hostile as the archive itself). Oracles: the
+// verifier never panics, and every refusal is classifiable, either it carries
+// ErrChecksumMismatch (the contract callers map the whole class on) or it is
+// the one manifest-read failure (a line beyond the scanner's token limit).
+// Budgets are small overrides so a fuzzed manifest can never buy hashing time
+// (the AUDIT-0001 finding-1.8 class).
+func FuzzValidateChecksums(f *testing.F) {
+	goodHex := hashOf("body")
+	seeds := []string{
+		goodHex + "  SKILL.md\n",                            // honest, two-space form
+		"# comment\n\n" + goodHex + " SKILL.md\n",           // comment + one-space form
+		goodHex + "  SKILL.md\n" + goodHex + "  SKILL.md\n", // duplicate entry
+		goodHex + "  ../../etc/passwd\n",                    // escaping entry
+		"deadbeef  missing.md\n",                            // file not on disk
+		"nospace\n",                                         // malformed line
+		goodHex + "  \n",                                    // missing path
+		goodHex + "  CHECKSUMS\n",                           // self-entry
+		strings.Repeat(goodHex+"  SKILL.md\n", 80),          // line repetition
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, manifest []byte) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("body"), 0o644); err != nil {
+			t.Fatalf("write SKILL.md: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "CHECKSUMS"), manifest, 0o644); err != nil {
+			t.Fatalf("write CHECKSUMS: %v", err)
+		}
+		err := validateChecksums(dir, 1<<12, 64) // must never panic
+		if err != nil && !errors.Is(err, ErrChecksumMismatch) &&
+			!strings.Contains(err.Error(), "read CHECKSUMS") {
+			t.Fatalf("unclassifiable refusal (callers map on ErrChecksumMismatch): %v", err)
+		}
 	})
 }

--- a/pkg/skillbundle/unpack.go
+++ b/pkg/skillbundle/unpack.go
@@ -46,6 +46,10 @@ const (
 	DefaultMaxExtractedBytes int64 = 100 << 20 // 100 MiB
 	// DefaultMaxExtractedFiles bounds the tar entry count (tar-bomb guard).
 	DefaultMaxExtractedFiles = 10000
+	// maxArchiveNameBytes bounds one tar entry name (AUDIT-0001 finding 1.9).
+	// Linux PATH_MAX is 4096; no legitimate bundle path is longer. Only
+	// PAX-long-name resource attacks are, so anything above is refused.
+	maxArchiveNameBytes = 4096
 )
 
 // Entry is one validated, in-memory archive member. By the time Unpack returns
@@ -104,6 +108,16 @@ func Unpack(archive []byte, opts UnpackOptions) ([]Entry, error) {
 		count++
 		if count > maxFiles {
 			return nil, fmt.Errorf("skillbundle: tar entry count exceeds %d (likely a tar bomb)", maxFiles)
+		}
+		// Header names are attacker-sized input too: a PAX long name or long
+		// linkname is decompressed and allocated by the tar reader before this
+		// loop ever sees the header, and dir entries carry no content that the
+		// TypeReg branch below would meter. Charge every entry's name bytes
+		// against the same global byte budget the file contents use
+		// (AUDIT-0001 finding 1.9).
+		written += int64(len(hdr.Name)) + int64(len(hdr.Linkname))
+		if written > maxBytes {
+			return nil, fmt.Errorf("skillbundle: extracted size exceeds %d bytes (likely a gzip bomb)", maxBytes)
 		}
 
 		rel, err := sanitizeArchivePath(hdr.Name)
@@ -302,6 +316,10 @@ func modeFor(rel string, isDir bool) fs.FileMode {
 func sanitizeArchivePath(name string) (string, error) {
 	if name == "" {
 		return "", nil
+	}
+	if len(name) > maxArchiveNameBytes {
+		return "", fmt.Errorf("skillbundle: tar entry name of %d bytes exceeds the %d byte limit",
+			len(name), maxArchiveNameBytes)
 	}
 	if strings.ContainsRune(name, 0) {
 		return "", fmt.Errorf("skillbundle: tar entry name contains NUL")

--- a/pkg/skillbundle/unpack_test.go
+++ b/pkg/skillbundle/unpack_test.go
@@ -21,11 +21,11 @@ type titem struct {
 	link string
 }
 
-func reg(name, body string) titem  { return titem{name: name, typ: tar.TypeReg, body: body} }
-func dir(name string) titem        { return titem{name: name, typ: tar.TypeDir} }
-func sym(name, to string) titem    { return titem{name: name, typ: tar.TypeSymlink, link: to} }
-func hard(name, to string) titem   { return titem{name: name, typ: tar.TypeLink, link: to} }
-func chardev(name string) titem    { return titem{name: name, typ: tar.TypeChar} }
+func reg(name, body string) titem { return titem{name: name, typ: tar.TypeReg, body: body} }
+func dir(name string) titem       { return titem{name: name, typ: tar.TypeDir} }
+func sym(name, to string) titem   { return titem{name: name, typ: tar.TypeSymlink, link: to} }
+func hard(name, to string) titem  { return titem{name: name, typ: tar.TypeLink, link: to} }
+func chardev(name string) titem   { return titem{name: name, typ: tar.TypeChar} }
 
 // makeArchive builds a gzip+tar blob from items, verbatim (no sanitisation) so
 // tests can inject hostile headers.
@@ -324,4 +324,59 @@ func keys(m map[string]Entry) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// AUDIT-0001 finding 1.9: entry names count against the byte ceiling. Before
+// the fix, only TypeReg content was metered, so an archive of dir entries with
+// long PAX names (the audit probe: 41MiB archive, 11.7GiB heap) passed every
+// budget. Three dir entries carrying 600 name bytes must trip a 512-byte
+// ceiling; the same archive under a roomier ceiling still passes.
+func TestUnpack_NameBytesCountAgainstByteCeiling(t *testing.T) {
+	blob := makeArchive(t, []titem{
+		dir(strings.Repeat("a", 200)),
+		dir(strings.Repeat("b", 200)),
+		dir(strings.Repeat("c", 200)),
+	})
+	_, err := Unpack(blob, UnpackOptions{MaxBytes: 512})
+	if err == nil {
+		t.Fatal("600 bytes of dir-entry names must trip a 512-byte ceiling")
+	}
+	if !strings.Contains(err.Error(), "exceeds 512 bytes") {
+		t.Fatalf("the refusal must name the ceiling: %v", err)
+	}
+	if entries, err := Unpack(blob, UnpackOptions{MaxBytes: 2048}); err != nil || len(entries) != 3 {
+		t.Fatalf("the same names within the ceiling must pass: entries=%d err=%v", len(entries), err)
+	}
+}
+
+// AUDIT-0001 finding 1.9: a linkname is header-carried input of attacker-chosen
+// size, so it counts against the ceiling too. The budget refusal must come
+// BEFORE the symlink refusal: that is what proves the bytes were metered.
+func TestUnpack_LinknameCountsAgainstByteCeiling(t *testing.T) {
+	blob := makeArchive(t, []titem{sym("l", strings.Repeat("t", 600))})
+	_, err := Unpack(blob, UnpackOptions{MaxBytes: 512})
+	if err == nil {
+		t.Fatal("601 header bytes must trip a 512-byte ceiling")
+	}
+	if !strings.Contains(err.Error(), "exceeds 512 bytes") {
+		t.Fatalf("the linkname must be metered before the symlink refusal: %v", err)
+	}
+}
+
+// AUDIT-0001 finding 1.9: one entry name longer than 4096 bytes (PATH_MAX) is
+// refused outright; a name of exactly 4096 bytes still passes. Only PAX
+// long-name resource attacks live above that line, no legitimate bundle does.
+func TestUnpack_RejectsAnOversizedEntryName(t *testing.T) {
+	over := makeArchive(t, []titem{reg(strings.Repeat("n", 4097), "x")})
+	_, err := Unpack(over, UnpackOptions{})
+	if err == nil {
+		t.Fatal("a 4097-byte entry name must be refused")
+	}
+	if !strings.Contains(err.Error(), "4096 byte limit") {
+		t.Fatalf("the refusal must name the limit: %v", err)
+	}
+	at := makeArchive(t, []titem{reg(strings.Repeat("n", 4096), "x")})
+	if entries, err := Unpack(at, UnpackOptions{}); err != nil || len(entries) != 1 {
+		t.Fatalf("a name of exactly 4096 bytes must pass: entries=%d err=%v", len(entries), err)
+	}
 }


### PR DESCRIPTION
## Befund (AUDIT-0001, Welle 1)

**1.8 (mittel), pkg/skillbundle/checksums.go:** ValidateChecksums hat kein Arbeitsbudget. Jede Manifestzeile ruft fileSHA256Hex erneut; 2000 identische GUELTIGE Zeilen auf eine 10MiB-Datei hashen 19.5GiB in 8s, 10 Mio Zeilen auf eine 1-Byte-Datei laufen 87s durch, err=nil.

**1.9 (mittel), pkg/skillbundle/unpack.go:** nur TypeReg-Inhalte zaehlen gegen MaxBytes; Dir-Entries und PAX-Langnamen (inkl. Linkname) zaehlen nie. Ein 41.49MiB-Archiv mit 9999 Dir-Entries und je ~0.96MiB PAX-Namen alloziert 11.70GiB Heap, err=nil.

## Fix

- **1.8a Dedup:** eine doppelt genannte Datei ist ErrChecksumMismatch; ein Manifest, das dieselbe Datei zweimal beschreibt, beschreibt nichts.
- **1.8b Byte-Budget:** Summe der gehashten Bytes gegen DefaultMaxExtractedBytes gekappt (dieselbe Konstante wie im Extraktionspfad, keine neue Zahl); fileSHA256Hex liest via LimitReader hoechstens Budget+1 Bytes, das Budget begrenzt Arbeit, nicht nur Output.
- **1.8c Zeilen-Budget:** Eintragszeilen gegen DefaultMaxExtractedFiles gekappt; Kommentare und Leerzeilen zaehlen nicht. Alle drei Refusals nennen die Grenze und tragen ErrChecksumMismatch als Sentinel. Exportierte Signatur unveraendert (interne budget-parametrisierte Form fuer Tests).
- **1.9a Header-Budget:** len(hdr.Name)+len(hdr.Linkname) zaehlt in der Header-Schleife gegen dasselbe MaxBytes-Budget, fuer JEDEN Entry-Typ.
- **1.9b Per-Name-Grenze:** sanitizeArchivePath verweigert Namen ueber 4096 Bytes (PATH_MAX); exakt 4096 passiert weiterhin.
- **Fuzz:** neues Target FuzzValidateChecksums (Muster der 7 bestehenden Targets; Orakel: kein Panic, jede Verweigerung ist ueber ErrChecksumMismatch klassifizierbar, kleine Budget-Overrides gegen erkaufte Hashzeit) plus Matrix-Eintrag in .github/workflows/fuzz.yml. Die Datei wurde nach der Aenderung mit einem Duplikatschluessel-verweigernden YAML-Parser geprueft (8 Matrix-Zeilen, keine Duplikate).

## Messung

Vorher (origin/master 58b6845, Probe-Tests in klein):

```
PROBE 1.8:  200 dup lines x 1MiB file: err=<nil> elapsed=90.6ms (hashed ~200 MiB)
PROBE 1.9a: 3 dir entries, 600 name bytes, MaxBytes=512: err=<nil> entries=3
PROBE 1.9b: 5000-byte PAX name: err=<nil> entries=1
```

Nachher (dieser Branch, identische Proben):

```
PROBE 1.8:  err=CHECKSUMS names "big.bin" twice: ... elapsed=573µs
PROBE 1.9a: err=skillbundle: extracted size exceeds 512 bytes (likely a gzip bomb), entries=0
PROBE 1.9b: err=skillbundle: tar entry name of 5000 bytes exceeds the 4096 byte limit, entries=0
```

Regressionsschutz: 6 neue Tests (Dup, Byte-Budget, Zeilen-Budget, Namens-Budget, Linkname-Budget, 4096er-Grenze inkl. Akzeptanz bei exakt 4096) + FuzzValidateChecksums.

Legitime Bundles unveraendert: `go test -count=1 ./pkg/skillbundle/ ./pkg/skillctl/install/ ./pkg/skillctl/registry/` gruen (alle bestehenden Paket-Tests + Fuzz-Seed-Replay); Fuzz-Smokes 20s FuzzValidateChecksums, je 15s FuzzUnpack + FuzzExtractTo ohne Crasher; `go build ./...`, `go vet` (3 betroffene Pakete) und `./scripts/check-no-emdash.sh` gruen.
