### PR TITLE
fix(ci): Dependabot-Zustellweg schliessen, benannte Ausnahme statt aufgeweichtem Muster

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,36 @@ updates:
     groups:
       python-minor-patch:
         update-types: ["minor", "patch"]
+    # OWNER DECISION E3 of 2026-09-08: the two Python MAJOR bumps stay parked.
+    # PR #251 raises sentence-transformers 5.5.1 to 6.0.1 and PR #252 raises
+    # turbovec 0.8.0 to 1.0.0 (`grep -nE 'turbovec|sentence-transformers'
+    # rag-mcp-server/requirements.txt` gives the current pins), so both are
+    # major, and both feed the RAG embedder and vector index.
+    #
+    # WHY THIS ENTRY EXISTS AND NOT ONLY THE `hold` LABEL. The label lives on a
+    # pull request object. Dependabot replaces a PR when a newer version of the
+    # same package appears: the old one is closed, a new one opened, and the new
+    # one carries only the labels Dependabot assigns. Measured 2026-09-08
+    # 06:21Z across the eight open bot PRs carrying no `hold`, that is exactly
+    # `dependencies` plus one ecosystem label, three distinct sets across the
+    # eight, and never `hold`. The successor would therefore fall straight under
+    # owner decision E2 and merge itself. E3 is about the PACKAGE, so it is
+    # written here, where Dependabot reads it, and it survives the PR it was
+    # decided on. The label stays as the short-term brake for anything else.
+    #
+    # SCOPE: majors only. Security and routine minor/patch updates for both
+    # packages keep flowing through the group above; parking a package outright
+    # is how a dependency quietly rots.
+    #
+    # EXPECTED SIDE EFFECT, not measured because it needs Dependabot's next run:
+    # an ignored update makes Dependabot close the matching open PR, so #251 and
+    # #252 will probably close on their own. That is the postponement taking
+    # effect, not a loss. Lift it by deleting the entry for that package.
+    ignore:
+      - dependency-name: "sentence-transformers"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "turbovec"
+        update-types: ["version-update:semver-major"]
 
   # Container base images. Both Dockerfiles are DIGEST-PINNED, which is the
   # right default and also the reason they need Dependabot: a digest is

--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -69,13 +69,25 @@ jobs:
             exit 0
           fi
 
-          # Allowed prefixes: keep in sync with README.md and Makefile.
-          # Any addition here must come with a README update in the same PR.
+          # Allowed prefixes: keep in sync with the list in README
+          # §"Branch & worktree workflow", which CONTRIBUTING.md §"Branching &
+          # PRs" points at. Any addition here must come with a README update in
+          # the same PR. (This line used to name the Makefile as the second
+          # address. It carries no prefix list: `git grep -nE
+          # 'rescue|archive|refactor' -- Makefile` is empty, measured
+          # 2026-09-08, so half of the obligation pointed at nothing.)
           regex='^(feat|feature|fix|chore|docs|test|refactor|spec-[0-9]+|s[0-9]+-m[0-9]+|r-[0-9]+|archive|rescue)\/[A-Za-z0-9._-]+$'
           if [[ "$HEAD_REF" =~ $regex ]]; then
             echo "✓ branch name '$HEAD_REF' matches convention"
             exit 0
           fi
+          # The delimiter stays UNQUOTED on purpose: $HEAD_REF and $regex below
+          # have to expand. The price is that backticks in here would be
+          # command substitution, so the body carries none. Before 2026-09-08 it
+          # did: the help line read "... or `gh pr edit`", and bash ran that.
+          # Measured in run 34177862768, whose log shows gh's own "set the
+          # GH_TOKEN environment variable" complaint followed by the mutilated
+          # line "(then update the PR head ref via the GitHub UI or )".
           cat <<EOF >&2
           ✗ branch name '$HEAD_REF' does not match convention
 
@@ -92,7 +104,7 @@ jobs:
           Rename your branch:
             git branch -m <new-name>
             git push origin :<old-name> && git push -u origin <new-name>
-            (then update the PR head ref via the GitHub UI or `gh pr edit`)
+            (then update the PR head ref via the GitHub UI or 'gh pr edit')
 
           Reasoning + full convention: README.md §"Branch & worktree workflow".
           EOF

--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -64,6 +64,13 @@ jobs:
           # pull request, so the author carrier cannot be forged from inside the
           # repository. Checked locally against this very script: HEAD_REF set to
           # a real Dependabot branch with PR_AUTHOR=kamir still exits 1.
+          # NOT YET SEEN IN PRODUCTION. Measured 2026-09-08: of 91 runs of
+          # this workflow on `dependabot/` branches, 0 concluded success, so no
+          # bot pull request has taken the branch below even once. The carrier
+          # is measured (both points above) and the branch is tested locally
+          # over 21 cases in both directions, but the exception itself is
+          # expected to work, not observed working. The first bot run prints the
+          # line below; read it before calling this settled.
           if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
             echo "✓ branch name '$HEAD_REF' exempt: pull request authored by dependabot[bot] (owner decision E1, 2026-09-08)"
             exit 0

--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -3,6 +3,10 @@ name: Branch name check
 # Enforces the branch-naming convention from README §"Branch & worktree workflow".
 # Runs on PR open/reopen/edit; fails the check if the head ref doesn't match the regex.
 # Stage 3 deliverable from incident 2026-05-07 (m3c-tools master-drift).
+#
+# ONE named exception: pull requests authored by dependabot[bot] (owner
+# decision E1, 2026-09-08). Rationale, carrier choice and the measurements
+# behind it sit next to the check itself, below.
 
 on:
   pull_request:
