### PR TITLE
docs: Regeldatei fuer Behauptungen (QG-0001 M5)

### DIFF
--- a/.claude/rules/claims.md
+++ b/.claude/rules/claims.md
@@ -1,0 +1,93 @@
+# Claims: what may be written as measured
+
+Read this **before** writing, not after. It is the sibling of
+[`prose-style.md`](prose-style.md), and unlike that one it has no hook behind
+it. It is enforced by review, and by the fact that a wrong claim in this tree
+is normally cheap to catch and expensive to have shipped.
+
+## Where this comes from
+
+The audit AUDIT-0001 ran nine changes past an adversarial reader. Seven came
+back with findings, and after sorting them, one failure class accounted for
+most of the volume:
+
+> **A sentence printed beside measurements is read as a measurement.**
+
+It appeared in a waiver register, in a calibration report, in a document
+header, in a commit message, in a job name and in a tool's own help text. In
+none of those places did anyone intend to mislead. The sentence was simply
+written at a moment when the thing it described had not been run.
+
+## The four rules
+
+**1. A new sentence is a new claim.**
+Measuring a defect and then describing the fix means the fix is undescribed.
+Every line of documentation, comment or commit text that says something about
+behaviour gets executed or read before it is written. The word "measured" is
+reserved for what was measured.
+
+**2. A promise in a header covers every line under it.**
+"Every line checked against the binary" is either true or it gets narrowed.
+The same holds for a tool that calls itself a gate, a job named "blocking",
+and a script whose help text describes a reach wider than its code.
+
+**3. Turning a behaviour off means hunting for whoever still claims it.**
+After any behaviour change, search the documentation, the scripts, the
+runbooks and the binary's own usage output for the old behaviour. The
+acceptance helper counts: a helper that prints PASS on a file that no longer
+does anything is worse than no helper.
+
+**4. A search that finds nothing proves nothing until it has found something.**
+Before writing "no occurrence remains", plant a known occurrence and show the
+search finds it. Otherwise an empty result only establishes that the search
+finds nothing.
+
+## Four traps that cost time in this tree
+
+- **Measure the object you are talking about.** Running a script without
+  `--skillctl` measures whatever is on `$PATH`. Running a gate after a failed
+  `cd` measures the wrong branch. Print the working directory or the binary
+  path beside the result, in the same output.
+- **Quote a number from the run it came from.** A line count taken before the
+  last edit and a gate count taken after it do not belong in one report.
+- **A push that says "everything up-to-date" is not a push.** A commit that
+  failed at the pre-commit hook leaves the branch where it was.
+  `git rev-list --count origin/master..HEAD` is the proof; the push output is
+  not.
+- **Numbers describe a population.** "28 of 48 jobs are required" says
+  something; "28 required" says nothing. Name the population in the same line.
+
+## Prefer the evidence that needs no counter-check
+
+Two ways to show that a gate had drifted while the document it guards stayed
+correct. One: quote the document, then quote the gate, and let the reader hold
+both. Two: `git show <fix> --name-only`, one file, and it is the gate. The
+second needs no second reading, because if the repair required no
+documentation change, the question of who was stale is no longer open to
+interpretation.
+
+When a claim can be pinned by a single command whose output admits one
+reading, look for that command before writing the paragraph. It is shorter,
+and it survives being quoted out of context.
+
+## Working next to other sessions
+
+The repository working copy and the scratchpad directory are shared with
+concurrent sessions and with the user.
+
+- Work in your own `git worktree`, not in the shared checkout.
+- Name every path you create after your own task. A directory called `before/`
+  or `tmp/` in a shared scratchpad belongs to somebody.
+- `rm -rf` only on a path you created in this session. Removing a directory
+  because its name looks generic has already happened once.
+
+## Verifying
+
+There is no script for this file. The check is a question, asked before the
+sentence is written:
+
+> Did I run this, or does it just sound right?
+
+If the answer is the second one, the sentence gets a hedge or gets deleted.
+The full derivation, with the four error classes and the five measures, is in
+`PLAN/QG-0001-fruehwarnung.md` in the maintenance repository.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,23 @@ that refuses the write, `./scripts/check-no-emdash.sh` locally and in
 `make ci`, and the blocking `prose-gate` CI job. Rationale and the two byte-level
 exemptions: [CODESTYLE.md](CODESTYLE.md#prose-no-em-dashes).
 
+## Claims (binding)
+
+Before writing any sentence about behaviour (a doc line, a code comment, a
+commit message, a job name, a tool's help text), read
+[`.claude/rules/claims.md`](.claude/rules/claims.md).
+
+The short version: **the word "measured" is reserved for what was measured.**
+A promise in a header covers every line under it. Turning a behaviour off means
+hunting for whoever still claims it. And a search that finds nothing proves
+nothing until it has been shown to find a planted occurrence.
+
+Unlike the prose rule below, this one has no hook behind it. It was written
+after an adversarial re-read of nine changes found the same failure class in
+seven of them: a sentence printed beside measurements gets read as a
+measurement. Derivation and the five measures: `PLAN/QG-0001-fruehwarnung.md`
+in the maintenance repository.
+
 ## Configuration
 
 Settings loaded from `.env` or `~/.m3c-tools.env` (see `.env.example`). Key variables:


### PR DESCRIPTION
Massnahme M5 aus QG-0001, der Lehre aus Welle 2 des Audits AUDIT-0001.

## Warum

Neun Aenderungen sind gegengelesen worden, sieben kamen mit Befunden zurueck. Nach dem Sortieren traegt **eine** Fehlerklasse den groessten Teil des Volumens:

> Ein Satz, der neben Messungen steht, wird als Messung gelesen.

Fundorte in dieser Welle: ein Waiver-Register, ein Kalibrierbericht, ein Dokumentenkopf, eine Commit-Nachricht, ein Job-Name, der Hilfetext eines Werkzeugs. Kein einziges Mal absichtlich. Der Satz war jeweils geschrieben, bevor das Beschriebene gelaufen war.

## Was drin steht

Vier Regeln, jede aus einem konkreten Befund dieser Welle abgeleitet:

1. eine neue Zeile ist eine neue Behauptung
2. eine Zusage im Kopf gilt fuer jede Zeile darunter
3. wer ein Verhalten abschaltet, sucht, wer es noch behauptet
4. eine Suche ohne Treffer ist erst nach einem gepflanzten Treffer ein Nachweis

Dazu vier Fallen, die in dieser Welle Zeit gekostet haben (am falschen Objekt gemessen, Zahlen aus verschiedenen Laeufen nebeneinander, ein Push der nichts geschoben hat, eine Zahl ohne ihre Grundgesamtheit), ein Abschnitt ueber die Beweisform, die keine Gegenprobe braucht, und die Regeln fuer das Arbeiten im geteilten Scratchpad neben nebenlaeufigen Sitzungen.

## Ehrlich zur eigenen Wirkung

Die Datei sagt in ihrem zweiten Absatz selbst, dass sie kein Werkzeug hinter sich hat und durch Review getragen wird. Das ist der Unterschied zu `prose-style.md`, und er steht dort, statt verschwiegen zu werden.

Die maschinell durchsetzbaren Massnahmen M1 bis M4 folgen als eigener PR, sobald die sechs offenen Welle-2-PRs gemergt sind: sie fassen dieselben Dateien an (`ci.yml`, `scripts/check-docs.sh`, `cmd/docaudit`).

Herleitung: `PLAN/QG-0001-fruehwarnung.md` im Wartungsrepo, PR kamir/m3c-tools-maintenance#101.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>