### PR TITLE
fix(release): lokalen Publikationspfad stilllegen, Freigabe aufschreiben (AUDIT-0001, 2.5 + 2.6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -434,6 +434,13 @@ check-docs:
 
 # Release targets: code review + docs check run before release
 #
+# Alle vier Ziele TAGGEN nur. scripts/release.sh baut nichts, laedt nichts hoch
+# und committet nichts mehr: es taggt origin/master by hash und schiebt das Tag,
+# und .github/workflows/release.yml baut, signiert, attestiert und publiziert.
+# Frueher hat das Skript lokal gebaut und das nackte Binary plus eine DMG per
+# `gh release create` an denselben v*-Kanal gehaengt; der checksums-Job hasht
+# aber nur die CI-Artefakte, also lagen dort unattestierte Assets (v2.9.0).
+#
 # `release` LEITET die Stufe aus den Commits ab (scripts/derive-bump.sh), statt
 # sie zu raten. Vorher war es fest `release-patch` verdrahtet: deshalb ist der
 # Fleet-Kill-Switch (FR-0045) als v2.8.1 ausgeliefert worden: eine Patch-Nummer
@@ -683,7 +690,7 @@ help:
 	@echo "  build-skillctl-demo Build the offline skillctl-demo (+ skillctl)"
 	@echo "  build-all      Build all binaries (CLI + POCs + skillctl + demo)"
 	@echo "  build-app      Build macOS .app bundle"
-	@echo "  dmg            Build macOS DMG installer"
+	@echo "  dmg            Build macOS DMG installer LOCALLY (dev only, never a release asset)"
 	@echo "  setup-venv     Create Python venv and install whisper"
 	@echo "  e2e            Run all e2e tests"
 	@echo "  test-unit      Run offline unit tests only"
@@ -699,11 +706,12 @@ help:
 	@echo "  clean          Remove build artifacts"
 	@echo "  code-review    Run pre-release code review checks"
 	@echo "  check-docs     Check documentation consistency with implementation"
-	@echo "  release        Release; bump level DERIVED from commits (code-review + check-docs first)"
+	@echo "  release        Tag origin/master; bump level DERIVED from commits (code-review + check-docs first)"
 	@echo "  release-auto   Same derivation without the pre-checks"
-	@echo "  release-patch  Release with patch version bump"
-	@echo "  release-minor  Release with minor version bump"
-	@echo "  release-major  Release with major version bump"
+	@echo "  release-patch  Tag origin/master with a patch version bump"
+	@echo "  release-minor  Tag origin/master with a minor version bump"
+	@echo "  release-major  Tag origin/master with a major version bump"
+	@echo "                   All four only TAG + PUSH. CI (release.yml) builds, signs and publishes."
 	@echo "  menubar        Build + run the menu bar .app in the FOREGROUND (stdout logs, Ctrl-C)"
 	@echo "  menubar-app    Build + launch the .app DETACHED via 'open' (background, quit from menu)"
 	@echo "  build-windows  Cross-compile CLI + tray for Windows (amd64)"

--- a/docs/PLATFORM-DIFFERENCES.md
+++ b/docs/PLATFORM-DIFFERENCES.md
@@ -102,7 +102,7 @@ Multi-platform parity is tracked under **Pending / SPEC-0251 §5** in
 | Platform | Package | Command |
 |----------|---------|---------|
 | macOS | Homebrew (planned) | `brew install kamir/tap/m3c-tools` |
-| macOS | DMG | Download, drag to Applications |
+| macOS | DMG (local build only) | `make dmg`; NOT a release asset, see [releasing.md](releasing.md#the-macos-dmg-is-not-a-release-asset) |
 | Windows | NSIS installer | `M3C-Tools-Setup.exe` |
 | Windows | Winget (planned) | `winget install kamir.m3c-tools` |
 | Linux | APT (planned) | `apt install m3c-tools` |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -47,6 +47,79 @@ see); `make release` aborts and demands the explicit `make release-major`.
 
 ---
 
+## Release approval: who signs off, and before what
+
+A tag push is the point of no return: it starts a workflow that builds, signs and
+publishes. Everything in this section happens **before** it.
+
+### The machine half is already a blocking gate
+
+The **SPEC-0406** two-party acceptance test runs in
+[`skillctl-release.yml`](../.github/workflows/skillctl-release.yml) as
+`acceptance-gate`, a matrix over **macOS and Windows**, placed *before* the build
+so a failure stops the release instead of annotating a finished artifact. It runs
+`TestAcceptance_TwoParty` (T01..T15) plus the twin rehearsal scripts
+[`scripts/skillctl-acceptance.sh`](../scripts/skillctl-acceptance.sh) and
+[`scripts/skillctl-acceptance.ps1`](../scripts/skillctl-acceptance.ps1);
+[`ci.yml`](../.github/workflows/ci.yml) runs the Unix twin on every push, so the
+gate is not first exercised at tag time.
+
+What it cannot see: whether **two people on two machines** compared a key
+fingerprint over a second channel (SPEC-0246 R6.3, Phase 0). That is a human act,
+and no CI job can observe it. The gate covers the machine half of SPEC-0406, and
+the workflow's own gate record says exactly that.
+
+### The human half: the second pair of eyes
+
+| # | Step | Who | What is checked | Where the result is recorded |
+|---|------|-----|-----------------|------------------------------|
+| 1 | Code review | someone who did not write the commits | the diff on `master` since the previous tag | the approving review on the pull request |
+| 2 | Fingerprint out of band (Phase 0) | the consumer, on their own machine | the author public key fingerprint, read back over a second channel | the [acceptance checklist](acceptance-skillctl-lifecycle.md#9-handover-checklist-for-erics-team) |
+| 3 | Consumer lane, Part B | the consumer, on their own machine | the **published** artifacts, never a local build | exit codes of `pull --install --trust-mode`, `verify`, `audit` |
+
+For the skillctl line step 3 has a natural home: `skillctl-release.yml` publishes a
+**draft**. Do not run `gh release edit skillctl/vX.Y.Z --draft=false` before step 3
+has been performed against that draft's artifacts. Promoting the draft *is* the
+sign-off, so treat it as one and not as a formality.
+
+Record the outcome in the release body, so the evidence sits next to the artifacts
+it is about:
+
+```bash
+gh release view skillctl/v0.5.0 --json body -q .body > /tmp/notes.md
+cat >> /tmp/notes.md <<'EOF'
+
+## Acceptance (SPEC-0406)
+- Second person: <name>, machine: <os/arch>, date: <YYYY-MM-DD>
+- Phase 0 fingerprint compared out of band: yes/no, channel: <...>
+- Part B exit codes: pull=0, verify=0, audit=0
+EOF
+gh release edit skillctl/v0.5.0 --notes-file /tmp/notes.md
+```
+
+The product line (`v*`) has no draft stage today, so its equivalent is: cut it,
+perform step 3 against the published assets, and use [Rollback](#rollback) if it
+fails.
+
+### Break-glass: the solo path
+
+**This repository has exactly one account with write access.** Steps 1 and 3 can
+therefore often not be filled by a different person, and naming a second reviewer
+who does not exist would be a decoration, not a control. The solo path is
+allowed, and it is **break-glass**:
+
+- it is a deliberate act, never the silent default;
+- the release body carries the same `## Acceptance (SPEC-0406)` heading, naming
+  who released, which of the three steps had no second person, and why;
+- the missing step is caught up afterwards. Either a second person performs it and
+  the result is appended under that heading, or the release is rolled back.
+
+> Written down because the alternative was already the practice: the last five
+> merged pull requests carried zero reviews, and `v2.9.0` was published from a
+> laptop. A solo path nobody documents is indistinguishable from a broken one.
+
+---
+
 ## The canonical path: tag `origin/master` by hash
 
 **Recommended, and what the maintainers actually use.** Because working copies
@@ -88,23 +161,57 @@ goreleaser check        # validate .goreleaser.yml before relying on it
 
 ---
 
-## The scripted path: `make release` (local, convenience)
+## The scripted path: `make release` (derive the level, tag, and stop)
 
 ```bash
-make release            # derive-bump → code-review → check-docs → release-auto
+make release            # derive-bump → code-review → check-docs → tag origin/master
 make release-minor      # force a level (also: release-patch / release-major)
 ```
 
-`make release` runs `code-review` + `check-docs` first, then
-[`scripts/release.sh`](../scripts/release.sh) bumps, tags and creates the release.
+`make release` runs `code-review` + `check-docs`, derives the bump level, and then
+[`scripts/release.sh`](../scripts/release.sh) **tags `origin/master` by hash and
+pushes the tag**. It prints the commit it is about to tag, plus its subject and
+author, and asks for a confirmation; `--yes` skips the prompt, and without a
+terminal it refuses rather than guessing. This is the canonical path above with
+the version arithmetic done for you.
 
-> ⚠️ **`scripts/release.sh` operates on your WORKING COPY.** It will
-> `git add -A && git commit` any dirty files, `git push` the **current** branch,
-> and create the release with **local macOS‑only** assets. Run it **only** from a
-> clean checkout of `master`: **never** from a feature branch or a worktree, or
-> you will publish the wrong branch. When in doubt, use the tag‑by‑hash path
-> above and let CI build every platform. The CI workflow then enriches the same
-> release with the full signed multi‑platform artifacts.
+It deliberately does **not** build, package, upload an asset, create a release, or
+commit anything: publication is `release.yml` alone. A modified tracked file makes
+it refuse, because it tags `origin/master` and your local changes would not be in
+the release either way.
+
+> **Why it used to be dangerous.** Until this change the script ran
+> `git add -A && git commit` over the working copy, built a macOS binary and a DMG
+> on the laptop, and uploaded both with `gh release create --latest`. The
+> `checksums` job in `release.yml` hashes only the CI artifacts (`*.tar.gz`,
+> `*.zip`, `*.exe`), so those two assets landed in neither `checksums.txt` nor the
+> SLSA subjects. `v2.9.0` still shows it: `m3c-tools` and `M3C-Tools-2.9.0.dmg`
+> are release assets, and its `checksums.txt` lists neither of them.
+
+### The macOS DMG is not a release asset
+
+`make dmg` still builds `build/M3C-Tools-<version>.dmg` locally, and that is now
+all it is: a development convenience. It is not published, because an asset CI
+does not build cannot be covered by `checksums.txt`, the cosign signature or the
+SLSA provenance, and an uncovered asset on a signed channel is worse than a
+missing one: a user cannot tell the two apart at the download page.
+
+Restoring it as a download is a CI job, not a script call. What it would take,
+deliberately **not** done here:
+
+1. a step in the existing `build-macos` job (already `macos-latest`, already with
+   PortAudio) that runs `make build-app` plus `scripts/make-dmg.sh` and uploads
+   the DMG as a workflow artifact. It would be arm64-only unless the two darwin
+   binaries are merged into a universal one with `lipo` first;
+2. `*.dmg` added to **both** globs in the `checksums` job (`checksums.txt` **and**
+   the base64 SLSA subjects) and to the loop in the `verify` job, or the DMG ships
+   unattested again, which is the defect this change removes;
+3. the asset added to the `files:` list of the `release` job;
+4. and the part that is not YAML: the `.app` bundle is neither codesigned nor
+   notarised (both are open items in [roadmap.md](roadmap.md)), so a downloaded
+   DMG is quarantined by Gatekeeper. Shipping an unsigned DMG through a signed
+   channel trades one trust problem for another; an Apple signing identity and a
+   notarisation step have to exist first.
 
 ---
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,12 +1,71 @@
 #!/usr/bin/env bash
-# release.sh: Automated version bumping, tagging, and GitHub release creation
-# Usage: ./scripts/release.sh [patch|minor|major]
+# release.sh: leitet die naechste Produktversion ab, taggt origin/master BY HASH
+# und schiebt das Tag. Mehr nicht.
+#
+# Usage: ./scripts/release.sh [patch|minor|major] [--yes]
+#
+# Publikation findet AUSSCHLIESSLICH in .github/workflows/release.yml statt.
+#
+# Vorher hat dieses Skript die Working Copy mit `git add -A` committet, lokal auf
+# dem Laptop gebaut, eine DMG erzeugt und beides mit `gh release create --latest`
+# hochgeladen. Der checksums-Job in release.yml hasht aber nur die CI-Artefakte
+# (*.tar.gz, *.zip, *.exe): das nackte Binary und die DMG standen damit weder in
+# checksums.txt noch in den SLSA-Subjects. Nachweis: v2.9.0 traegt die Assets
+# `m3c-tools` und `M3C-Tools-2.9.0.dmg`, und seine checksums.txt kennt beide
+# nicht. Ein signierter Kanal, auf dem unattestierte Assets liegen, ist als
+# Ganzes nicht mehr pruefbar: der Nutzer sieht denselben v*-Download und kann an
+# der Oberflaeche nicht unterscheiden, was durch die Gates lief.
+#
+# Was daraus folgt: dieses Skript baut nichts, laedt nichts hoch und committet
+# nichts. Es setzt genau einen Zeiger, und alles Weitere entsteht in CI, wo die
+# Signatur- und Provenance-Kette haengt.
 set -euo pipefail
 
-BUMP_TYPE="${1:-patch}"
-BINARY="m3c-tools"
-BUILD_DIR="./build"
+BUMP_TYPE=""
+ASSUME_YES=0
+
+for arg in "$@"; do
+    case "$arg" in
+        patch|minor|major)
+            BUMP_TYPE="$arg"
+            ;;
+        --yes|-y)
+            ASSUME_YES=1
+            ;;
+        *)
+            echo "Error: unknown argument '$arg'"
+            echo "Usage: ./scripts/release.sh [patch|minor|major] [--yes]"
+            exit 1
+            ;;
+    esac
+done
+BUMP_TYPE="${BUMP_TYPE:-patch}"
+
 BASE_VERSION="1.4.1"