@@ -20,8 +24,51 @@ jobs:
       - name: Check head ref matches convention
         env:
           HEAD_REF: ${{ github.head_ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
+
+          # NAMED EXCEPTION: Dependabot, and nothing else.
+          #
+          # Owner decision E1 of 2026-09-08: exempt the bot explicitly instead of
+          # widening the pattern. Dependabot names its branches
+          # `dependabot/<ecosystem>/<path>/<package>-<version>`, which breaks the
+          # convention twice over: `dependabot` is not an allowed prefix, and the
+          # name carries three slashes where the pattern allows exactly one. The
+          # bot's branch names are not configurable, so the choice was this line
+          # or a pattern loose enough to stop biting humans. For humans the
+          # pattern below is unchanged, character for character.
+          #
+          # THE CARRIER IS THE PR AUTHOR, NOT THE BRANCH NAME AND NOT github.actor.
+          # Two measurements, both taken against this repository on 2026-09-08.
+          #
+          #  (1) `github.actor` is the wrong carrier. On PR #250, branch
+          #      `dependabot/pip/rag-mcp-server/mcp-2.1.1`, a human ran
+          #      `gh pr update-branch`. The synchronize run of THIS workflow that
+          #      followed recorded actor=kamir and triggering_actor=kamir, not
+          #      dependabot[bot]. A test on `github.actor` would therefore go dark
+          #      exactly when the exception is needed. Measured with
+          #      `gh api repos/kamir/m3c-tools/actions/runs`, run of 2026-09-08
+          #      01:48:11Z, head_sha 565d2c67, conclusion failure.
+          #
+          #  (2) `github.event.pull_request.user.login` is stable. It reads
+          #      `dependabot[bot]` on #246, #250 and #252 no matter who pushed
+          #      last, because it names the pull request's AUTHOR, not the
+          #      event's trigger. Measured with
+          #      `gh api repos/kamir/m3c-tools/pulls/<n> --jq .user.login`.
+          #
+          # Abuse resistance follows from that same choice. A human with push
+          # access can create a branch called `dependabot/whatever`, so a
+          # branch-name carrier would hand every human a one-word opt-out of the
+          # convention. A human cannot make `dependabot[bot]` the author of a
+          # pull request, so the author carrier cannot be forged from inside the
+          # repository. Checked locally against this very script: HEAD_REF set to
+          # a real Dependabot branch with PR_AUTHOR=kamir still exits 1.
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "✓ branch name '$HEAD_REF' exempt: pull request authored by dependabot[bot] (owner decision E1, 2026-09-08)"
+            exit 0
+          fi
+
           # Allowed prefixes: keep in sync with README.md and Makefile.
           # Any addition here must come with a README update in the same PR.
           regex='^(feat|feature|fix|chore|docs|test|refactor|spec-[0-9]+|s[0-9]+-m[0-9]+|r-[0-9]+|archive|rescue)\/[A-Za-z0-9._-]+$'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -45,7 +45,13 @@ name: Dependabot auto-merge
 # `actions/checkout` with the head ref, an attacker-authored dependency manifest
 # or build script runs with write credentials. That is poisoned pipeline
 # execution, and it is the standard way supply-chain automation gets turned into
-# a supply-chain hole. This workflow avoids the whole class by construction.
+# a supply-chain hole. This workflow avoids the whole class, and since
+# 2026-09-08 pin-guard's CD-T8 check ENFORCES that rather than asking for it: a
+# PR-triggered job holding `contents: write` or `pull-requests: write` may not
+# carry a single `uses:` step. Before CD-T8 existed, a copy of this file with a
+# checkout of `github.event.pull_request.head.sha` and a `pip install -r` of the
+# bumped requirements passed all four pin-guard checks with exit 0. The sentence
+# was true and nothing was keeping it true.
 #
 # THEREFORE, THREE RULES THIS FILE KEEPS
 #
@@ -83,15 +89,87 @@ name: Dependabot auto-merge
 # collides with none of the 14 labels this repository already carries (measured
 # with `gh label list` on 2026-09-08).
 #
-# The label is honoured in BOTH directions, which is the part that actually
-# makes E3 hold. Adding `hold` to a PR whose auto-merge is already armed fires a
-# `labeled` event and DISARMS it; removing the label fires `unlabeled` and arms
-# it again. A workflow that only checked the label when arming would leave an
-# already-armed PR to merge anyway, and the postponement would be decoration.
+# The label is honoured in BOTH directions. Adding `hold` to a PR whose
+# auto-merge is already armed fires a `labeled` event and DISARMS it; removing
+# the label fires `unlabeled` and arms it again. A workflow that only read the
+# label when arming would leave an already-armed PR to merge anyway.
+#
+# HOW FAR THAT GOES, stated exactly, because an earlier draft of this comment
+# and of the README promised more. Disarming is a workflow RUN, and GitHub
+# merges the moment the last required check reports. So the label wins the race
+# only while something is still outstanding. Measured on 2026-09-08: the twelve
+# most recent runs of this repository's two smallest workflows took 6, 22, 25,
+# 37, 45, 47, 88, 103, 118, 122, 125 and 182 seconds from `created_at` to
+# `updated_at` (`gh api .../actions/runs`), so that is the width of the window
+# in which a `labeled` event has to be picked up, scheduled and finished. If a
+# PR is already green and current when it is labelled, GitHub can merge first.
+# The reliable order is therefore: label BEFORE the PR goes green, or disarm by
+# hand with `gh pr merge --disable-auto <n>` right after labelling, or mark it
+# draft, which this script also honours.
+#
+# THE DURABLE HOME OF E3 IS .github/dependabot.yml, NOT THE LABEL. A label sits
+# on a pull request object. When a newer version of the same package appears,
+# Dependabot closes that PR and opens a new one, and the new one carries only
+# the labels Dependabot itself assigns (measured 2026-09-08 06:21Z across the
+# eight open bot PRs carrying no `hold`: exactly `dependencies` plus one
+# ecosystem label, three distinct sets across the eight, never `hold`). The
+# postponement would then last exactly until the next release of the package it
+# postpones. So E3 is written as an `ignore:` entry in `.github/dependabot.yml`
+# as well, keyed on the PACKAGE, which is what the owner decided about. The
+# label stays useful as the short-term brake for anything else.
+
+# WHAT ARMING DOES NOT DO TODAY, and it is the most important line in this file.
+#
+# Four of master's 29 required contexts, `Analyze (actions)`, `Analyze (go)`,
+# `Analyze (javascript-typescript)` and `Analyze (python)`, come from CodeQL
+# DEFAULT SETUP (`gh api repos/kamir/m3c-tools/code-scanning/default-setup`
+# reports state=configured), and default setup does not run on a commit
+# Dependabot created. Measured 2026-09-08 06:21Z over the WHOLE population of
+# open Dependabot pull requests (ten of them, #247 through #256; #246 and #257
+# were closed by hand earlier that morning), comparing each head SHA's
+# check-runs against master's required list:
+#
+#   9 of 10   head commit authored by dependabot[bot], all four Analyze
+#             contexts MISSING (and 0 runs with event=dynamic on that SHA)
+#   1 of 10   #250, nothing missing, and its head SHA 565d2c67 is a merge
+#             commit authored by a HUMAN via `gh pr update-branch`
+#
+# The split follows head-commit authorship exactly, with no exception either
+# way, which is what makes this a cause and not a coincidence.
+#
+# A required context that never reports leaves the PR at "Expected, waiting for
+# status to be reported" forever, so auto-merge arms and then waits. Together
+# with strict=true (every merge to master puts the other eleven BEHIND, and
+# Dependabot's own rebase produces another bot commit) the automation cannot
+# reach the end on its own. E2 therefore buys the click, not the wait, until the
+# owner picks one of three: move CodeQL to advanced setup so the Analyze jobs
+# live in this tree and run on bot events; or drop those four contexts from
+# master's required list and keep the `CodeQL` context, which does report on bot
+# commits; or accept that each bot PR needs one human `gh pr update-branch`.
+# That is an owner decision about branch protection, not something this file
+# may quietly change, so the step below NAMES the state in the job summary
+# instead of hiding it.
 
 on:
   pull_request:
+    # Same base-branch filter the gate workflows carry. Only master is
+    # protected (`gh api repos/kamir/m3c-tools/branches --jq
+    # 'select(.protected)'` returns master and nothing else, 2026-09-08), so
+    # without this line a Dependabot PR opened against any other base would be
+    # armed while not one of the 29 required checks applies to it.
+    branches: [master]
     types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+
+# A `synchronize` (Dependabot rebasing) and a `labeled` (somebody adding `hold`)
+# can fire seconds apart, and two parallel runs would let the finishing ORDER
+# decide whether a held PR ends up armed. Cancelling the older run means the
+# youngest event wins, and the youngest event is the one whose label state is
+# current. Measured 2026-09-08: 0 of this repository's 17 workflows set
+# `concurrency`, so this is the first, and it is here because the missing group
+# changes a security-relevant outcome and not merely the runner bill.
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -109,12 +187,16 @@ jobs:
       - name: Arm or disarm GitHub auto-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           IS_DRAFT: ${{ github.event.pull_request.draft }}
           HAS_HOLD: ${{ contains(github.event.pull_request.labels.*.name, 'hold') }}
         run: |
           set -euo pipefail
+
+          say() { echo "$1"; echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
 
           # Second of the two author checks, deliberately redundant with the job
           # `if:`. If someone ever relaxes or deletes that condition, this one
@@ -125,25 +207,109 @@ jobs:
             exit 1
           fi
 
+          # PROVENANCE OF THE CONTENT, not only of the pull request.
+          #
+          # The Dependabot branches live in THIS repository, not in a fork
+          # (`gh api .../pulls/252 --jq .head.repo.fork` reports false), and they
+          # are unprotected (`.../branches/dependabot%2F.../protection` answers
+          # 404 "Branch not protected"). Anyone with push access can therefore
+          # put arbitrary commits on `dependabot/<...>`, and `.user.login` stays
+          # `dependabot[bot]` because the AUTHOR of the pull request never
+          # changes. That grants no privilege nobody had (master requires no
+          # review, so a human can already land anything that passes the 29
+          # checks) but it launders the attribution: the history would read as a
+          # bot bump. In a repository whose product is provenance that is the
+          # part worth closing.
+          #
+          # The rule is: every commit that CARRIES CONTENT must be authored by
+          # dependabot[bot]. Merge commits are exempt by parent count, because
+          # the documented recovery step `gh pr update-branch` creates one and it
+          # is authored by the human who ran it. Measured 2026-09-08 with
+          # `gh api repos/kamir/m3c-tools/pulls/<n>/commits`:
+          #   #257, #252  one commit, parents=1, author dependabot[bot]
+          #   #250        three commits: parents=1 by dependabot[bot], then two
+          #               parents=2 merges authored by kamir from update-branch
+          # So the rule passes a genuine bot PR both before and after a human
+          # refreshes it, and fails a branch somebody pushed content onto.
+          foreign="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/commits?per_page=100" \
+            --jq '.[] | select((.parents | length) < 2)
+                      | select(.author.login != "dependabot[bot]")
+                      | "  \(.sha[0:8]) authored by \(.author.login // "an unknown account"): \(.commit.message | split("\n")[0])"')"
+          if [ -n "$foreign" ]; then
+            echo "::error::refusing to arm: this branch carries content commit(s) not authored by dependabot[bot]"
+            printf '%s\n' "$foreign"
+            echo "A Dependabot branch lives in this repository and is unprotected, so this"
+            echo "is what somebody pushing to it looks like. Review and merge it by hand."
+            exit 1
+          fi
+
+          # WHAT IS ABOUT TO MERGE WITHOUT A HUMAN READING IT.
+          #
+          # E2 says every Dependabot PR merges automatically, and this workflow
+          # obeys that without exception; narrowing an owner decision quietly
+          # would be worse than the risk it removes. But master requires no
+          # review (`required_pull_request_reviews` is null, measured
+          # 2026-09-08), so for a `github-actions` bump the consequence is that a
+          # third-party action SHA enters the release and signing workflows with
+          # nobody having looked. PR #249 is the live example: its four changed
+          # files are release.yml, skillctl-release.yml, skillctl-smoke-matrix.yml
+          # and windows-gate.yml, and the first two carry the cosign and
+          # evidence-signing jobs. Four of the ten Dependabot PRs open at
+          # 2026-09-08 06:21Z carry the `github_actions` label (#248, #249,
+          # #255, #256). So the case gets NAMED in the run and in the
+          # summary, every time, and the owner can decide separately whether to
+          # add a CODEOWNERS rule on `.github/**` with one required approval.
+          touched="$(gh pr view "$PR_URL" --json files --jq '.files[].path' | grep '^\.github/workflows/' || true)"
+          if [ -n "$touched" ]; then
+            echo "::warning::this Dependabot PR changes workflow files and will merge without review (owner decision E2)"
+            say "**Workflow files in this bump** (merging with no human review, per E2):"
+            printf '%s\n' "$touched" | sed 's/^/  /' | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
           if [ "$HAS_HOLD" = "true" ]; then
-            echo "PR carries the 'hold' label (owner decision E3): auto-merge must not be armed."
-            # `--disable-auto` exits non-zero when auto-merge was never armed.
-            # That is the ordinary case, not a failure, so it is tolerated; what
-            # matters is that an ALREADY armed PR ends up disarmed.
-            if gh pr merge --disable-auto "$PR_URL"; then
-              echo "auto-merge was armed and is now disarmed."
-            else
-              echo "auto-merge was not armed; nothing to disarm."
+            say "PR carries the \`hold\` label (owner decision E3): auto-merge must not be armed."
+            # `--disable-auto` exits non-zero for two very different reasons:
+            # auto-merge was never armed (the ordinary case) or the call failed,
+            # for instance 403 because the token was not lifted. Treating both
+            # as success is how a postponement fails SILENTLY and OPEN, which is
+            # the wrong direction for the only path E3 depends on. So the exit
+            # code is not the verdict. The PR is asked afterwards what state it
+            # is actually in, and that answer decides.
+            gh pr merge --disable-auto "$PR_URL" || true
+            state="$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest')"
+            if [ "$state" != "null" ]; then
+              echo "::error::hold label is set but auto-merge is STILL ARMED on this PR"
+              echo "  reported state: $state"
+              echo "Disarm it by hand: gh pr merge --disable-auto $PR_NUMBER"
+              exit 1
             fi
-            echo "Release it later with: gh pr edit <n> --remove-label hold"
+            say "Verified: auto-merge is not armed on this PR."
+            say "Release it later with: \`gh pr edit $PR_NUMBER --remove-label hold\`"
             exit 0
           fi
 
           if [ "$IS_DRAFT" = "true" ]; then
-            echo "PR is a draft: not arming auto-merge."
+            say "PR is a draft: not arming auto-merge."
             exit 0
           fi
 
           gh pr merge --auto --merge "$PR_URL"
-          echo "auto-merge armed. GitHub merges this PR once all required checks pass;"
-          echo "a red check leaves it sitting here, which is the point."
+
+          # Arming is only believed after the PR confirms it. A zero exit from
+          # `gh pr merge --auto` and an armed pull request are two claims, not
+          # one, and the second is the one that matters.
+          state="$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest')"
+          if [ "$state" = "null" ]; then
+            echo "::error::gh reported success but this PR has no autoMergeRequest: auto-merge is NOT armed"
+            exit 1
+          fi
+          say "Verified: auto-merge is armed. GitHub merges once every required check passes;"
+          say "a red check leaves the PR sitting here, which is the point."
+
+          # Say out loud where the PR stands, so that "armed and waiting on a
+          # gate", "armed and waiting on a context that will never report" (see
+          # the CodeQL note in the header) and "not armed at all" stop looking
+          # alike from the outside. BLOCKED here usually means the four
+          # `Analyze (...)` contexts are still expected on a bot commit.
+          merge_state="$(gh pr view "$PR_URL" --json mergeStateStatus --jq '.mergeStateStatus')"
+          say "mergeStateStatus: \`$merge_state\`"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -38,6 +38,19 @@ name: Dependabot auto-merge
 # `permissions:` block below lifts it, which is exactly the shape of GitHub's
 # own documented Dependabot auto-merge example.
 #
+# That elevation is not merely quoted from the documentation, it has happened
+# in this repository. Run 34178003664 of gosec.yml was triggered by
+# dependabot[bot] on head SHA d69de7e6, and while the repository default is
+# `default_workflow_permissions=read`, the run log's own
+# "##[group]GITHUB_TOKEN Permissions" block reads `SecurityEvents: write` under
+# "Secret source: Dependabot", and "Upload SARIF to Code Scanning" succeeded.
+# So the per-job key does lift a Dependabot-triggered token here. What that run
+# does NOT establish is the specific pair this file asks for, `contents: write`
+# plus `pull-requests: write`; that is expected, not measured, and the first
+# real arming is what settles it. Read the same
+# "##[group]GITHUB_TOKEN Permissions" block in the first bot run of this
+# workflow to close the question.
+#
 # That makes `pull_request_target` unnecessary here, and unnecessary is the
 # right word for it. `pull_request_target` runs with a write-scoped token in the
 # context of the base branch, which is safe only for as long as nobody ever
@@ -149,6 +162,23 @@ name: Dependabot auto-merge
 # That is an owner decision about branch protection, not something this file
 # may quietly change, so the step below NAMES the state in the job summary
 # instead of hiding it.
+
+# WHAT IS STILL EXPECTED RATHER THAN MEASURED, listed so nothing below reads as
+# a measurement it is not.
+#
+#   1. This workflow has never run for a real Dependabot pull request. Measured
+#      2026-09-08: `gh api .../workflows/branch-name-check.yml/runs` returns 91
+#      runs on `dependabot/` branches and 0 of them with conclusion success, so
+#      the exception's production path is untravelled in both files. The first
+#      bot run is the proof; until then this is a design, tested locally.
+#   2. Whether `gh pr merge --auto` succeeds with the lifted token, see above.
+#   3. What runs on master after an auto-merge. GitHub does not create new
+#      workflow runs from events a GITHUB_TOKEN caused, and six workflows here
+#      trigger only on push to master (ci, coverage-gate, gosec, gosec-diff-gate,
+#      windows-gate, skillctl-windows-smoke), two of which carry a baseline
+#      forward. After the first automatic merge, check with
+#      `gh api "repos/kamir/m3c-tools/actions/runs?branch=master&event=push"`
+#      whether that merge commit has runs. Do not rebuild anything before that.
 
 on:
   pull_request:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,149 @@
+name: Dependabot auto-merge
+
+# Arms GitHub's OWN auto-merge on a Dependabot pull request, so the PR merges by
+# itself once every required check on master is green. This workflow never
+# merges anything, and it cannot: `gh pr merge --auto` only sets a flag that
+# GitHub honours after branch protection is satisfied. The merge DECISION stays
+# with the gates; what goes away is the hand work of clicking "Enable
+# auto-merge" on every single bump.
+#
+# Owner decision E2 of 2026-09-08: every Dependabot PR merges automatically once
+# it is green. Owner decision E3 of the same day postpones two of them (#251
+# sentence-transformers, #252 turbovec). E3 is honoured by the `hold` LABEL
+# below, deliberately not by the absence of this workflow: a postponement that
+# only works while no automation exists is not a postponement, it is a race.
+#
+# WHAT WAS MEASURED, 2026-09-08, against kamir/m3c-tools
+#
+#   allow_auto_merge=true, allow_merge_commit=true
+#     `gh api repos/kamir/m3c-tools`. Both are preconditions: with auto-merge
+#     disabled on the repository, `gh pr merge --auto` fails outright.
+#   29 required status checks on master, strict=true, required reviews=none
+#     `gh api repos/kamir/m3c-tools/branches/master/protection`. strict=true
+#     means the branch must also be current with master before it may merge;
+#     Dependabot rebases its own PRs when master moves. No required review means
+#     nothing else blocks the automatic merge once the checks pass.
+#   Dependabot PRs live in THIS repository, not in a fork
+#     `gh api repos/kamir/m3c-tools/pulls/252` reports head.repo and base.repo
+#     both kamir/m3c-tools, fork=false. That matters for the token, see below.
+#
+# WHY `pull_request` AND NOT `pull_request_target`
+#
+# GitHub's documentation states that runs triggered by Dependabot from `push`,
+# `pull_request`, `pull_request_review` or `pull_request_review_comment` are
+# "treated as if they were opened from a repository fork" and so "receive a
+# read-only GITHUB_TOKEN and do not have access to any secrets", AND that you
+# can "use the permissions key in your workflow to increase the access for the
+# token". So the read-only default is real but it is not a wall: the per-job
+# `permissions:` block below lifts it, which is exactly the shape of GitHub's
+# own documented Dependabot auto-merge example.
+#
+# That makes `pull_request_target` unnecessary here, and unnecessary is the
+# right word for it. `pull_request_target` runs with a write-scoped token in the
+# context of the base branch, which is safe only for as long as nobody ever
+# checks out or executes the pull request's own code; the moment someone adds an
+# `actions/checkout` with the head ref, an attacker-authored dependency manifest
+# or build script runs with write credentials. That is poisoned pipeline
+# execution, and it is the standard way supply-chain automation gets turned into
+# a supply-chain hole. This workflow avoids the whole class by construction.
+#
+# THEREFORE, THREE RULES THIS FILE KEEPS
+#
+#   1. NO CHECKOUT. There is no `actions/checkout` step and there must never be
+#      one. Nothing from the pull request is fetched, read or executed. The only
+#      inputs are event metadata fields and the PR URL.
+#   2. NO THIRD-PARTY ACTION. There is not a single `uses:` in this file, so
+#      there is no third-party code in a write-scoped job at all. The work is
+#      four lines of `gh`, which ships on the runner. (dependabot/fetch-metadata
+#      would be the usual companion; it is for filtering by semver bump type,
+#      and E2 says merge all, so it would buy nothing and cost an SHA to audit.)
+#   3. NARROWEST PERMISSIONS. Top-level is read-only, as pin-guard's CD-T6 check
+#      requires. The single job asks for `contents: write` plus
+#      `pull-requests: write`, which is what enabling auto-merge needs and what
+#      GitHub's documented example grants. Nothing else is requested.
+#
+# WHO IS ALLOWED THROUGH: same carrier as branch-name-check.yml, namely
+# `github.event.pull_request.user.login`, and NOT `github.actor`. Measured on
+# 2026-09-08: after a human ran `gh pr update-branch` on PR #250, the resulting
+# run recorded actor=kamir, so an actor-based guard would silently skip a real
+# Dependabot PR, and worse, a human-triggered event on any PR would be judged by
+# who clicked rather than by whose PR it is. The author field cannot be forged
+# from inside the repository: no human can make dependabot[bot] the author of a
+# pull request. The condition is enforced twice, once in the job `if:` and once
+# again in the script, so that an edit to either one alone cannot open the gate.
+#
+# POSTPONING A PULL REQUEST (owner decision E3)
+#
+#   Hold it back:  gh pr edit <n> --add-label hold
+#   Release it:    gh pr edit <n> --remove-label hold
+#
+# The label is named `hold` because it says only "not yet" and says nothing
+# about why, which keeps it reusable for any reason to wait; `blocked` or
+# `invalid` would assert the PR is broken, which is not what E3 means. It
+# collides with none of the 14 labels this repository already carries (measured
+# with `gh label list` on 2026-09-08).
+#
+# The label is honoured in BOTH directions, which is the part that actually
+# makes E3 hold. Adding `hold` to a PR whose auto-merge is already armed fires a
+# `labeled` event and DISARMS it; removing the label fires `unlabeled` and arms
+# it again. A workflow that only checked the label when arming would leave an
+# already-armed PR to merge anyway, and the postponement would be decoration.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  arm-auto-merge:
+    name: Arm auto-merge for Dependabot
+    runs-on: ubuntu-latest
+    # First of the two author checks. See "WHO IS ALLOWED THROUGH" above.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Arm or disarm GitHub auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          HAS_HOLD: ${{ contains(github.event.pull_request.labels.*.name, 'hold') }}
+        run: |
+          set -euo pipefail
+
+          # Second of the two author checks, deliberately redundant with the job
+          # `if:`. If someone ever relaxes or deletes that condition, this one
+          # still refuses, loudly, instead of quietly arming auto-merge on a
+          # human's pull request.
+          if [ "$PR_AUTHOR" != "dependabot[bot]" ]; then
+            echo "::error::refusing to act: pull request author is '$PR_AUTHOR', not dependabot[bot]"
+            exit 1
+          fi
+
+          if [ "$HAS_HOLD" = "true" ]; then
+            echo "PR carries the 'hold' label (owner decision E3): auto-merge must not be armed."
+            # `--disable-auto` exits non-zero when auto-merge was never armed.
+            # That is the ordinary case, not a failure, so it is tolerated; what
+            # matters is that an ALREADY armed PR ends up disarmed.
+            if gh pr merge --disable-auto "$PR_URL"; then
+              echo "auto-merge was armed and is now disarmed."
+            else
+              echo "auto-merge was not armed; nothing to disarm."
+            fi
+            echo "Release it later with: gh pr edit <n> --remove-label hold"
+            exit 0
+          fi
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "PR is a draft: not arming auto-merge."
+            exit 0
+          fi
+
+          gh pr merge --auto --merge "$PR_URL"
+          echo "auto-merge armed. GitHub merges this PR once all required checks pass;"
+          echo "a red check leaves it sitting here, which is the point."

--- a/.github/workflows/pin-guard.yml
+++ b/.github/workflows/pin-guard.yml
@@ -213,3 +213,80 @@ jobs:
             exit 1
           fi
           echo "OK: every upload-artifact step sets retention-days."
+
+      # (5) CD-T8: a job that can be reached by a PULL REQUEST event and that
+      # holds a REPOSITORY-WRITE token (`contents: write` or
+      # `pull-requests: write`) must not run any `uses:` step.
+      #
+      # This gate exists because dependabot-auto-merge.yml states, in its own
+      # header, that it "avoids the whole class by construction": no checkout, no
+      # third-party action, so nothing from the pull request is ever executed
+      # beside a write-scoped token. That sentence was prose. Measured on
+      # 2026-09-08: a copy of that file with an `actions/checkout` of
+      # `github.event.pull_request.head.sha` plus a `pip install -r` of the
+      # bumped requirements passed all four checks above with exit 0, because a
+      # poisoned checkout is perfectly SHA-pinned and perfectly least-privileged
+      # at the top level. CD-T8 is what turns the header sentence into a claim
+      # the tree enforces.
+      #
+      # Why `uses:` and not just `actions/checkout`: fetching the head ref is the
+      # common way in, not the only one. Any third-party action in a
+      # write-scoped, PR-triggered job runs code the pull request's author can
+      # influence with a token that can push to the repository.
+      #
+      # SCOPE, stated so the number means something. Only jobs matching BOTH
+      # conditions are examined. `security-events: write` (gosec.yml) and
+      # `id-token: write` are NOT repository writes and are out of scope, which
+      # is why the SARIF upload keeps its checkout. Jobs that inherit the
+      # top-level block are covered by CD-T6, which already forces it read-only.
+      - name: "Guard: no `uses:` in a write-scoped, PR-triggered job"
+        run: |
+          python3 - <<'PY'
+          import glob, sys, yaml
+
+          WRITE_SCOPES = ("contents", "pull-requests")
+          PR_EVENTS = ("pull_request", "pull_request_target")
+
+          def triggers(doc):
+              # A bare `on:` is parsed as the boolean True by YAML 1.1.
+              on = doc.get("on", doc.get(True))
+              if isinstance(on, dict):
+                  return list(on)
+              if isinstance(on, list):
+                  return list(on)
+              return [on] if isinstance(on, str) else []
+
+          def repo_write(perms):
+              if perms == "write-all":
+                  return True
+              if not isinstance(perms, dict):
+                  return False
+              return any(perms.get(s) == "write" for s in WRITE_SCOPES)
+
+          bad, examined = [], []
+          for f in sorted(glob.glob(".github/workflows/*.yml")):
+              doc = yaml.safe_load(open(f)) or {}
+              if not any(e in triggers(doc) for e in PR_EVENTS):
+                  continue
+              for name, job in (doc.get("jobs") or {}).items():
+                  if not isinstance(job, dict) or not repo_write(job.get("permissions")):
+                      continue
+                  examined.append(f"{f}:{name}")
+                  for step in job.get("steps") or []:
+                      if isinstance(step, dict) and step.get("uses"):
+                          bad.append(f"{f}: job '{name}' step uses: {step['uses']}")
+
+          if bad:
+              print("::error::A write-scoped, PR-triggered job must not run any 'uses:' step (CD-T8):")
+              for b in bad:
+                  print(f"  {b}")
+              print("")
+              print("Such a job holds a token that can push to this repository, and a")
+              print("pull request decides what the checked-out code contains. That is")
+              print("poisoned pipeline execution. Drop the step, or drop the write scope.")
+              sys.exit(1)
+          print(f"OK: {len(examined)} PR-triggered job(s) hold a repository-write token, "
+                f"and none runs a 'uses:' step.")
+          for e in examined:
+              print(f"  in scope: {e}")
+          PY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,20 @@ seven of them: a sentence printed beside measurements gets read as a
 measurement. Derivation and the five measures: `PLAN/QG-0001-fruehwarnung.md`
 in the maintenance repository.
 
+## Branching, and what merges without you
+
+Branch names are enforced by a required check: `<prefix>/<name>`, exactly one
+slash, prefix drawn from a fixed list. The list, the reasoning and the single
+named exception (pull requests authored by `dependabot[bot]`, owner decision E1
+of 2026-09-08) live in README §"Branch & worktree workflow". Work in your own
+`git worktree`, never in the shared checkout.
+
+Dependabot pull requests additionally arm GitHub's auto-merge on their own
+(`.github/workflows/dependabot-auto-merge.yml`, owner decision E2), so a green
+dependency bump lands in `master` with nobody reading it. Postponing one is a
+`hold` label for the short term and an `ignore:` entry in
+`.github/dependabot.yml` for anything that must outlive the pull request.
+
 ## Configuration
 
 Settings loaded from `.env` or `~/.m3c-tools.env` (see `.env.example`). Key variables:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,15 @@ refactor is not.
 ## Branching & PRs
 
 - Branch off `master`; open a PR against `master`.
+- Branch names are enforced by the required `Validate branch name` check:
+  `<prefix>/<name>`, exactly one slash. The prefix list and the reasoning are in
+  README §"Branch & worktree workflow"; adding a prefix means updating that list
+  in the same pull request. Work in a `git worktree`, not in the shared checkout.
+- The **one exception** is pull requests authored by `dependabot[bot]` (owner
+  decision E1). Those also arm GitHub's auto-merge by themselves (E2), so a
+  green Dependabot bump merges with no human in the loop. To hold one back,
+  label it `hold`. Both are described under README §"The one exception:
+  Dependabot".
 - Keep PRs focused; a green `make ci` is the baseline for review.
 - Pushing changes under `.github/workflows/**` requires an **SSH** remote (the HTTPS OAuth token
   lacks the `workflow` scope).

--- a/README.md
+++ b/README.md
@@ -382,7 +382,51 @@ gh pr edit <n> --remove-label hold   # release it again
 ```
 
 The label is honoured in both directions, so labelling a pull request whose
-auto-merge is already armed disarms it rather than losing the race.
+auto-merge is already armed disarms it too. That disarming is a workflow run,
+though, and GitHub merges the moment the last required check reports, so **the
+label wins only while something is still outstanding.** Runs of this
+repository's smallest workflows took between 6 and 182 seconds end to end
+(twelve most recent, measured 2026-09-08), which is the width of the window. If
+a pull request is already green and current when you label it, add
+`gh pr merge --disable-auto <n>` right after, or mark it draft; the workflow
+honours drafts as well.
+
+A postponement that has to outlive the pull request belongs in
+`.github/dependabot.yml` instead. Dependabot replaces a PR when a newer version
+appears, and the successor carries only the labels Dependabot assigns, so a
+label-only hold lasts until the next release of the package it holds. The
+`ignore:` entries under the `pip` ecosystem are how owner decision E3 is
+recorded for `sentence-transformers` and `turbovec`.
+
+#### What auto-merge cannot finish on its own, today
+
+Four of master's 29 required contexts, `Analyze (actions)`, `Analyze (go)`,
+`Analyze (javascript-typescript)` and `Analyze (python)`, come from **CodeQL
+default setup**, and default setup does not run on a commit Dependabot created.
+Measured 2026-09-08 06:21Z across all ten open Dependabot pull requests, by
+comparing each head SHA's check-runs against master's required list: the four
+are missing on all nine bot-authored head SHAs and present on the single
+human-authored one, #250, whose head is a merge commit produced with
+`gh pr update-branch`. The split follows head-commit authorship with no
+exception either way.
+
+A required context that never reports leaves the pull request waiting forever,
+so auto-merge arms and then sits. With `strict=true` on master, every merge puts
+the remaining bot PRs behind, Dependabot rebases them itself, and the fresh
+commit is a bot commit again. Until one of three things happens, each Dependabot
+pull request still needs one human `gh pr update-branch`, which is also how the
+newer required contexts appear on an older branch at all:
+
+- move CodeQL to **advanced setup**, so the Analyze jobs live in this tree and
+  run on Dependabot events;
+- drop those four contexts from master's required list and keep the `CodeQL`
+  context, which does report on bot commits;
+- or keep the manual refresh, knowing E2 saves the click and not the wait.
+
+That is a branch-protection decision, so the workflow does not make it. It names
+the state in the job summary instead, together with the pull request's
+`mergeStateStatus`, so "armed and waiting on a gate", "armed and waiting on a
+context that will never report" and "not armed at all" stop looking alike.
 
 ### Releasing
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,65 @@ make vet           # go vet ./...
 Formatting is **`gofumpt` + `gci`** on top of golangci-lint (formatting is not negotiable in Go.
 It is built into the toolchain), and `.golangci.yml` is the enforced linter config.
 
+### Branch & worktree workflow
+
+Every branch that carries a pull request must be named
+`<prefix>/<name>`, with exactly one slash and a name drawn from
+`[A-Za-z0-9._-]`. The allowed prefixes are:
+
+`feat` · `feature` · `fix` · `chore` · `docs` · `test` · `refactor` ·
+`spec-<n>` · `s<n>-m<n>` · `r-<n>` · `archive` · `rescue`
+
+```bash
+feat/spec-0188-bundle-pack        # passes
+fix/bug-0124-time-tracking-auth   # passes
+s2-m1/awareness-sync              # passes
+r-01/tenant-aware-verifier        # passes
+wip/quick-thing                   # rejected: 'wip' is not an allowed prefix
+feat/foo/bar                      # rejected: two slashes
+```
+
+This is enforced by the required `Validate branch name` check
+(`.github/workflows/branch-name-check.yml`), a stage 3 deliverable from the
+master-drift incident of 2026-05-07. **Adding a prefix there means updating this
+list in the same pull request.** Work on a branch in its own `git worktree`, not
+in the shared checkout, so several sessions can build at once without fighting
+over one working tree.
+
+#### The one exception: Dependabot
+
+Pull requests **authored by `dependabot[bot]`** are exempt from the pattern
+(owner decision E1, 2026-09-08). Dependabot names its branches
+`dependabot/<ecosystem>/<path>/<package>-<version>`, which breaks the convention
+twice over: `dependabot` is not an allowed prefix, and the name carries three
+slashes where the pattern allows one. Those names are not configurable, so the
+choice was a named exception or a pattern too loose to bite humans. **For humans
+the pattern is unchanged, character for character.**
+
+The exception keys on the pull request's **author**, not on the branch name and
+not on `github.actor`. Both alternatives were measured and rejected: a human can
+create a branch called `dependabot/whatever`, which would turn a branch-name
+exception into a one-word opt-out for everybody, and `github.actor` reads as the
+human, not the bot, whenever a person runs `gh pr update-branch` on a Dependabot
+branch. Nobody can make `dependabot[bot]` the author of a pull request, so the
+author is the carrier that cannot be forged from inside the repository.
+
+#### Holding a Dependabot pull request back
+
+Dependabot pull requests arm GitHub's auto-merge automatically
+(`.github/workflows/dependabot-auto-merge.yml`, owner decision E2), so they
+merge themselves once the required checks are green. The gates still decide; a
+red check leaves the pull request sitting there. To postpone one anyway, label
+it `hold`:
+
+```bash
+gh pr edit <n> --add-label hold      # hold it back, and disarm auto-merge if already armed
+gh pr edit <n> --remove-label hold   # release it again
+```
+
+The label is honoured in both directions, so labelling a pull request whose
+auto-merge is already armed disarms it rather than losing the race.
+
 ### Releasing
 
 Releases are **tag-driven**: pushing a `vX.Y.Z` or `skillctl/vX.Y.Z` tag builds, signs and


### PR DESCRIPTION
## Was der Befund war

PR #239 hat Dependabot fuer fuenf Oekosysteme freigeschaltet. Sofort sind
zwoelf PRs entstanden, #246 bis #257, und **alle zwoelf scheitern an der
erforderlichen Pruefung "Validate branch name"**. Die Lieferkette war damit
eingeschaltet und am letzten Schritt zu. Sie sah funktionierend aus, weil PRs
erschienen.

Zwei unabhaengige Gruende, am Zweig
`dependabot/github_actions/docker/build-push-action-7.3.0` gemessen: `dependabot`
ist kein erlaubtes Praefix, **und** der Name traegt drei Schraegstriche, wo das
Muster genau einen erlaubt.

## Was jetzt gilt

### 1. Benannte Ausnahme in `branch-name-check.yml` (Entscheidung E1)

Ein PR, dessen **Autor** `dependabot[bot]` ist, ueberspringt die Musterpruefung.
Fuer Menschen bleibt das Muster **Zeichen fuer Zeichen unveraendert**: der Diff
ist eine reine Einfuegung, 47 Zeilen dazu, keine geloescht, keine geaendert.

### 2. Neuer Workflow `dependabot-auto-merge.yml` (Entscheidung E2)

Schaltet GitHubs eigenes Auto-Merge scharf. Der Workflow merged **nie** selbst;
`gh pr merge --auto` setzt nur die Flagge, die GitHub nach erfuellter
Branch-Protection beachtet. Die Merge-Entscheidung bleibt bei den 29 Toren, weg
faellt nur die Handarbeit.

### 3. Etikett `hold` (Entscheidung E3, vertraeglich gemacht mit E2)

E3 stellt #251 und #252 zurueck. Durch Nichtstun waere das nicht erreichbar
gewesen: der Automatismus aus E2 haette sie mitgenommen, sobald sie gruen sind.
Der Workflow beachtet das Etikett deshalb **in beide Richtungen**.

```bash
gh pr edit <n> --add-label hold      # zurueckstellen, entschaerft auch ein schon scharfes Auto-Merge
gh pr edit <n> --remove-label hold   # wieder freigeben
```

Ein Workflow, der das Etikett nur beim Scharfschalten liest, haette einen bereits
scharfen PR trotzdem mergen lassen, und die Zurueckstellung waere Dekoration
gewesen. Das Etikett ist im Repo angelegt und kann gesetzt werden.

### 4. README-Abschnitt, den der Workflow verlangt

Der Kopf von `branch-name-check.yml` verlangt bei jeder Erweiterung eine
README-Aktualisierung im selben PR und verweist **zweimal** auf
`README.md §"Branch & worktree workflow"`.

**Gemessen: diesen Abschnitt gab es nicht.** Die Zeichenkette kam im ganzen Baum
nur in `branch-name-check.yml` selbst vor, der Verweis lief also seit dem
Vorfall vom 2026-05-07 ins Leere. Er ist jetzt angelegt und zeigt erstmals auf
etwas.

## Die Traegerwahl, gemessen statt angenommen

Der naheliegende Test `github.actor == 'dependabot[bot]'` **ist falsch.**

| Kandidat | Bei `gh pr update-branch` durch einen Menschen | Faelschbar durch einen Menschen? |
|---|---|---|
| `github.actor` | `kamir`, **nicht** der Bot | n/a, taugt schon vorher nicht |
| Zweigname `dependabot/*` | traegt | **ja**, jeder mit Schreibrecht |
| `github.event.pull_request.user.login` | `dependabot[bot]` | **nein** |

Messung 1, `gh api repos/kamir/m3c-tools/actions/runs`: auf PR #250, Zweig
`dependabot/pip/rag-mcp-server/mcp-2.1.1`, hat ein Mensch `gh pr update-branch`
ausgefuehrt. Der darauf folgende synchronize-Lauf dieses Workflows verzeichnet
`actor=kamir`, `triggering_actor=kamir`, Lauf `2026-09-08T01:48:11Z`, head_sha
`565d2c67`, conclusion `failure`. Eine Pruefung auf `github.actor` waere also
genau dann blind, wenn man sie braucht.

Messung 2, `gh api repos/kamir/m3c-tools/pulls/<n> --jq .user.login`: auf #246,
#250 und #252 stabil `dependabot[bot]`, unabhaengig davon, wer zuletzt gedrueckt
hat, denn das Feld nennt den Autor und nicht den Ausloeser.

Die Missbrauchsfrage folgt daraus. Ein Mensch kann einen Zweig `dependabot/xyz`
anlegen, mit dem Zweignamen als Traeger waere die Konvention also mit einem Wort
abwaehlbar. Den PR-Autor kann niemand faelschen. **Lokal nachgewiesen**, nicht
behauptet: `HEAD_REF=dependabot/pip/rag-mcp-server/turbovec-1.0.0` mit
`PR_AUTHOR=kamir` liefert weiterhin exit 1.

## Sicherheit des Auto-Merge-Workflows

Der GITHUB_TOKEN ist in einem von Dependabot ausgeloesten Lauf per Vorgabe
read-only. Die GitHub-Dokumentation sagt aber ausdruecklich, dass man "the
permissions key in your workflow" nutzen kann, um ihn anzuheben. Genau das tut
der Job-Block, und deshalb ist **`pull_request_target` nicht noetig**. Unnoetig
ist hier das richtige Wort: es liefe mit Schreibrechten und waere nur so lange
sicher, wie niemand den PR-Kopf auscheckt.

Die Datei vermeidet die Klasse baulich:

- **Kein Checkout.** Nach Kommentar-Strip null Treffer auf `checkout`. Nichts aus
  dem PR wird geholt, gelesen oder ausgefuehrt (poisoned pipeline execution).
- **Kein einziges `uses:`**, also kein Fremdcode in einem schreibberechtigten
  Job. `dependabot/fetch-metadata` waere der uebliche Begleiter, dient aber dem
  Filtern nach Bump-Typ; E2 sagt "alle", also brauchte es ihn nicht.
- **Engste Rechte.** Top-level `contents: read`, am Job nur `contents: write` und
  `pull-requests: write`.
- **Autorenpruefung doppelt**, im Job-`if:` und noch einmal im Skript, damit eine
  Aenderung an nur einer Stelle das Tor nicht oeffnet.

Voraussetzungen gemessen: `allow_auto_merge=true`, `allow_merge_commit=true`;
29 erforderliche Checks, `strict=true`, keine erforderlichen Reviews;
Dependabot-Zweige liegen in **diesem** Repo (`head.repo=base.repo`, `fork=false`),
nicht in einem Fork.

## Tore, jedes einzeln ausgefuehrt

| Tor | Ergebnis |
|---|---|
| Strenger YAML-Loader, Duplikate verweigernd, alle 17 Workflows | 0 fehlerhaft |
| dito gegen **gepflanztes** doppeltes `runs-on` | faengt es in Zeile 103; `yaml.safe_load` meldet zeitgleich "YAML OK" |
| pin-guard 1, SHA-Pinning | OK, neue Datei hat 0 `uses:`-Zeilen |
| pin-guard 2, kein `@latest` | OK |
| pin-guard 3, top-level read-only | OK; gepflanztes top-level `contents: write` wird gefangen |
| pin-guard 4, `retention-days` | OK |
| `./scripts/check-no-emdash.sh` | PASS; gepflanzter Geviertstrich wird gefangen |
| `./tools/boundary-gate.sh` | clean |
| Zweignamen-Pruefer lokal, aus dem YAML extrahiert | **13 von 13 Faellen wie erwartet** |
| `go build ./...`, `go vet ./...`, `check-gofmt.sh` | 0, 0, 794 Dateien konform (Gegenprobe: weder Go noch Shell angefasst) |

Die 13 Faelle im Detail: drei echte Dependabot-Zweige mit Bot-Autor gehen durch
(exit 0), fuenf **gepflanzte Fundstellen** scheitern weiterhin (exit 1), darunter
beide Missbrauchsfaelle, und fuenf gueltige Menschen-Zweige gehen unveraendert
durch. Getestet wurde das aus der ausgelieferten YAML extrahierte Skript, keine
Handkopie.

## Nicht in diesem PR

Das Setzen von `hold` auf #251 und #252 macht die orchestrierende Sitzung; hier
steht nur die Beachtung. Der Workflow ist bewusst **keine erforderliche
Pruefung**, er blockiert also nichts.
