### PR TITLE
fix(plaud): warte auf den Cloud-Text, statt eine Aufnahme zu verbrennen (BUG-0222)

### DIFF
--- a/cmd/m3c-tools/main.go
+++ b/cmd/m3c-tools/main.go
@@ -5286,6 +5286,7 @@ type devSyncProgress func(recID, name, phase, disposition, docID string, err err
 // devSyncTotals summarizes a dev-sync run for a clear progress report.
 type devSyncTotals struct {
 	Synced, Skipped, Failed       int
+	Deferred                      int // BUG-0222: waiting for Plaud's cloud transcript
 	Plaud, Queued, Whisper, Audio int // transcript disposition of the synced items
 }
 
@@ -5294,6 +5295,58 @@ type devSyncTotals struct {
 // importType "plaud") + the SPEC-0117 server mapping. Returns the ER1 doc_id.
 // localWhisperTranscript transcribes MP3 bytes on THIS Mac via the whisper CLI.
 // Returns "" if whisper is unavailable or fails (caller falls back to audio-only).
+
+// plaudTranscriptGrace is how long a recording with NO Plaud transcript is left
+// alone before we conclude Plaud will never produce one. BUG-0222: an empty
+// source_list means two different things, "there will never be a transcript" and
+// "the cloud ASR is not finished yet", and the hourly timer reliably hits the
+// second case: a recording that stops at :19:38 is read at :20:00, 22 seconds
+// later. Treating that as the first case burns the recording, because a synced
+// recording is never looked at again. Within the grace window we defer instead.
+// PLAUD_TRANSCRIPT_GRACE_MIN tunes it; 0 disables the wait (old behavior).
+func plaudTranscriptGrace() time.Duration {
+	graceMin := 30
+	if v := strings.TrimSpace(os.Getenv("PLAUD_TRANSCRIPT_GRACE_MIN")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			graceMin = n
+		}
+	}
+	return time.Duration(graceMin) * time.Minute
+}
+
+// plaudTranscriptPending reports whether a recording without a Plaud transcript
+// is merely still being processed. It measures from the END of the recording
+// (start + duration), not its start: a 40-minute recording started an hour ago
+// stopped 20 minutes ago, and the cloud has had 20 minutes, not 60.
+func plaudTranscriptPending(r plaud.DevRecording, grace time.Duration) (bool, time.Duration) {
+	if grace <= 0 {
+		return false, 0
+	}
+	start, ok := plaud.ParseDevTime(r.StartAt)
+	if !ok {
+		return false, 0 // an unreadable timestamp must not stall the recording
+	}
+	ready := start.Add(time.Duration(r.Duration) * time.Millisecond).Add(grace)
+	if wait := time.Until(ready); wait > 0 {
+		return true, wait
+	}
+	return false, 0
+}
+
+// plaudDeferForTranscript is THE decision "leave this recording alone for now".
+// Both the dry run and the real sync call it, so a preview can never promise a
+// sync the real run would defer. That divergence is how the dry run came to
+// report WOULD sync for exactly the recordings BUG-0222 was about.
+//
+// A recording is deferred only when all three hold: no Plaud transcript, the
+// caller did not force it, and the cloud has not yet had its grace period.
+func plaudDeferForTranscript(r plaud.DevRecording, transcript string, force bool, grace time.Duration) (bool, time.Duration) {
+	if force || strings.TrimSpace(transcript) != "" {
+		return false, 0
+	}
+	return plaudTranscriptPending(r, grace)
+}
+
 // plaudMaxAudioBytes is the largest audio clip attached to an ER1 upload. Bigger
 // clips are dropped (transcript-only) to stay under the ER1 ingress limit: Cloud
 // Run / GFE reject requests over ~32 MiB with HTTP 413. Raise PLAUD_MAX_AUDIO_MB to
@@ -5347,12 +5400,27 @@ func localWhisperTranscript(audio []byte, id string) string {
 //	"audio", no transcript and no server-side transcription (audio only)
 func syncOneDevRecording(client *plaud.DevClient, er1Cfg *er1.Config, contentType string,
 	filesDB *tracking.FilesDB, syncAPI *plaud.SyncAPIClient, accountID string,
-	r plaud.DevRecording, tags string, useWhisper bool, existingDocID string) (string, string, error) {
+	r plaud.DevRecording, tags string, useWhisper, force bool, existingDocID string) (string, string, error) {
 
 	detail, err := client.GetDetail(r.ID)
 	if err != nil {
 		return "", "", fmt.Errorf("detail: %w", err)
 	}
+	transcript := detail.TranscriptText()
+	notes := detail.NotesText()
+
+	// BUG-0222: read an empty Plaud transcript BEFORE spending an audio download,
+	// and do not mistake "not finished yet" for "never". Inside the grace window
+	// the recording is DEFERRED: nothing is uploaded, nothing is written to the
+	// ledger or the SPEC-0117 mapping, so it stays `new` and the next hourly pass
+	// takes it again, with the real text. --force means "do it now anyway".
+	if pending, wait := plaudDeferForTranscript(r, transcript, force, plaudTranscriptGrace()); pending {
+		log.Printf("[plaud-dev] %s: Plaud has no transcript yet. Deferring for ~%s "+
+			"so the cloud can finish; the recording stays unsynced and the next pass retries",
+			r.ID, wait.Round(time.Minute))
+		return "", "pending", nil
+	}
+
 	var audio []byte
 	if detail.PresignedURL != "" {
 		if audio, err = client.DownloadAudio(detail.PresignedURL); err != nil {
@@ -5367,8 +5435,6 @@ func syncOneDevRecording(client *plaud.DevClient, er1Cfg *er1.Config, contentTyp
 	// which is local; without this the two producers disagree by 1-2 h and the
 	// braindump corpus mixes both. FR-0095.
 	captureTime := parseDevTime(r.StartAt).Local()
-	transcript := detail.TranscriptText()
-	notes := detail.NotesText()
 
 	// Cap the attached audio: the ER1 ingress (Cloud Run / Google Front End)
 	// rejects requests over ~32 MiB with HTTP 413. Audio is OPTIONAL whenever we
@@ -5436,7 +5502,7 @@ func syncOneDevRecording(client *plaud.DevClient, er1Cfg *er1.Config, contentTyp
 		ContentType:        contentType,
 		CurrentTime:        er1.FormatCaptureTime(captureTime),
 		DoTranscribe:       doTranscribe,
-		DocID:              existingDocID, // overwrite on forced re-sync (no duplicate)
+		DocID:              existingDocID, // asks for an overwrite; NOT honored yet, see BUG-0223
 	}
 	if len(audio) > 0 {
 		payload.AudioData = audio
@@ -5528,11 +5594,20 @@ func runDevSyncByIDs(client *plaud.DevClient, recByID map[string]plaud.DevRecord
 			}
 			continue
 		}
-		docID, disp, err := syncOneDevRecording(client, er1Cfg, cfg.ContentType, filesDB, syncAPI, accountID, r, tags, whisper, states[id].DocID)
+		docID, disp, err := syncOneDevRecording(client, er1Cfg, cfg.ContentType, filesDB, syncAPI, accountID, r, tags, whisper, force, states[id].DocID)
 		if err != nil {
 			t.Failed++
 			if prog != nil {
 				prog(id, r.Name, "failed", "", "", err)
+			}
+			continue
+		}
+		// BUG-0222: deferred, not done. Nothing was uploaded and nothing was
+		// recorded, so the recording stays `new` and the next pass retries it.
+		if disp == "pending" {
+			t.Deferred++
+			if prog != nil {
+				prog(id, r.Name, "deferred", disp, "", nil)
 			}
 			continue
 		}
@@ -5591,15 +5666,32 @@ func cmdPlaudDevSync(selectors []string, all bool, limit int, dryRun, force, whi
 
 	if dryRun {
 		states := resolvePlaudSyncStates(ids, client.AccessToken())
-		would := 0
+		grace := plaudTranscriptGrace()
+		would, wait := 0, 0
 		for _, r := range todo {
 			if !force && plaudStateSynced(states[r.ID]) {
 				continue
 			}
+			// BUG-0222: a preview that promises a sync the real run would defer is
+			// the same misreport in a quieter place. Only recordings still inside
+			// the grace window can be deferred, so only those cost a detail call,
+			// and that is normally none or one.
+			// Only a recording still inside the grace window can be deferred, so
+			// only those cost a detail call: normally none or one.
+			if pending, _ := plaudTranscriptPending(r, grace); pending && !force {
+				if d, derr := client.GetDetail(r.ID); derr == nil {
+					if defer_, left := plaudDeferForTranscript(r, d.TranscriptText(), force, grace); defer_ {
+						fmt.Printf("  WOULD WAIT: %s  %s  (Plaud transcript not ready, ~%s left)\n",
+							r.ID, stripCtrl(r.Name), left.Round(time.Minute))
+						wait++
+						continue
+					}
+				}
+			}
 			fmt.Printf("  WOULD sync: %s  %s\n", r.ID, stripCtrl(r.Name))
 			would++
 		}
-		fmt.Printf("\nDone (dry-run). would_sync=%d of %d selected\n", would, len(todo))
+		fmt.Printf("\nDone (dry-run). would_sync=%d  would_wait=%d  of %d selected\n", would, wait, len(todo))
 		return
 	}
 
@@ -5609,12 +5701,22 @@ func cmdPlaudDevSync(selectors []string, all bool, limit int, dryRun, force, whi
 		case "done":
 			done++
 			fmt.Printf("  [%d/%d] ✓ %-7s  %s → %s\n", done, len(ids), disp, stripCtrl(name), docID)
+		case "deferred":
+			done++
+			fmt.Printf("  [%d/%d] … waiting   %s (Plaud transcript not ready, retried next pass)\n",
+				done, len(ids), stripCtrl(name))
 		case "failed":
 			done++
 			fmt.Fprintf(os.Stderr, "  [%d/%d] ✗ %s: %v\n", done, len(ids), stripCtrl(name), err)
 		}
 	})
-	fmt.Printf("\nDone. synced=%d  skipped(already)=%d  failed=%d\n", tot.Synced, tot.Skipped, tot.Failed)
+	fmt.Printf("\nDone. synced=%d  skipped(already)=%d  deferred=%d  failed=%d\n",
+		tot.Synced, tot.Skipped, tot.Deferred, tot.Failed)
+	if tot.Deferred > 0 {
+		fmt.Printf("  → %d waiting for Plaud's cloud transcript. They stay unsynced on purpose; "+
+			"the next pass takes them WITH the text (--force to sync one now, "+
+			"PLAUD_TRANSCRIPT_GRACE_MIN=0 to disable the wait).\n", tot.Deferred)
+	}
 	if tot.Synced > 0 {
 		fmt.Printf("  transcripts: %d Plaud · %d queued(server-side whisper) · %d local-whisper · %d audio-only\n",
 			tot.Plaud, tot.Queued, tot.Whisper, tot.Audio)
@@ -6273,6 +6375,11 @@ func menubarHandlePlaudSync(app *menubar.App) {
 				if docID != "" {
 					menubar.SetPlaudSyncRowDoc(id, docID, er1Cfg.MemoryItemURL(docID))
 				}
+			// BUG-0222: deferred is neither success nor failure. The row must NOT
+			// go green: nothing was uploaded, and the next pass takes it with the
+			// text. Showing it as synced is exactly the lie this bug was about.
+			case "deferred":
+				menubar.SetPlaudSyncStatus(id, "waiting")
 			case "failed":
 				failed++
 				menubar.SetPlaudSyncStatus(id, "failed")
@@ -6287,11 +6394,14 @@ func menubarHandlePlaudSync(app *menubar.App) {
 		}
 
 		tot := runDevSyncByIDs(client, recByID, recordingIDs, customTags, false, false, prog)
-		log.Printf("[plaud] dev sync DONE: %d synced (%d Plaud, %d queued server-side, %d whisper), %d skipped, %d failed",
-			tot.Synced, tot.Plaud, tot.Queued, tot.Whisper, tot.Skipped, tot.Failed)
+		log.Printf("[plaud] dev sync DONE: %d synced (%d Plaud, %d queued server-side, %d whisper), %d skipped, %d deferred, %d failed",
+			tot.Synced, tot.Plaud, tot.Queued, tot.Whisper, tot.Skipped, tot.Deferred, tot.Failed)
 		note := fmt.Sprintf("Fertig: %d synchronisiert, %d übersprungen, %d Fehler", tot.Synced, tot.Skipped, tot.Failed)
 		if tot.Queued > 0 {
 			note += fmt.Sprintf(" · %d in Server-Transkription", tot.Queued)
+		}
+		if tot.Deferred > 0 {
+			note += fmt.Sprintf(" · %d warten auf den Plaud-Text", tot.Deferred)
 		}
 		app.Notify("Plaud Sync", note)
 		menubar.SetPlaudSyncProgress(menubar.BulkRunState{

--- a/cmd/m3c-tools/plaud_bug0222_test.go
+++ b/cmd/m3c-tools/plaud_bug0222_test.go
@@ -1,3 +1,13 @@
+//go:build darwin
+
+// Diese Tests rufen plaudTranscriptPending auf, und die Funktion lebt in
+// cmd/m3c-tools/main.go hinter //go:build darwin. Ohne dieselbe Marke wird die
+// Datei auf Windows und Linux mituebersetzt und `go vet` bricht mit
+// "undefined: plaudTranscriptPending". Gemessen auf PR #263, Lauf 34196926495:
+//   vet.exe: cmd\m3c-tools\plaud_bug0222_test.go:32:19: undefined: plaudTranscriptPending
+// Der Fehlschlag trat NUR auf der anderen Plattform auf; auf macOS war go vet
+// gruen. Genau dafuer gibt es die Windows-Tore.
+
 package main
 
 import (

--- a/cmd/m3c-tools/plaud_bug0222_test.go
+++ b/cmd/m3c-tools/plaud_bug0222_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kamir/m3c-tools/pkg/plaud"
+)
+
+// BUG-0222: an empty Plaud transcript means two different things. On a fresh
+// recording it means "the cloud ASR is not finished"; only after a grace period
+// does it mean "there will never be a transcript". The hourly timer reliably hit
+// the first case (a recording ending at :19:38 was read at :20:00) and the
+// recording was then marked synced forever, so the real text never arrived.
+//
+// The window is measured from the END of the recording, not its start.
+
+// devRec builds a recording that ENDED `endedAgo` before now.
+func devRec(endedAgo, dur time.Duration) plaud.DevRecording {
+	start := time.Now().Add(-endedAgo - dur)
+	return plaud.DevRecording{
+		ID:       "rec",
+		StartAt:  start.UTC().Format("2006-01-02T15:04:05"),
+		Duration: dur.Milliseconds(),
+	}
+}
+
+func TestTranscriptPendingWithinGrace(t *testing.T) {
+	// The exact shape of the reported incident: 6m23s recording, read 22s after
+	// it stopped. It must be deferred, not queued.
+	r := devRec(22*time.Second, 6*time.Minute+23*time.Second)
+	pending, wait := plaudTranscriptPending(r, 30*time.Minute)
+	if !pending {
+		t.Fatalf("a recording that stopped 22s ago must be deferred, got pending=false")
+	}
+	if wait <= 0 || wait > 30*time.Minute {
+		t.Fatalf("wait %v is outside the grace window", wait)
+	}
+}
+
+func TestTranscriptNotPendingAfterGrace(t *testing.T) {
+	// Past the grace, "no transcript" is a real answer: the old behavior
+	// (server-side queue / local whisper) must still take over.
+	r := devRec(45*time.Minute, 2*time.Minute)
+	if pending, _ := plaudTranscriptPending(r, 30*time.Minute); pending {
+		t.Fatalf("a recording that stopped 45min ago must NOT be deferred")
+	}
+}
+
+func TestTranscriptGraceMeasuresFromEndNotStart(t *testing.T) {
+	// A 40-minute recording STARTED 45 minutes ago stopped only 5 minutes ago.
+	// Measuring from start would wave it through with an unfinished transcript.
+	r := devRec(5*time.Minute, 40*time.Minute)
+	if pending, _ := plaudTranscriptPending(r, 30*time.Minute); !pending {
+		t.Fatalf("grace must be measured from the recording's END, not its start")
+	}
+}
+
+func TestTranscriptGraceZeroDisablesTheWait(t *testing.T) {
+	r := devRec(1*time.Second, time.Minute)
+	if pending, _ := plaudTranscriptPending(r, 0); pending {
+		t.Fatalf("grace 0 must restore the old, immediate behavior")
+	}
+}
+
+func TestTranscriptUnreadableTimestampNeverStalls(t *testing.T) {
+	// A timestamp we cannot parse must not park a recording forever: fail open.
+	r := plaud.DevRecording{ID: "rec", StartAt: "not-a-time", Duration: 1000}
+	if pending, _ := plaudTranscriptPending(r, 30*time.Minute); pending {
+		t.Fatalf("an unparseable start_at must not defer the recording")
+	}
+}
+
+func TestTranscriptGraceEnvOverride(t *testing.T) {
+	if got := plaudTranscriptGrace(); got != 30*time.Minute {
+		t.Fatalf("default grace = %v, want 30m", got)
+	}
+	t.Setenv("PLAUD_TRANSCRIPT_GRACE_MIN", "5")
+	if got := plaudTranscriptGrace(); got != 5*time.Minute {
+		t.Fatalf("PLAUD_TRANSCRIPT_GRACE_MIN=5 → %v, want 5m", got)
+	}
+	t.Setenv("PLAUD_TRANSCRIPT_GRACE_MIN", "0")
+	if got := plaudTranscriptGrace(); got != 0 {
+		t.Fatalf("PLAUD_TRANSCRIPT_GRACE_MIN=0 → %v, want 0", got)
+	}
+	// A malformed value must not silently disable the guard.
+	t.Setenv("PLAUD_TRANSCRIPT_GRACE_MIN", "später")
+	if got := plaudTranscriptGrace(); got != 30*time.Minute {
+		t.Fatalf("a malformed grace value must fall back to the default, got %v", got)
+	}
+}
+
+// --- the shared decision both the preview and the real run consult -----------
+//
+// These cover the WIRING, not just the clock. The dry run and the real sync
+// each decided for themselves at first, and they disagreed: the preview
+// reported "WOULD sync" for precisely the recordings the real run defers.
+
+func TestDeferDecisionFreshRecordingWithoutTranscript(t *testing.T) {
+	r := devRec(22*time.Second, 6*time.Minute+23*time.Second)
+	got, wait := plaudDeferForTranscript(r, "", false, 30*time.Minute)
+	if !got {
+		t.Fatalf("a fresh recording with no Plaud transcript must be deferred")
+	}
+	if wait <= 0 {
+		t.Fatalf("a deferred recording must report how long to wait, got %v", wait)
+	}
+}
+
+func TestDeferDecisionNotWhenPlaudHasText(t *testing.T) {
+	r := devRec(1*time.Second, time.Minute)
+	if got, _ := plaudDeferForTranscript(r, "Mirko Kämpf: das Problem …", false, 30*time.Minute); got {
+		t.Fatalf("a recording WITH a Plaud transcript must never be deferred")
+	}
+}
+
+func TestDeferDecisionWhitespaceOnlyTranscriptCountsAsEmpty(t *testing.T) {
+	r := devRec(1*time.Second, time.Minute)
+	if got, _ := plaudDeferForTranscript(r, "  \n\t ", false, 30*time.Minute); !got {
+		t.Fatalf("a blank transcript is no transcript and must be deferred")
+	}
+}
+
+func TestDeferDecisionForceMeansNow(t *testing.T) {
+	r := devRec(1*time.Second, time.Minute)
+	if got, _ := plaudDeferForTranscript(r, "", true, 30*time.Minute); got {
+		t.Fatalf("--force must bypass the wait: an explicit selection means now")
+	}
+}
+
+func TestDeferDecisionOldRecordingFallsThroughToTheQueue(t *testing.T) {
+	// Past the grace, an empty transcript is a real answer and the old
+	// behavior (server-side queue / local whisper) must still take over.
+	r := devRec(2*time.Hour, time.Minute)
+	if got, _ := plaudDeferForTranscript(r, "", false, 30*time.Minute); got {
+		t.Fatalf("past the grace the recording must proceed, not stall forever")
+	}
+}

--- a/pkg/er1/upload.go
+++ b/pkg/er1/upload.go
@@ -26,9 +26,14 @@ type UploadPayload struct {
 	ImageFilename      string // e.g. "videoID_thumbnail.jpg"
 	Tags               string // comma-separated tags
 	ContentType        string // per-observation content type (overrides cfg.ContentType if set)
-	DocID              string // if set, request ER1 to overwrite this existing document
-	DoTranscribe       bool   // if true, send DO_TRANSCRIBE=true: server transcribes audio
-	CurrentTime        string // real capture time "2006-01-02 15:04:05"; empty → server stamps now.
+	// DocID ASKS the server to overwrite this existing document. BUG-0223: as of
+	// 2026-09-08 /upload_2 does NOT read this field. It creates a new document and
+	// answers 200 with the NEW id, so a caller that sets this gets a DUPLICATE, not
+	// an overwrite. The field is kept so the client is ready once the server honors
+	// it; until then do not describe a forced re-sync as duplicate-free.
+	DocID        string
+	DoTranscribe bool   // if true, send DO_TRANSCRIBE=true: server transcribes audio
+	CurrentTime  string // real capture time "2006-01-02 15:04:05"; empty → server stamps now.
 	// Positions the item at its true creation time in the memory viewer instead
 	// of the import time: important for multi-device capture (SPEC-0117).
 }

--- a/pkg/menubar/plaud_sync_darwin.go
+++ b/pkg/menubar/plaud_sync_darwin.go
@@ -281,6 +281,10 @@ extern void goPlaudSyncAction(char* action);
 				[cell setTextColor:[NSColor systemBlueColor]];
 			} else if ([st isEqualToString:@"syncing"]) {
 				[cell setTextColor:[NSColor systemOrangeColor]];
+			} else if ([st isEqualToString:@"waiting"]) {
+				// BUG-0222: deferred, waiting for Plaud's cloud transcript.
+				// Deliberately NOT green: nothing was uploaded yet.
+				[cell setTextColor:[NSColor systemOrangeColor]];
 			} else if ([st isEqualToString:@"failed"]) {
 				[cell setTextColor:[NSColor systemRedColor]];
 			}


### PR DESCRIPTION
## Das Problem

Ein leeres `source_list` von der Plaud-Developer-API heisst zweierlei:
"es wird nie einen Text geben" und "die Cloud ist noch nicht fertig".
Der Sync las beides als das erste.

Der stuendliche Zeitgeber trifft aber zuverlaessig das zweite:

| Zeitpunkt | Ereignis |
|---|---|
| 08:13:15 | Aufnahme beginnt |
| 08:19:38 | Aufnahme endet (6m23s) |
| **08:20:00** | **launchd startet den Sync** |

22 Sekunden. Die Aufnahme ging in die serverseitige Whisper-Queue und galt als
`SYNCED`. Weil `SYNCED` ein Endzustand ist und `runDevSyncByIDs` jede bereits
synchronisierte Aufnahme ueberspringt, erreicht der spaeter fertige Plaud-Text
ER1 **nie**, obwohl beide Systeme ihn haben.

## Die Aenderung

Innerhalb einer Karenzzeit wird die Aufnahme ZURUECKGESTELLT: kein Upload,
kein Eintrag im Ledger, keine SPEC-0117-Zuordnung. Sie bleibt `new`, und der
naechste stuendliche Lauf nimmt sie mit dem echten Text. Nach der Karenz greift
unveraendert der bisherige Weg, denn dann ist "kein Text" eine echte Antwort.

- gemessen wird ab dem **Ende** der Aufnahme, nicht ab ihrem Anfang
- `PLAUD_TRANSCRIPT_GRACE_MIN` stellt die Karenz (Vorgabe 30 min), `0` schaltet sie ab
- `--force` uebergeht sie: eine ausdrueckliche Auswahl heisst "jetzt"
- ein unlesbarer Zeitstempel stellt nie zurueck, sonst haengt die Aufnahme
- die Menubar-Zeile wird `waiting` (orange), ausdruecklich **nicht** gruen

Der Trockenlauf entschied getrennt und meldete `WOULD sync` fuer genau die
Aufnahmen, die der echte Lauf zurueckstellt. Beide Pfade fragen jetzt
`plaudDeferForTranscript`, also koennen sie nicht mehr auseinanderlaufen.

## Nebenbei richtiggestellt

`pkg/er1/upload.go` und `main.go` behaupteten, das Feld `doc_id` lasse ER1 ein
bestehendes Dokument ueberschreiben. `/upload_2` liest das Feld nicht und legt
immer ein neues an; ein erzwungener Re-Sync **dupliziert** also. Die Kommentare
sagen das jetzt. Der Serverfehler ist getrennt erfasst.

## Pruefung

- 11 neue Tests, aufgesetzt auf die gemessene Zeitlage des Vorfalls
- `go build ./...`, `go vet`, `gofmt` sauber
- volle Suite: nur die drei vorbestehenden `cmd/thinking-engine`-Fehler
  (fehlendes Build-Artefakt), gegen `origin/master` als identische Baseline nachgemessen
- `scripts/check-no-emdash.sh` gruen

🤖 Generated with [Claude Code](https://claude.com/claude-code)