+
+# --- Pre-flight: remote + a fresh view of it ---
+if ! git remote get-url origin >/dev/null 2>&1; then
+    echo "Error: No git remote 'origin' configured."
+    echo "  Add one with: git remote add origin https://github.com/<owner>/m3c-tools.git"
+    exit 1
+fi
+
+echo "Fetching origin (tags + master)..."
+git fetch --tags --quiet origin
+
+# Ein schmutziger Baum wird NICHT mehr committet. Frueher hat `git add -A` genau
+# das getan und damit unreviewten Inhalt in ein Release gehoben. Getaggt wird
+# ohnehin origin/master, also traegt der lokale Stand nichts zum Release bei:
+# die Warnung existiert, damit niemand glaubt, seine offenen Aenderungen seien
+# mit ausgeliefert worden. Untracked-Dateien blockieren bewusst nicht.
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    echo ""
+    echo "Error: tracked files are modified in this working copy."
+    echo "  This script tags origin/master, so local changes would NOT be released."
+    echo "  Commit them, get them reviewed and merged to master, then run again:"
+    git status --short --untracked-files=no | sed 's/^/    /'
+    exit 1
+fi
 
 # --- Determine current version from git tags ---
 LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
@@ -46,94 +105,67 @@ esac
 
 NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
 NEW_TAG="v${NEW_VERSION}"
