### PR TITLE
QG-0001 M4: die Namensbindung an den Zweigschutz als Tor

### DIFF
--- a/.github/workflows/pin-guard.yml
+++ b/.github/workflows/pin-guard.yml
@@ -1,15 +1,25 @@
 name: Pin Guard (supply-chain)
 
-# CD-T1 keystone + CD-T2/T6/T7 drift guard. Modeled on the drift-guard grep
-# block in windows-gate.yml. Four cheap, robust checks keep the supply-chain
-# hardening honest on every push/PR:
+# CD-T1 keystone + CD-T2/T6/T7/T8 drift guard. Modeled on the drift-guard grep
+# block in windows-gate.yml. Seven cheap, robust checks keep the supply-chain
+# hardening honest on every push/PR, in the order the steps below run them:
 #
-#   1. CD-T1  every remote `uses:` must be pinned to a full 40-hex commit SHA.
-#   2. CD-T2  no `@latest` ref may appear in any workflow (pin tool versions).
-#   3. CD-T6  every workflow must declare a top-level `permissions:` block AND
-#             that block must be READ-ONLY (least privilege), no `write-all`,
-#             no top-level `: write` scope; writes are granted per-job.
-#   4. CD-T7  every actions/upload-artifact step must set `retention-days:`.
+#   0. parse   every workflow file parses under a loader that REFUSES duplicate
+#              keys, which is what GitHub does and what `yaml.safe_load` does not.
+#   1. CD-T1   every remote `uses:` must be pinned to a full 40-hex commit SHA.
+#   2. CD-T2   no `@latest` ref may appear in any workflow (pin tool versions).
+#   3. CD-T6   every workflow must declare a top-level `permissions:` block AND
+#              that block must be READ-ONLY (least privilege), no `write-all`,
+#              no top-level `: write` scope; writes are granted per-job.
+#   4. CD-T7   every actions/upload-artifact step must set `retention-days:`.
+#   5. CD-T8   a PR-triggered job holding a repository-write token runs no
+#              `uses:` step (poisoned pipeline execution).
+#   6. QG-0001 M4  every required status check still has a job of that exact
+#              name; a rename must not unhook the requirement.
+#
+# The header said "four" and listed four while the job ran six: guards 0 and 5
+# were added without the list following. Adding guard 6 on 2026-09-10 made the
+# arithmetic worth repairing rather than continuing.
 #
 # Self-reference: this file necessarily contains the tokens it searches for
 # ("uses:", "@latest", "upload-artifact", and now "write-all"/": write"). The
@@ -29,6 +39,15 @@ permissions:
 
 jobs:
   pin-guard:
+    # THIS NAME IS AN INTERFACE. "Enforce pinning + least-privilege + retention"
+    # is one of the contexts branch protection requires on master, and the only
+    # thing joining the two sides is this string. Rename it here and the
+    # required context stops reporting for good: the pull request goes on
+    # showing green ticks, and the requirement waits forever for a name that no
+    # longer exists. If this job must be renamed, the branch-protection setting
+    # and docs/security/required-checks.txt change in the SAME commit, and the
+    # step below is what turns a forgotten half into a red build. Fixing the
+    # gate by renaming the job would be precisely the failure it guards.
     name: Enforce pinning + least-privilege + retention
     runs-on: ubuntu-latest
     steps:
@@ -290,3 +309,27 @@ jobs:
           for e in examined:
               print(f"  in scope: {e}")
           PY
+
+      # (6) QG-0001 M4: a required status check is bound to a job by its NAME,
+      # and by nothing else. Branch protection holds one copy of the name and
+      # this tree holds the other, and no mechanism connects them.
+      #
+      # Measured on 2026-09-10 on pull request #265: a job was renamed for an
+      # honest reason, from "Prose (no em dash)" to "Prose (no em dash, no real
+      # names)", while branch protection went on requiring the old name. Two
+      # names, no match. The required context would never have reported again,
+      # the enforcement would have vanished without a sound, and the surface
+      # showed thirty-two green ticks while it happened. A pull request whose
+      # whole purpose was a new gate would have unhooked an existing one.
+      #
+      # This step holds docs/security/required-checks.txt, the tree's copy of
+      # the branch-protection side, against the job names the workflows declare,
+      # in both directions. It lives HERE, as a step of an already-required job,
+      # on purpose: a new job would carry a new name, that name would not be in
+      # the required list, and a gate nobody has to pass is a report.
+      #
+      # It cannot see the live branch-protection setting; only the human-run
+      # `--refresh` does, and the script prints that limit on every green run
+      # rather than leaving the reach to be guessed.
+      - name: "Guard: required-check names still match the job names"
+        run: ./scripts/check-required-checks.sh

--- a/.github/workflows/pin-guard.yml
+++ b/.github/workflows/pin-guard.yml
@@ -1,7 +1,7 @@
 name: Pin Guard (supply-chain)
 
 # CD-T1 keystone + CD-T2/T6/T7/T8 drift guard. Modeled on the drift-guard grep
-# block in windows-gate.yml. Seven cheap, robust checks keep the supply-chain
+# block in windows-gate.yml. Eight cheap, robust checks keep the supply-chain
 # hardening honest on every push/PR, in the order the steps below run them:
 #
 #   0. parse   every workflow file parses under a loader that REFUSES duplicate
@@ -16,10 +16,13 @@ name: Pin Guard (supply-chain)
 #              `uses:` step (poisoned pipeline execution).
 #   6. QG-0001 M4  every required status check still has a job of that exact
 #              name; a rename must not unhook the requirement.
+#   7. wiring  guard 6 is still wired up in both places it is meant to run:
+#              this file, and the `ci:` target in the Makefile.
 #
 # The header said "four" and listed four while the job ran six: guards 0 and 5
 # were added without the list following. Adding guard 6 on 2026-09-10 made the
-# arithmetic worth repairing rather than continuing.
+# arithmetic worth repairing rather than continuing, and guard 7 was added the
+# same day, so the count is checked again here: eight entries, eight steps.
 #
 # Self-reference: this file necessarily contains the tokens it searches for
 # ("uses:", "@latest", "upload-artifact", and now "write-all"/": write"). The
@@ -107,7 +110,8 @@ jobs:
               yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_duplicate_keys)
 
           bad = 0
-          for f in sorted(glob.glob(".github/workflows/*.yml")):
+          for f in sorted(glob.glob(".github/workflows/*.yml")
+                          + glob.glob(".github/workflows/*.yaml")):
               try:
                   yaml.load(open(f), Strict)
               except Exception as e:
@@ -126,7 +130,8 @@ jobs:
         run: |
           set -euo pipefail
           bad=""
