### PR TITLE
fix(exitcode): Exit-Code-20-Kollision, bundle_revoked wird zur 6 (Befund 1.4)

### DIFF
--- a/cmd/skillctl/exitcode_parity_test.go
+++ b/cmd/skillctl/exitcode_parity_test.go
@@ -1,0 +1,32 @@
+package main
+
+// Befund 1.4 (Welle 1): the exit numbers cmd/skillctl allocates as local
+// consts are registered in pkg/skillctl/exitcode so TestCodes_NumberTheme
+// sees every cross-surface number claim. This guard fails the moment a local
+// const and its registry row drift, same pattern as
+// TestExitCode_VerifyRegistryParity in the exitcode package.
+
+import (
+	"testing"
+
+	"github.com/kamir/m3c-tools/pkg/skillctl/exitcode"
+)
+
+func TestExitConsts_RegistryParity(t *testing.T) {
+	cases := []struct {
+		name  string
+		local int // const in cmd/skillctl
+		reg   int // exitcode registry Number
+	}{
+		{"agentid_expired", exitAgentIDExpired, exitcode.AgentIDExpired.Number},
+		{"pin need_priv_msg", pinExitNeedPrivMsg, exitcode.PinNeedPrivMsg.Number},
+		{"translog not_included", exitTranslogNotIncluded, exitcode.TranslogNotIncluded.Number},
+		{"translog split_view", exitTranslogSplitView, exitcode.TranslogSplitView.Number},
+		{"translog rewrite", exitTranslogRewrite, exitcode.TranslogRewrite.Number},
+	}
+	for _, c := range cases {
+		if c.local != c.reg {
+			t.Errorf("exit-code drift for %q: cmd/skillctl const=%d, exitcode registry=%d: update both", c.name, c.local, c.reg)
+		}
+	}
+}

--- a/cmd/skillctl/pull_cmds.go
+++ b/cmd/skillctl/pull_cmds.go
@@ -448,8 +448,12 @@ func resolvePullTrustRoots(registryName, trustPath string) (*registry.SelfTrustR
 //
 // Four gates map onto the numbers SPEC-0188 §11 already assigns. The fifth had no
 // number at all: the specification named 15 for bundle_revoked, but 15 has meant
-// blob_missing in every shipped build (BUG-0216). Decided 2026-09-06: revocation
-// takes 20, the specification is corrected, and 15 keeps the meaning callers have.
+// blob_missing in every shipped build (BUG-0216). The first FR-0122 cut gave
+// revocation the 20 on the claim "20 is free"; true against the exitcode
+// register, false against the exit surfaces outside it (verify.ExitSelfAttested,
+// SPEC-0246 §5.2, has shipped 20 for weeks). Befund 1.4: the one-day-old,
+// unreleased side yields. Revocation is exitcode.RevokedBundle (6), the
+// specification is corrected, and 15 keeps the meaning callers have.
 //
 // MIXED refusals stay 1, deliberately. One number cannot describe two causes, and
 // picking the "worst" would invent a ranking nothing else in this tool uses. The

--- a/pkg/skillctl/exitcode/guard_drift_test.go
+++ b/pkg/skillctl/exitcode/guard_drift_test.go
@@ -45,6 +45,29 @@ func TestExitCode_VerifyRegistryParity(t *testing.T) {
 	}
 }
 
+// Chain-extension parity: the Tier 8 registry rows for the codes the §7
+// verifier emits ABOVE the pinned 10-19 ladder (SPEC-0246 §5.2 / SPEC-0279 R3 /
+// SPEC-0278 L1) must equal their verify.Exit* consts, same drift logic as
+// TestExitCode_VerifyRegistryParity. The agentid/translog/pin consts live in
+// package main (cmd/skillctl) and are pinned there
+// (TestExitConsts_RegistryParity in exitcode_parity_test.go).
+func TestExitCode_ChainExtensionParity(t *testing.T) {
+	cases := []struct {
+		name string
+		reg  int // exitcode registry Number
+		got  int // verify package const
+	}{
+		{"self_attested", exitcode.ChainSelfAttested.Number, verify.ExitSelfAttested},
+		{"revocation_stale", exitcode.ChainRevocationStale.Number, verify.ExitRevocationStale},
+		{"inclusion_missing", exitcode.ChainInclusionMissing.Number, verify.ExitLogInclusionMissing},
+	}
+	for _, c := range cases {
+		if c.reg != c.got {
+			t.Errorf("exit-code drift for %q: exitcode registry=%d, verify const=%d: update both", c.name, c.reg, c.got)
+		}
+	}
+}
+
 // SPEC-0198 / BUG-0144: an explicitly revoked author identity maps to 17, the
 // SAME number + theme as data-source-denied, and ExitCode checks revoke FIRST
 // so it wins. Pin both the value and the deliberate overload so a future edit

