### PR TITLE
fix(install): install --bundle bekommt den Revocation-Input seines verify-Zwillings (Befund 1.10)

### DIFF
--- a/cmd/skillctl/install_bundle_cmds.go
+++ b/cmd/skillctl/install_bundle_cmds.go
@@ -29,13 +29,21 @@ type installBundleParams struct {
 	bundlePath     string
 	metaPath       string
 	trustRootsPath string
-	registryURL    string
-	governanceMin  string
-	allowYellow    bool
-	ignoreDeps     bool
-	tenantFlag     string
-	homeOverride   string
-	verbose        bool
+	// Offline revocation enforcement (SPEC-0276 R4.4) + freshness contract
+	// (SPEC-0279 R4/R5), same three inputs as the verify twin: a signed
+	// revocation list, an optional signed freshness checkpoint, an optional
+	// signed emergency deny-list. All optional; when empty the behavior is
+	// unchanged.
+	revocationsPath string
+	checkpointPath  string
+	emergencyPath   string
+	registryURL     string
+	governanceMin   string
+	allowYellow     bool
+	ignoreDeps      bool
+	tenantFlag      string
+	homeOverride    string
+	verbose         bool
 }
 
 func runInstallBundle(p installBundleParams, stdout, stderr io.Writer) (code int) {
@@ -95,6 +103,55 @@ func runInstallBundle(p installBundleParams, stdout, stderr io.Writer) (code int
 		logger = stderr
 	}
 
+	// Offline revocation + freshness gate (SPEC-0276 R4.4, SPEC-0279 R3/R4/R5),
+	// the SAME checks the verify twin runs, in the same order and with the same
+	// exit codes: forged/untrusted list → 12, revoked digest → 17, emergency hit
+	// → 17, stale snapshot for a high-risk bundle → 22. It runs as InstallBundle's
+	// PostVerify hook so it binds to the digest of the verified blob and refuses
+	// BEFORE anything is staged or written. Fail-closed: an unreadable list is an
+	// error, never a pass. gateCode carries the twin's exit code out of the hook;
+	// gateFresh carries the freshness decision for the twin's diagnostics.
+	var gateCode int
+	var gateFresh *freshnessOutcome
+	postVerify := func(res *verify.VerifyResult) error {
+		// The digest is signed-verified the moment the hook runs; record it even
+		// on a refusal, so the audit trail names WHAT was refused.
+		audDigest = res.Digest
+		var snap revocationSnapshot
+		if p.revocationsPath != "" {
+			var revErr error
+			snap, revErr = checkBundleRevoked(p.revocationsPath, root, res.Digest)
+			if revErr != nil {
+				gateCode = verify.ExitCode(revErr)
+				return revErr
+			}
+			if snap.revoked {
+				gateCode = exitBundleRevoked
+				return fmt.Errorf("REVOKED: %s is in the signed revocation list (%s); refusing to install", res.Digest, p.revocationsPath)
+			}
+		}
+		if p.revocationsPath != "" || p.checkpointPath != "" || p.emergencyPath != "" {
+			fresh := evaluateFreshness(freshnessInputs{
+				root:            root,
+				checkpointPath:  p.checkpointPath,
+				emergencyPath:   p.emergencyPath,
+				syncedEpoch:     snap.epoch,
+				syncedIssuedAt:  snap.issuedAt,
+				risk:            bundleActionRisk(res.DataScopes),
+				emergencyTokens: []string{res.Digest, res.AuthorIdentity},
+			})
+			// SPEC-0279 R6: every freshness decision leaves a durable record,
+			// allow or deny.
+			auditFreshnessDecision("install-bundle", res.Digest, fresh)
+			if fresh.Err != nil {
+				gateCode = freshnessExitCode(fresh)
+				gateFresh = &fresh
+				return fresh.Err
+			}
+		}
+		return nil
+	}
+
 	res, err := install.InstallBundle(install.BundleOpts{
 		BundlePath:    p.bundlePath,
 		Meta:          meta,
@@ -105,11 +162,18 @@ func runInstallBundle(p installBundleParams, stdout, stderr io.Writer) (code int
 		IgnoreDeps:    p.ignoreDeps,
 		Tenant:        resolveTenant(p.tenantFlag, tr),
 		Logger:        logger,
+		PostVerify:    postVerify,
 		Ctx:           context.Background(),
 	})
 	if err != nil {
 		audErr = err
 		fmt.Fprintln(stderr, err)
+		if gateFresh != nil {
+			printFreshness(stderr, *gateFresh, p.checkpointPath, p.emergencyPath)
+		}
+		if gateCode != 0 {
+			return gateCode
+		}
 		return verify.ExitCode(err)
 	}
 	audDigest = res.Verify.Digest

--- a/cmd/skillctl/install_bundle_revocations_test.go
+++ b/cmd/skillctl/install_bundle_revocations_test.go
@@ -1,0 +1,284 @@
+package main
+
+// Befund 1.10 (Enterprise-Audit Welle 1): `install --bundle` nahm die
+// Offline-Revocation-Eingaben seines verify-Zwillings nicht an; die Kette
+// pruefte Revocation nur ueber das unsignierte meta.Status-Feld. Diese Tests
+// fahren den ECHTEN Flag-Parser (runInstall), damit genau der gemessene Defekt
+// ("flag provided but not defined: -revocations") abgedeckt ist, und messen
+// nach jedem Refusal den Installationszustand: ein verweigertes Bundle darf
+// NICHTS auf der Platte hinterlassen.
+//
+// Exit-Codes sind die des Zwillings (verify --bundle): revoked digest → 17,
+// forged/untrusted list → 12, stale snapshot (high risk) → 22, emergency → 17,
+// unlesbare Liste → 1 (generic, fail-closed).
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/install"
+	"github.com/kamir/m3c-tools/pkg/skillctl/registry"
+	"github.com/kamir/m3c-tools/pkg/skillctl/verify"
+)
+
+// installableFixture is a real, extractable .skb (tar.gz with a signed
+// bundle.json) plus sidecar, pinned trust-roots and a private home. Unlike
+// bundleFixture (arbitrary bytes, enough for verify), install needs the real
+// archive because InstallBundle reads the signed name out of it.
+type installableFixture struct {
+	skbPath      string
+	trPath       string
+	home         string
+	dir          string
+	digest       string
+	authorID     string
+	regURL       string
+	regPriv      ed25519.PrivateKey
+	regPubB64    string
+	authorPubB64 string
+}
+
+func buildInstallableFixture(t *testing.T) installableFixture {
+	t.Helper()
+	dir := t.TempDir()
+
+	authorPub, authorPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("author keygen: %v", err)
+	}
+	regPub, regPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("reg keygen: %v", err)
+	}
+
+	blob := twoPartyBundle(t, "revo-demo", "a bundle for the revocation gate")
+	sum := sha256.Sum256(blob)
+	digest := "sha256:" + hex.EncodeToString(sum[:])
+
+	skbPath := filepath.Join(dir, "revo-demo@1.0.0.skb")
+	if err := os.WriteFile(skbPath, blob, 0o644); err != nil {
+		t.Fatalf("write skb: %v", err)
+	}
+
+	authorID := "id:kamir@m3c"
+	regURL := "https://reg.example/api/skills"
+
+	meta := registry.BundleMeta{
+		Bundle: map[string]any{
+			"bundle_digest": digest,
+			"name":          "revo-demo",
+			"version":       "1.0.0",
+			"status":        "admitted",
+		},
+		Signatures: []registry.SignatureRow{
+			{Role: "author", IdentityID: authorID, SignatureB64: signB64(authorPriv, sum), Status: "active"},
+			{Role: "registry", IdentityID: "id:registry@aims-core", SignatureB64: signB64(regPriv, sum), Status: "active"},
+		},
+		CurrentGovernance: "green",
+	}
+	metaJSON, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	if err := os.WriteFile(defaultMetaSidecar(skbPath), metaJSON, 0o644); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+
+	regPubB64 := base64.StdEncoding.EncodeToString(regPub)
+	authorPubB64 := base64.StdEncoding.EncodeToString(authorPub)
+	trPath := filepath.Join(dir, "trust-roots.pinned.yaml")
+	writePinnedTrustRoots(t, trPath, regURL, regPubB64, authorID, authorPubB64)
+
+	return installableFixture{
+		skbPath: skbPath, trPath: trPath, home: t.TempDir(), dir: dir,
+		digest: digest, authorID: authorID, regURL: regURL, regPriv: regPriv,
+		regPubB64: regPubB64, authorPubB64: authorPubB64,
+	}
+}
+
+// installedSkillDirs lists what actually landed under <home>/.claude/skills,
+// minus the tool's own staging dir. Empty slice = nothing installed.
+func installedSkillDirs(t *testing.T, home string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(home, ".claude", "skills"))
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() && e.Name() != install.StagingDirName {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+// runInstallArgs drives the real CLI entry point, flags and all.
+func runInstallArgs(f installableFixture, extra ...string) (int, string) {
+	args := append([]string{
+		"--bundle", f.skbPath, "--trust-roots", f.trPath, "--home", f.home,
+	}, extra...)
+	var out bytes.Buffer
+	code := runInstall(args, &out, &out)
+	return code, out.String()
+}
+
+// (a) A signed revocation list naming the bundle's digest refuses the install
+// with the twin's exit code, and NOTHING lands on disk.
+func TestInstallBundle_RevokedDigestRefused(t *testing.T) {
+	f := buildInstallableFixture(t)
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-09-06T10:00:00Z", 1, []string{f.digest}, f.regPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revPath := writeRevocations(t, f.dir, list)
+
+	before := installedSkillDirs(t, f.home)
+	code, out := runInstallArgs(f, "--revocations", revPath)
+	if code != exitBundleRevoked {
+		t.Fatalf("revoked digest must exit %d, got %d; output=%s", exitBundleRevoked, code, out)
+	}
+	after := installedSkillDirs(t, f.home)
+	if len(before) != 0 || len(after) != 0 {
+		t.Fatalf("a refused install must leave the skills dir untouched; before=%v after=%v", before, after)
+	}
+}
+
+// (b) A signed list that does NOT name the digest lets the install through.
+func TestInstallBundle_NotRevokedInstalls(t *testing.T) {
+	f := buildInstallableFixture(t)
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-09-06T10:00:00Z", 1, []string{otherDigest()}, f.regPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revPath := writeRevocations(t, f.dir, list)
+
+	code, out := runInstallArgs(f, "--revocations", revPath)
+	if code != exitOK {
+		t.Fatalf("not-revoked bundle must install (exit 0), got %d; output=%s", code, out)
+	}
+	after := installedSkillDirs(t, f.home)
+	if len(after) != 1 || after[0] != "revo-demo" {
+		t.Fatalf("expected exactly [revo-demo] installed, got %v", after)
+	}
+}
+
+// (c) An unreadable revocation list is an ERROR, never a pass, and nothing is
+// installed (fail-closed).
+func TestInstallBundle_UnreadableRevocationListFailsClosed(t *testing.T) {
+	f := buildInstallableFixture(t)
+	code, out := runInstallArgs(f, "--revocations", filepath.Join(f.dir, "no-such-file.json"))
+	if code != exitGeneric {
+		t.Fatalf("unreadable revocation list must exit %d, got %d; output=%s", exitGeneric, code, out)
+	}
+	if after := installedSkillDirs(t, f.home); len(after) != 0 {
+		t.Fatalf("fail-closed means nothing installed, got %v", after)
+	}
+}
+
+// A list signed by a key the trust root does not pin is refused (12), and
+// nothing is installed. Same as the verify twin's forged-list case.
+func TestInstallBundle_ForgedRevocationListRefused(t *testing.T) {
+	f := buildInstallableFixture(t)
+	_, attackerPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, err := verify.NewSignedRevocationList(f.regURL, "2026-09-06T10:00:00Z", 1, []string{f.digest}, attackerPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revPath := writeRevocations(t, f.dir, list)
+
+	code, out := runInstallArgs(f, "--revocations", revPath)
+	if code != verify.ExitRegistryNotTrusted {
+		t.Fatalf("forged list must exit %d, got %d; output=%s", verify.ExitRegistryNotTrusted, code, out)
+	}
+	if after := installedSkillDirs(t, f.home); len(after) != 0 {
+		t.Fatalf("a forged list must not install anything, got %v", after)
+	}
+}
+
+// (d) Without the new flags the behavior is exactly as before: the bundle
+// installs, no new mandatory parameter.
+func TestInstallBundle_NoRevocationFlagsUnchanged(t *testing.T) {
+	f := buildInstallableFixture(t)
+	code, out := runInstallArgs(f)
+	if code != exitOK {
+		t.Fatalf("install without revocation flags must stay exit 0, got %d; output=%s", code, out)
+	}
+	if after := installedSkillDirs(t, f.home); len(after) != 1 || after[0] != "revo-demo" {
+		t.Fatalf("expected exactly [revo-demo] installed, got %v", after)
+	}
+}
+
+// A stale snapshot for a high-risk bundle (no declared data-scopes) fails
+// closed with the twin's exit code 22, before anything is written.
+func TestInstallBundle_StaleHighRiskFailsClosed(t *testing.T) {
+	f := buildInstallableFixture(t)
+	writePinnedTrustRootsFresh(t, f.trPath, f.regURL, f.regPubB64, f.authorID, f.authorPubB64, "24h", "open")
+
+	list, err := verify.NewSignedRevocationList(f.regURL, freshBundleISO(48*time.Hour), 1, []string{otherDigest()}, f.regPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revPath := writeRevocations(t, f.dir, list)
+
+	code, out := runInstallArgs(f, "--revocations", revPath)
+	if code != verify.ExitRevocationStale {
+		t.Fatalf("stale high-risk install must exit %d, got %d; output=%s", verify.ExitRevocationStale, code, out)
+	}
+	if after := installedSkillDirs(t, f.home); len(after) != 0 {
+		t.Fatalf("a stale-refused install must leave nothing behind, got %v", after)
+	}
+}
+
+// An emergency deny-list naming the digest denies immediately (17), even with a
+// fresh snapshot, and nothing is installed.
+func TestInstallBundle_EmergencyDeniesDigest(t *testing.T) {
+	f := buildInstallableFixture(t)
+	writePinnedTrustRootsFresh(t, f.trPath, f.regURL, f.regPubB64, f.authorID, f.authorPubB64, "24h", "open")
+
+	list, err := verify.NewSignedRevocationList(f.regURL, freshBundleISO(1*time.Hour), 1, []string{otherDigest()}, f.regPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revPath := writeRevocations(t, f.dir, list)
+
+	em, err := verify.NewSignedEmergencyDenyList(f.regURL, freshBundleISO(30*time.Minute), 1, []string{f.digest}, f.regPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emPath := filepath.Join(f.dir, "emergency.json")
+	if b, _ := json.MarshalIndent(em, "", "  "); os.WriteFile(emPath, b, 0o644) != nil {
+		t.Fatal("write emergency")
+	}
+
+	code, out := runInstallArgs(f, "--revocations", revPath, "--emergency", emPath)
+	if code != exitBundleRevoked {
+		t.Fatalf("emergency deny must exit %d, got %d; output=%s", exitBundleRevoked, code, out)
+	}
+	if after := installedSkillDirs(t, f.home); len(after) != 0 {
+		t.Fatalf("an emergency-denied install must leave nothing behind, got %v", after)
+	}
+}
+
+// The three offline inputs belong to --bundle. On the registry path they are
+// refused (usage), never silently ignored: an accepted-but-unenforced security
+// flag would be its own fail-open.
+func TestInstall_RevocationFlagsRequireBundle(t *testing.T) {
+	var out bytes.Buffer
+	code := runInstall([]string{"--revocations", "somewhere.json", "some-skill"}, &out, &out)
+	if code != exitUsage {
+		t.Fatalf("--revocations without --bundle must exit %d, got %d; output=%s", exitUsage, code, out.String())
+	}
+}

--- a/cmd/skillctl/install_cmds.go
+++ b/cmd/skillctl/install_cmds.go
@@ -54,10 +54,14 @@ func runInstall(args []string, stdout, stderr io.Writer) (code int) {
 	bundlePath := fs.String("bundle", "", "Install a standalone .skb FILE that arrived over an untrusted transport (SPEC-0406). Offline, against pinned trust-roots. Requires a sidecar <file>.skbmeta.json (or --meta).")
 	metaPath := fs.String("meta", "", "Path to the BundleMeta envelope JSON for --bundle (default: the .skbmeta.json sidecar next to the .skb).")
 	trustRootsPath := fs.String("trust-roots", "", "Path to a trust-roots YAML to use instead of the default. Pair with --bundle for a portable verification kit.")
+	revocationsPath := fs.String("revocations", "", "Path to a signed revocation list (JSON) to enforce offline for --bundle. A revoked digest → exit 17; an untrusted/forged list → exit 12.")
+	checkpointPath := fs.String("checkpoint", "", "Path to a signed freshness checkpoint (SPEC-0279 R4) that can reset the staleness clock for --revocations without a full re-sync. A forged/stale/rollback checkpoint → exit 12.")
+	emergencyPath := fs.String("emergency", "", "Path to a signed emergency deny-list (SPEC-0279 R5). A named digest denies immediately (exit 17), short-circuiting the staleness cadence; a forged list → exit 12.")
 
 	fs.Usage = func() {
 		fmt.Fprintln(stderr, "Usage: skillctl install <name>[@<version>] [flags]")
 		fmt.Fprintln(stderr, "   or: skillctl install --bundle <file.skb> [--meta <f>] [--trust-roots <f>]")
+		fmt.Fprintln(stderr, "                        [--revocations <f>] [--checkpoint <f>] [--emergency <f>]")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Pulls a skill bundle from the registry, runs the SPEC-0188 §7 verifier,")
 		fmt.Fprintln(stderr, "and atomically installs it under ~/.claude/skills/<name>/. Refuses if any")
@@ -93,17 +97,31 @@ func runInstall(args []string, stdout, stderr io.Writer) (code int) {
 			return exitUsage
 		}
 		return runInstallBundle(installBundleParams{
-			bundlePath:     *bundlePath,
-			metaPath:       *metaPath,
-			trustRootsPath: *trustRootsPath,
-			registryURL:    *registryURL,
-			governanceMin:  *governanceMin,
-			allowYellow:    *allowYellow,
-			ignoreDeps:     *ignoreDeps,
-			tenantFlag:     *tenantFlag,
-			homeOverride:   *homeOverride,
-			verbose:        *verboseFlag,
+			bundlePath:      *bundlePath,
+			metaPath:        *metaPath,
+			trustRootsPath:  *trustRootsPath,
+			revocationsPath: *revocationsPath,
+			checkpointPath:  *checkpointPath,
+			emergencyPath:   *emergencyPath,
+			registryURL:     *registryURL,
+			governanceMin:   *governanceMin,
+			allowYellow:     *allowYellow,
+			ignoreDeps:      *ignoreDeps,
+			tenantFlag:      *tenantFlag,
+			homeOverride:    *homeOverride,
+			verbose:         *verboseFlag,
 		}, stdout, stderr)
+	}
+
+	// The offline enforcement inputs belong to the --bundle path. On the
+	// registry path they would be silently unused, and a security input that is
+	// accepted but not enforced is worse than one that is refused: the operator
+	// believes a gate is active that is not. Refuse rather than ignore.
+	// (Before these flags existed, the same invocation failed flag parsing with
+	// the same exit code, so no working call changes behavior.)
+	if *revocationsPath != "" || *checkpointPath != "" || *emergencyPath != "" {
+		fmt.Fprintln(stderr, "skillctl install: --revocations/--checkpoint/--emergency require --bundle; the registry path checks revocation via the registry itself.")
+		return exitUsage
 	}
 
 	if fs.NArg() != 1 {

--- a/docs/manual-skillctl.md
+++ b/docs/manual-skillctl.md
@@ -120,7 +120,7 @@ Additional codes surface in specific commands:
 | `19` | `awareness reset`, `import-public` | identity mismatch: `client_identity` ≠ `admitted_by_identity`; also source-blocked on import. |
 | `20` | `agentid verify` | self-attested / approver-floor not met (reviewer_id == author_id; SPEC-0246 §5.2). |
 | `21` | `agentid verify` | AgentID mandate expired. |
-| `22` | `agentid verify`, `verify --bundle`, `verify-hook` | revocation snapshot stale: freshness fail-closed (SPEC-0279 R3 / FR-0045 D4). |
+| `22` | `agentid verify`, `verify --bundle`, `install --bundle`, `verify-hook` | revocation snapshot stale: freshness fail-closed (SPEC-0279 R3 / FR-0045 D4). |
 | `23` | `translog verify`, `verify` | transparency-log inclusion missing / receipt not included (SPEC-0278 L1). |
 | `24` | `translog witness` | split-view (equivocation) detected. |
 | `25` | `translog consistency` | consistency / append-only rewrite violation detected. |
@@ -362,6 +362,7 @@ skillctl cross-sign --key governance-root.priv \
 
 ```bash
 skillctl install <name>[@<version>] [flags]
+skillctl install --bundle <file.skb> [--meta <f>] [--trust-roots <f>] [--revocations <f>] [--checkpoint <f>] [--emergency <f>]
 ```
 
 Pulls a bundle from the registry, runs the SPEC-0188 §7 verifier, and **atomically** installs
@@ -369,23 +370,41 @@ it under `~/.claude/skills/<name>/`. Refuses if *any* trust-chain step fails. `<
 be a human version string (`1.0.0`) or a digest pin (`sha256:<hex>`); omit it to install the
 newest admitted version.
 
+`--bundle` installs a **standalone `.skb` file** that arrived over an untrusted transport
+(SPEC-0406 D2): fully offline, against locally pinned trust-roots, with the sidecar
+`<file>.skbmeta.json` (or `--meta`) as the envelope. It refuses for exactly the reasons
+`verify --bundle` refuses, including the offline revocation inputs: a signed revocation
+list (`--revocations`), a signed freshness checkpoint (`--checkpoint`) and a signed
+emergency deny-list (`--emergency`) are enforced *before* anything is written, fail-closed
+(an unreadable or forged list is an error, never a pass). Where the skill lands is decided
+by the signed `bundle.json`, never by the file name. The three offline inputs require
+`--bundle`; on the registry path they are refused rather than silently ignored.
+
 | Flag | Purpose |
 |------|---------|
 | `-allow-yellow` | Lower the gate from green to yellow for this install (audited). |
+| `-bundle` | Install a standalone `.skb` file from an untrusted transport, fully offline against pinned trust-roots (SPEC-0406 D2). |
+| `-checkpoint` | Signed freshness checkpoint (SPEC-0279 R4) to reset the `--revocations` staleness clock (with `--bundle`). Forged/untrusted → `12`. |
+| `-emergency` | Signed emergency deny-list (SPEC-0279 R5, with `--bundle`). Named digest → `17`; forged list → `12`. |
 | `-governance-min green\|yellow` | Override the trust-root's `governance_minimum`. Empty = use trust-root. |
 | `-home` | Override the install root (advanced; defaults to `$HOME`). |
 | `-ignore-deps` | Skip `depends_on` resolution (audited). |
+| `-meta` | Path to the BundleMeta envelope JSON for `--bundle` (default: the sidecar `.skbmeta.json`). |
 | `-registry` | Registry base URL. Required only when trust-roots pins multiple registries. |
+| `-revocations` | Signed revocation list to enforce offline (with `--bundle`), same semantics as on `verify --bundle`. Revoked digest → `17`; forged list → `12`; stale snapshot for a high-risk bundle → `22`. |
 | `-tenant` | Pin this install to a tenant scope (§7 step 5.5). Overrides trust-roots `tenant_scope`. |
 | `-timeout` | HTTP timeout for registry calls (default `30s`). |
+| `-trust-roots` | Trust-roots YAML to use instead of the default. Pair with `--bundle` for a portable kit. |
 | `-verbose` | Print structured per-step log lines to stderr. |
 
 ```bash
 skillctl install my-skill@1.0.0
 skillctl install my-skill@sha256:<hex> --verbose
+skillctl install --bundle demo@1.0.0.skb --trust-roots roots.yaml --revocations revocations.json
 ```
 
-Exit: `0`, `1`, `2`, `10`–`16` (see [Exit codes](#exit-codes)).
+Exit: `0`, `1`, `2`, `10`–`16`; with `--bundle` also `17` (revoked / emergency-denied) and
+`22` (revocation snapshot stale) (see [Exit codes](#exit-codes)).
 
 ---
 

--- a/pkg/skillctl/install/install_bundle.go
+++ b/pkg/skillctl/install/install_bundle.go
@@ -58,6 +58,18 @@ type BundleOpts struct {
 	// is always decided by signed bytes. Empty is the normal case.
 	Name string
 
+	// PostVerify, when set, runs AFTER the trust chain passed and BEFORE
+	// anything is staged or written. A non-nil error aborts the install and is
+	// returned verbatim, so the caller keeps control of its exit-code mapping.
+	//
+	// This is the seam the CLI uses to enforce the offline revocation list and
+	// the SPEC-0279 freshness contract on `install --bundle`, the same checks
+	// `verify --bundle` runs. Without it, the two paths could not stay
+	// mirror-equal: the revocation verdict must bind to the digest of the very
+	// blob this call verified, not to a digest computed in a separate earlier
+	// pass over a file that may have changed in between.
+	PostVerify func(*verify.VerifyResult) error
+
 	HomeDir           string
 	GovernanceMin     string
 	AllowYellow       bool
@@ -119,6 +131,17 @@ func InstallBundle(opts BundleOpts) (*Result, error) {
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// ----- caller's post-verify gate, still BEFORE any write -----
+	//
+	// Revocation and freshness are part of the trust decision, so they belong on
+	// this side of the staging line: a revoked bundle must leave the target
+	// directory untouched, not be installed and then complained about.
+	if opts.PostVerify != nil {
+		if err := opts.PostVerify(verRes); err != nil {
+			return nil, err
+		}
 	}
 
 	// ----- WHERE the skill lands is decided by SIGNED bytes -----


### PR DESCRIPTION
## Befund (Enterprise-Audit Welle 1, 1.10, mittel)

Gemessen auf origin/master (58b6845):

- `skillctl install --bundle x.skb --revocations /pfad` scheitert mit `flag provided but not defined: -revocations`
- `install --help`: 0 Treffer `revocations`; `verify --help`: 4 Treffer
- `installBundleParams` hat kein Revocations-Feld; `runInstallBundle` ruft weder `checkBundleRevoked` noch eine Emergency-Liste; die Offline-Kette prueft Revocation nur ueber das unsignierte `meta.Status`-Feld

Der Code behauptet Spiegelgleichheit der beiden Pfade; wer vor dem Install verifizierte und dabei REVOKED sah, konnte dasselbe Bundle im naechsten Schritt trotzdem installieren.

## Fix

- `--revocations`, `--checkpoint`, `--emergency` in den `--bundle`-Zweig von `install` durchgereicht (Beschreibungstexte identisch zum Zwilling)
- Neuer `PostVerify`-Hook in `install.BundleOpts`: laeuft NACH der Signaturkette und VOR jedem Schreibvorgang (vor Staging und `finishInstall`); die CLI haengt dort exakt die Zwillingspruefung ein (`checkBundleRevoked` + `evaluateFreshness` + `auditFreshnessDecision`, Quelle `install-bundle`). Damit bindet das Urteil an den Digest genau des verifizierten Blobs; ein separater Verify-Lauf vor dem Install haette ein Austausch-Fenster gelassen
- Exit-Codes wie im Zwilling: revoked `17`, forged/untrusted `12`, stale (high risk) `22`, Emergency-Treffer `17`. Fail-closed: unlesbare Liste = Fehler (`1`), kein Durchwinken
- Ohne die Flags: Verhalten unveraendert, kein neuer Pflichtparameter
- Auf dem Registry-Pfad (ohne `--bundle`) werden die drei Flags mit Usage-Fehler verweigert statt still ignoriert; vorher brach derselbe Aufruf ebenfalls mit Exit 2 ab (Flag-Parser), es aendert sich also kein funktionierender Aufruf
- Audit: der refusierte Digest wird im Lifecycle-Event mitgeschrieben (der Digest ist im Hook bereits signaturgeprueft)

## Messung vorher/nachher

Vorher (origin/master):
```
$ skillctl install --bundle x.skb --revocations r.json
flag provided but not defined: -revocations   (Exit 2)
install --help | grep -c revocations  → 0
verify  --help | grep -c revocations  → 4
```

Nachher (dieser Branch):
```
install --help | grep -c revocations  → 3   (revocations, checkpoint-Beschreibung, Usage-Zeile)
verify  --help | grep -c revocations  → 4   (unveraendert)
```

Tests (alle gruen, `go test ./cmd/skillctl/ ./pkg/skillctl/install/ -count=1`):

- (a) Liste MIT Bundle-Digest: Exit `17`, Skills-Verzeichnis vorher wie nachher leer (nichts installiert)
- (b) Liste OHNE den Digest: Exit `0`, genau `[revo-demo]` installiert
- (c) unlesbare Liste: Exit `1`, nichts installiert (fail-closed)
- geforgte Liste (fremder Key): Exit `12`, nichts installiert
- (d) ohne Flags: Exit `0`, unveraendert; bestehende Suiten beider Pakete gruen
- stale Snapshot, high risk: Exit `22`, nichts installiert
- Emergency-Liste mit Digest: Exit `17`, nichts installiert
- `--revocations` ohne `--bundle`: Exit `2`

Alle Faelle fahren den echten Flag-Parser (`runInstall`), nicht die Params-Struktur direkt, damit genau der gemessene Defekt abgedeckt ist.

## Gates

- `go build ./...`, `go vet` (betroffene Pakete): gruen
- `./scripts/check-no-emdash.sh`: PASS
- `./scripts/check-docs.sh` inkl. docaudit: PASS (204 Code-Flags, 204 dokumentiert); Manual: install-Abschnitt (`--bundle`-Usage-Form, Flag-Tabelle, Beispiel), Exit-Code-Register (`22`-Zeile um `install --bundle` ergaenzt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)