-          for f in .github/workflows/*.yml; do
+          for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+            [ -e "$f" ] || continue
             # Strip trailing comments, keep only real step/job-level `uses:` keys,
             # drop local (./) and docker:// refs, drop anything already pinned to
             # @<40 hex>, then drop the tag-pinned SLSA generator reusable workflow
@@ -175,7 +180,8 @@ jobs:
         run: |
           set -euo pipefail
           bad=""
-          for f in .github/workflows/*.yml; do
+          for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+            [ -e "$f" ] || continue
             if ! grep -qE '^permissions:' "$f"; then
               bad="$bad$f: missing a top-level 'permissions:' block"$'\n'
               continue
@@ -210,7 +216,8 @@ jobs:
         run: |
           set -euo pipefail
           bad=""
-          for f in .github/workflows/*.yml; do
+          for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+            [ -e "$f" ] || continue
             # For each real `uses: …upload-artifact…` step key, scan its block
             # (until the next `- ` step item) for a retention-days: key.
             out="$(awk '
@@ -283,7 +290,8 @@ jobs:
               return any(perms.get(s) == "write" for s in WRITE_SCOPES)
 
           bad, examined = [], []
-          for f in sorted(glob.glob(".github/workflows/*.yml")):
+          for f in sorted(glob.glob(".github/workflows/*.yml")
+                          + glob.glob(".github/workflows/*.yaml")):
               doc = yaml.safe_load(open(f)) or {}
               if not any(e in triggers(doc) for e in PR_EVENTS):
                   continue
@@ -333,3 +341,39 @@ jobs:
       # rather than leaving the reach to be guessed.
       - name: "Guard: required-check names still match the job names"
         run: ./scripts/check-required-checks.sh
+
+      # (7) The gate above hangs off ONE line in this file. Delete that line and
+      # the gate is gone with nothing turning red: this job keeps its name, so
+      # the required context goes on reporting success, which is the very shape
+      # of failure guard 6 exists to catch.
+      #
+      # Be exact about how far this reaches. Checking the Makefile from here is
+      # a real check: dropping the gate out of `ci:` is caught by CI. Checking
+      # THIS file from here is self-referential, and it only catches deleting
+      # the step while leaving this guard behind; delete both and CI notices
+      # nothing. What covers that case is not a check but a second place to run
+      # from: `make ci` still exercises the gate on any developer machine.
+      #
+      # Self-reference, as everywhere else in this file: the search below must
+      # not find ITSELF. It therefore anchors to a real YAML `run:` key holding
+      # the script and nothing else, which the grep program lines here can never
+      # look like. The first draft searched for the bare path, matched its own
+      # program text, and stayed green while the step it guards was deleted.
+      - name: "Guard: the required-check gate is still wired up"
+        run: |
+          set -euo pipefail
+          missing=""
+          grep -qE '^ +run: \./scripts/check-required-checks\.sh$' .github/workflows/pin-guard.yml \
+            || missing="$missing  .github/workflows/pin-guard.yml no longer runs the gate"$'\n'
+          grep -qE '^ci:.*[[:space:]]check-required-checks([[:space:]]|$)' Makefile \
+            || missing="$missing  the Makefile 'ci:' target no longer names check-required-checks"$'\n'
+          if [ -n "$missing" ]; then
+            echo "::error::the required-check gate lost a wiring:"
+            printf '%s' "$missing"
+            echo ""
+            echo "A gate that is not invoked reports nothing, and reporting"
+            echo "nothing looks exactly like passing. Restore the wiring, or"
+            echo "remove the gate deliberately and say so in the commit."
+            exit 1
+          fi
+          echo "OK: the required-check gate is wired up in this workflow and in 'make ci'."

--- a/Makefile
+++ b/Makefile
@@ -432,6 +432,28 @@ code-review:
 check-docs:
 	@./scripts/check-docs.sh
 
+# The required status checks against the job names that must produce them.
+#
+# Two targets rather than one flag, because the two are not the same kind of
+# act. `check-required-checks` reads nothing but the tree and belongs in any
+# build; it is the same command the pin-guard job runs, so a red build can be
+# reproduced here verbatim. `refresh-required-checks` reaches out to the GitHub
+# API, needs admin rights on the repository, and REWRITES a committed file: it
+# is a deliberate human step after a deliberate change to branch protection,
+# never something a build does on its own. Giving them separate names keeps the
+# second one from being typed by accident.
+#
+# The modes live in the script and not in the Makefile, so the parsing and the
+# classification have one home and cannot drift apart. These targets only give
+# them a name a human can remember.
+.PHONY: check-required-checks
+check-required-checks:
+	@./scripts/check-required-checks.sh
+
+.PHONY: refresh-required-checks
+refresh-required-checks:
+	@./scripts/check-required-checks.sh --refresh
+
 # Release targets: code review + docs check run before release
 #
 # Alle vier Ziele TAGGEN nur. scripts/release.sh baut nichts, laedt nichts hoch

--- a/Makefile
+++ b/Makefile
@@ -534,10 +534,17 @@ checksums:
 	@cat $(BUILD_DIR)/checksums.txt
 
 # Run CI checks locally (mirrors .github/workflows/ci.yml)
+#
+# `check-required-checks` is in this list for a reason beyond tidiness. In CI
+# the gate hangs off ONE line, the step in .github/workflows/pin-guard.yml, and
+# deleting that line removes the gate without turning anything red: the job
+# keeps its name, so the required context goes on reporting success. Naming the
+# gate here gives it a second, independent place to be run from, so the local
+# one-liner still exercises it if the CI step ever goes missing.
 .PHONY: ci
-ci: vet lint check-emdash check-gofmt check-redirect-guard test-unit build
+ci: vet lint check-emdash check-gofmt check-redirect-guard check-required-checks test-unit build
 	@echo ""
-	@echo "CI passed: vet ✓  lint ✓  prose ✓  gofmt ✓  redirect-guard ✓  test ✓  build ✓"
+	@echo "CI passed: vet ✓  lint ✓  prose ✓  gofmt ✓  redirect-guard ✓  required-checks ✓  test ✓  build ✓"
 
 # Prose gate: no U+2014 EM DASH anywhere in the tree (CODESTYLE.md).
 .PHONY: check-emdash

--- a/docs/security/required-checks.txt
+++ b/docs/security/required-checks.txt
@@ -1,0 +1,79 @@
+# Required status checks on master, as branch protection requires them.
+#
+# WHY THIS FILE IS COMMITTED
+#
+# A required status check is bound to a job by its NAME. Branch protection holds
+# one copy of that name, this tree holds the other, and nothing connects them
+# but the string. On 2026-09-10 a job was renamed for an honest reason, "Prose
+# (no em dash)" became "Prose (no em dash, no real names)", and the required
+# context would have stopped reporting for good while the pull request showed
+# thirty-two green ticks. A human caught that one.
+#
+# This file is the tree's copy of the branch-protection side, so that
+# scripts/check-required-checks.sh can hold the two names against each other on
+# every push and every pull request. A rename is an API change: change the job
+# name, this file and the branch-protection setting in the SAME commit.
+#
+# FORMAT
+#
+# One record per line: a producer keyword, whitespace, the app id GitHub
+# recorded for that context, whitespace, then the exact check name to the end of
+# the line. A '#' starts a comment only at column 0, so a name may contain one.
+# Whitespace around a name is stripped and is not part of it.
+#
+# Producer keywords. An unknown one is an error rather than an assumed external,
+# so a typo cannot become a silently skipped check. The app id is measured, not
+# chosen, and the gate refuses a record whose keyword and app id disagree:
+#
+#   workflow          15368  a job in .github/workflows/**; the name is checked
+#   actions-external  15368  a GitHub Actions workflow with NO file in this
+#                            repository, the CodeQL default setup
+#   code-scanning     57789  the GitHub code scanning results check, one context
+#                            per analysis tool
+#
+# Only `workflow` records can be held against the tree. The others are recorded
+# so the count is complete and so nobody reads their absence from
+# .github/workflows/** as drift. From the API, an `actions-external` record is
+# indistinguishable from a renamed job, which is why a human classifies it once
+# and the gate then keeps that classification honest in both directions.
+#
+# HOW TO REFRESH THIS FILE after a DELIBERATE change to branch protection:
+#
+#     make refresh-required-checks
+#     # or: ./scripts/check-required-checks.sh --refresh
+#
+# It rewrites the file from the live API and refuses to guess: a context that is
+# neither a job name in this tree nor already classified here stops the refresh
+# and asks you to classify it by hand.
+#
+# Generated from: gh api repos/kamir/m3c-tools/branches/master/protection
+# records: 29 (actions-external 4, code-scanning 2, workflow 23)
+workflow          15368  Unit Tests
+workflow          15368  Lint & Vet
+workflow          15368  boundary-gate
+workflow          15368  Prose (no em dash)
+workflow          15368  Trust-Plane Simulation (theory vs measurement)
+workflow          15368  CLI/manual consistency (docaudit)
+workflow          15368  Ratchet coverage (skillctl trust surface)
+code-scanning     57789  gosec
+workflow          15368  gosec SAST (SARIF -> Code Scanning)
+workflow          15368  gosec no-new-findings (in-CI diff gate)
+workflow          15368  govulncheck (reachable CVEs)
+workflow          15368  gitleaks (secret scan)
+workflow          15368  go mod tidy is a no-op
+workflow          15368  Enforce pinning + least-privilege + retention
+workflow          15368  Validate branch name
+workflow          15368  Drift Guard (opt-out parity)
+workflow          15368  Build Cross-Platform (Linux + Windows)
+workflow          15368  Build macOS (arm64 + amd64)
+workflow          15368  Windows Cross-Compile (ubuntu)
+workflow          15368  Binary Smoke Test (windows-latest)
+workflow          15368  Trust Surface (windows-latest)
+workflow          15368  skillctl Security Tests (-race)
+code-scanning     57789  CodeQL
+actions-external  15368  Analyze (go)
+actions-external  15368  Analyze (actions)
+actions-external  15368  Analyze (python)
+actions-external  15368  Analyze (javascript-typescript)
+workflow          15368  Format (gofmt)
+workflow          15368  Python servers (ruff + pytest)

--- a/docs/security/required-checks.txt
+++ b/docs/security/required-checks.txt
@@ -22,18 +22,26 @@
 # Whitespace around a name is stripped and is not part of it.
 #
 # Producer keywords. An unknown one is an error rather than an assumed external,
-# so a typo cannot become a silently skipped check. The app id is measured, not
-# chosen, and the gate refuses a record whose keyword and app id disagree:
+# so a typo cannot become a silently skipped check:
 #
-#   workflow          15368  a job in .github/workflows/**; the name is checked
+#   workflow          15368  a job in the workflow files; the name is checked
 #   actions-external  15368  a GitHub Actions workflow with NO file in this
 #                            repository, the CodeQL default setup
 #   code-scanning     57789  the GitHub code scanning results check, one context
 #                            per analysis tool
 #
+# The app id is measured rather than chosen, and the gate refuses a record whose
+# keyword and app id disagree. Note what that does and does not buy: it tells
+# `code-scanning` apart from the other two, and it does NOT tell `workflow`
+# apart from `actions-external`, because those two share app 15368. Relabelling
+# a record between them is therefore blocked by a second, independent fetter:
+# only the four CodeQL default-setup contexts allow-listed in
+# scripts/check-required-checks.sh may carry `actions-external`, and any other
+# name with that keyword is a hard error.
+#
 # Only `workflow` records can be held against the tree. The others are recorded
-# so the count is complete and so nobody reads their absence from
-# .github/workflows/** as drift. From the API, an `actions-external` record is
+# so the count is complete and so nobody reads their absence from the workflow
+# files as drift. From the API, an `actions-external` record is
 # indistinguishable from a renamed job, which is why a human classifies it once
 # and the gate then keeps that classification honest in both directions.
 #

--- a/scripts/check-required-checks.sh
+++ b/scripts/check-required-checks.sh
@@ -667,11 +667,17 @@ for lineno, producer, app, name, raw in records:
                     f"that never arrives.")
         elif not any(h[5] for h in hits):
             where = "; ".join(f"{h[1]} on:{','.join(h[3])}" for h in hits)
+            # Name the reason that actually applies. A message that explains
+            # the wrong cause sends the next reader to the wrong file, which is
+            # the failure mode this whole gate is about, one level down.
+            why = ("A push filtered to tags alone never produces a check run "
+                   "on a pull request head."
+                   if any("push" in h[3] for h in hits) else
+                   "None of those events fires on a pull request head.")
             problems.append(
                 f"{MANIFEST}:{lineno}: required check {name!r} is declared "
                 f"{len(hits)} time(s), and no declaration can report on a pull "
-                f"request head: {where}. A push filtered to tags alone never "
-                f"produces a check run on a pull request head.")
+                f"request head: {where}. {why}")
     elif hits:
         where = ", ".join(sorted({h[1] for h in hits}))
         problems.append(

--- a/scripts/check-required-checks.sh
+++ b/scripts/check-required-checks.sh
@@ -308,9 +308,13 @@ def pr_capable(on):
     if "push" in on:
         spec = on["push"]
         if isinstance(spec, dict):
-            tagged = any(k in spec for k in ("tags", "tags-ignore"))
-            branched = any(k in spec for k in ("branches", "branches-ignore"))
-            if tagged and not branched:
+            # `tags:` is an allow-list, so a push filtered by it and nothing
+            # else runs for tag pushes only. `tags-ignore:` is the opposite, an
+            # exclusion, and a push carrying only that still runs for every
+            # branch: treating it as tag-only would be a FALSE red, which in a
+            # gate meant to be believed costs as much as a false green.
+            if "tags" in spec and not any(
+                    k in spec for k in ("branches", "branches-ignore")):
                 return False
         return True
     return False

--- a/scripts/check-required-checks.sh
+++ b/scripts/check-required-checks.sh
@@ -24,7 +24,9 @@
 #
 # The rule, from .claude/rules/claims.md: a binding through a name breaks
 # silently the moment either side changes the name. This script is that rule
-# made mechanical for one instance of it, the workflow job names.
+# made mechanical for one instance of it, the workflow job names. The reference
+# names the file and not a section inside it, because a section title is itself
+# a binding through a string and would be the same mistake one level down.
 #
 # STATE ON THE DAY IT WAS WRITTEN
 #
@@ -36,18 +38,25 @@
 #
 # WHAT IT CHECKS
 #
-#   1. every `workflow` record resolves to a job name declared in
-#      .github/workflows/**, matrix names expanded
-#   2. the workflow owning such a job can report on a pull request head at all,
-#      that is, it triggers on push, pull_request, pull_request_target or
-#      workflow_call
+#   1. every `workflow` record resolves to a job name declared LITERALLY in the
+#      workflow files, matrix names expanded. A job name that still holds an
+#      unresolved `${{ }}` expression can never satisfy a required record: see
+#      MATRIX JOBS below for why that is fail-closed and not pedantry.
+#   2. at least one of the workflows declaring such a job can report on a pull
+#      request head at all. `pull_request`, `pull_request_target` and
+#      `workflow_call` always can; a `push` can, EXCEPT when it is filtered to
+#      tags alone, because a pull request head is never a tag.
 #   3. no record classified as produced OUTSIDE the tree is in fact produced by
 #      a job inside it, which would mean the classification is wrong and the
-#      gate is skipping a check it could have made
-#   4. the producer keyword agrees with the app id recorded beside it, so that
-#      relabelling a record cannot be used to walk around check 1
+#      gate is skipping a check it could have made.
+#   4. the producer keyword agrees with the app id recorded beside it, and every
+#      `actions-external` record names one of the contexts allow-listed in this
+#      script. What the app id can and cannot do is set out under HOW THE THREE
+#      PRODUCERS ARE TOLD APART; the allow-list is what actually stops a record
+#      being relabelled around check 1.
 #   5. the manifest is internally consistent: known keywords, no duplicate
-#      names, and the counts in its header equal what was parsed
+#      names, at least MIN_RECORDS records, and header counts equal to what was
+#      parsed.
 #
 # WHAT IT CANNOT CHECK, and this matters more than one further tick
 #
@@ -60,14 +69,32 @@
 #   c. check runs made through `workflow_call`. GitHub renames those to
 #      "<calling job> / <called job>"; this script resolves the called job's own
 #      name. No required context is produced that way today.
+#   d. whether every gate in this tree that OUGHT to be required actually is.
+#      This runs one way only: it asks whether every required name is
+#      satisfiable, never whether every gate is required. A new blocking job
+#      that nobody added to branch protection passes here in silence. That is
+#      not an oversight to be fixed with a warning: 42 of the 65 names this tree
+#      declares are deliberately not required, so the question is not
+#      mechanically decidable and belongs to a human.
 #
 # HOW THE THREE PRODUCERS ARE TOLD APART
 #
 # `gh api .../protection` returns an app id beside every required context, and
-# it is what separates the classes without guesswork. Measured on 2026-09-10:
+# it separates the code-scanning class without guesswork. Measured on
+# 2026-09-10:
 #
 #     app 15368  github-actions             27 of the 29 contexts
 #     app 57789  github-advanced-security     2, "CodeQL" and "gosec"
+#
+# The app id does exactly that much and no more. It tells `code-scanning` apart
+# from the other two; it does NOT tell `workflow` apart from `actions-external`,
+# because both of those are app 15368. Relabelling a record from `workflow` to
+# `actions-external` would therefore switch check 1 off for that context while
+# every app id still agreed, and a job renamed in the same commit would sail
+# through: precisely the failure of 2026-09-10, wearing the gate's own uniform.
+# ACTIONS_EXTERNAL_ALLOWED below is what closes that, by naming the four
+# contexts that may carry the keyword. Adding a fifth means editing this script,
+# which is a visible act in a reviewed diff, and that is the whole point.
 #
 # App 15368 alone does not mean "a job in this tree": the four "Analyze (...)"
 # contexts come from the CodeQL DEFAULT SETUP, which is a GitHub Actions
@@ -84,13 +111,35 @@
 # value, and a matrix job with no `name:` yields GitHub's default `<job-id> (v1,
 # v2)`. Where an expression survives expansion, because the matrix came from
 # `fromJSON` or the name interpolates something other than the matrix, the
-# template is kept as a PATTERN and required names are matched against it
-# instead of pretending to know the value. `--list` marks those rows `pattern`.
+# template is kept as a PATTERN, shown by `--list`, and it can never satisfy a
+# required record.
+#
+# That last clause is the load-bearing one. A pattern is matched by turning each
+# surviving `${{ ... }}` into `.*`, so a name that is nothing but an expression
+# collapses to `^.*$` and would answer to every required context at once. Read
+# as caution it sounds careful; measured, it is a blanket permission, and one
+# workflow file declaring one such job would have emptied check 1 for all 23
+# records. So a pattern is evidence for a human reading `--list` and never
+# evidence for the gate: a required context whose only candidate is a pattern is
+# reported as drift, with the remedy being to give that job a literal name.
+#
+# Today this machinery is exercised and inconsequential at once: all three
+# matrices in the tree expand to literals, zero rows stay patterns, and no
+# required context hangs off a matrix at all. The two required names that LOOK
+# matrix-shaped, "Binary Smoke Test (windows-latest)" and "Trust Surface
+# (windows-latest)", are typed out by hand in windows-gate.yml.
 #
 # The include/exclude merge implemented here is GitHub's rule in its ordinary
 # form: the cartesian product of the plain keys, minus `exclude`, then each
 # `include` entry merged into every combination it is compatible with, or
 # appended when it is compatible with none. Exotic overrides are not modelled.
+#
+# WHICH FILES ARE READ
+#
+# `.github/workflows/*.yml` and `.github/workflows/*.yaml`, because GitHub
+# accepts both extensions. The tree holds 17 files and all of them are `.yml`,
+# so reading the second extension changes nothing today; it is here so that a
+# `.yaml` file cannot become a place where check 3 stops looking.
 #
 # python3 with PyYAML does the parsing, and the loader REFUSES duplicate keys:
 # a loader that tolerates them answers "can I parse this somehow", and GitHub
@@ -103,8 +152,11 @@
 #   ./scripts/check-required-checks.sh --refresh  # rewrite the manifest from the API
 #
 # Exit: 0 clean, 1 drift or an inconsistent manifest, 2 usage error,
-#       3 --refresh could not complete (no gh, no permission, a name it will
-#         not classify on its own)
+#       3 the gate could not run at all, or --refresh could not complete (no
+#         python3, no PyYAML, no gh, no permission, a name it will not classify
+#         on its own). Exit 3 is a statement about the TOOLING and exit 1 a
+#         statement about the TREE, and keeping them apart is why a missing
+#         PyYAML is not allowed to look like drift.
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
@@ -118,6 +170,20 @@ case "$MODE" in
   ""|--list|--refresh) ;;
   *) echo "usage: $0 [--list|--refresh]" >&2; exit 2 ;;
 esac
+
+# The tooling before the tree. Without this, a missing PyYAML ends in a raw
+# traceback and exit 1, which is the code reserved for drift: "the gate could
+# not run" and "the gate found drift" would be the same signal.
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "FAIL: this gate needs python3, and it is not on PATH." >&2
+  exit 3
+fi
+if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+  echo "FAIL: this gate needs python3 with PyYAML; 'import yaml' failed." >&2
+  echo "      That is a statement about the tooling and not about the tree," >&2
+  echo "      so this is exit 3 and not exit 1." >&2
+  exit 3
+fi
 
 if [ "$MODE" = "--refresh" ] && ! command -v gh >/dev/null 2>&1; then
   echo "FAIL: --refresh needs the gh CLI, and it is not on PATH." >&2
@@ -139,7 +205,7 @@ fi
 
 MANIFEST="$MANIFEST" MODE="$MODE" LIVE="$LIVE" REPO="$REPO" BRANCH="$BRANCH" \
 python3 - <<'PY'
-import glob, itertools, os, re, sys, yaml
+import collections, glob, itertools, os, re, sys, yaml
 
 MANIFEST = os.environ["MANIFEST"]
 MODE     = os.environ["MODE"]
@@ -155,7 +221,7 @@ APP_GHAS    = "57789"   # github-advanced-security (code scanning results)
 PRODUCERS = {
     "workflow": (
         APP_ACTIONS, True,
-        "a job in .github/workflows/**"),
+        "a job in the workflow files"),
     "actions-external": (
         APP_ACTIONS, False,
         "a GitHub Actions workflow with no file in this repository, "
@@ -164,7 +230,29 @@ PRODUCERS = {
         APP_GHAS, False,
         "the GitHub code scanning results check, one context per analysis tool"),
 }
-PR_CAPABLE = ("push", "pull_request", "pull_request_target", "workflow_call")
+
+# The closed list of contexts that may carry `actions-external`. It exists
+# because `workflow` and `actions-external` share app id 15368, so the app id
+# cannot tell them apart, and without this a record could be relabelled from
+# `workflow` to `actions-external` to switch its name check off. These four are
+# the CodeQL default setup's analyses, measured on 2026-09-10. A fifth external
+# context means editing this line, in a diff a reviewer sees.
+ACTIONS_EXTERNAL_ALLOWED = {
+    "Analyze (go)",
+    "Analyze (actions)",
+    "Analyze (python)",
+    "Analyze (javascript-typescript)",
+}
+
+# A floor that does not come from the file being checked. The header count
+# catches a TRUNCATED manifest, but it cannot catch a manifest emptied on
+# purpose with the header pulled down to match: that is internally consistent
+# and would print "OK: 0 required context(s)". Branch protection required 29
+# contexts on 2026-09-10; the floor sits below that so ordinary churn does not
+# trip it, and far enough above zero that gutting the file is a red build and a
+# deliberate edit here.
+MIN_RECORDS = 25
+
 EXPR = re.compile(r"\$\{\{.*?\}\}")
 
 
@@ -187,12 +275,45 @@ Strict.add_constructor(
     yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_duplicate_keys)
 
 
-def triggers(doc):
+def on_block(doc):
     # A bare `on:` is parsed as the boolean True by YAML 1.1.
     on = doc.get("on", doc.get(True))
-    if isinstance(on, (dict, list)):
-        return [str(e) for e in on]
-    return [on] if isinstance(on, str) else []
+    if isinstance(on, dict):
+        return on
+    if isinstance(on, list):
+        return {str(e): None for e in on}
+    if isinstance(on, str):
+        return {on: None}
+    return {}
+
+
+def pr_capable(on):
+    """Can a workflow with this `on:` block report on a PULL REQUEST head?
+
+    `pull_request`, `pull_request_target` and `workflow_call` always can. A
+    `push` normally can too, because pushing the branch behind a pull request
+    produces check runs on that same head commit. A push filtered to TAGS and
+    nothing else cannot, since a pull request head is never a tag.
+
+    That last case is not hypothetical. release.yml is `on: {push: {tags: v*}}`
+    and declares jobs named "CLI/manual consistency (docaudit)" and "Build macOS
+    (arm64 + amd64)", the same names ci.yml declares. Reading only the `push`
+    key, a rename of the ci.yml copy left this gate green, because the tag-only
+    copy went on carrying the name while the copy that actually reports on pull
+    requests had been renamed away.
+    """
+    for ev in ("pull_request", "pull_request_target", "workflow_call"):
+        if ev in on:
+            return True
+    if "push" in on:
+        spec = on["push"]
+        if isinstance(spec, dict):
+            tagged = any(k in spec for k in ("tags", "tags-ignore"))
+            branched = any(k in spec for k in ("branches", "branches-ignore"))
+            if tagged and not branched:
+                return False
+        return True
+    return False
 
 
 def combinations(matrix):
@@ -236,17 +357,24 @@ def substitute(template, combo):
     return EXPR.sub(one, template)
 
 
+def workflow_files():
+    """Both extensions GitHub accepts, so a .yaml file is not a blind spot."""
+    return sorted(glob.glob(".github/workflows/*.yml")
+                  + glob.glob(".github/workflows/*.yaml"))
+
+
 def resolve():
-    """Every check-run name this tree declares: (name, file, job, events, kind)."""
+    """Every check-run name declared: (name, file, job, events, kind, prcap)."""
     rows, parse_errors = [], []
-    for f in sorted(glob.glob(".github/workflows/*.yml")):
+    for f in workflow_files():
         try:
             with open(f, encoding="utf-8") as fh:
                 doc = yaml.load(fh, Strict) or {}
         except Exception as e:                       # noqa: BLE001
             parse_errors.append(f"{f}: {e}")
             continue
-        events = triggers(doc)
+        on = on_block(doc)
+        events, prcap = list(on), pr_capable(on)
         for jid, job in (doc.get("jobs") or {}).items():
             if not isinstance(job, dict):
                 continue
@@ -256,32 +384,44 @@ def resolve():
             if not combos:
                 nm = str(explicit) if explicit else jid
                 rows.append((nm, f, jid, events,
-                             "pattern" if EXPR.search(nm) else "literal"))
+                             "pattern" if EXPR.search(nm) else "literal", prcap))
                 continue
             for c in combos:
                 nm = (substitute(str(explicit), c) if explicit
                       else f"{jid} ({', '.join(str(v) for v in c.values())})")
                 rows.append((nm, f, jid, events,
-                             "pattern" if EXPR.search(nm) else "literal"))
+                             "pattern" if EXPR.search(nm) else "literal", prcap))
     return rows, parse_errors
 
 
 ROWS, PARSE_ERRORS = resolve()
-LITERALS = {r[0]: r for r in ROWS if r[4] == "literal"}
+
+# EVERY declaration of a name is kept, not the last one parsed. Two files
+# declaring the same job name is normal here (ci.yml and release.yml share
+# two), and a dict would have hidden all but one of them, which is exactly how
+# a tag-only copy came to answer for a renamed pull-request copy.
+LITERALS = collections.defaultdict(list)
+for _r in ROWS:
+    if _r[4] == "literal":
+        LITERALS[_r[0]].append(_r)
 PATTERNS = [r for r in ROWS if r[4] == "pattern"]
 
 
-def match(name):
-    """The job declaring this check name, or None."""
-    if name in LITERALS:
-        return LITERALS[name]
+def literal_hits(name):
+    """Every job declaring exactly this name. The only evidence the gate takes."""
+    return LITERALS.get(name, [])
+
+
+def pattern_hits(name):
+    """Jobs whose unresolved name COULD expand to this. Evidence for a human."""
+    out = []
     for r in PATTERNS:
         rx = "^" + "".join(
             ".*" if p.startswith("${{") else re.escape(p)
             for p in re.split(r"(\$\{\{.*?\}\})", r[0]) if p) + "$"
         if re.match(rx, name):
-            return r
-    return None
+            out.append(r)
+    return out
 
 
 def parse_manifest(path):
@@ -318,9 +458,10 @@ if MODE == "--list":
     print(f"{len(ROWS)} declared check name(s) from "
           f"{len(set((r[1], r[2]) for r in ROWS))} job(s) in "
           f"{len(set(r[1] for r in ROWS))} workflow file(s), matrix expanded:")
-    for name, f, jid, events, kind in sorted(ROWS):
+    for name, f, jid, events, kind, prcap in sorted(ROWS):
         print(f"  {kind:8} {name}")
-        print(f"           {f}  job:{jid}  on:{','.join(events)}")
+        print(f"           {f}  job:{jid}  on:{','.join(events)}"
+              f"  pr-head:{'yes' if prcap else 'no'}")
     for e in PARSE_ERRORS:
         print(f"  FAIL: workflow will not parse: {e}")
     sys.exit(1 if PARSE_ERRORS else 0)
@@ -350,18 +491,26 @@ HEADER = """# Required status checks on {branch}, as branch protection requires 
 # Whitespace around a name is stripped and is not part of it.
 #
 # Producer keywords. An unknown one is an error rather than an assumed external,
-# so a typo cannot become a silently skipped check. The app id is measured, not
-# chosen, and the gate refuses a record whose keyword and app id disagree:
+# so a typo cannot become a silently skipped check:
 #
-#   workflow          15368  a job in .github/workflows/**; the name is checked
+#   workflow          15368  a job in the workflow files; the name is checked
 #   actions-external  15368  a GitHub Actions workflow with NO file in this
 #                            repository, the CodeQL default setup
 #   code-scanning     57789  the GitHub code scanning results check, one context
 #                            per analysis tool
 #
+# The app id is measured rather than chosen, and the gate refuses a record whose
+# keyword and app id disagree. Note what that does and does not buy: it tells
+# `code-scanning` apart from the other two, and it does NOT tell `workflow`
+# apart from `actions-external`, because those two share app 15368. Relabelling
+# a record between them is therefore blocked by a second, independent fetter:
+# only the four CodeQL default-setup contexts allow-listed in
+# scripts/check-required-checks.sh may carry `actions-external`, and any other
+# name with that keyword is a hard error.
+#
 # Only `workflow` records can be held against the tree. The others are recorded
-# so the count is complete and so nobody reads their absence from
-# .github/workflows/** as drift. From the API, an `actions-external` record is
+# so the count is complete and so nobody reads their absence from the workflow
+# files as drift. From the API, an `actions-external` record is
 # indistinguishable from a renamed job, which is why a human classifies it once
 # and the gate then keeps that classification honest in both directions.
 #
@@ -392,10 +541,13 @@ if MODE == "--refresh":
                 old[name] = producer
     out, unknown = [], []
     for app, name in live:
-        if app == APP_ACTIONS and match(name):
+        keep = old.get(name)
+        if keep == "actions-external" and name not in ACTIONS_EXTERNAL_ALLOWED:
+            keep = None          # never carry an unvetted relabel forward
+        if app == APP_ACTIONS and literal_hits(name):
             out.append(("workflow", app, name))
-        elif name in old and old[name] in PRODUCERS and old[name] != "workflow":
-            out.append((old[name], app, name))
+        elif keep in PRODUCERS and keep != "workflow":
+            out.append((keep, app, name))
         elif app == APP_GHAS:
             out.append(("code-scanning", app, name))
         else:
@@ -405,16 +557,16 @@ if MODE == "--refresh":
         for app, name in unknown:
             print(f"  app {app}  {name}")
         print()
-        print("Each is required from GitHub Actions, no job in")
-        print(".github/workflows/** answers to that name, and none is already")
-        print(f"classified in {MANIFEST}.")
+        print("Each is required from GitHub Actions, no job in the workflow")
+        print("files answers to that name, and none is already classified in")
+        print(f"{MANIFEST} in a way this script will carry forward.")
         print()
         print("Two very different things look like this. One: a workflow that")
         print("lives outside the repository, such as the CodeQL default setup.")
         print("Two: a job in this tree that was RENAMED while branch protection")
-        print("kept asking for the old name. Only you can tell them apart. Add a")
-        print("line for each with the producer that really makes it, then run")
-        print("the gate to confirm.")
+        print("kept asking for the old name. Only you can tell them apart. An")
+        print("external context must ALSO be added to ACTIONS_EXTERNAL_ALLOWED")
+        print("in scripts/check-required-checks.sh, deliberately and in review.")
         sys.exit(3)
     per = {}
     for producer, _app, _name in out:
@@ -437,6 +589,19 @@ if not os.path.exists(MANIFEST):
 
 records, counts = parse_manifest(MANIFEST)
 problems, seen, per = [], {}, {}
+
+if not records:
+    problems.append(
+        f"{MANIFEST}: holds no records at all. An empty list of things to "
+        f"check is not a clean result, it is a gate with nothing to say.")
+elif len(records) < MIN_RECORDS:
+    problems.append(
+        f"{MANIFEST}: holds {len(records)} records, and this gate expects at "
+        f"least {MIN_RECORDS}. Branch protection required 29 contexts when the "
+        f"floor was set. Either protection was loosened on purpose, in which "
+        f"case lower MIN_RECORDS in scripts/check-required-checks.sh in the "
+        f"same commit, or the manifest was gutted and the header pulled down "
+        f"to match.")
 
 for lineno, producer, app, name, raw in records:
     if producer not in PRODUCERS:
@@ -465,24 +630,53 @@ for lineno, producer, app, name, raw in records:
             f"Relabelling a record does not change who produces it.")
         continue
 
-    hit = match(name)
+    if producer == "actions-external" and name not in ACTIONS_EXTERNAL_ALLOWED:
+        problems.append(
+            f"{MANIFEST}:{lineno}: {name!r} is recorded as 'actions-external', "
+            f"which switches OFF the check that a job of that name exists, but "
+            f"it is not one of the contexts allow-listed in "
+            f"scripts/check-required-checks.sh. 'workflow' and "
+            f"'actions-external' share app {APP_ACTIONS}, so the app id cannot "
+            f"tell them apart and this list is what stops a record being "
+            f"relabelled around the name check. If this context really is "
+            f"produced outside the repository, add it to "
+            f"ACTIONS_EXTERNAL_ALLOWED deliberately.")
+        continue
+
+    hits = literal_hits(name)
     if must_resolve:
-        if hit is None:
+        if not hits:
+            pats = pattern_hits(name)
+            if pats:
+                where = ", ".join(sorted({p[1] for p in pats}))
+                problems.append(
+                    f"{MANIFEST}:{lineno}: required check {name!r} has no job "
+                    f"of that name. It is matched only by a job whose `name:` "
+                    f"still holds an unresolved expression ({where}), and a "
+                    f"template is not a name: an expression is matched as '.*' "
+                    f"here, so accepting it would let one such job answer for "
+                    f"any required context at all. Give that job a literal "
+                    f"name, or correct this record.")
+            else:
+                problems.append(
+                    f"{MANIFEST}:{lineno}: required check {name!r} has NO job "
+                    f"of that name in the workflow files. Either a job was "
+                    f"renamed and branch protection still asks for the old "
+                    f"name, or the job was deleted. Both make the requirement "
+                    f"unsatisfiable, and the pull request waits for a context "
+                    f"that never arrives.")
+        elif not any(h[5] for h in hits):
+            where = "; ".join(f"{h[1]} on:{','.join(h[3])}" for h in hits)
             problems.append(
-                f"{MANIFEST}:{lineno}: required check {name!r} has NO job of "
-                f"that name in .github/workflows/**. Either a job was renamed "
-                f"and branch protection still asks for the old name, or the job "
-                f"was deleted. Both make the requirement unsatisfiable, and the "
-                f"pull request waits for a context that never arrives.")
-        elif not any(e in PR_CAPABLE for e in hit[3]):
-            problems.append(
-                f"{MANIFEST}:{lineno}: required check {name!r} is declared in "
-                f"{hit[1]}, which triggers on {hit[3]} and therefore cannot "
-                f"report on a pull request head.")
-    elif hit is not None:
+                f"{MANIFEST}:{lineno}: required check {name!r} is declared "
+                f"{len(hits)} time(s), and no declaration can report on a pull "
+                f"request head: {where}. A push filtered to tags alone never "
+                f"produces a check run on a pull request head.")
+    elif hits:
+        where = ", ".join(sorted({h[1] for h in hits}))
         problems.append(
             f"{MANIFEST}:{lineno}: {name!r} is recorded as '{producer}' "
-            f"({prose}), but {hit[1]} declares a job of exactly that name. One "
+            f"({prose}), but {where} declares a job of exactly that name. One "
             f"of the two is wrong, and while it is wrong this gate skips a "
             f"check it could make.")
 
@@ -490,7 +684,11 @@ if counts is None:
     problems.append(
         f"{MANIFEST}: the header line '# records: N (keyword N, ...)' is "
         f"missing. It is what catches a truncated file.")
-else:
+elif not problems:
+    # Only when no record is broken. A record skipped for a bad keyword or a
+    # missing name is not counted in `per` but is counted in `records`, so
+    # running this anyway would add a header-count complaint on top of the real
+    # one and send the next reader to --refresh instead of to the broken line.
     total, header_per = counts
     if total != len(records) or header_per != per:
         have = ", ".join(f"{k} {per[k]}" for k in sorted(per))
@@ -504,22 +702,25 @@ for e in PARSE_ERRORS:
     problems.append(f"workflow will not parse: {e}")
 
 if problems:
-    print(f"::error::required-check drift ({MANIFEST} vs .github/workflows/**)")
+    print(f"::error::required-check drift ({MANIFEST} vs the workflow files)")
     for p in problems:
         print(f"  {p}")
     print()
     print("A required status check is bound to a job by its NAME and by nothing")
     print("else. When the two names differ the context never reports again and")
-    print("the enforcement is gone without a sound. See .claude/rules/claims.md,")
-    print("section 'The tools that answer a different question'.")
+    print("the enforcement is gone without a sound. See .claude/rules/claims.md.")
     sys.exit(1)
 
 wf = per.get("workflow", 0)
 jobs = len(set((r[1], r[2]) for r in ROWS))
-print(f"OK: {len(records)} required context(s) in {MANIFEST}. {wf} are produced "
-      f"by a job in this tree, and every one of them has a job of exactly that "
-      f"name among the {len(ROWS)} check names this tree declares "
-      f"({jobs} jobs, matrix names expanded).")
+files = len(workflow_files())
+print(f"OK: {len(records)} context(s) recorded as required in {MANIFEST}. This "
+      f"is a statement about that file, not about branch protection; see limit "
+      f"(a) below.")
+print(f"    {wf} of them name a job in this tree. Each has a job of exactly "
+      f"that name, declared in a workflow that can report on a pull request "
+      f"head, among the {len(ROWS)} check names this tree declares "
+      f"({jobs} jobs in {files} files, matrix names expanded).")
 print(f"    {len(records) - wf} come from outside the tree and are recorded as "
       f"such, not checked:")
 for _, producer, _app, name, _ in records:
@@ -533,4 +734,9 @@ print("      b. whether a declared job is REACHED on a pull request; a path")
 print("         filter, an `if:` or a skipped `needs:` leaves it unreported.")
 print("      c. check runs made through `workflow_call`, which GitHub renames")
 print("         to '<calling job> / <called job>'.")
+print("      d. whether every gate that OUGHT to be required actually is. This")
+print("         gate runs one way only. Of the "
+      f"{len(ROWS)} names this tree declares, {len(ROWS) - wf} are")
+print("         deliberately not required, so a new blocking job that nobody")
+print("         added to branch protection passes here in silence.")
 PY

--- a/scripts/check-required-checks.sh
+++ b/scripts/check-required-checks.sh
@@ -548,6 +548,12 @@ if MODE == "--refresh":
         keep = old.get(name)
         if keep == "actions-external" and name not in ACTIONS_EXTERNAL_ALLOWED:
             keep = None          # never carry an unvetted relabel forward
+        if keep in PRODUCERS and PRODUCERS[keep][0] != app:
+            # The recorded keyword and the live app id disagree, so the old
+            # classification is stale. Carrying it forward would write a record
+            # the gate rejects on the next run: --refresh would produce a red
+            # build and no explanation of it. Ask instead.
+            keep = None
         if app == APP_ACTIONS and literal_hits(name):
             out.append(("workflow", app, name))
         elif keep in PRODUCERS and keep != "workflow":

--- a/scripts/check-required-checks.sh
+++ b/scripts/check-required-checks.sh
@@ -1,0 +1,536 @@
+#!/usr/bin/env bash
+# check-required-checks.sh: the required-check manifest against the job names.
+#
+# WHY THIS EXISTS
+#
+# A required status check is bound to a job by its NAME, and by nothing else.
+# The two sides of that binding live apart: the name GitHub requires sits in the
+# branch-protection settings, the name a job reports sits in a `name:` key in
+# this tree. Nothing connects them but the string.
+#
+# Measured on 2026-09-10 on pull request #265. A session had renamed a job,
+# honestly, because the job had grown:
+#
+#     "Prose (no em dash)"  ->  "Prose (no em dash, no real names)"
+#
+#     gh api .../branches/master/protection  requires  "Prose (no em dash)"
+#     gh pr checks 265                       reports   "Prose (no em dash, no real names)"
+#
+# Two names, no match. The required context would never have reported again,
+# the enforcement would have vanished without a sound, and the pull request
+# showed thirty-two green ticks while it happened. Nothing was silent and
+# nothing reported a false success: both sides worked perfectly and simply
+# talked past each other, because the channel between them is a string.
+#
+# The rule, from .claude/rules/claims.md: a binding through a name breaks
+# silently the moment either side changes the name. This script is that rule
+# made mechanical for one instance of it, the workflow job names.
+#
+# STATE ON THE DAY IT WAS WRITTEN
+#
+# There was no drift to repair. Branch protection required 29 contexts, the
+# workflow files declared 53 jobs, and each of the 23 contexts that GitHub
+# Actions produces from a file in this tree had a job answering to its exact
+# name. The gate is prevention against the next rename, not a repair, and that
+# is worth saying plainly rather than dressing it up as a fix.
+#
+# WHAT IT CHECKS
+#
+#   1. every `workflow` record resolves to a job name declared in
+#      .github/workflows/**, matrix names expanded
+#   2. the workflow owning such a job can report on a pull request head at all,
+#      that is, it triggers on push, pull_request, pull_request_target or
+#      workflow_call
+#   3. no record classified as produced OUTSIDE the tree is in fact produced by
+#      a job inside it, which would mean the classification is wrong and the
+#      gate is skipping a check it could have made
+#   4. the producer keyword agrees with the app id recorded beside it, so that
+#      relabelling a record cannot be used to walk around check 1
+#   5. the manifest is internally consistent: known keywords, no duplicate
+#      names, and the counts in its header equal what was parsed
+#
+# WHAT IT CANNOT CHECK, and this matters more than one further tick
+#
+#   a. whether the 29 names still equal what branch protection requires TODAY.
+#      A context added or removed in the GitHub settings is invisible from the
+#      tree. Only `--refresh` reads the live API, and running it is a human act.
+#   b. whether a declared job is actually REACHED on a pull request. A path
+#      filter, an `if:` condition or a skipped `needs:` chain each leave a job
+#      declared and unreported.
+#   c. check runs made through `workflow_call`. GitHub renames those to
+#      "<calling job> / <called job>"; this script resolves the called job's own
+#      name. No required context is produced that way today.
+#
+# HOW THE THREE PRODUCERS ARE TOLD APART
+#
+# `gh api .../protection` returns an app id beside every required context, and
+# it is what separates the classes without guesswork. Measured on 2026-09-10:
+#
+#     app 15368  github-actions             27 of the 29 contexts
+#     app 57789  github-advanced-security     2, "CodeQL" and "gosec"
+#
+# App 15368 alone does not mean "a job in this tree": the four "Analyze (...)"
+# contexts come from the CodeQL DEFAULT SETUP, which is a GitHub Actions
+# workflow with no file in this repository. From the API those four look exactly
+# like the failure this gate exists to catch, a required Actions context with no
+# job of that name. Only a human can tell the two apart, which is why --refresh
+# refuses to classify such a context and asks.
+#
+# MATRIX JOBS
+#
+# Branch protection sees the EXPANDED names, so this script expands them. A
+# matrix whose values are literals in the YAML (all three in this tree are)
+# becomes concrete names: `${{ matrix.os }}` in a `name:` yields one name per
+# value, and a matrix job with no `name:` yields GitHub's default `<job-id> (v1,
+# v2)`. Where an expression survives expansion, because the matrix came from
+# `fromJSON` or the name interpolates something other than the matrix, the
+# template is kept as a PATTERN and required names are matched against it
+# instead of pretending to know the value. `--list` marks those rows `pattern`.
+#
+# The include/exclude merge implemented here is GitHub's rule in its ordinary
+# form: the cartesian product of the plain keys, minus `exclude`, then each
+# `include` entry merged into every combination it is compatible with, or
+# appended when it is compatible with none. Exotic overrides are not modelled.
+#
+# python3 with PyYAML does the parsing, and the loader REFUSES duplicate keys:
+# a loader that tolerates them answers "can I parse this somehow", and GitHub
+# answers a different question. Both the interpreter and the library are already
+# relied on by the pin-guard job that runs this script.
+#
+# Usage:
+#   ./scripts/check-required-checks.sh            # the gate (exit 1 on drift)
+#   ./scripts/check-required-checks.sh --list     # every resolved job name
+#   ./scripts/check-required-checks.sh --refresh  # rewrite the manifest from the API
+#
+# Exit: 0 clean, 1 drift or an inconsistent manifest, 2 usage error,
+#       3 --refresh could not complete (no gh, no permission, a name it will
+#         not classify on its own)
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+MANIFEST="docs/security/required-checks.txt"
+REPO="kamir/m3c-tools"
+BRANCH="master"
+
+MODE="${1:-}"
+case "$MODE" in
+  ""|--list|--refresh) ;;
+  *) echo "usage: $0 [--list|--refresh]" >&2; exit 2 ;;
+esac
+
+if [ "$MODE" = "--refresh" ] && ! command -v gh >/dev/null 2>&1; then
+  echo "FAIL: --refresh needs the gh CLI, and it is not on PATH." >&2
+  exit 3
+fi
+
+# --refresh reads the live state first, so a failure there costs nothing. The
+# `checks` array carries the app id per context; `contexts` carries only names.
+LIVE=""
+if [ "$MODE" = "--refresh" ]; then
+  if ! LIVE="$(gh api "repos/$REPO/branches/$BRANCH/protection" \
+                  --jq '.required_status_checks.checks[] | "\(.app_id)\t\(.context)"' 2>&1)"; then
+    echo "FAIL: could not read the branch protection of $REPO@$BRANCH." >&2
+    echo "      Reading it needs admin rights on the repository." >&2
+    printf '%s\n' "$LIVE" >&2
+    exit 3
+  fi
+fi
+
+MANIFEST="$MANIFEST" MODE="$MODE" LIVE="$LIVE" REPO="$REPO" BRANCH="$BRANCH" \
+python3 - <<'PY'
+import glob, itertools, os, re, sys, yaml
+
+MANIFEST = os.environ["MANIFEST"]
+MODE     = os.environ["MODE"]
+REPO     = os.environ["REPO"]
+BRANCH   = os.environ["BRANCH"]
+
+APP_ACTIONS = "15368"   # github-actions
+APP_GHAS    = "57789"   # github-advanced-security (code scanning results)
+
+# Producer keyword -> (app id it must carry, must it resolve to a job here,
+# one line of prose). An unknown keyword is a HARD ERROR and never an assumed
+# external: a typo must not turn into a silently skipped check.
+PRODUCERS = {
+    "workflow": (
+        APP_ACTIONS, True,
+        "a job in .github/workflows/**"),
+    "actions-external": (
+        APP_ACTIONS, False,
+        "a GitHub Actions workflow with no file in this repository, "
+        "the CodeQL default setup"),
+    "code-scanning": (
+        APP_GHAS, False,
+        "the GitHub code scanning results check, one context per analysis tool"),
+}
+PR_CAPABLE = ("push", "pull_request", "pull_request_target", "workflow_call")
+EXPR = re.compile(r"\$\{\{.*?\}\}")
+
+
+class Strict(yaml.SafeLoader):
+    pass
+
+
+def no_duplicate_keys(loader, node, deep=False):
+    seen, out = set(), {}
+    for k, v in node.value:
+        key = loader.construct_object(k, deep=deep)
+        if key in seen:
+            raise ValueError(f"duplicate key {key!r} at line {k.start_mark.line + 1}")
+        seen.add(key)
+        out[key] = loader.construct_object(v, deep=deep)
+    return out
+
+
+Strict.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_duplicate_keys)
+
+
+def triggers(doc):
+    # A bare `on:` is parsed as the boolean True by YAML 1.1.
+    on = doc.get("on", doc.get(True))
+    if isinstance(on, (dict, list)):
+        return [str(e) for e in on]
+    return [on] if isinstance(on, str) else []
+
+
+def combinations(matrix):
+    """GitHub's matrix expansion in its ordinary form."""
+    if not isinstance(matrix, dict):
+        return []
+    plain = {k: v for k, v in matrix.items()
+             if k not in ("include", "exclude") and isinstance(v, list)}
+    if plain:
+        keys = list(plain)
+        combos = [dict(zip(keys, vals))
+                  for vals in itertools.product(*(plain[k] for k in keys))]
+    else:
+        combos = [{}]
+    for ex in matrix.get("exclude") or []:
+        if isinstance(ex, dict):
+            combos = [c for c in combos
+                      if not all(c.get(k) == v for k, v in ex.items())]
+    inc = [i for i in (matrix.get("include") or []) if isinstance(i, dict)]
+    if inc and not plain:
+        return inc
+    for entry in inc:
+        fitting = [c for c in combos
+                   if all(c.get(k) == v for k, v in entry.items() if k in c)]
+        if fitting:
+            for c in fitting:
+                c.update(entry)
+        else:
+            combos.append(dict(entry))
+    return combos
+
+
+def substitute(template, combo):
+    def one(m):
+        inner = m.group(0)[3:-2].strip()
+        if inner.startswith("matrix."):
+            field = inner[len("matrix."):].strip()
+            if field in combo:
+                return str(combo[field])
+        return m.group(0)
+    return EXPR.sub(one, template)
+
+
+def resolve():
+    """Every check-run name this tree declares: (name, file, job, events, kind)."""
+    rows, parse_errors = [], []
+    for f in sorted(glob.glob(".github/workflows/*.yml")):
+        try:
+            with open(f, encoding="utf-8") as fh:
+                doc = yaml.load(fh, Strict) or {}
+        except Exception as e:                       # noqa: BLE001
+            parse_errors.append(f"{f}: {e}")
+            continue
+        events = triggers(doc)
+        for jid, job in (doc.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            matrix = (job.get("strategy") or {}).get("matrix")
+            combos = combinations(matrix) if matrix else []
+            explicit = job.get("name")
+            if not combos:
+                nm = str(explicit) if explicit else jid
+                rows.append((nm, f, jid, events,
+                             "pattern" if EXPR.search(nm) else "literal"))
+                continue
+            for c in combos:
+                nm = (substitute(str(explicit), c) if explicit
+                      else f"{jid} ({', '.join(str(v) for v in c.values())})")
+                rows.append((nm, f, jid, events,
+                             "pattern" if EXPR.search(nm) else "literal"))
+    return rows, parse_errors
+
+
+ROWS, PARSE_ERRORS = resolve()
+LITERALS = {r[0]: r for r in ROWS if r[4] == "literal"}
+PATTERNS = [r for r in ROWS if r[4] == "pattern"]
+
+
+def match(name):
+    """The job declaring this check name, or None."""
+    if name in LITERALS:
+        return LITERALS[name]
+    for r in PATTERNS:
+        rx = "^" + "".join(
+            ".*" if p.startswith("${{") else re.escape(p)
+            for p in re.split(r"(\$\{\{.*?\}\})", r[0]) if p) + "$"
+        if re.match(rx, name):
+            return r
+    return None
+
+
+def parse_manifest(path):
+    """(lineno, producer, app_id, name, raw) records plus the header counts.
+
+    A '#' starts a comment only at column 0, so a '#' inside a check name can
+    never be silently truncated."""
+    records, counts = [], None
+    with open(path, encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            raw = line.rstrip("\n")
+            if not raw.strip():
+                continue
+            if raw.startswith("#"):
+                m = re.match(r"^# records: (\d+) \((.*)\)$", raw)
+                if m:
+                    per = {}
+                    for part in m.group(2).split(","):
+                        bits = part.split()
+                        if len(bits) == 2 and bits[1].isdigit():
+                            per[bits[0]] = int(bits[1])
+                    counts = (int(m.group(1)), per)
+                continue
+            parts = raw.split(None, 2)
+            if len(parts) < 3 or not parts[2].strip():
+                records.append((lineno, parts[0] if parts else "", "", "", raw))
+                continue
+            records.append((lineno, parts[0], parts[1], parts[2].strip(), raw))
+    return records, counts
+
+
+# ---------------------------------------------------------------- --list
+if MODE == "--list":
+    print(f"{len(ROWS)} declared check name(s) from "
+          f"{len(set((r[1], r[2]) for r in ROWS))} job(s) in "
+          f"{len(set(r[1] for r in ROWS))} workflow file(s), matrix expanded:")
+    for name, f, jid, events, kind in sorted(ROWS):
+        print(f"  {kind:8} {name}")
+        print(f"           {f}  job:{jid}  on:{','.join(events)}")
+    for e in PARSE_ERRORS:
+        print(f"  FAIL: workflow will not parse: {e}")
+    sys.exit(1 if PARSE_ERRORS else 0)
+
+# -------------------------------------------------------------- --refresh
+HEADER = """# Required status checks on {branch}, as branch protection requires them.
+#
+# WHY THIS FILE IS COMMITTED
+#
+# A required status check is bound to a job by its NAME. Branch protection holds
+# one copy of that name, this tree holds the other, and nothing connects them
+# but the string. On 2026-09-10 a job was renamed for an honest reason, "Prose
+# (no em dash)" became "Prose (no em dash, no real names)", and the required
+# context would have stopped reporting for good while the pull request showed
+# thirty-two green ticks. A human caught that one.
+#
+# This file is the tree's copy of the branch-protection side, so that
+# scripts/check-required-checks.sh can hold the two names against each other on
+# every push and every pull request. A rename is an API change: change the job
+# name, this file and the branch-protection setting in the SAME commit.
+#
+# FORMAT
+#
+# One record per line: a producer keyword, whitespace, the app id GitHub
+# recorded for that context, whitespace, then the exact check name to the end of
+# the line. A '#' starts a comment only at column 0, so a name may contain one.
+# Whitespace around a name is stripped and is not part of it.
+#
+# Producer keywords. An unknown one is an error rather than an assumed external,
+# so a typo cannot become a silently skipped check. The app id is measured, not
+# chosen, and the gate refuses a record whose keyword and app id disagree:
+#
+#   workflow          15368  a job in .github/workflows/**; the name is checked
+#   actions-external  15368  a GitHub Actions workflow with NO file in this
+#                            repository, the CodeQL default setup
+#   code-scanning     57789  the GitHub code scanning results check, one context
+#                            per analysis tool
+#
+# Only `workflow` records can be held against the tree. The others are recorded
+# so the count is complete and so nobody reads their absence from
+# .github/workflows/** as drift. From the API, an `actions-external` record is
+# indistinguishable from a renamed job, which is why a human classifies it once
+# and the gate then keeps that classification honest in both directions.
+#
+# HOW TO REFRESH THIS FILE after a DELIBERATE change to branch protection:
+#
+#     make refresh-required-checks
+#     # or: ./scripts/check-required-checks.sh --refresh
+#
+# It rewrites the file from the live API and refuses to guess: a context that is
+# neither a job name in this tree nor already classified here stops the refresh
+# and asks you to classify it by hand.
+#
+# Generated from: gh api repos/{repo}/branches/{branch}/protection
+# records: {total} ({percounts})
+"""
+
+if MODE == "--refresh":
+    live = []
+    for line in os.environ["LIVE"].splitlines():
+        if not line.strip():
+            continue
+        app, _, name = line.partition("\t")
+        live.append((app.strip(), name.strip()))
+    old = {}
+    if os.path.exists(MANIFEST):
+        for _, producer, _app, name, _ in parse_manifest(MANIFEST)[0]:
+            if name:
+                old[name] = producer
+    out, unknown = [], []
+    for app, name in live:
+        if app == APP_ACTIONS and match(name):
+            out.append(("workflow", app, name))
+        elif name in old and old[name] in PRODUCERS and old[name] != "workflow":
+            out.append((old[name], app, name))
+        elif app == APP_GHAS:
+            out.append(("code-scanning", app, name))
+        else:
+            unknown.append((app, name))
+    if unknown:
+        print("FAIL: --refresh will not guess a producer for these contexts.")
+        for app, name in unknown:
+            print(f"  app {app}  {name}")
+        print()
+        print("Each is required from GitHub Actions, no job in")
+        print(".github/workflows/** answers to that name, and none is already")
+        print(f"classified in {MANIFEST}.")
+        print()
+        print("Two very different things look like this. One: a workflow that")
+        print("lives outside the repository, such as the CodeQL default setup.")
+        print("Two: a job in this tree that was RENAMED while branch protection")
+        print("kept asking for the old name. Only you can tell them apart. Add a")
+        print("line for each with the producer that really makes it, then run")
+        print("the gate to confirm.")
+        sys.exit(3)
+    per = {}
+    for producer, _app, _name in out:
+        per[producer] = per.get(producer, 0) + 1
+    kw = max((len(p) for p, _, _ in out), default=8)
+    aw = max((len(a) for _, a, _ in out), default=5)
+    body = "".join(f"{p.ljust(kw)}  {a.ljust(aw)}  {n}\n" for p, a, n in out)
+    percounts = ", ".join(f"{k} {per[k]}" for k in sorted(per))
+    with open(MANIFEST, "w", encoding="utf-8") as fh:
+        fh.write(HEADER.format(branch=BRANCH, repo=REPO,
+                               total=len(out), percounts=percounts))
+        fh.write(body)
+    print(f"wrote {MANIFEST}: {len(out)} record(s) ({percounts}).")
+    sys.exit(0)
+
+# ------------------------------------------------------------------ gate
+if not os.path.exists(MANIFEST):
+    print(f"FAIL: {MANIFEST} is missing. Run --refresh to create it.")
+    sys.exit(1)
+
+records, counts = parse_manifest(MANIFEST)
+problems, seen, per = [], {}, {}
+
+for lineno, producer, app, name, raw in records:
+    if producer not in PRODUCERS:
+        problems.append(
+            f"{MANIFEST}:{lineno}: unknown producer {producer!r}; expected one "
+            f"of {', '.join(sorted(PRODUCERS))}")
+        continue
+    if not name:
+        problems.append(
+            f"{MANIFEST}:{lineno}: record needs producer, app id and a check "
+            f"name; got {raw!r}")
+        continue
+    if name in seen:
+        problems.append(
+            f"{MANIFEST}:{lineno}: duplicate check name {name!r} "
+            f"(first at line {seen[name]})")
+        continue
+    seen[name] = lineno
+    per[producer] = per.get(producer, 0) + 1
+
+    want_app, must_resolve, prose = PRODUCERS[producer]
+    if app != want_app:
+        problems.append(
+            f"{MANIFEST}:{lineno}: {name!r} is recorded as '{producer}', which "
+            f"means app {want_app}, but the app id beside it is {app!r}. "
+            f"Relabelling a record does not change who produces it.")
+        continue
+
+    hit = match(name)
+    if must_resolve:
+        if hit is None:
+            problems.append(
+                f"{MANIFEST}:{lineno}: required check {name!r} has NO job of "
+                f"that name in .github/workflows/**. Either a job was renamed "
+                f"and branch protection still asks for the old name, or the job "
+                f"was deleted. Both make the requirement unsatisfiable, and the "
+                f"pull request waits for a context that never arrives.")
+        elif not any(e in PR_CAPABLE for e in hit[3]):
+            problems.append(
+                f"{MANIFEST}:{lineno}: required check {name!r} is declared in "
+                f"{hit[1]}, which triggers on {hit[3]} and therefore cannot "
+                f"report on a pull request head.")
+    elif hit is not None:
+        problems.append(
+            f"{MANIFEST}:{lineno}: {name!r} is recorded as '{producer}' "
+            f"({prose}), but {hit[1]} declares a job of exactly that name. One "
+            f"of the two is wrong, and while it is wrong this gate skips a "
+            f"check it could make.")
+
+if counts is None:
+    problems.append(
+        f"{MANIFEST}: the header line '# records: N (keyword N, ...)' is "
+        f"missing. It is what catches a truncated file.")
+else:
+    total, header_per = counts
+    if total != len(records) or header_per != per:
+        have = ", ".join(f"{k} {per[k]}" for k in sorted(per))
+        want = ", ".join(f"{k} {header_per[k]}" for k in sorted(header_per))
+        problems.append(
+            f"{MANIFEST}: the header states {total} records ({want}), the file "
+            f"holds {len(records)} ({have}). Run --refresh after a deliberate "
+            f"change to branch protection.")
+
+for e in PARSE_ERRORS:
+    problems.append(f"workflow will not parse: {e}")
+
+if problems:
+    print(f"::error::required-check drift ({MANIFEST} vs .github/workflows/**)")
+    for p in problems:
+        print(f"  {p}")
+    print()
+    print("A required status check is bound to a job by its NAME and by nothing")
+    print("else. When the two names differ the context never reports again and")
+    print("the enforcement is gone without a sound. See .claude/rules/claims.md,")
+    print("section 'The tools that answer a different question'.")
+    sys.exit(1)
+
+wf = per.get("workflow", 0)
+jobs = len(set((r[1], r[2]) for r in ROWS))
+print(f"OK: {len(records)} required context(s) in {MANIFEST}. {wf} are produced "
+      f"by a job in this tree, and every one of them has a job of exactly that "
+      f"name among the {len(ROWS)} check names this tree declares "
+      f"({jobs} jobs, matrix names expanded).")
+print(f"    {len(records) - wf} come from outside the tree and are recorded as "
+      f"such, not checked:")
+for _, producer, _app, name, _ in records:
+    if producer != "workflow" and name:
+        print(f"      {name}  ({PRODUCERS[producer][2]})")
+print("    NOT checked here, and deliberately so:")
+print("      a. whether these names still equal what branch protection requires")
+print("         today. Only scripts/check-required-checks.sh --refresh reads the")
+print("         live API, and running it is a human act.")
+print("      b. whether a declared job is REACHED on a pull request; a path")
+print("         filter, an `if:` or a skipped `needs:` leaves it unreported.")
+print("      c. check runs made through `workflow_call`, which GitHub renames")
+print("         to '<calling job> / <called job>'.")
+PY


### PR DESCRIPTION
## Der Anlass

Ein erforderlicher Kontext ist ueber seinen **Namen** an einen Job gebunden, und
ueber sonst nichts. Die eine Haelfte des Namens steht im Zweigschutz, die andere
in einem `name:`-Schluessel im Baum, und dazwischen liegt kein Mechanismus, nur
eine Zeichenkette.

Gemessen am 2026-09-10 an PR #265. Eine Sitzung hatte einen Job umbenannt, aus
gutem Grund, weil er mehr prueft als vorher:

```
"Prose (no em dash)"  ->  "Prose (no em dash, no real names)"

gh api .../branches/master/protection   fordert   "Prose (no em dash)"
gh pr checks 265                        meldet    "Prose (no em dash, no real names)"
```

Zwei Namen, kein Treffer. Der geforderte Kontext haette nie wieder gemeldet, die
Durchsetzung waere still verschwunden, und die Oberflaeche zeigte dabei 32 gruene
Haken. Die Form ist eigen: hier schweigt kein Werkzeug und keines meldet
faelschlich Erfolg. Beide Seiten arbeiten einwandfrei und reden nur aneinander
vorbei, weil der Kanal ein String ist.

## Stand heute, gemessen

Es gibt nichts zu reparieren. Der Zweigschutz fordert 29 Kontexte, die 17
Workflow-Dateien erklaeren 53 Jobs und daraus 65 Pruefnamen (Matrix expandiert),
und **jeder** der 23 Kontexte, die ein Job aus diesem Baum erzeugt, hat heute
einen Job mit genau diesem Namen. Dieser PR ist Vorsorge gegen die naechste
Umbenennung, keine Reparatur, und das gehoert so gesagt.

## Wie die drei Erzeuger auseinandergehalten werden

Die entscheidende Messung: `gh api .../protection` liefert zu jedem Kontext eine
**App-ID**. Damit braucht die Klassifikation nicht zu raten.

| App-ID | Slug | Kontexte |
|---|---|---|
| 15368 | `github-actions` | 27 der 29 |
| 57789 | `github-advanced-security` | 2, `CodeQL` und `gosec` |

Beleg fuer 57789 als Erzeuger statt Vermutung: auf den Kopf-Commits von PR #265
und PR #261 liegen die Check-Runs `CodeQL` (success) und `gosec` (neutral), beide
von App-ID 57789. Auf einem `push`-Kopf erscheinen sie nicht, was erklaert, warum
`gosec` auf `master` in keiner Check-Run-Liste auftaucht.

App 15368 allein heisst nicht "ein Job in diesem Baum": die vier Kontexte
`Analyze (...)` kommen aus dem CodeQL default setup, einem GitHub-Actions-
Workflow ohne Datei in diesem Repository. Ueber die API sehen die vier **genau so
aus wie der Fehler**, gegen den dieses Tor gebaut ist, naemlich ein geforderter
Actions-Kontext ohne Job dieses Namens. Nur ein Mensch kann die beiden Faelle
unterscheiden, also klassifiziert `--refresh` sie nicht selbst, sondern
verweigert und fragt. Beim Anlegen der Datei ist genau das passiert, und es hat
genau diese vier genannt.

## Was geliefert wird

**A. `docs/security/required-checks.txt`**, das committete Manifest der 29
Namen. Ein Datensatz je Zeile: Erzeuger-Schluesselwort, App-ID, dann der exakte
Name bis Zeilenende. `#` ist nur in Spalte 0 ein Kommentar, damit ein `#` in
einem Namen nicht stillschweigend abgeschnitten wird. Der Ort war schon
vergeben: der neue Abschnitt in `.claude/rules/claims.md` nennt
`docs/security/required-checks.txt` beim Namen.

Drei Schluesselwoerter, und ein unbekanntes ist ein harter Fehler statt eines
angenommenen Externen, damit ein Tippfehler nicht zur stillschweigend
uebersprungenen Pruefung wird:

| Schluesselwort | App | Bedeutung | Anzahl |
|---|---|---|---|
| `workflow` | 15368 | ein Job in `.github/workflows/**`, der Name wird geprueft | 23 |
| `actions-external` | 15368 | ein Actions-Workflow ohne Datei hier, das CodeQL default setup | 4 |
| `code-scanning` | 57789 | der Code-Scanning-Ergebnis-Check, ein Kontext je Werkzeug | 2 |

**B. `scripts/check-required-checks.sh`**, das Tor in beide Richtungen.

Was es prueft:

1. jeder `workflow`-Eintrag loest sich auf einen erklaerten Jobnamen auf
2. der besitzende Workflow kann ueberhaupt an einem PR-Kopf melden (`push`,
   `pull_request`, `pull_request_target` oder `workflow_call`)
3. kein als extern gefuehrter Eintrag wird in Wahrheit von einem Job hier erzeugt
4. Schluesselwort und danebenstehende App-ID stimmen ueberein, damit Umetikettieren
   kein Weg an Pruefung 1 vorbei ist
5. das Manifest ist in sich stimmig: Schluesselwort bekannt, keine Doppelnamen,
   Kopfzeilen-Zaehlung gleich dem Geparsten

Was es **nicht** pruefen kann, und das steht in jedem gruenen Lauf mit im Log,
nicht nur in einer Datei:

- **a.** ob diese 29 Namen heute noch dem entsprechen, was der Zweigschutz
  fordert. Ein im UI hinzugefuegter oder entfernter Kontext ist vom Baum aus
  unsichtbar. Nur `--refresh` liest die lebende API, und das ist eine
  menschliche Handlung.
- **b.** ob ein erklaerter Job an einem PR wirklich ERREICHT wird. Ein
  Pfadfilter, ein `if:` oder eine uebersprungene `needs:`-Kette lassen ihn stumm.
- **c.** Check-Runs aus `workflow_call`, die GitHub in `<rufender Job> /
  <gerufener Job>` umbenennt. Heute wird kein geforderter Kontext so erzeugt.

**Matrix-Jobs**: der Zweigschutz sieht die EXPANDIERTEN Namen, also expandiert
das Skript sie. Alle drei Matrizen hier sind Literale und loesen sich
vollstaendig auf, belegt ueber `--list`: 8 Fuzz-Ziele, `SPEC-0406 acceptance gate
(macos-latest)` und `(windows-latest)`, fuenfmal `smoke (<plattform>)`. Null
Zeilen bleiben Muster. Bleibt ein Ausdruck stehen, etwa bei `fromJSON`, wird die
Vorlage als Muster behalten, statt einen Wert zu erfinden. Die Begruendung steht
im Skriptkopf.

Der YAML-Loader **verweigert doppelte Schluessel**, weil ein Loader, der sie
duldet, die Frage "kann ich das irgendwie parsen" beantwortet, und GitHub eine
andere.

**C. Verdrahtung** als siebter Schritt im BESTEHENDEN Job `Enforce pinning +
least-privilege + retention` in `pin-guard.yml`, weil dieser Name selbst in der
required-Liste steht. Ein neuer Job waere ein neuer Name und damit nicht
blockierend: ein Tor, das niemand passieren muss, ist ein Bericht. Der Jobname
ist unangetastet, und ueber dem `name:`-Schluessel steht jetzt ein Kommentar,
dass er eine Schnittstelle zum Zweigschutz ist.

**D. Auffrischung**: `make refresh-required-checks`. Zwei Ziele statt eines
Schalters, weil es zwei verschiedene Handlungen sind. Das Pruefziel liest nur den
Baum und gehoert in jeden Build; das Auffrischziel braucht Adminrechte und
UEBERSCHREIBT eine committete Datei. Die Modi liegen im Skript, nicht im
Makefile, damit Parsen und Klassifizieren ein Zuhause haben.

## Gepflanzte Fundstellen

Ohne Gegenprobe waere "das Tor greift" eine Behauptung. Jede Pflanzung einzeln,
jede zurueckgenommen, Arbeitskopie danach sauber:

| # | Pflanzung | Ergebnis |
|---|---|---|
| 1 | Jobnamen in `pin-guard.yml` umbenannt (der Vorfall selbst) | rot, exit 1 |
| 1r | zurueckgenommen | gruen, exit 0 |
| 2 | ein Job nimmt den Namen `CodeQL` an (Gegenrichtung) | rot, exit 1 |
| 3 | `workflow`-Eintrag auf `code-scanning` umetikettiert | rot, exit 1 |
| 4 | Manifest um einen Eintrag gekuerzt | rot, exit 1 |
| 5 | Tippfehler im Schluesselwort (`workflw`) | rot, exit 1 |
| 6 | `pin-guard.yml` nur noch `schedule`, kann nicht an PR melden | rot, exit 1 |
| 7 | doppelter YAML-Schluessel in `boundary-gate.yml` | rot, exit 1 |
| | nach allen Ruecknahmen | gruen, exit 0 |

Pflanzung 1 traf bewusst den Job, der das Tor selbst ausfuehrt: er ist zugleich
das Beispiel und der Traeger.

## Nebenbefund, im selben Kopf mitrepariert

`pin-guard.yml` sagte "Four cheap, robust checks" und zaehlte vier auf, waehrend
der Job **sechs** ausfuehrte. Wache 0 (doppelte Schluessel) und Wache 5 (CD-T8)
waren ohne die Liste nachgezogen worden. Mit der siebten war die Arithmetik das
Reparieren wert; Kopf und Schritte sind jetzt 7 zu 7, nachgezaehlt mit
`grep -c '^      - name: "Guard'` gleich 7.

## Tore vor dem Push, jedes einzeln, ohne Pipe

```
shellcheck scripts/check-required-checks.sh                       exit 0
./scripts/check-no-emdash.sh                                      exit 0
strenger YAML-Loader ueber alle Workflows        17 von 17 parsen, exit 0
pin-guard (1) CD-T1 uses gepinnt                                  exit 0
pin-guard (2) CD-T2 kein @latest                                  exit 0
pin-guard (3) CD-T6 permissions read-only                         exit 0
pin-guard (4) CD-T7 retention-days                                exit 0
pin-guard (5) CD-T8 kein uses in schreibendem PR-Job              exit 0
pin-guard (6) neu, Namensbindung                                  exit 0
--refresh, danach diff gegen die committete Datei    kein Unterschied
--bogus                                                           exit 2
```

`ci.yml` und `skillctl-windows-smoke.yml` sind unberuehrt (PR #265 haelt sie).
`git diff --cached --name-only` vor dem Commit: vier Dateien, keine davon.

Die Regel steht in `.claude/rules/claims.md`, Abschnitt "The tools that answer a
different question": eine Bindung ueber einen Namen bricht lautlos, sobald eine
Seite den Namen aendert.


---

## Nachtrag nach der Gegenlesung (Commits `1a38f45`, `78eccac`)

Zwei Sitzungen haben das Tor gegengelesen und drei Wege daran vorbei gefunden.
Jeder ist nachgebaut, jeder ist jetzt rot, jeder Nachbau wurde zurueckgenommen.

### 1. Umetikettieren (HOCH)

`workflow` und `actions-external` tragen **beide** App 15368. Die App-ID kann sie
also nicht scheiden, der Skriptkopf sagte aber zu, Umetikettieren komme nicht an
Pruefung 1 vorbei. Gemessen: Job umbenannt **plus** ein Wort im Manifest
geaendert, `exit 0`, der Anlassfall in gruen.

Jetzt fuehrt `ACTIONS_EXTERNAL_ALLOWED` die vier CodeQL-Default-Setup-Kontexte als
geschlossene Liste **im Skript**, also ausserhalb der Datei, die veraendert wird.
Jeder weitere Datensatz mit diesem Schluesselwort ist ein harter Fehler, und
`--refresh` traegt eine ungepruefte Umetikettierung nicht mehr fort. Der Kopf sagt
jetzt, was die App-ID wirklich leistet: sie scheidet `code-scanning` aus, mehr
nicht.

### 2. Muster als Blankovollmacht (HOCH)

Ein `name:` aus einem unaufgeloesten Ausdruck wurde zu `.*`, ein Job namens
`${{ matrix.label }}` erfuellte damit **jeden** geforderten Kontext. Gemessen: mit
einer solchen Datei im Baum wurde der umbenannte Prose-Job nicht mehr gemeldet,
und ein gezielt gebautes Muster deckte sogar den Job zu, in dem das Tor selbst
laeuft.

Jetzt ist ein Mustertreffer Beleg fuer einen Menschen in `--list` und nie fuer das
Tor. Nebenwirkung mitgemessen: die Fehlalarme, die ein breites Muster auf
Pruefung 3 ausloeste, fielen von 6 auf 0, weil Pruefung 3 nur noch literal
vergleicht.

### 3. Tags-only-Dublette (HOCH)

`release.yml` ist `on: {push: {tags: v*}}` und erklaert zwei Jobnamen, die auch
`ci.yml` erklaert. `LITERALS` war ein `dict`, der letzte Treffer gewann, und
`triggers()` las nur den Schluessel `push` ohne den `tags:`-Filter darunter.
Gemessen: die PR-meldende Kopie umbenannt, `exit 0`, weil die Tag-Kopie den Namen
weitertrug.

Jetzt werden **alle** Erklaerungen eines Namens gesammelt, und ein `push`, das nur
Tags traegt und keine Branches, gilt nicht als PR-faehig.

**Eine Haelfte des vorgeschlagenen Fixes habe ich gemessen und verworfen:**
"Dublette gleich harter Fehler" haette den heutigen Baum rot gemacht. Zwei
erforderliche Namen sind legitim doppelt erklaert:

```
2x  CLI/manual consistency (docaudit)   ci.yml (pr-faehig)  +  release.yml (nicht)
2x  Build macOS (arm64 + amd64)         ci.yml (pr-faehig)  +  release.yml (nicht)
```

Richtig ist nur die andere Haelfte: mindestens **eine** PR-faehige Erklaerung.

### Kleinere Befunde

| Befund | Zustand |
|---|---|
| `.yaml` wurde nicht gelesen, der Kopf sagte `**` | beide Endungen, hier und in den sechs anderen Wachen; 17 von 17 Dateien sind heute `.yml`, also gemessen folgenlos |
| konsistent geleertes Manifest war gruen | `0` Datensaetze sind ein harter Fehler; `MIN_RECORDS=25` ist ein Boden **ausserhalb** der geprueften Datei |
| fehlendes PyYAML gab Traceback + `exit 1` | `exit 3`, damit "konnte nicht laufen" nicht aussieht wie "hat Drift gefunden" |
| Kopfzahl-Meldung zeigte auf die falsche Ursache | schweigt, wenn schon eine Zeile defekt ist |
| gruene Kopfzeile behauptete etwas ueber den Zweigschutz | behauptet nur noch etwas ueber die Datei |
| Verweis auf einen Abschnitt in `claims.md`, der nicht auf master steht | Abschnittsname entfernt; ein Abschnittstitel ist dieselbe Bindung ueber einen String |

### Neu: Grenze d

Bei jedem gruenen Lauf gedruckt. Das Tor laeuft in **eine** Richtung: 42 der 65
erklaerten Namen sollen nicht erforderlich sein, ein neues blockierend gemeintes
Tor faellt hier also nicht auf. Das ist keine Luecke zum Schliessen, sondern eine
Frage fuer einen Menschen.

### Neu: Wache 7, die Verdrahtung

Das Tor hing an **einer** Zeile. Jetzt steht es auch im `ci`-Ziel des Makefile,
und eine achte Wache prueft beide Verdrahtungen.

Der erste Entwurf dieser Wache suchte den blossen Pfad, fand **seinen eigenen
Programmtext** und blieb gruen, waehrend der bewachte Schritt geloescht war. Sie
ankert jetzt an einem echten YAML-`run:`-Schluessel. Reichweite ehrlich benannt:
die Makefile-Haelfte ist eine echte Pruefung, die Selbstpruefung faengt nur das
Loeschen des Schritts bei stehender Wache.

### Drei eigene Nachproben, drei eigene Fehler (`78eccac`, `862e8ef`, `a64fd4f`)

Ein erforderlicher Job in einem schedule-only-Workflow wurde richtig rot, aber
mit falscher Begruendung ("A push filtered to tags alone ..."), obwohl von Tags
nirgends die Rede war. Genau die Klasse, die die Gegenlesung an der
Kopfzahl-Meldung beanstandet hatte. Der Tag-Satz steht jetzt nur noch da, wo eine
Erklaerung wirklich ein `push` traegt.

Und ein zweiter: ich hatte `tags:` und `tags-ignore:` in einen Topf geworfen.
`tags:` ist eine Positivliste, ein `push`, der nur sie traegt, laeuft
ausschliesslich bei Tag-Pushes. `tags-ignore:` ist ein Ausschluss, und ein
`push`, der nur ihn traegt, laeuft weiter bei jedem Branch-Push. Alle vier
Formen an einem erforderlichen Kontext gemessen:

```
push: {tags: [v*]}          exit 1   nicht PR-faehig   richtig
push: {tags-ignore: [v*]}   exit 0   PR-faehig         vorher falsch rot
push: {branches: [master]}  exit 0   PR-faehig         richtig
push:                       exit 0   PR-faehig         richtig
```

Heute traegt keine der 17 Dateien diese Form, der Fehler war also latent. Er
gehoert trotzdem weg: ein falsches Rot kostet an einem Tor, dem geglaubt werden
soll, so viel wie ein falsches Gruen, denn beim naechsten Mal wird es umgangen
statt gelesen.

Und ein dritter, an `--refresh`: wechselt ein Kontext die erzeugende App, trug
`--refresh` die alte Klassifikation weiter und schrieb einen Datensatz, dessen
Schluesselwort und App-ID sich widersprechen. Das Tor verwirft so einen
Datensatz, also erzeugte `--refresh` einen roten Bau und keine Erklaerung dafuer.
Gemessen mit einem `gh`-Ersatz auf PATH, der `CodeQL` mit App 15368 statt 57789
liefert:

```
vorher   --refresh exit 0, geschrieben: code-scanning     15368  CodeQL
         Gate danach exit 1 ("... means app 57789, but the app id ... is 15368")
jetzt    --refresh exit 3, nichts geschrieben, Manifest byte-gleich
```

`--refresh` liefert jetzt entweder eine Datei, die das Tor besteht, oder gar
keine und fragt.

### Tore

`shellcheck` 0 · `check-no-emdash.sh` 0 · strenger Loader 17 von 17 · alle **acht**
pin-guard-Wachen 0, in CI gelaufen unter dem unveraenderten Jobnamen
`Enforce pinning + least-privilege + retention` · `--list` 0 mit 65 Namen aus 53
Jobs in 17 Dateien und 0 Musterzeilen · `--bogus` 2 · `--refresh` gefolgt von
`diff` gegen die committete Datei: kein Unterschied, die 29 Datensaetze sind
byte-gleich · `make check-required-checks` 0 · Manifest weiter 29 zu 29 deckungs-
gleich mit `gh api .../protection`, Namen und App-IDs.

Alle zerstoerenden Proben liefen in Kopien unter `scratchpad/lab2..lab7`, nie im
Zweig. `diff -r` gegen den Zweig nach allen Ruecknahmen leer.

`ci.yml` und `skillctl-windows-smoke.yml` sind unberuehrt (Kollision mit PR #265),
belegt ueber `git diff --cached --name-only` vor jedem Commit.



### Was offen bleibt

| Offen | Warum |
|---|---|
| Grenze a: eine Aenderung am Zweigschutz im GitHub-UI bleibt vom Baum aus unsichtbar | nicht ohne einen periodischen Lauf gegen die API mit `admin:repo` schliessbar; die Form waere `--refresh` gefolgt von `git diff --exit-code` |
| Grenzen b und c: Pfadfilter, `if:`, uebersprungene `needs:`-Ketten, `workflow_call`-Umbenennung | gedruckt, nicht geprueft |
| Grenze d: die Gegenrichtung ist nicht maschinell entscheidbar | 42 der 65 Namen **sollen** nicht erforderlich sein |
| `MIN_RECORDS` faengt das Ausweiden, nicht das Streichen einer einzelnen Zeile | gemessen: 28 Datensaetze mit mitgezogenem Kopf bleiben gruen (Boden 25) |
| die Selbstpruefung in Wache 7 ist selbstbezueglich | Schritt und Wache zusammen geloescht faellt in CI nicht auf; die Makefile-Haelfte ist eine echte Pruefung |
| exotische `include`/`exclude`-Ueberschreibungen sind nicht modelliert | heute unkritisch: alle drei Matrizen sind reine include-Listen oder reine Schluesselprodukte |
| die Regel in `.claude/rules/claims.md` steht noch nicht auf master (PR #267) | der Verweis nennt jetzt keinen Abschnitt mehr, haengt also nicht mehr in der Luft |

