### PR TITLE
fix(release): Evidenz-Anhang nennt das Repo explizit

### DIFF
--- a/.github/workflows/skillctl-release.yml
+++ b/.github/workflows/skillctl-release.yml
@@ -683,8 +683,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Dieser Job hat KEIN checkout; gh wuerde das Repo sonst aus dem
+          # nicht vorhandenen git-Kontext raten ("not a git repository",
+          # Run 34494178085). Das Repo steht deshalb explizit am Aufruf.
           gh release upload "${GITHUB_REF_NAME}" \
             dist/release-evidence.json \
             dist/release-evidence.json.cosign.bundle \
             dist/release-evidence.intoto.json \
-            --clobber
+            --clobber --repo "${GITHUB_REPOSITORY}"


### PR DESCRIPTION
Fuenfter Kalibrier-Befund von Zug 05: der Attach-Job laeuft ohne checkout, gh riet das Repo aus nicht vorhandenem git-Kontext (Run 34494178085; Binder-Assembly und cosign-Signatur der Evidenz waren erstmals gruen). Fix: --repo GITHUB_REPOSITORY am Upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)