### PR TITLE
fix(ci): der Auto-Merge-Workflow vergleicht gegen ein Wort, das jq nie druckt

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -306,8 +306,13 @@ jobs:
             # code is not the verdict. The PR is asked afterwards what state it
             # is actually in, and that answer decides.
             gh pr merge --disable-auto "$PR_URL" || true
-            state="$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest')"
-            if [ "$state" != "null" ]; then
+            state="$(gh pr view "$PR_URL" --json autoMergeRequest --jq '(.autoMergeRequest != null)')"
+            # `--jq '.autoMergeRequest'` prints NOTHING when the field is null,
+            # not the word "null". The test therefore has to read a boolean the
+            # filter produces, not a string it never emits. Measured on this
+            # repository: disarmed gives "" for the old filter and "false" for
+            # the new one, armed gives a JSON object and "true".
+            if [ "$state" = "true" ]; then
               echo "::error::hold label is set but auto-merge is STILL ARMED on this PR"
               echo "  reported state: $state"
               echo "Disarm it by hand: gh pr merge --disable-auto $PR_NUMBER"
@@ -328,8 +333,8 @@ jobs:
           # Arming is only believed after the PR confirms it. A zero exit from
           # `gh pr merge --auto` and an armed pull request are two claims, not
           # one, and the second is the one that matters.
-          state="$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest')"
-          if [ "$state" = "null" ]; then
+          state="$(gh pr view "$PR_URL" --json autoMergeRequest --jq '(.autoMergeRequest != null)')"
+          if [ "$state" != "true" ]; then
             echo "::error::gh reported success but this PR has no autoMergeRequest: auto-merge is NOT armed"
             exit 1
           fi


### PR DESCRIPTION
Beide Rueckfragen des neuen Auto-Merge-Workflows lasen `--jq '.autoMergeRequest'` und verglichen mit der Zeichenkette `null`. jq druckt bei einem Null-Feld aber **nichts**, nicht das Wort.

## Aufgefallen an einem echten Lauf

PR #250, Lauf 34196506788:

```
PR carries the `hold` label (owner decision E3): auto-merge must not be armed.
##[error]hold label is set but auto-merge is STILL ARMED on this PR
  reported state:
```

Die gemeldete Zustandszeile ist leer, und trotzdem Alarm. Auto-Merge war da schon entschaerft.

## Gemessen, alle vier Faelle an echten PRs

| Fall | alt `.autoMergeRequest` | neu `(!= null)` | ALT-Urteil | NEU-Urteil |
|---|---|---|---|---|
| HOLD, entschaerft (#250) | `[]` | `false` | **ALARM** | still |
| ARM, Scharfschalten schlug fehl | `[]` | `false` | **still** | ALARM |
| HOLD, scharf (#247) | `{"auth…` | `true` | ALARM | ALARM |
| ARM, scharf (#247) | `{"auth…` | `true` | still | still |

Die alte Bedingung war genau in den zwei Faellen falsch, auf die es ankommt, und richtig nur dort, wo nichts passiert.

**Zeile zwei ist die schlimmere.** Scheitert das Scharfschalten still, ist `$state` leer, `[ "$state" = "null" ]` also falsch, und der Workflow druckt darauf `Verified: auto-merge is armed`, waehrend es das nicht ist. Genau das zu verhindern ist der erklaerte Zweck der Rueckfrage. Ihr eigener Kommentar sagt: *"A zero exit from `gh pr merge --auto` and an armed pull request are two claims, not one"*. Die Rueckfrage selbst war die dritte Behauptung.

## Wirkung

Praktisch: jeder `hold`-PR zeigt heute einen dauerhaft roten Workflow-Lauf im richtigen Zustand. Ein Tor, das im Normalfall Alarm schlaegt, wird ignoriert, und dann faellt der echte Fall auch nicht mehr auf.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>