-echo "New version: ${NEW_TAG}"
 
-# --- Pre-flight checks ---
-if ! command -v gh >/dev/null 2>&1; then
-    echo "Error: GitHub CLI (gh) is required. Install: brew install gh"
+# --- Refuse to re-tag ---
+if git rev-parse -q --verify "refs/tags/${NEW_TAG}" >/dev/null; then
+    echo "Error: tag ${NEW_TAG} already exists locally. See docs/releasing.md (Rollback)."
+    exit 1
+fi
+if git ls-remote --exit-code --tags origin "refs/tags/${NEW_TAG}" >/dev/null 2>&1; then
+    echo "Error: tag ${NEW_TAG} already exists on origin. See docs/releasing.md (Rollback)."
     exit 1
 fi
 
-if ! git remote get-url origin >/dev/null 2>&1; then
-    echo "Error: No git remote 'origin' configured."
-    echo "  Add one with: git remote add origin https://github.com/<owner>/m3c-tools.git"
+# --- The commit that will be tagged: origin/master, by hash ---
+# Working copies drift onto feature branches and worktrees, deshalb wird nie
+# "der aktuelle Branch" getaggt, sondern der reviewte Stand auf master.
+if ! HASH=$(git rev-parse -q --verify 'origin/master^{commit}'); then
+    echo "Error: origin/master not found after fetch."
     exit 1
 fi
 
