### PR TITLE
fix(release): der Trust Binder kennt das SPEC-0406-Abnahmetor

### DIFF
--- a/cmd/release-evidence/main.go
+++ b/cmd/release-evidence/main.go
@@ -86,7 +86,7 @@ var registry = []gateMeta{
 	{"slsa-provenance", "SLSA L3 provenance + slsa-verifier gate", "provenance", true, "re-verify", "attestation"},
 	{"cosign-signature", "cosign sign-blob SHA256SUMS (keyless OIDC)", "signature", true, "re-verify", "attestation"},
 	{"platform-smoke", "Per-platform runtime smoke of the signed binary", "smoke", true, "trust-ci", "ci-log"},
-	{"two-party-acceptance", "SPEC-0406 acceptance rehearsal (macOS + Windows twins)", "acceptance", true, "trust-ci", "ci-log"},
+	{"two-party-acceptance", "SPEC-0406 acceptance rehearsal (macOS + Windows twins)", "test", true, "trust-ci", "ci-log"},
 	{"threat-model-delta", "Threat-model / security-triad delta", "threat-model", false, "reference", "external"},
 }
 

--- a/cmd/release-evidence/main.go
+++ b/cmd/release-evidence/main.go
@@ -66,7 +66,10 @@ type gateMeta struct {
 // registry is the mandatory gate-set G (H10d). Order is presentational and
 // mirrors the H10p prototype. The `required` column IS policy G:
 //
-//	12 required (the now-real gates) + threat-model-delta advisory.
+//	13 required (the now-real gates) + threat-model-delta advisory.
+//	two-party-acceptance kam am 2026-09-10 dazu: das SPEC-0406-Tor meldete
+//	sich beim ersten Release-Lauf in die Evidenz, stand aber nicht in G;
+//	der Binder hat den Release zu Recht verweigert (Run 34491670456).
 //
 // If a gate id here drifts from the shipped JSON-schema enum, the -schema
 // cross-check fails the build (keeps schema and policy in lockstep).
@@ -83,6 +86,7 @@ var registry = []gateMeta{
 	{"slsa-provenance", "SLSA L3 provenance + slsa-verifier gate", "provenance", true, "re-verify", "attestation"},
 	{"cosign-signature", "cosign sign-blob SHA256SUMS (keyless OIDC)", "signature", true, "re-verify", "attestation"},
 	{"platform-smoke", "Per-platform runtime smoke of the signed binary", "smoke", true, "trust-ci", "ci-log"},
+	{"two-party-acceptance", "SPEC-0406 acceptance rehearsal (macOS + Windows twins)", "acceptance", true, "trust-ci", "ci-log"},
 	{"threat-model-delta", "Threat-model / security-triad delta", "threat-model", false, "reference", "external"},
 }
 

--- a/cmd/release-evidence/main_test.go
+++ b/cmd/release-evidence/main_test.go
@@ -61,9 +61,10 @@ func TestRecompute_AllRequiredPass_IsReady(t *testing.T) {
 	if b.Summary.RequiredPassed != b.Summary.RequiredTotal {
 		t.Fatalf("required_passed %d != required_total %d", b.Summary.RequiredPassed, b.Summary.RequiredTotal)
 	}
-	// Sanity: policy G currently has 12 required gates.
-	if b.Summary.RequiredTotal != 12 {
-		t.Fatalf("required_total = %d, want 12 (gate-set G)", b.Summary.RequiredTotal)
+	// Sanity: policy G currently has 13 required gates
+	// (two-party-acceptance seit 2026-09-10, SPEC-0406).
+	if b.Summary.RequiredTotal != 13 {
+		t.Fatalf("required_total = %d, want 13 (gate-set G)", b.Summary.RequiredTotal)
 	}
 }
 

--- a/docs/security/release-evidence.schema.json
+++ b/docs/security/release-evidence.schema.json
@@ -88,7 +88,7 @@
               "unit-tests", "race", "e2e", "lint", "gosec-sast",
               "govulncheck-cve", "gitleaks-secret", "sbom", "docaudit",
               "slsa-provenance", "cosign-signature", "platform-smoke",
-              "threat-model-delta"
+              "two-party-acceptance", "threat-model-delta"
             ]
           },
           "name": { "type": "string", "description": "Human label; SHOULD match the CI job name so a consumer can find it in the run." },


### PR DESCRIPTION
Vierter Kalibrier-Befund von Zug 05: das neue Abnahmetor speist two-party-acceptance in die Release-Evidenz, die Policy-Gate-Menge G kannte den Namen nicht; der Binder verweigerte zu Recht (Run 34491670456, alles andere gruen inkl. aller fuenf Smoke-Beine). Registry +1 Pflicht-Tor, Schema-Enum im Gleichschritt, Test 12 auf 13. Lokal: go build + go test gruen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)