--- a/pkg/skillctl/exitcode/registry.go
+++ b/pkg/skillctl/exitcode/registry.go
@@ -193,7 +193,8 @@ var (
 // FAMILY NOTE: 20/22/23 are emitted by the §7 verifier (verify.ExitCode),
 // but their Family is NOT "verify": TestExitCode_VerifyFamilyCompleteness
 // pins Family=="verify" to exactly the 10-19 ladder, and that pin is
-// load-bearing. The SPEC-0246/0277/0278/0279 checks layered on the chain
+// load-bearing. The checks that SPEC-0246, SPEC-0277, SPEC-0278 and
+// SPEC-0279 layer on the chain
 // therefore carry the family "verify-chain"; agentid, translog and pin are
 // named after the subcommand surfaces that actually exit with them.
 //

--- a/pkg/skillctl/exitcode/registry.go
+++ b/pkg/skillctl/exitcode/registry.go
@@ -67,20 +67,31 @@ var (
 	// meaning changes silently is worse than a number that was never allocated:
 	// a caller that reads 15 as "revoked" would treat a transport failure as a
 	// security verdict, and one that reads it as "blob missing" would retry a
-	// revocation. Decided 2026-09-06: bundle_revoked takes 20, the specification
-	// is corrected, and 15 keeps the meaning every existing caller already has.
+	// revocation. Decided 2026-09-06: bundle_revoked gets its own number, the
+	// specification is corrected, and 15 keeps the meaning every existing caller
+	// already has.
 	//
 	// It sits outside the 10-19 verify ladder deliberately, and its family is
 	// "pull", not "verify". TestExitCode_VerifyFamilyCompleteness pins the verify
 	// family to exactly those ten numbers, and that pin is worth more than the
 	// convenience of reusing the name: the code is emitted by `pull --trust-mode`,
 	// which is the surface FR-0122 is about, so "pull" is also simply what is
-	// true. 20 is free, and below the skillgate band at 30-39.
+	// true.
+	//
+	// NUMBER: 6, the lowest number no exit surface claims (census 2026-09-07:
+	// 0-2 generic, 3 pin, 4-5 import-public, 10-29 the ladders and their chain
+	// extensions, 30-39 the skillgate band). The first FR-0122 cut took 20 on
+	// the claim "20 is free"; that claim was measured against this register
+	// only, not against the exit surfaces outside it, and verify.ExitSelfAttested
+	// (SPEC-0246 §5.2) had been shipping 20 for weeks, documented in the manual
+	// and CLI-VERBS. The one-day-old, unreleased side yields (Befund 1.4).
+	// Tier 8 below registers the out-of-register numbers so the next "N is
+	// free" claim collides in TestCodes_NumberTheme instead of in the field.
 	//
 	// Its theme is its own because a revocation is not a failed check. The chain
 	// verified. Someone withdrew the bundle afterwards, and a caller has to be
 	// able to tell those two apart: one is retried, the other never is.
-	RevokedBundle = Code{20, "trust-chain revocation", "pull", "bundle_revoked"}
+	RevokedBundle = Code{6, "trust-chain revocation", "pull", "bundle_revoked"}
 )
 
 // ---------------------------------------------------------------------------
@@ -167,6 +178,45 @@ var (
 	OfflineUnverifiable   = Code{25, "offline / no-policy-basis", "state-machine", "offline_unverifiable_managed"}
 )
 
+// ---------------------------------------------------------------------------
+// Tier 8: out-of-register exit surfaces (census 2026-09-07, Befund 1.4).
+// These numbers were allocated in pkg/skillctl/verify/errors.go (SPEC-0246
+// §5.2, SPEC-0279 R3, SPEC-0278 L1), cmd/skillctl/agentid_cmds.go,
+// cmd/skillctl/translog_cmds.go and cmd/skillctl/pin_cmds.go, but never
+// entered here, so TestCodes_NumberTheme could not see them. That blindness
+// is how bundle_revoked briefly claimed 20: "20 is free" was measured
+// against this register only, while verify.ExitSelfAttested had been
+// shipping 20 for weeks. Registered so that every number an exit surface
+// holds is visible to the invariant, and the next "N is free" claim
+// collides in CI instead of in the field.
+//
+// FAMILY NOTE: 20/22/23 are emitted by the §7 verifier (verify.ExitCode),
+// but their Family is NOT "verify": TestExitCode_VerifyFamilyCompleteness
+// pins Family=="verify" to exactly the 10-19 ladder, and that pin is
+// load-bearing. The SPEC-0246/0277/0278/0279 checks layered on the chain
+// therefore carry the family "verify-chain"; agentid, translog and pin are
+// named after the subcommand surfaces that actually exit with them.
+//
+// KNOWN LEGACY COLLISION ON 25: TranslogRewrite (a real process exit of
+// `skillctl translog`, shipped since v0.3.0) and OfflineUnverifiable (a
+// message-borne refusal_code, shipped since v0.3.1) both hold 25 with
+// different themes. Both sides are in releases, so neither can yield the
+// way the unreleased bundle_revoked-20 did. The pair is pinned as the ONLY
+// tolerated violation in TestCodes_KnownLegacyCollision25 and excluded from
+// TestCodes_NumberTheme; resolving it needs a release-level decision.
+// ---------------------------------------------------------------------------
+
+var (
+	PinNeedPrivMsg        = Code{3, "pin privacy confirmation", "pin", "need_priv_msg"}
+	ChainSelfAttested     = Code{20, "attestation reviewer-independence", "verify-chain", "self_attested"}
+	AgentIDExpired        = Code{21, "agent-identity expiry", "agentid", "agentid_expired"}
+	ChainRevocationStale  = Code{22, "revocation freshness", "verify-chain", "revocation_stale"}
+	ChainInclusionMissing = Code{23, "log inclusion", "verify-chain", "inclusion_missing"}
+	TranslogNotIncluded   = Code{23, "log inclusion", "translog", "not_included"}
+	TranslogSplitView     = Code{24, "log equivocation", "translog", "split_view"}
+	TranslogRewrite       = Code{25, "log rewrite", "translog", "translog_rewrite"}
+)
+
 // AllCodes returns every Code currently registered. Used by the
 // CI invariant test (TestCodes_NumberTheme) and by the generator
 // that emits the SKILLCTL-MANUAL.md exit-code table.
@@ -190,5 +240,8 @@ func AllCodes() []Code {
 		GuardPathSidechannelDenied,
 		// Tier 7) offline state machine (locked + unverifiable) + audit-durability
 		OfflineLocked, LocalAuditUnavailable, OfflineUnverifiable,
+		// Tier 8: out-of-register surfaces (pin, verify-chain, agentid, translog)
+		PinNeedPrivMsg, ChainSelfAttested, AgentIDExpired, ChainRevocationStale,
+		ChainInclusionMissing, TranslogNotIncluded, TranslogSplitView, TranslogRewrite,
 	}
 }