-# --- Commit all changes if working directory is dirty ---
-if [ -n "$(git status --porcelain)" ]; then
-    echo ""
-    echo "Committing all changes..."
-    git add -A
-    git commit -m "Release ${NEW_TAG}"
+echo ""
+echo "New version:  ${NEW_TAG}   (bump: ${BUMP_TYPE})"
+echo "Tagging:      origin/master @ ${HASH}"
+echo "              $(git log -1 --format='%s' "$HASH")"
+echo "              $(git log -1 --format='%an, %ad' --date=short "$HASH")"
+echo ""
+echo "Release approval (docs/releasing.md, 'Release approval'):"
+echo "  the tag push is the point of no return. The SPEC-0406 acceptance gate"
+echo "  covers the machine half; the two-person half is a human step and is not"
+echo "  observable from here. If you are releasing alone, record it as break-glass."
+echo ""
+echo "This script will NOT build, upload or commit anything."
+echo "Publication happens in .github/workflows/release.yml, triggered by this tag."
+echo ""
+
+# --- Point of no return: confirm ---
+if [ "$ASSUME_YES" -ne 1 ]; then
+    if [ ! -t 0 ]; then
+        echo "Error: no terminal to confirm on. Re-run with --yes if this is intended."
+        exit 1
+    fi
+    printf 'Push tag %s and start the release workflow? [y/N] ' "$NEW_TAG"
+    read -r reply
+    case "$reply" in
+        y|Y|yes|YES) ;;
+        *)
+            echo "Aborted. Nothing was tagged or pushed."
+            exit 1
+            ;;
+    esac
 fi
 
