### PR TITLE
docs(skillctl): CHANGELOG v0.5.0 + gosec-Baseline-Schrumpfung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,34 @@ version is ldflags-stamped (`skillctl version`). Release tags: `skillctl/vX.Y.Z`
   a verbatim move ships half-extracted shared state, so it needs a dedicated
   refactor pass, not a release-eve edit.
 
+## [skillctl/v0.5.0], 2026-09-10, executable runbooks + gates that name what they checked
+First train of the delivery channel's skillctl line (SPEC-0426).
+
+### Added
+- **`runbook publish --meta <sidecar>`** reads a `runbook.meta.json` with
+  `steps[]` (SPEC-0275 G3, one descriptor path); the publisher ships its own
+  descriptor with steps s1..s14, and BOTH publish paths now warn on a
+  step-less descriptor instead of passing it silently. Catalog cards without
+  steps stay legal; unworkable-looking ones no longer happen quietly (BUG-0224).
+- The acceptance gate says WHAT it checked (SPEC-0406).
+- QG-0001 M4: name binding to branch protection as a gate, with the three
+  bypass routes around it closed.
+- Prose gate: U+2014 em dashes are kept out of the tree.
+
+### Changed
+- `mcp` dependency moved to the 1.x line the server actually imports.
+- Exit-code documentation measured against the binary and gated (docaudit).
+
+### Fixed
+- The Python gate reads the file Dependabot actually changes; several QA-gate
+  refusal messages now name the cause that really applies.
+
+### Security
+- gosec in-CI baseline shrunk by two resolved findings so their
+  reintroduction keeps blocking; the one new G304 at the operator-supplied
+  `--meta` file read is accepted with a justified `#nosec` (reading the
+  caller's own file with the caller's privileges is the feature).
+
 ## [skillctl/v0.4.0], 2026-09-03, federated registries + the P1/P2 security-remediation wave
 ### Added
 - **Decentralized / federated registries (SPEC-0359).** The folder *is* the

--- a/docs/security/gosec-inci-baseline.txt
+++ b/docs/security/gosec-inci-baseline.txt
@@ -39,7 +39,6 @@ G104	pkg/config/healthcheck.go	defer resp.Body.Close() io.Copy(io.Discard, io.Li
 G104	pkg/config/profile.go	if _, err := f.WriteString(name + "\\n"); err != nil { f.Close() //nolint:errcheck // best-effort close on error path; the write error is already returned below return fmt.Errorf("write active-profile: %w", err)
 G104	pkg/config/profile.go	if err := f.Sync(); err != nil { f.Close() //nolint:errcheck // best-effort close on error path; the sync error is already returned below return fmt.Errorf("sync active-profile: %w", err)
 G104	pkg/er1/config.go	defer resp.Body.Close() io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20)) //nolint:errcheck // draining the response body for connection reuse; the data is discarded
-G104	pkg/er1/config.go	if os.Getenv(k) == "" { os.Setenv(k, v) //nolint:errcheck // best-effort .env->process env; a malformed key is simply skipped, same as an absent line }
 G104	pkg/er1/device.go	defer resp.Body.Close() io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20)) //nolint:errcheck // draining the response body for connection reuse; the data is discarded
 G104	pkg/menubar/app.go	Clicked: func() { CopyToClipboard("Transcript for " + entry.VideoID) //nolint:errcheck // best-effort UI clipboard write a.fireAction(ActionCopyTranscript, entry.VideoID)
 G104	pkg/menubar/app.go	Clicked: func() { exec.Command("open", a.Config.LogPath).Run() //nolint:errcheck // fire-and-forget UI action: open the log file in the default app a.fireAction(ActionOpenLog, a.Config.LogPath)
@@ -239,7 +238,6 @@ G304	cmd/skillctl/replay_cmds.go	for _, p := range candidates { data, err := os.
 G304	cmd/skillctl/replay_cmds.go	} data, err := os.ReadFile(path) if err != nil {
 G304	cmd/skillctl/revoked_cache.go	func loadInstalledSidecar(home, name string) (registry.ProvenanceSidecar, bool) { b, err := os.ReadFile(filepath.Join(home, ".claude", "skills", name, registry.ProvenanceSidecarName)) if err != nil {
 G304	cmd/skillctl/revoked_cache.go	} b, err := os.ReadFile(p) if err != nil {
-G304	cmd/skillctl/runbook_cmds.go	func loadRunbookDescriptor(metaPath, ver string) (map[string]any, error) { raw, err := os.ReadFile(metaPath) if err != nil {
 G304	cmd/skillctl/runbook_cmds.go	html, err := os.ReadFile(htmlPath) if err != nil {
 G304	cmd/skillctl/scan_body_cmds.go	func scanBodyFile(skillMD string) (bodyscan.BodyScanReport, error) { raw, err := os.ReadFile(skillMD) if err != nil {
 G304	cmd/skillctl/scanner_cmds.go	func loadInventory(path string) (*model.Inventory, error) { data, err := os.ReadFile(path) if err != nil {


### PR DESCRIPTION
Phase 2 vor dem Tag skillctl/v0.5.0 (Zug 05 der Delivery-Pipe, SPEC-0426): Versionssektion aus dem Log, Baseline um die zwei geloesten Findings geschrumpft (Empfehlung des Tors selbst), docaudit PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)