--- a/pkg/skillctl/exitcode/registry_test.go
+++ b/pkg/skillctl/exitcode/registry_test.go
@@ -16,6 +16,16 @@ func TestCodes_NumberTheme(t *testing.T) {
 		if c.Number == 0 {
 			continue // 0 is "success": codes don't claim 0
 		}
+		if c.Number == 25 {
+			// The ONE tolerated legacy collision: translog rewrite (real
+			// process exit, shipped since v0.3.0) vs offline_unverifiable
+			// (message-borne refusal_code, shipped since v0.3.1). Both are
+			// released, so neither side can yield without breaking a shipped
+			// contract. TestCodes_KnownLegacyCollision25 pins the pair
+			// exactly; a third claimant of 25 (or a resolution of the pair)
+			// fails there, so nothing NEW hides behind this skip.
+			continue
+		}
 		if prev, ok := themeByNum[c.Number]; ok {
 			if prev != c.Theme {
 				t.Errorf("exit code %d theme collision: %q (%s/%s) vs %q (%s/%s)",
@@ -27,6 +37,41 @@ func TestCodes_NumberTheme(t *testing.T) {
 		} else {
 			themeByNum[c.Number] = c.Theme
 			originByNum[c.Number] = c
+		}
+	}
+}
+
+// TestCodes_KnownLegacyCollision25 pins the one tolerated Number-Theme
+// violation that TestCodes_NumberTheme skips. Exactly TWO codes may hold 25,
+// with exactly these families, labels and (differing) themes; both were in
+// releases before the register saw them (census 2026-09-07, Befund 1.4), so
+// unlike the unreleased bundle_revoked-20 neither side can be renumbered
+// without a release-level decision. If that decision is ever taken and one
+// side moves, this test fails, which forces the exemption in
+// TestCodes_NumberTheme to be deleted along with it. A third surface trying
+// to claim 25 fails here too.
+func TestCodes_KnownLegacyCollision25(t *testing.T) {
+	want := map[string]Code{
+		"state-machine/offline_unverifiable_managed": {25, "offline / no-policy-basis", "state-machine", "offline_unverifiable_managed"},
+		"translog/translog_rewrite":                  {25, "log rewrite", "translog", "translog_rewrite"},
+	}
+	got := map[string]Code{}
+	for _, c := range AllCodes() {
+		if c.Number == 25 {
+			got[c.Family+"/"+c.Label] = c
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("exit code 25 is held by %d codes, the pinned legacy pair allows exactly %d: %v", len(got), len(want), got)
+	}
+	for k, w := range want {
+		g, ok := got[k]
+		if !ok {
+			t.Errorf("pinned legacy holder %q no longer holds 25: delete this exemption AND the Number==25 skip in TestCodes_NumberTheme", k)
+			continue
+		}
+		if g != w {
+			t.Errorf("pinned legacy holder %q drifted: got %+v want %+v", k, g, w)
 		}
 	}
 }

--- a/pkg/skillctl/sim/discrimination.go
+++ b/pkg/skillctl/sim/discrimination.go
@@ -216,7 +216,7 @@ func (rep Report) WriteDiscrimination(w io.Writer) {
 	fmt.Fprintf(w, "  A caller, an audit record and any automated policy see the SIGNAL, not the\n")
 	fmt.Fprintf(w, "  cause. Where one signal stands for several causes, they cannot tell them\n")
 	fmt.Fprintf(w, "  apart. Since FR-0122 was implemented on 2026-09-06 the pull path reports a\n")
-	fmt.Fprintf(w, "  typed code per gate (12, 10, 11, 13, 20), so an overload left here is no\n")
+	fmt.Fprintf(w, "  typed code per gate (12, 10, 11, 13, 6), so an overload left here is no\n")
 	fmt.Fprintf(w, "  longer a missing code. Read the remaining ones as questions about the\n")
 	fmt.Fprintf(w, "  THREAT MODEL: a suppressed revoke makes a bundle ungoverned, and gate 4 is\n")
 	fmt.Fprintf(w, "  then the honest answer, because nothing in a plain git registry can tell a\n")

--- a/pkg/skillctl/sim/generate.go
+++ b/pkg/skillctl/sim/generate.go
@@ -271,9 +271,13 @@ func whyGate(gate string, p Params) string {
 // then written from the decision record, and the conflicts cleared because the
 // binary agrees with the decision, not because the model was fitted to it.
 //
-// Gate 5 is 20 rather than the 15 SPEC-0188 named, because 15 has meant
-// blob_missing in every shipped build (BUG-0216) and a number whose meaning
-// changes silently is worse than one that was never allocated.
+// Gate 5 is 6, twice removed from the 15 SPEC-0188 named: 15 has meant
+// blob_missing in every shipped build (BUG-0216), and the 20 the first FR-0122
+// cut chose was "free" only in the exitcode register, not on the exit surfaces
+// (verify.ExitSelfAttested has shipped 20 since SPEC-0246 §5.2). Befund 1.4
+// renumbered the one-day-old, unreleased side to 6, the lowest number no
+// surface claims; the census now lives in exitcode.AllCodes(), which is why
+// this pinned decision changed a second time and should not change again.
 func gateExit(gate string) int {
 	switch gate {
 	case "gate 1":
@@ -285,7 +289,7 @@ func gateExit(gate string) int {
 	case "gate 4":
 		return 13 // governance_below_min
 	case "gate 5":
-		return 20 // bundle_revoked
+		return 6 // bundle_revoked (exitcode.RevokedBundle)
 	default:
 		return 1
 	}


### PR DESCRIPTION
## Befund 1.4 (Welle 1, hoch): Exit-Code-20-Kollision

Zwei Flaechen verlassen den Prozess mit 20 und meinen Verschiedenes:

- `pkg/skillctl/verify/errors.go:142`: `ExitSelfAttested = 20` (SPEC-0246 §5.2), seit Wochen ausgeliefert (v0.3.x), in Manual und CLI-VERBS dokumentiert; auch `cmd/skillctl/agentid_cmds.go` emittiert die 20 (Approver-Floor).
- `pkg/skillctl/exitcode/registry.go`: `RevokedBundle = 20` (FR-0122, PR von gestern), Begruendung war "20 is free". Gemessen war das nur am Register, nicht an den Exit-Flaechen ausserhalb. Diese 20 ist in keinem Release.

Also weicht `bundle_revoked` aus.

## Fix

1. **Zensus** aller Prozess-Exit-Nummern ueber alle Flaechen (vollstaendig im Commit-Text): 0-5 belegt (generisch, pin 3, import 4/5), 6-9 frei, 10-29 Leitern und Kettenerweiterungen, 30-39 skillgate-Band. Niedrigste freie Nummer: **6**.
2. **`bundle_revoked`: 20 wird 6** (`registry.go`, `sim/generate.go` Tor 5, `sim/discrimination.go`); der "20 is free"-Kommentar ist ehrlich korrigiert. `pull_cmds.go:488` folgt dem Register automatisch.
3. **Tier 8 im Register**: die ausserhalb vergebenen Nummern (3 pin, 20 self_attested, 21 agentid_expired, 22 revocation_stale, 23 inclusion_missing + translog not_included, 24 split_view, 25 translog_rewrite) stehen jetzt in `exitcode.AllCodes()`. Familie ist nicht "verify" (der Pin-Test haelt verify auf exakt 10-19), sondern `verify-chain` / `agentid` / `translog` / `pin`, benannt nach den Flaechen, die wirklich emittieren.
4. **Alt-Kollision 25** (translog rewrite, echter Exit seit v0.3.0, gegen offline_unverifiable, signierter refusal_code seit v0.3.1): beide Seiten sind ausgeliefert, keine weicht. Als einzige geduldete Ausnahme exakt gepinnt (`TestCodes_KnownLegacyCollision25`); ein dritter Anspruch auf 25 oder eine Aufloesung des Paars macht den Pin rot.
5. **Drift-Waechter**: `TestExitCode_ChainExtensionParity` (Register gegen verify-Konstanten) und `TestExitConsts_RegistryParity` (Register gegen cmd/skillctl-Konstanten).

## Messung

**Vorher** (origin/master):

```
$ go test ./pkg/skillctl/exitcode/
ok    (gruen TROTZ live kollidierender 20: das Register war blind)
```

**Zwischenschritt** (nur Registrierung, vor der Umnummerierung), der Beweis, dass der Invariantentest jetzt sieht:

```
--- FAIL: TestCodes_NumberTheme
    exit code 20 theme collision: "trust-chain revocation" (pull/bundle_revoked) vs "attestation reviewer-independence" (verify-chain/self_attested)
    exit code 25 theme collision: "offline / no-policy-basis" (state-machine/offline_unverifiable_managed) vs "log rewrite" (translog/translog_rewrite)
```

**Nachher** (dieser Branch):

```
$ go test ./pkg/skillctl/exitcode/ ./pkg/skillctl/verify/ ./pkg/skillctl/sim/ ./cmd/skillctl/
ok  x4

$ /tmp/w1c-sim run -t 2 -n 100 -jobs 8 -skillctl /tmp/w1c-sk
conflicts: none, the specification predicted every claimed outcome
  gate 5   13 time(s)          (Modell-Anspruch)
  exit 6   13 time(s) pull x13 (beobachtet am echten Binary)
```

Ein Pull gegen ein revoziertes Bundle liefert die 6; im Pull-Pfad kommt keine 20 mehr vor. `./scripts/check-no-emdash.sh` PASS, `go build ./...` und `go vet` gruen.

## Nicht angefasst (bewusst)

- Wartungsrepo: `grep -rn "bundle_revoked.*20|20.*bundle_revoked" --include="*.md"` findet dort **keine** Datei; die Fundstellen, die `bundle_revoked` nennen (SPEC-0188 §7/§11, S3-DECISIONS, S3-QUESTIONS, BUG-0216, SPEC-0190, SPEC-0198), pinnen noch die **alte 15** und brauchen die SPEC-Korrektur auf 6 (Folgearbeit, anderes Repo).
- `verify_hook_cmds.go` nutzt weiterhin den botschaftsgetragenen Grund `bundle_revoked` mit Code 17 (SPEC-0198-Thema, ausgelieferte Konvention, nicht die FR-0122-Nummer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