-# --- Build binary ---
+# --- Tag + push ---
 echo ""
-echo "Building ${BINARY}..."
-mkdir -p "${BUILD_DIR}"
-COMMIT=$(git rev-parse --short HEAD)
-BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-go build -ldflags "-s -w -X main.version=${NEW_VERSION} -X main.commit=${COMMIT} -X main.date=${BUILD_DATE}" -o "${BUILD_DIR}/${BINARY}" ./cmd/m3c-tools
-echo "Built ${BUILD_DIR}/${BINARY}"
+echo "Creating tag ${NEW_TAG} on ${HASH}..."
+git tag -a "${NEW_TAG}" "${HASH}" -m "Release ${NEW_TAG}"
 
-# --- Build app bundle + DMG ---
-echo ""
-echo "Building app bundle..."
-APP_VERSION="${NEW_VERSION}" make build-app
-echo "Building DMG..."
-./scripts/make-dmg.sh "${NEW_VERSION}"
-DMG_PATH="${BUILD_DIR}/M3C-Tools-${NEW_VERSION}.dmg"
-
-# --- Push commits to origin ---
-echo ""
-CURRENT_BRANCH=$(git branch --show-current)
-echo "Pushing ${CURRENT_BRANCH} to origin..."
-git push origin "${CURRENT_BRANCH}"
-
-# --- Tag ---
-echo ""
-echo "Creating tag ${NEW_TAG}..."
-git tag -a "${NEW_TAG}" -m "Release ${NEW_TAG}"
-
-# --- Push tag ---
 echo "Pushing tag to origin..."
 git push origin "${NEW_TAG}"
 
-# --- Create GitHub release ---
 echo ""
-echo "Creating GitHub release ${NEW_TAG}..."
-# Build release assets list
-RELEASE_ASSETS=("${BUILD_DIR}/${BINARY}")
-if [ -f "$DMG_PATH" ]; then
-    RELEASE_ASSETS+=("$DMG_PATH")
-    DMG_SHA=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
-    DMG_SIZE=$(du -h "$DMG_PATH" | awk '{print $1}')
-    DMG_NOTES="
-### macOS Installer
-- **${DMG_PATH##*/}** (${DMG_SIZE})
-- SHA-256: \`${DMG_SHA}\`
-
-### First-time setup
-\`\`\`bash
-# After dragging to /Applications:
-/Applications/M3C-Tools.app/Contents/MacOS/m3c-tools setup
-\`\`\`"
-else
-    DMG_NOTES=""
-fi
-
-gh release create "${NEW_TAG}" \
-    "${RELEASE_ASSETS[@]}" \
-    --title "Release ${NEW_TAG}" \
-    --notes "## ${BINARY} ${NEW_TAG}
-
-### Changes since ${LATEST_TAG:-initial}
-$(git log ${LATEST_TAG:+${LATEST_TAG}..}HEAD --oneline --no-decorate 2>/dev/null || echo "- Initial release")
-${DMG_NOTES}
-" \
-    --latest
-
-echo ""
-echo "Release ${NEW_TAG} created successfully!"
-echo "  View: $(gh release view ${NEW_TAG} --json url -q .url)"
+echo "Tag ${NEW_TAG} pushed. CI now builds, signs, attests and publishes."
+echo "  Watch:  gh run watch \"\$(gh run list --workflow=release.yml --limit 1 --json databaseId -q '.[0].databaseId')\""
+echo "  Assets: gh release view ${NEW_TAG} --json assets -q '.assets[].name'"
+echo "  Undo:   docs/releasing.md, section 'Rollback'"


### PR DESCRIPTION
Welle 2 des Enterprise-Audits AUDIT-0001, Aufgabe D. Zwei Befunde, beide gemessen.

## Befund 2.5 (hoch): unattestierte Assets auf dem signierten v*-Kanal

`scripts/release.sh` hat die Working Copy mit `git add -A` committet (Z.67),
lokal auf dem Laptop gebaut (Z.77), eine DMG erzeugt (Z.85) und beides mit
`gh release create ... --latest` hochgeladen (Z.126-135). Der `checksums`-Job in
`release.yml` hasht dagegen nur die CI-Artefakte.

**Vorher, am realen Release v2.9.0:**

```
$ gh release view v2.9.0 --json assets -q '.assets[].name'
checksums.txt
m3c-tools                 <-- nacktes, lokal gebautes Binary
M3C-Tools-2.9.0.dmg       <-- lokal gebaute DMG
m3c-tools-darwin-amd64.tar.gz
...

$ gh release download v2.9.0 -p checksums.txt && grep -cE "dmg|  m3c-tools$" checksums.txt
0
```

14 Zeilen in `checksums.txt`, keine davon nennt die DMG oder das nackte Binary.
Dieselbe Dateiliste geht als base64-Subjects in die SLSA-Provenance: beide Assets
sind also weder gehasht noch attestiert, liegen aber am selben Downloadpunkt wie
die geprueften. Genau das ist der Schaden: an der Oberflaeche unterscheidbar ist
das nicht.

**Fix:** `release.sh` reduziert auf tag-by-hash plus Push.

```
$ grep -vE '^\s*#' scripts/release.sh | grep -cE 'git add -A|gh release create|go build|make build-app|make-dmg|hdiutil'
0
$ grep -n "git push" scripts/release.sh
165:git push origin "${NEW_TAG}"
```

Nachher-Verhalten, gemessen in einem sicheren Klon:

```
$ ./scripts/release.sh minor </dev/null
Fetching origin (tags + master)...
Current version: v2.11.0
New version:  v2.12.0   (bump: minor)
Tagging:      origin/master @ 71894eda4cbb9f9ce1515849b7143b37df577d6d
              Merge pull request #226 from kamir/fix/workflow-duplicate-key-gate
...
Error: no terminal to confirm on. Re-run with --yes if this is intended.
exit=1
$ git tag --list 'v2.12*' | wc -l
0
```

Weitere Verweigerung, gemessen: ein modifizierter getrackter File bricht ab,
statt ihn wie frueher stillschweigend mitzucommitten.

Die Makefile-Ziele funktionieren unveraendert und sagen jetzt, was sie tun:

```
$ make -n release-patch
./scripts/release.sh patch
$ make help | grep -A1 "release-major"
  release-major  Tag origin/master with a major version bump
                   All four only TAG + PUSH. CI (release.yml) builds, signs and publishes.
```

### Die DMG: bewusst NICHT blind nach CI gehoben

`make dmg` baut sie weiterhin lokal, sie ist ab jetzt kein Release-Asset mehr
(`docs/PLATFORM-DIFFERENCES.md` nennt sie nicht mehr als Download; sie war seit
v2.9.0 ohnehin in keinem Release mehr, v2.10.0 und v2.11.0 kamen per Tag-Push).

Was ein CI-Job braeuchte, steht praezise in `docs/releasing.md`:

1. Ein Schritt im vorhandenen `build-macos`-Job (schon `macos-latest`, schon mit
   PortAudio), der `make build-app` plus `scripts/make-dmg.sh` laufen laesst und
   die DMG als Workflow-Artefakt hochlaedt. Sie waere arm64-only, solange die
   beiden darwin-Binaries nicht per `lipo` zu einem universellen verschmolzen
   werden.
2. `*.dmg` in BEIDE Globs des `checksums`-Jobs (`checksums.txt` UND die
   base64-SLSA-Subjects) und in die Schleife des `verify`-Jobs. Fehlt eines
   davon, ist der Befund exakt reproduziert.
3. Das Asset in die `files:`-Liste des `release`-Jobs.
4. Und der Teil, der kein YAML ist: das `.app`-Bundle ist weder codesigned noch
   notarisiert (beides offene Punkte in `docs/roadmap.md`). Eine geladene DMG
   landet damit in der Gatekeeper-Quarantaene. Eine unsignierte DMG durch einen
   signierten Kanal zu schicken tauscht ein Vertrauensproblem gegen ein anderes:
   erst braucht es eine Apple-Signing-Identity und einen Notarisierungsschritt.

Deshalb hier nur die Entschaerfung, nicht der Neubau. Offener Punkt, benannt.

## Befund 2.6 (hoch): kein Freigabeschritt

**Vorher:**

```
$ wc -l docs/releasing.md
     213 docs/releasing.md
$ grep -cE "0406|acceptance|abnahme|zweit" docs/releasing.md
0
```

Alle menschlichen Schritte waren von einer Person allein ausfuehrbar.

**Fix:** neuer Abschnitt `## Release approval: who signs off, and before what`,
direkt vor dem Tag-Push-Abschnitt. Er trennt zwei Dinge, die vorher gar nicht
benannt waren:

- **Maschinenhaelfte:** der SPEC-0406-`acceptance-gate` in
  `skillctl-release.yml` existiert bereits, blockend, Matrix ueber macOS und
  Windows, vor dem Build. Das Dokument verweist jetzt darauf, statt es zu
  ignorieren.
- **Menschenhaelfte:** Fingerprint-Abgleich ueber einen zweiten Kanal (Phase 0,
  SPEC-0246 R6.3) und Part B auf der Maschine des Zweiten. Kein CI-Job kann das
  sehen; der Workflow sagt das in seinem eigenen Gate-Record selbst.

Tabelle mit drei Schritten: wer prueft, was geprueft wird, wo das Ergebnis
landet. Fuer die skillctl-Linie hat Schritt 3 einen natuerlichen Ort: der
Workflow publiziert einen Draft, und `gh release edit --draft=false` IST die
Freigabe. Festgehalten wird das Ergebnis im Release-Body unter der festen
Ueberschrift `## Acceptance (SPEC-0406)`, mit vorhandenem Werkzeug
(`gh release edit --notes-file`), ohne neues Artefakt und ohne neues Skript.

**Der Solo-Pfad ist ausdruecklich benannt, nicht wegdefiniert.** Es gibt genau
ein Konto mit Schreibrecht. Einen zweiten Pruefer zu fordern, den es nicht gibt,
waere Dekoration statt Kontrolle. Also: break-glass, bewusste Handlung, gleiche
Ueberschrift im Release-Body mit der Angabe welcher Schritt ohne Zweiten blieb
und warum, und Nachdokumentationspflicht (entweder ein Zweiter holt den Schritt
nach, oder das Release wird zurueckgerollt). Begruendet mit den beiden
gemessenen Tatsachen: null Reviews auf den letzten fuenf gemergten PRs, und
v2.9.0 vom Laptop publiziert.

## Gates, alle gruen

```
./scripts/check-no-emdash.sh   exit=0
./scripts/check-gofmt.sh       exit=0   (786 Dateien konform, keine Go-Datei angefasst)
go build ./...                 exit=0
./scripts/check-docs.sh        exit=0   (nach `go build -o build/skillctl ./cmd/skillctl`)
bash -n scripts/release.sh     OK
shellcheck scripts/release.sh  OK
```

`.github/workflows` wurde nicht angefasst.

## Geaenderte Dateien

- `scripts/release.sh`: nur noch tag-by-hash plus Push, mit Bestaetigung und
  Verweigerung bei schmutzigem Baum, doppeltem Tag und fehlendem Terminal.
- `Makefile`: Kommentarblock und `help` sagen jetzt, dass die vier
  Release-Ziele nur taggen.
- `docs/releasing.md`: Freigabeabschnitt neu; `make release` neu beschrieben;
  Unterabschnitt, warum die DMG kein Release-Asset ist und was ein CI-Job
  braeuchte.
- `docs/PLATFORM-DIFFERENCES.md`: die DMG-Zeile behauptet keinen Download mehr.

## Offene Punkte

- Die DMG wird nicht mehr publiziert. Wer sie als Download will, braucht die
  vier oben genannten Schritte, davon einen ausserhalb von YAML (Apple-Signing
  und Notarisierung).
- Die Produktlinie `v*` hat keine Draft-Stufe. Schritt 3 der Freigabe kann dort
  nur nach der Publikation laufen, mit Rollback als Korrektur. Ein
  `draft: true` im `release`-Job waere die saubere Loesung, ist aber eine
  eigene Aenderung an der Publikationskette und gehoert nicht in diesen PR.
- Der Freigabeschritt ist Dokument, nicht Tor. Maschinell erzwingbar waere er
  erst mit Branch-Protection (Required reviews) und einem Check auf die
  `## Acceptance (SPEC-0406)`-Ueberschrift im Release-Body. Beides braucht
  Rechte beziehungsweise einen zweiten Menschen.
